### PR TITLE
Add PRD for OpenHands-Tab VS Code extension

### DIFF
--- a/prd.md
+++ b/prd.md
@@ -1,0 +1,155 @@
+# Product Requirements: OpenHands-Tab VS Code Extension
+
+## 1. Objective
+Deliver a VS Code extension that provides an in-IDE tab to interact with an OpenHands agent, using the agent-server (OpenHands server) to execute user prompts. The extension streams events in real time, previews proposed code changes, and lets users apply changes to their local workspace.
+
+## 2. Scope
+- In scope
+  - VS Code extension with a dedicated tab (Webview) for chat and agent interaction
+  - Connection to an OpenHands agent-server via WebSocket/HTTP
+  - Real-time streaming of agent events (messages, tool runs, logs)
+  - Display and apply code changes proposed by the agent to the local workspace
+  - Basic session management: create/reset sessions, persist last session per workspace
+  - Configuration UI for server URL and credentials
+- Out of scope (v1)
+  - Reproducing the full OpenHands web UI
+  - Server lifecycle management (installing/running Docker, etc.)
+  - Multi-tenant/team administration
+  - Arbitrary tool configuration on the server (assumed to be preconfigured)
+
+## 3. Target Users
+- Developers who want to use OpenHands agents directly within VS Code
+- Users with access to a running OpenHands agent-server (local or remote)
+
+## 4. Architecture Overview
+- VS Code Extension (Extension Host)
+  - Activation + Commands
+  - Connection Manager (WebSocket + HTTP proxy layer)
+  - Session/State Manager (conversation lifecycle, persistence)
+  - File Change Applier (apply patches to workspace)
+  - Telemetry/Logging (optional, off by default)
+- Webview (Tab UI)
+  - Chat composer and transcript
+  - Streaming event view (tool outputs, logs)
+  - File changes list with inline diff preview and apply/revert controls
+  - Status/connection indicators
+- OpenHands Agent-Server (External)
+  - Exposes WebSocket API to stream oh_event and accept oh_user_action
+  - Executes tools (bash, python, web, etc.) in its own runtime/sandbox
+  - Provides proposed code edits as patches/contents
+
+Data flow notes
+- Webview does not call the network directly. All network calls and WebSocket connections go through the Extension Host (to avoid CORS and centralize auth/secrets).
+- Extension Host relays messages to/from the Webview via VS Code postMessage API.
+
+## 5. External Dependencies & Protocol
+- OpenHands Server (agent-server)
+  - Default URL: http://localhost:3000 (configurable)
+  - Authentication: API key/bearer token (optional, configurable)
+  - WebSocket: Socket.IO endpoint /socket.io
+    - Query params include conversation_id and latest_event_id, per OpenHands docs
+    - Receives events: "oh_event"
+    - Sends actions: "oh_user_action" (type: message)
+  - HTTP endpoints (optional, as needed): create/list conversations, fetch history
+- Versions
+  - Aim for compatibility with current OpenHands docs (WebSocket Connection guide)
+
+## 6. Functional Requirements
+- Commands
+  - OpenHands: Open Tab (opens/activates the Webview)
+  - OpenHands: New Session (creates a new agent conversation)
+  - OpenHands: Configure (opens settings quick-pick/form)
+  - OpenHands: Reconnect (restarts WebSocket)
+  - OpenHands: Apply All Proposed Changes (batch apply)
+  - OpenHands: Stop/Cancel Current Run (sends cancel if supported; otherwise disconnect/reconnect)
+- Settings
+  - openhands.serverUrl (string; default http://localhost:3000)
+  - openhands.apiKey (secret storage)
+  - openhands.autoReconnect (boolean; default true)
+  - openhands.showTelemetryPrompt (boolean; default false)
+- Connection & Session
+  - Establish Socket.IO connection with conversation_id
+  - If no conversation_id exists, create one via HTTP or let server auto-create if supported
+  - Persist last used conversation_id per workspace (workspaceState); allow reset
+  - Reconnect logic: exponential backoff; UI indicates connection state
+- Chat & Streaming
+  - Text input send -> oh_user_action: { type: "message", source: "user", message }
+  - Render assistant messages and tool events as they stream
+  - Show structured tool steps (bash/python commands, outputs, status)
+  - Allow user to stop current run (best-effort)
+- File Change Handling
+  - Parse code edit events (diff/patch or content replace) from oh_event stream
+  - Present list of proposed edits grouped by file
+  - Diff preview: original vs proposed (VS Code diff editor)
+  - Apply: write changes to workspace files; create files/directories as needed
+  - Conflict handling: if local file changed since patch base, show conflict banner, require manual review
+  - Batch apply and per-change apply
+- Persistence
+  - Store conversation_id and minimal transcript index for resume (workspaceState)
+  - Store settings in standard VS Code Settings/SecretStorage
+- Telemetry/Logging
+  - None by default; if enabled, only extension-level anonymized events (no content). Must be opt-in.
+
+## 7. Non-Functional Requirements
+- Security & Privacy
+  - Secrets stored via VS Code SecretStorage
+  - Do not log API keys or user content
+  - All network traffic via Extension Host
+- Performance
+  - Stream updates without blocking the UI
+  - Efficient diff rendering for typical file sizes (<1 MB per file in v1)
+- Reliability
+  - Graceful handling of server unavailability; retry with backoff
+  - Resilient to transient Socket.IO disconnects
+
+## 8. UX Overview
+- Tab Layout
+  - Header: server status, session actions (New, Reset, Reconnect), settings gear
+  - Main: message list (user/assistant and tool events), live streaming
+  - Side panel: proposed file changes with counts
+  - Bottom: chat composer with Send and Stop buttons
+- Flows
+  - First Run: prompt to configure server URL/API key → test connection → create session → open tab
+  - Send Prompt: user enters message → stream events → proposed changes appear → user reviews → apply/skip
+  - Reconnect: on disconnect, show banner; user can retry or auto-reconnect
+
+## 9. API/Event Mapping (Initial)
+- Outbound (to server)
+  - oh_user_action: { type: "message", source: "user", message: string }
+  - Optional: cancel/run control if supported by server
+- Inbound (from server via oh_event)
+  - message events (assistant/system)
+  - tool events (bash/python start, output, end, exit code)
+  - code edit events: unified diff or file content replacement payloads
+  - run lifecycle events (start, progress, end)
+
+## 10. Extension Structure (Code)
+- src/extension.ts (activate, register commands)
+- src/connection/ConnectionManager.ts (Socket.IO client, HTTP helpers)
+- src/session/SessionManager.ts (conversation_id, resume state)
+- src/edits/EditApplier.ts (diff parsing, apply, conflicts)
+- src/panels/OpenHandsPanel.ts (Webview setup, message bridge)
+- webview-src/ (UI bundle; framework-agnostic or lightweight React)
+  - ChatView, EventStream, ChangesPanel, StatusBar, SettingsModal
+
+## 11. Packaging & Distribution
+- Engine: VS Code >= 1.85.0
+- Node: 22.x
+- Publish as VSIX initially; Marketplace later
+- Extension identifiers
+  - Name: openhands-tab
+  - Display Name: OpenHands Tab
+  - Publisher: enyst (placeholder)
+
+## 12. Milestones
+- M0: Scaffold extension + Webview shell; settings storage; connection test command
+- M1: WebSocket connect; send message; render basic assistant text
+- M2: Stream tool events/logs with structured UI; stop button
+- M3: Parse and preview code edits; single-file apply
+- M4: Batch apply; conflict detection; UX polish
+- M5: Error handling, reconnection, minimal telemetry (opt-in)
+
+## 13. Assumptions
+- Server provides a stable oh_event stream and recognizes oh_user_action per current OpenHands docs
+- Server is responsible for model/provider configuration and tool availability
+- Code edits arrive as either unified diffs or full-file contents sufficient to apply locally

--- a/prd.md
+++ b/prd.md
@@ -110,7 +110,7 @@ Data flow notes
 - Tab Layout
   - Header: server status indicator (green/red dot), settings gear; reconnect is automatic; no separate New/Reset buttons in v1 (new conversation from command palette)
   - Main: message list (user/assistant and tool events), live streaming
-  - Optional: show a lightweight list of recent file ops with links to open diffs in standard VS Code views (SCM/editor)
+  - Show a lightweight list of recent file ops (tool results) with links to open diffs in standard VS Code views (SCM/editor)
   - Bottom: chat composer with Send and Stop buttons
 - Flows
   - First Run: prompt to configure server URL → test connection → create conversation → open tab

--- a/prd.md
+++ b/prd.md
@@ -88,15 +88,13 @@ Data flow notes
   - Approve -> POST /api/conversations/{id}/events/respond_to_confirmation { accept: true }
   - Reject -> POST /api/conversations/{id}/events/respond_to_confirmation { accept: false, reason }
 - File Change Handling
-  - Reflect file system changes performed by the server in the connected workspace folder (no local patch application in v1)
-  - Optional future: client-side patch preview/apply if running read-only server mode
+  - Reflect file system changes performed by the server in the connected workspace folder (no client-side patch application planned)
 - Persistence
   - Store last-used conversation_id per workspace (workspaceState)
   - Store settings in standard VS Code Settings/SecretStorage
-  - Conversation persistence folder (optional, for local transcripts and metadata):
-    - Default: .openhands/conversations in the first workspace folder
-    - Each conversation: {conversation_id}.json (serialized events or minimal transcript)
-    - Toggle to enable/disable local transcript persistence
+  - Conversation persistence (optional, for local transcripts and metadata):
+    - Location: ~/.openhands/conversations (user-level, not per workspace)
+    - Persist the server-provided JSON for a conversation (use the SDK’s pydantic serialization output; do not define our own schema).
 - Telemetry/Logging
   - None by default; if enabled, only extension-level anonymized events (no content). Must be opt-in.
 
@@ -152,6 +150,24 @@ Data flow notes
   - Publisher: enyst (placeholder)
 
 ## 12. Milestones
+
+## 14. Phased Delivery
+- POC
+  - Connect to server; create/restore conversation; send/stream messages and events
+  - Minimal chat UI; basic status; reconnect handling
+- Settings
+  - Configure server URL, API key; auto-reconnect; persist last conversation id
+  - Optional: enable/disable user-level persistence to ~/.openhands/conversations
+- Confirmation Mode
+  - Surface WAITING_FOR_CONFIRMATION state; list pending actions; Approve/Reject flow
+  - Policies selectable when starting a conversation (NeverConfirm, AlwaysConfirm, ConfirmRisky)
+- Switch LLM During Conversation
+  - If supported by server/SDK: expose command(s) to update agent model/provider mid-conversation
+  - Otherwise: provide “Start New Conversation with Model…” flow
+- UI Polish Rounds
+  - Iteratively improve event rendering, layout, and diff views
+  - Note: OpenHands V0 (current web) vs V1 (agent-sdk centric) — we will prefer reusing visual patterns where feasible, but the authoritative APIs and models are from agent-sdk (V1 rewrite). Visual similarity is desired; implementation details may differ.
+
 - M0: Scaffold extension + Webview shell; settings storage; connection test command
 - M1: WebSocket connect; send message; render basic assistant text
 - M2: Stream tool events/logs with structured UI; stop button
@@ -160,6 +176,6 @@ Data flow notes
 - M5: Error handling, reconnection, minimal telemetry (opt-in)
 
 ## 13. Assumptions
-- Server provides a stable oh_event stream and recognizes oh_user_action per current OpenHands docs
+- Server provides a stable EventBase WebSocket stream and accepts Message JSON per agent-sdk
 - Server is responsible for model/provider configuration and tool availability
-- Code edits arrive as either unified diffs or full-file contents sufficient to apply locally
+- Code edits are reflected by the server in the workspace folder; client does not apply patches

--- a/prd.md
+++ b/prd.md
@@ -1,4 +1,4 @@
-# Product Requirements: OpenHands-Tab VS Code Extension
+# OpenHands-Tab VS Code Extension
 
 ## 1. Objective
 Deliver a VS Code extension that provides an in-IDE tab to interact with an OpenHands agent, using the agent-server (OpenHands server) to execute user prompts. The extension streams events in real time, supports action approval (confirmation mode), and reflects file changes in the workspace when the server runs against the workspace folder.
@@ -8,13 +8,13 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
   - VS Code extension with a dedicated tab (Webview) for chat and agent interaction
   - Connection to an OpenHands agent-server via WebSocket/HTTP
   - Real-time streaming of agent events (messages, tool runs, logs)
-  - Display and apply code changes proposed by the agent to the local workspace
-  - Conversation management: create/reset conversations, persist last conversation per workspace (by ID only)
+  - Display live agent activity and any resulting workspace file changes
+  - Conversation management: start/restore conversations
   - Configuration UI for server URL and credentials
 - Out of scope (v1)
   - Reproducing the full OpenHands web UI
   - Server lifecycle management (installing/running Docker, etc.)
-  - Multi-tenant/team administration
+
   - Arbitrary tool configuration on the server (assumed to be preconfigured)
 
 ## 3. Target Users
@@ -26,13 +26,12 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
   - Activation + Commands
   - Connection Manager (WebSocket + HTTP proxy layer)
   - Session/State Manager (conversation lifecycle, persistence)
-  - File Change Applier (apply patches to workspace)
   - Telemetry/Logging (optional, off by default)
 - Webview (Tab UI)
   - Chat composer and transcript
   - Streaming event view (tool outputs, logs)
-  - File changes list with inline diff preview and apply/revert controls
   - Status/connection indicators
+  - No dedicated diff viewer in the tab; file diffs open in standard VS Code editors/SCM. The tab may provide links to open those diffs.
 - OpenHands Agent-Server (External)
   - Exposes native WebSocket API streaming EventBase JSON; accepts Message JSON
   - Executes tools (bash, python, web, etc.) in its own runtime/sandbox
@@ -62,20 +61,19 @@ Data flow notes
 ## 6. Functional Requirements
 - Commands
   - OpenHands: Open Tab (opens/activates the Webview)
-  - OpenHands: New Session (creates a new agent conversation)
+  - OpenHands: Start New Conversation
   - OpenHands: Configure (opens settings quick-pick/form)
-  - OpenHands: Reconnect (restarts WebSocket)
-  - OpenHands: Apply All Proposed Changes (batch apply)
+  - OpenHands: Reconnect (restarts WebSocket; rarely needed since reconnect is automatic)
+
   - OpenHands: Stop/Cancel Current Run (sends cancel if supported; otherwise disconnect/reconnect)
 - Settings
   - openhands.serverUrl (string; default http://localhost:3000)
   - openhands.apiKey (secret storage)
   - openhands.autoReconnect (boolean; default true)
-  - openhands.showTelemetryPrompt (boolean; default false)
 - Connection & Conversation Lifecycle
   - Establish WebSocket connection to /api/conversations/{id}/events/socket
   - If no conversation_id exists, create one via POST /api/conversations with desired confirmation_policy
-  - Persist last used conversation_id per workspace (workspaceState); allow reset
+  - Maintain current conversation_id in workspaceState for convenience (for quick tab reload), independent of global persistence in ~/.openhands/conversations
   - Reconnect logic: exponential backoff; UI indicates connection state
 - Chat & Streaming
   - Text input -> send Message JSON over socket or POST /events/
@@ -92,10 +90,9 @@ Data flow notes
 - Persistence
   - Store last-used conversation_id per workspace (workspaceState)
   - Store settings in standard VS Code Settings/SecretStorage
-  - Conversation persistence (optional, for local transcripts and metadata):
-    - Location: ~/.openhands/conversations (user-level, not per workspace)
-    - Persist the server-provided JSON for a conversation (use the SDK’s pydantic serialization output; do not define our own schema).
-    - Default: ON
+  - Conversation persistence (default ON):
+    - Location: ~/.openhands/conversations (user-level; not tied to workspace)
+    - Persist server/SDK JSON as-is (pydantic model_dump_json); no custom schema
 - Telemetry/Logging
   - None by default; if enabled, only extension-level anonymized events (no content). Must be opt-in.
 
@@ -115,11 +112,11 @@ Data flow notes
 - Tab Layout
   - Header: server status indicator (green/red dot), settings gear; reconnect is automatic; no separate New/Reset buttons in v1 (new conversation from command palette)
   - Main: message list (user/assistant and tool events), live streaming
-  - Side panel: proposed file changes with counts
+  - Optional: show a lightweight list of recent file ops with links to open diffs in standard VS Code views (SCM/editor)
   - Bottom: chat composer with Send and Stop buttons
 - Flows
   - First Run: prompt to configure server URL/API key → test connection → create conversation → open tab
-  - Send Prompt: user enters message → stream events → proposed changes appear → user reviews → apply/skip
+  - Send Prompt: user enters message → stream events → source control shows diffs → user reviews in standard editors/SCM
   - Reconnect: on disconnect, show banner; user can retry or auto-reconnect
 
 ## 9. API/Event Mapping (Initial)
@@ -136,10 +133,10 @@ Data flow notes
 - src/extension.ts (activate, register commands)
 - src/connection/ConnectionManager.ts (native WebSocket client, HTTP helpers)
 - src/session/ConversationManager.ts (conversation_id, resume state)
-- src/edits/EditApplier.ts (diff parsing, apply, conflicts)
+
 - src/panels/OpenHandsPanel.ts (Webview setup, message bridge)
 - webview-src/ (UI bundle; framework-agnostic or lightweight React)
-  - ChatView, EventStream, ChangesPanel, StatusBar, SettingsModal
+  - ChatView, EventStream, StatusBar, SettingsModal
 
 ## 11. Packaging & Distribution
 - Engine: VS Code >= 1.85.0
@@ -158,7 +155,7 @@ Data flow notes
   - Minimal chat UI; basic status; reconnect handling
 - Settings
   - Configure server URL, API key; auto-reconnect; persist last conversation id
-  - Optional: enable/disable user-level persistence to ~/.openhands/conversations
+  - User-level persistence to ~/.openhands/conversations (default ON)
 - Confirmation Mode
   - Surface WAITING_FOR_CONFIRMATION state; list pending actions; Approve/Reject flow
   - Policies selectable when starting a conversation (NeverConfirm, AlwaysConfirm, ConfirmRisky)
@@ -166,15 +163,14 @@ Data flow notes
   - If supported by server/SDK: expose command(s) to update agent model/provider mid-conversation
   - Otherwise: provide “Start New Conversation with Model…” flow
 - UI Polish Rounds
-  - Iteratively improve event rendering, layout, and diff views
+  - Iteratively improve event rendering and layout
   - Note: OpenHands V0 (current web) vs V1 (agent-sdk centric) — we will prefer reusing visual patterns where feasible, but the authoritative APIs and models are from agent-sdk (V1 rewrite). Visual similarity is desired; implementation details may differ.
 
 - M0: Scaffold extension + Webview shell; settings storage; connection test command
 - M1: WebSocket connect; send message; render basic assistant text
 - M2: Stream tool events/logs with structured UI; stop button
-- M3: Parse and preview code edits; single-file apply
-- M4: Batch apply; conflict detection; UX polish
-- M5: Error handling, reconnection, minimal telemetry (opt-in)
+- M3: Error handling, reconnection, minimal telemetry (opt-in)
+- M4: (Later) Revisit any optional file change summaries or links
 
 ## 13. Assumptions
 - Server provides a stable EventBase WebSocket stream and accepts Message JSON per agent-sdk

--- a/prd.md
+++ b/prd.md
@@ -1,7 +1,7 @@
 # OpenHands-Tab VS Code Extension
 
-## 1. Objective
-Deliver a VS Code extension that provides an in-IDE tab to interact with an OpenHands agent, using the agent-server (OpenHands server) to execute user prompts. The extension streams events in real time, supports action approval (confirmation mode), and reflects file changes in the workspace when the server runs against the workspace folder.
+## 1. Goal
+A VS Code extension that provides a tab to interact with the OpenHands agent, using the agent-server (OpenHands server) to execute user prompts. The extension streams events in real time, supports action approval (confirmation mode), and reflects file changes in the workspace when the server runs against the workspace folder.
 
 ## 2. Scope
 - In scope
@@ -10,31 +10,30 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
   - Real-time streaming of agent events (messages, tool runs, logs)
   - Display live agent activity and any resulting workspace file changes
   - Conversation management: start/restore conversations
-  - Configuration UI for server URL and credentials
+  - Configuration UI for server URL
 - Out of scope (v1)
   - Reproducing the full OpenHands web UI
   - Server lifecycle management (installing/running Docker, etc.)
-
   - Arbitrary tool configuration on the server (assumed to be preconfigured)
 
-## 3. Target Users
+## 3. Target
 - Developers who want to use OpenHands agents directly within VS Code
-- Users with access to a local OpenHands agent-server
 
 ## 4. Architecture Overview
 - VS Code Extension (Extension Host)
   - Activation + Commands
   - Connection Manager (WebSocket + HTTP proxy layer)
   - Session/State Manager (conversation lifecycle, persistence)
-  - Telemetry/Logging (optional, off by default)
+  - Logging (debug)
 - Webview (Tab UI)
-  - Chat composer and transcript
-  - Streaming event view (tool outputs, logs)
+  - User messages entry (chat box)
+  - Streaming event view (tool outputs, agent messages, user messages)
+  - logs/system informations
   - Status/connection indicators
   - No dedicated diff viewer in the tab; file diffs open in standard VS Code editors/SCM. The tab may provide links to open those diffs.
 - OpenHands Agent-Server (External)
   - Exposes native WebSocket API streaming EventBase JSON; accepts Message JSON
-  - Executes tools (bash, python, web, etc.) in its own runtime/sandbox
+  - Executes tools (bash, python, web, etc.) in its own runtime
   - Produces events that may include code edits or file operations (reflected in workspace)
 
 Data flow notes
@@ -54,8 +53,6 @@ Data flow notes
     - POST /api/conversations/{id}/events/ (SendMessageRequest) when not using the socket
     - GET /api/conversations/{id}/events/search, /count, /{event_id}, batch GET
     - POST /api/conversations/{id}/events/respond_to_confirmation to accept/reject pending actions
-- Versions
-  - Aim for compatibility with current OpenHands docs (WebSocket Connection guide)
 
 ## 6. Functional Requirements
 - Commands
@@ -63,36 +60,32 @@ Data flow notes
   - OpenHands: Start New Conversation
   - OpenHands: Configure (opens settings quick-pick/form)
   - OpenHands: Reconnect (restarts WebSocket; rarely needed since reconnect is automatic)
-
-  - OpenHands: Stop/Cancel Current Run (sends cancel if supported; otherwise disconnect/reconnect)
+  - OpenHands: Pause Current Run (sends pause)
 - Settings
   - openhands.serverUrl (string; default http://localhost:3000)
-  - openhands.autoReconnect (boolean; default true)
 - Connection & Conversation Lifecycle
   - Establish WebSocket connection to /api/conversations/{id}/events/socket
   - If no conversation_id exists, create one via POST /api/conversations with desired confirmation_policy
-  - Maintain current conversation_id in workspaceState for convenience (for quick tab reload), independent of global persistence in ~/.openhands/conversations
+  - Maintain current conversation_id in workspaceState for convenience (for quick tab reload)
   - Reconnect logic: exponential backoff; UI indicates connection state
 - Chat & Streaming
   - Text input -> send Message JSON over socket or POST /events/
   - Render assistant messages and tool events (EventBase JSON) as they stream
   - Show structured tool steps (bash/python commands, outputs, status)
-  - Allow user to stop/pause current run via POST /conversations/{id}/pause; resume via /resume
+  - Allow user to pause current run via POST /conversations/{id}/pause; resume via /resume
 - Action Confirmation Mode
   - Policies: NeverConfirm, AlwaysConfirm, ConfirmRisky(threshold: LOW|MEDIUM|HIGH, confirm_unknown: bool)
   - When agent status = WAITING_FOR_CONFIRMATION, surface pending actions in UI with Approve/Reject
   - Approve -> POST /api/conversations/{id}/events/respond_to_confirmation { accept: true }
   - Reject -> POST /api/conversations/{id}/events/respond_to_confirmation { accept: false, reason }
-- File Change Handling
-  - Reflect file system changes performed by the server in the connected workspace folder (no client-side patch application planned)
 - Persistence
   - Store last-used conversation_id per workspace (workspaceState)
   - Store settings in standard VS Code Settings/SecretStorage
   - Conversation persistence (default ON):
-    - Location: ~/.openhands/conversations (user-level; not tied to workspace)
+    - Location: ~/.openhands/conversations
     - Persist server/SDK JSON as-is (pydantic model_dump_json); no custom schema
-- Telemetry/Logging
-  - None by default; if enabled, only extension-level anonymized events (no content). Must be opt-in.
+- Logging
+  - For debugging.
 
 ## 7. Non-Functional Requirements
 - Security & Privacy
@@ -101,19 +94,18 @@ Data flow notes
   - All network traffic via Extension Host
 - Performance
   - Stream updates without blocking the UI
-  - Efficient diff rendering for typical file sizes (<1 MB per file in v1)
 - Reliability
   - Graceful handling of server unavailability; retry with backoff
   - Resilient to transient WebSocket disconnects
 
 ## 8. UX Overview
 - Tab Layout
-  - Header: server status indicator (green/red dot), settings gear; reconnect is automatic; no separate New/Reset buttons in v1 (new conversation from command palette)
+  - Header: server status indicator (green/red dot), settings gear
   - Main: message list (user/assistant and tool events), live streaming
-  - Show a lightweight list of recent file ops (tool results) with links to open diffs in standard VS Code views (SCM/editor)
+  - Tool results can be file editor results, show links for filenames so the user can see the diff in the main editor
   - Bottom: chat composer with Send and Stop buttons
 - Flows
-  - First Run: prompt to configure server URL → test connection → create conversation → open tab
+  - First Run: prompt to configure server URL → create conversation → open tab
   - Send Prompt: user enters message → stream events → source control shows diffs → user reviews in standard editors/SCM
   - Reconnect: on disconnect, show banner; user can retry or auto-reconnect
 
@@ -131,7 +123,6 @@ Data flow notes
 - src/extension.ts (activate, register commands)
 - src/connection/ConnectionManager.ts (native WebSocket client, HTTP helpers)
 - src/session/ConversationManager.ts (conversation_id, resume state)
-
 - src/panels/OpenHandsPanel.ts (Webview setup, message bridge)
 - webview-src/ (UI bundle; framework-agnostic or lightweight React)
   - ChatView, EventStream, StatusBar, SettingsModal
@@ -145,9 +136,7 @@ Data flow notes
   - Display Name: OpenHands Tab
   - Publisher: openhands
 
-## 12. Milestones
-
-## 14. Phased Delivery
+## 12. Phases
 - POC
   - Connect to server; create/restore conversation; send/stream messages and events
   - Minimal chat UI; basic status; reconnect handling
@@ -174,7 +163,7 @@ Data flow notes
 - Server provides a stable EventBase WebSocket stream and accepts Message JSON per agent-sdk
 - Server is responsible for model/provider configuration and tool availability
 
-## 15. References
+## 14. References
 - agent-sdk (core models, agent/LLM abstractions)
   - openhands/sdk/agent/agent.py (Agent class, run loop, event generation)
   - openhands/sdk/llm/llm.py; utils/model_features.py; utils/metrics.py (model naming, metrics)

--- a/prd.md
+++ b/prd.md
@@ -1,7 +1,7 @@
 # Product Requirements: OpenHands-Tab VS Code Extension
 
 ## 1. Objective
-Deliver a VS Code extension that provides an in-IDE tab to interact with an OpenHands agent, using the agent-server (OpenHands server) to execute user prompts. The extension streams events in real time, previews proposed code changes, and lets users apply changes to their local workspace.
+Deliver a VS Code extension that provides an in-IDE tab to interact with an OpenHands agent, using the agent-server (OpenHands server) to execute user prompts. The extension streams events in real time, supports action approval (confirmation mode), and reflects file changes in the workspace when the server runs against the workspace folder.
 
 ## 2. Scope
 - In scope
@@ -9,7 +9,7 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
   - Connection to an OpenHands agent-server via WebSocket/HTTP
   - Real-time streaming of agent events (messages, tool runs, logs)
   - Display and apply code changes proposed by the agent to the local workspace
-  - Basic session management: create/reset sessions, persist last session per workspace
+  - Conversation management: create/reset conversations, persist last conversation per workspace (by ID only)
   - Configuration UI for server URL and credentials
 - Out of scope (v1)
   - Reproducing the full OpenHands web UI
@@ -46,11 +46,16 @@ Data flow notes
 - OpenHands Server (agent-server)
   - Default URL: http://localhost:3000 (configurable)
   - Authentication: API key/bearer token (optional, configurable)
-  - WebSocket: Socket.IO endpoint /socket.io
-    - Query params include conversation_id and latest_event_id, per OpenHands docs
-    - Receives events: "oh_event"
-    - Sends actions: "oh_user_action" (type: message)
-  - HTTP endpoints (optional, as needed): create/list conversations, fetch history
+  - WebSocket: native WebSocket endpoint /api/conversations/{conversation_id}/events/socket (JSON messages)
+    - Inbound: server streams EventBase JSON objects
+    - Outbound: client may send Message JSON to enqueue and run
+  - HTTP endpoints:
+    - POST /api/conversations to start a conversation (Agent, confirmation_policy, initial_message, max_iterations)
+    - GET /api/conversations/search, /count, /{id}
+    - POST /api/conversations/{id}/pause, /resume; DELETE /api/conversations/{id}
+    - POST /api/conversations/{id}/events/ (SendMessageRequest) when not using the socket
+    - GET /api/conversations/{id}/events/search, /count, /{event_id}, batch GET
+    - POST /api/conversations/{id}/events/respond_to_confirmation to accept/reject pending actions
 - Versions
   - Aim for compatibility with current OpenHands docs (WebSocket Connection guide)
 
@@ -67,26 +72,31 @@ Data flow notes
   - openhands.apiKey (secret storage)
   - openhands.autoReconnect (boolean; default true)
   - openhands.showTelemetryPrompt (boolean; default false)
-- Connection & Session
-  - Establish Socket.IO connection with conversation_id
-  - If no conversation_id exists, create one via HTTP or let server auto-create if supported
+- Connection & Conversation Lifecycle
+  - Establish WebSocket connection to /api/conversations/{id}/events/socket
+  - If no conversation_id exists, create one via POST /api/conversations with desired confirmation_policy
   - Persist last used conversation_id per workspace (workspaceState); allow reset
   - Reconnect logic: exponential backoff; UI indicates connection state
 - Chat & Streaming
-  - Text input send -> oh_user_action: { type: "message", source: "user", message }
-  - Render assistant messages and tool events as they stream
+  - Text input -> send Message JSON over socket or POST /events/
+  - Render assistant messages and tool events (EventBase JSON) as they stream
   - Show structured tool steps (bash/python commands, outputs, status)
-  - Allow user to stop current run (best-effort)
+  - Allow user to stop/pause current run via POST /conversations/{id}/pause; resume via /resume
+- Action Confirmation Mode
+  - Policies: NeverConfirm, AlwaysConfirm, ConfirmRisky(threshold: LOW|MEDIUM|HIGH, confirm_unknown: bool)
+  - When agent status = WAITING_FOR_CONFIRMATION, surface pending actions in UI with Approve/Reject
+  - Approve -> POST /api/conversations/{id}/events/respond_to_confirmation { accept: true }
+  - Reject -> POST /api/conversations/{id}/events/respond_to_confirmation { accept: false, reason }
 - File Change Handling
-  - Parse code edit events (diff/patch or content replace) from oh_event stream
-  - Present list of proposed edits grouped by file
-  - Diff preview: original vs proposed (VS Code diff editor)
-  - Apply: write changes to workspace files; create files/directories as needed
-  - Conflict handling: if local file changed since patch base, show conflict banner, require manual review
-  - Batch apply and per-change apply
+  - Reflect file system changes performed by the server in the connected workspace folder (no local patch application in v1)
+  - Optional future: client-side patch preview/apply if running read-only server mode
 - Persistence
-  - Store conversation_id and minimal transcript index for resume (workspaceState)
+  - Store last-used conversation_id per workspace (workspaceState)
   - Store settings in standard VS Code Settings/SecretStorage
+  - Conversation persistence folder (optional, for local transcripts and metadata):
+    - Default: .openhands/conversations in the first workspace folder
+    - Each conversation: {conversation_id}.json (serialized events or minimal transcript)
+    - Toggle to enable/disable local transcript persistence
 - Telemetry/Logging
   - None by default; if enabled, only extension-level anonymized events (no content). Must be opt-in.
 
@@ -100,7 +110,7 @@ Data flow notes
   - Efficient diff rendering for typical file sizes (<1 MB per file in v1)
 - Reliability
   - Graceful handling of server unavailability; retry with backoff
-  - Resilient to transient Socket.IO disconnects
+  - Resilient to transient WebSocket disconnects
 
 ## 8. UX Overview
 - Tab Layout
@@ -114,19 +124,19 @@ Data flow notes
   - Reconnect: on disconnect, show banner; user can retry or auto-reconnect
 
 ## 9. API/Event Mapping (Initial)
-- Outbound (to server)
-  - oh_user_action: { type: "message", source: "user", message: string }
-  - Optional: cancel/run control if supported by server
-- Inbound (from server via oh_event)
-  - message events (assistant/system)
-  - tool events (bash/python start, output, end, exit code)
-  - code edit events: unified diff or file content replacement payloads
-  - run lifecycle events (start, progress, end)
+- Outbound
+  - WebSocket send: Message JSON (role/content) to queue and run
+  - HTTP POST /api/conversations/{id}/events/: SendMessageRequest when needed outside the socket
+  - Pause/Resume: POST /api/conversations/{id}/pause, /resume
+  - Confirmation: POST /api/conversations/{id}/events/respond_to_confirmation
+- Inbound
+  - WebSocket: EventBase JSON stream (includes ActionEvent, MessageEvent, AgentErrorEvent, etc.)
+  - HTTP: Events search/count for backfill on reconnect
 
 ## 10. Extension Structure (Code)
 - src/extension.ts (activate, register commands)
-- src/connection/ConnectionManager.ts (Socket.IO client, HTTP helpers)
-- src/session/SessionManager.ts (conversation_id, resume state)
+- src/connection/ConnectionManager.ts (native WebSocket client, HTTP helpers)
+- src/session/ConversationManager.ts (conversation_id, resume state)
 - src/edits/EditApplier.ts (diff parsing, apply, conflicts)
 - src/panels/OpenHandsPanel.ts (Webview setup, message bridge)
 - webview-src/ (UI bundle; framework-agnostic or lightweight React)

--- a/prd.md
+++ b/prd.md
@@ -19,7 +19,7 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
 
 ## 3. Target Users
 - Developers who want to use OpenHands agents directly within VS Code
-- Users with access to a running OpenHands agent-server (local or remote)
+- Users with access to a local OpenHands agent-server
 
 ## 4. Architecture Overview
 - VS Code Extension (Extension Host)
@@ -43,8 +43,7 @@ Data flow notes
 
 ## 5. External Dependencies & Protocol
 - OpenHands Server (agent-server)
-  - Default URL: http://localhost:3000 (configurable)
-  - Authentication: API key/bearer token (optional, configurable)
+  - Default URL: http://localhost:3000 (local PoC)
   - WebSocket: native WebSocket endpoint /api/conversations/{conversation_id}/events/socket (JSON messages)
     - Inbound: server streams EventBase JSON objects
     - Outbound: client may send Message JSON to enqueue and run
@@ -68,7 +67,6 @@ Data flow notes
   - OpenHands: Stop/Cancel Current Run (sends cancel if supported; otherwise disconnect/reconnect)
 - Settings
   - openhands.serverUrl (string; default http://localhost:3000)
-  - openhands.apiKey (secret storage)
   - openhands.autoReconnect (boolean; default true)
 - Connection & Conversation Lifecycle
   - Establish WebSocket connection to /api/conversations/{id}/events/socket
@@ -154,7 +152,7 @@ Data flow notes
   - Connect to server; create/restore conversation; send/stream messages and events
   - Minimal chat UI; basic status; reconnect handling
 - Settings
-  - Configure server URL, API key; auto-reconnect; persist last conversation id
+  - Configure server URL; auto-reconnect; persist last conversation id
   - User-level persistence to ~/.openhands/conversations (default ON)
 - Confirmation Mode
   - Surface WAITING_FOR_CONFIRMATION state; list pending actions; Approve/Reject flow

--- a/prd.md
+++ b/prd.md
@@ -38,7 +38,7 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
   - Produces events that may include code edits or file operations (reflected in workspace)
 
 Data flow notes
-- Webview does not call the network directly. All network calls and WebSocket connections go through the Extension Host (to avoid CORS and centralize auth/secrets).
+- Webview does not call the network directly. All network calls and WebSocket connections go through the Extension Host (to avoid CORS and webview limitations).
 - Extension Host relays messages to/from the Webview via VS Code postMessage API.
 
 ## 5. External Dependencies & Protocol
@@ -113,7 +113,7 @@ Data flow notes
   - Optional: show a lightweight list of recent file ops with links to open diffs in standard VS Code views (SCM/editor)
   - Bottom: chat composer with Send and Stop buttons
 - Flows
-  - First Run: prompt to configure server URL/API key → test connection → create conversation → open tab
+  - First Run: prompt to configure server URL → test connection → create conversation → open tab
   - Send Prompt: user enters message → stream events → source control shows diffs → user reviews in standard editors/SCM
   - Reconnect: on disconnect, show banner; user can retry or auto-reconnect
 

--- a/prd.md
+++ b/prd.md
@@ -34,9 +34,9 @@ Deliver a VS Code extension that provides an in-IDE tab to interact with an Open
   - File changes list with inline diff preview and apply/revert controls
   - Status/connection indicators
 - OpenHands Agent-Server (External)
-  - Exposes WebSocket API to stream oh_event and accept oh_user_action
+  - Exposes native WebSocket API streaming EventBase JSON; accepts Message JSON
   - Executes tools (bash, python, web, etc.) in its own runtime/sandbox
-  - Provides proposed code edits as patches/contents
+  - Produces events that may include code edits or file operations (reflected in workspace)
 
 Data flow notes
 - Webview does not call the network directly. All network calls and WebSocket connections go through the Extension Host (to avoid CORS and centralize auth/secrets).
@@ -95,6 +95,7 @@ Data flow notes
   - Conversation persistence (optional, for local transcripts and metadata):
     - Location: ~/.openhands/conversations (user-level, not per workspace)
     - Persist the server-provided JSON for a conversation (use the SDK’s pydantic serialization output; do not define our own schema).
+    - Default: ON
 - Telemetry/Logging
   - None by default; if enabled, only extension-level anonymized events (no content). Must be opt-in.
 
@@ -112,12 +113,12 @@ Data flow notes
 
 ## 8. UX Overview
 - Tab Layout
-  - Header: server status, session actions (New, Reset, Reconnect), settings gear
+  - Header: server status indicator (green/red dot), settings gear; reconnect is automatic; no separate New/Reset buttons in v1 (new conversation from command palette)
   - Main: message list (user/assistant and tool events), live streaming
   - Side panel: proposed file changes with counts
   - Bottom: chat composer with Send and Stop buttons
 - Flows
-  - First Run: prompt to configure server URL/API key → test connection → create session → open tab
+  - First Run: prompt to configure server URL/API key → test connection → create conversation → open tab
   - Send Prompt: user enters message → stream events → proposed changes appear → user reviews → apply/skip
   - Reconnect: on disconnect, show banner; user can retry or auto-reconnect
 
@@ -147,7 +148,7 @@ Data flow notes
 - Extension identifiers
   - Name: openhands-tab
   - Display Name: OpenHands Tab
-  - Publisher: enyst (placeholder)
+  - Publisher: openhands
 
 ## 12. Milestones
 
@@ -178,4 +179,17 @@ Data flow notes
 ## 13. Assumptions
 - Server provides a stable EventBase WebSocket stream and accepts Message JSON per agent-sdk
 - Server is responsible for model/provider configuration and tool availability
-- Code edits are reflected by the server in the workspace folder; client does not apply patches
+
+## 15. References
+- agent-sdk (core models, agent/LLM abstractions)
+  - openhands/sdk/agent/agent.py (Agent class, run loop, event generation)
+  - openhands/sdk/llm/llm.py; utils/model_features.py; utils/metrics.py (model naming, metrics)
+- agent-server (FastAPI service and WS/HTTP interface)
+  - openhands/agent_server/README.md (WS endpoint, HTTP routes for conversations/events)
+  - openhands/agent_server/conversation_service.py (StoredConversation meta save/load; conversations_path)
+  - openhands/agent_server/event_service.py (event stream; persist meta via pydantic model_dump_json)
+  - openhands/agent_server/routes/* (conversations, events, confirmation)
+- Persistence utilities
+  - openhands/sdk/io/local.py (LocalFileStore; expands "~"; basic sandboxing)
+- Event/Conversation serialization
+  - Pydantic model_dump/model_dump_json on Conversation/StoredConversation/EventBase


### PR DESCRIPTION
This PR adds the initial product requirements document for the VS Code extension that integrates with the OpenHands agent-server.

Highlights:
- Objective, scope (v1), and assumptions
- Architecture: Extension Host, Webview, agent-server integration
- Functional requirements: commands, settings, session handling, streaming UI, file change apply/preview
- Non-functional requirements: security/privacy, performance, reliability
- UX outline and API/event mapping
- Proposed code structure and packaging
- Milestones M0–M5

File added:
- prd.md

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6b0dfb35893b46f582dda68f0a86b651)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Product Requirements document for the OpenHands Tab VS Code extension, covering objectives, target users, UX layout and user flows, architecture and data flow with the OpenHands agent, supported interactions (chat/streaming, connection/session lifecycle, action confirmation, file-change handling), persistence and telemetry expectations, security/performance/reliability constraints, API/event mappings, packaging, milestones, phased delivery, dependencies, and implementation assumptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->