### PR TITLE
docs(microagent): add runtime-no-set microagent (no triggers)

### DIFF
--- a/.openhands/microagents/runtime-no-set.md
+++ b/.openhands/microagents/runtime-no-set.md
@@ -1,0 +1,9 @@
+---
+name: runtime-no-set
+type: knowledge
+version: 1.0.0
+agent: CodeActAgent
+triggers: []
+---
+
+REMINDER: do NOT use `set -e` or any `set` in this runtime environment. Just run commands simply, it will work.


### PR DESCRIPTION
Summary
- Add a repository microagent `.openhands/microagents/runtime-no-set.md` with no triggers.
- Documents the runtime rule: do NOT use `set -e` or any `set` flags in this environment; run commands plainly.

Details
- Type: knowledge
- Agent: CodeActAgent
- Triggers: [] (intentionally none)
- Purpose: Provide clear guidance for shell usage within this runtime without enforcing behavior programmatically.

Testing
- N/A (documentation-only change)

Checklist
- [x] Created microagent markdown with YAML frontmatter
- [x] Committed change on a new branch with a descriptive name
- [x] Pushed branch to origin and opened this PR

Notes
- Base branch is `develop` as the repository's default remote HEAD.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a8f54e9aec224e5e8f47fa92fc4bac54)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a knowledge document outlining microagent runtime guidelines.
  - Clarifies that shell scripts should avoid using set -e or any set commands; run commands plainly.
  - Includes metadata for discoverability (name, type, version, agent, triggers).
  - Aims to reduce runtime errors by standardizing execution practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->