### PR TITLE
fix(e2e): remove --disable-extensions flag that prevented extension l…

### DIFF
--- a/tests/e2e/agentSdkEvents.test.ts
+++ b/tests/e2e/agentSdkEvents.test.ts
@@ -25,7 +25,6 @@ describe('OpenHands-Tab Agent-SDK Events E2E', function () {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [
-        '--disable-extensions',
         '--no-sandbox',
         '--user-data-dir', userDataDir,
         '--disable-gpu',

--- a/tests/e2e/diagnostics.test.ts
+++ b/tests/e2e/diagnostics.test.ts
@@ -24,7 +24,6 @@ describe('OpenHands-Tab diagnostics', function () {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [
-        '--disable-extensions',
         '--no-sandbox',
         '--user-data-dir', userDataDir,
         '--disable-gpu',

--- a/tests/e2e/openTab.test.ts
+++ b/tests/e2e/openTab.test.ts
@@ -27,7 +27,6 @@ describe('OpenHands-Tab E2E', function () {
       extensionDevelopmentPath,
       extensionTestsPath,
       launchArgs: [
-        '--disable-extensions',
         '--no-sandbox',
         '--user-data-dir', userDataDir,
         '--disable-gpu',


### PR DESCRIPTION
…oading

The --disable-extensions flag was preventing the OpenHands extension from loading during e2e tests, causing the error "command 'openhands.openTab' not found".

Removed this flag from all three test files:
- tests/e2e/openTab.test.ts
- tests/e2e/diagnostics.test.ts
- tests/e2e/agentSdkEvents.test.ts