### PR TITLE
feat(settings): VS Code Settings architecture, secrets, and ConnectionManager integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,32 @@
           "default": "http://localhost:3000",
           "description": "OpenHands agent-server base URL"
         }
+,
+          "openhands.llm.usageId": {
+            "type": ["string", "null"],
+            "default": "default-llm",
+            "markdownDescription": "Preferred usage_id for LLM config sent to agent-server. If unset, server defaults apply."
+          },
+          "openhands.llm.model": {
+            "type": ["string", "null"],
+            "default": "claude-sonnet-4-20250514",
+            "markdownDescription": "Default model name for LLM requests."
+          },
+          "openhands.llm.baseUrl": {
+            "type": ["string", "null"],
+            "default": null,
+            "markdownDescription": "Optional LLM base URL override."
+          },
+          "openhands.agent.enableSecurityAnalyzer": {
+            "type": "boolean",
+            "default": false,
+            "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
+          },
+          "openhands.agent.filterToolsRegex": {
+            "type": ["string", "null"],
+            "default": null,
+            "markdownDescription": "Regex to filter available tools sent to the agent."
+          }
       }
     }
   },

--- a/src/connection/ConnectionManager.ts
+++ b/src/connection/ConnectionManager.ts
@@ -54,7 +54,7 @@ export class ConnectionManager {
             usage_id: s?.llm.usageId || 'default-llm',
             model: s?.llm.model || 'claude-sonnet-4-20250514',
             base_url: s?.llm.baseUrl,
-            api_key: s?.secrets.llmApiKey || undefined
+            api_key: s?.secrets.llmApiKey
           },
           tools: [
             { name: 'BashTool', params: { working_dir: process.cwd() } },
@@ -62,7 +62,7 @@ export class ConnectionManager {
             { name: 'TaskTrackerTool', params: { save_dir: process.cwd() } }
           ],
           security_analyzer: s?.agent.enableSecurityAnalyzer ? { kind: 'LLMSecurityAnalyzer' } : undefined,
-          filter_tools_regex: s?.agent.filterToolsRegex || undefined,
+          filter_tools_regex: s?.agent.filterToolsRegex ?? undefined,
         },
         max_iterations: 50
       };

--- a/src/connection/ConnectionManager.ts
+++ b/src/connection/ConnectionManager.ts
@@ -1,6 +1,7 @@
 import WebSocket from 'ws';
 import type { Event, Message } from '../types/agent-sdk';
 import { isEvent as isAgentEvent } from '../types/agent-sdk';
+import type { OpenHandsSettings } from '../settings/SettingsManager';
 
 export type ConnectionEvents = {
   onStatus: (status: 'online' | 'offline' | 'connecting') => void;
@@ -11,6 +12,7 @@ export type ConnectionEvents = {
 
 export class ConnectionManager {
   private serverUrl: string;
+  private settings?: OpenHandsSettings;
   private conversationId?: string;
   private ws?: WebSocket;
   private status: 'online' | 'offline' | 'connecting' = 'offline';
@@ -27,6 +29,10 @@ export class ConnectionManager {
     this.events = events;
   }
 
+  setSettings(settings: OpenHandsSettings) {
+    this.settings = settings;
+  }
+
   setServerUrl(url: string) {
     this.serverUrl = url;
   }
@@ -41,25 +47,27 @@ export class ConnectionManager {
   async startNewConversation() {
     try {
       const base = this.serverUrl.replace(/\/$/, '');
-      const llmApiKey = process.env.LITELLM_API_KEY || process.env.OPENAI_API_KEY || '';
+      const s = this.settings;
       const req = {
         agent: {
           llm: {
-            service_id: 'test-llm',
-            model: 'litellm_proxy/anthropic/claude-sonnet-4-20250514',
-            base_url: 'https://llm-proxy.eval.all-hands.dev',
-            api_key: llmApiKey || undefined
+            usage_id: s?.llm.usageId || 'default-llm',
+            model: s?.llm.model || 'claude-sonnet-4-20250514',
+            base_url: s?.llm.baseUrl,
+            api_key: s?.secrets.llmApiKey || undefined
           },
           tools: [
             { name: 'BashTool', params: { working_dir: process.cwd() } },
             { name: 'FileEditorTool', params: { workspace_root: process.cwd() } },
             { name: 'TaskTrackerTool', params: { save_dir: process.cwd() } }
-          ]
+          ],
+          security_analyzer: s?.agent.enableSecurityAnalyzer ? { kind: 'LLMSecurityAnalyzer' } : undefined,
+          filter_tools_regex: s?.agent.filterToolsRegex || undefined,
         },
         max_iterations: 50
       };
       const headers: any = { 'Content-Type': 'application/json' };
-      const sessionKey = process.env.SESSION_API_KEY || '';
+      const sessionKey = s?.secrets.sessionApiKey || '';
       if (sessionKey) headers['X-Session-API-Key'] = sessionKey;
       const res = await fetch(base + '/api/conversations/', {
         method: 'POST',
@@ -107,7 +115,7 @@ export class ConnectionManager {
       try {
         const base = this.serverUrl.replace(/\/$/, '');
         const headers: any = { 'Content-Type': 'application/json' };
-        const sessionKey = process.env.SESSION_API_KEY || '';
+        const sessionKey = this.settings?.secrets.sessionApiKey || '';
         if (sessionKey) headers['X-Session-API-Key'] = sessionKey;
         await fetch(`${base}/api/conversations/${this.conversationId}/events/`, {
           method: 'POST', headers, body: JSON.stringify(payload)
@@ -146,7 +154,7 @@ export class ConnectionManager {
   private connect() {
     if (!this.conversationId) return;
     const base = this.serverUrl.replace(/\/$/, '');
-    const sessionKey = process.env.SESSION_API_KEY || '';
+    const sessionKey = this.settings?.secrets.sessionApiKey || '';
     // agent-sdk WS path moved to /sockets/events/{conversation_id} with optional session_api_key
     const qs = sessionKey ? `?session_api_key=${encodeURIComponent(sessionKey)}` : '';
     const wsUrl = base.replace(/^http/, 'ws') + `/sockets/events/${this.conversationId}${qs}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { ConnectionManager } from './connection/ConnectionManager';
+import { SettingsManager } from './settings/SettingsManager';
+import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 
 let panel: vscode.WebviewPanel | undefined;
 let connection: ConnectionManager | undefined;
@@ -31,6 +33,8 @@ export function activate(context: vscode.ExtensionContext) {
         onError: (err) => panel?.webview.postMessage({ type: 'error', error: String(err) }),
         onConversationId: (id) => context.workspaceState.update('openhands.conversationId', id),
       });
+      const settings = await new SettingsManager(new VscodeSettingsAdapter(context)).get();
+      connection.setSettings(settings);
       const savedId = context.workspaceState.get<string>('openhands.conversationId');
       if (savedId) connection.restoreConversation(savedId);
     }
@@ -94,18 +98,79 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const configure = vscode.commands.registerCommand('openhands.configure', async () => {
-    const current = vscode.workspace.getConfiguration().get<string>('openhands.serverUrl') ?? 'http://localhost:3000';
-    const input = await vscode.window.showInputBox({
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const existing = await settingsMgr.get();
+
+    // Step 1: Server URL
+    const serverUrl = await vscode.window.showInputBox({
       title: 'OpenHands Server URL',
-      value: current,
+      value: existing.serverUrl,
       placeHolder: 'http://localhost:3000'
     });
-    if (input) {
-      await vscode.workspace.getConfiguration().update('openhands.serverUrl', input, vscode.ConfigurationTarget.Workspace);
-      vscode.window.showInformationMessage(`OpenHands server URL set to ${input}`);
-      panel?.webview.postMessage({ type: 'configUpdated', serverUrl: input });
-      connection?.setServerUrl(input);
-    }
+    if (!serverUrl) return;
+
+    // Step 2: LLM
+    const usageId = await vscode.window.showInputBox({
+      title: 'LLM Usage ID (preferred)',
+      value: existing.llm.usageId,
+      placeHolder: 'e.g. default-llm',
+      prompt: 'Maps to agent-sdk usage_id; leave blank to use server defaults.'
+    });
+    const llmModel = await vscode.window.showInputBox({
+      title: 'LLM Model',
+      value: existing.llm.model,
+      placeHolder: 'e.g. claude-3-5-sonnet-20241022 or openrouter/*'
+    });
+    const llmBaseUrl = await vscode.window.showInputBox({
+      title: 'LLM Base URL (optional)',
+      value: existing.llm.baseUrl,
+      placeHolder: 'e.g. https://api.openrouter.ai',
+      prompt: 'Optional override; leave empty for provider default.'
+    });
+    const llmApiKey = await vscode.window.showInputBox({
+      title: 'LLM API Key (secret)',
+      value: existing.secrets.llmApiKey,
+      password: true,
+      prompt: 'Stored securely in VS Code SecretStorage.'
+    });
+
+    // Step 3: Agent options
+    const enableSec = await vscode.window.showQuickPick(['Yes', 'No'], {
+      title: 'Enable Security Analyzer?',
+      canPickMany: false,
+      placeHolder: existing.agent.enableSecurityAnalyzer ? 'Yes' : 'No'
+    });
+    const filterRegex = await vscode.window.showInputBox({
+      title: 'Filter Tools (regex, optional)',
+      value: existing.agent.filterToolsRegex ?? undefined,
+      placeHolder: 'e.g. ^(BashTool|FileEditorTool)$'
+    });
+
+    // Step 4: Session API Key (optional)
+    const sessionApiKey = await vscode.window.showInputBox({
+      title: 'Session API Key (optional, secret)',
+      value: existing.secrets.sessionApiKey,
+      password: true,
+      prompt: 'If your server requires authentication, enter the Session API key. Stored in SecretStorage.'
+    });
+
+    await settingsMgr.update({
+      serverUrl,
+      llm: { usageId: usageId || undefined, model: llmModel || undefined, baseUrl: llmBaseUrl || undefined },
+      agent: {
+        enableSecurityAnalyzer: enableSec ? enableSec === 'Yes' : existing.agent.enableSecurityAnalyzer,
+        filterToolsRegex: filterRegex ?? null
+      },
+      secrets: { llmApiKey: llmApiKey || undefined, sessionApiKey: sessionApiKey || undefined }
+    }, 'workspace');
+
+    vscode.window.showInformationMessage('OpenHands settings updated.');
+
+    // Apply to connection
+    connection?.setServerUrl(serverUrl);
+    const newSettings = await settingsMgr.get();
+    connection?.setSettings(newSettings);
+    panel?.webview.postMessage({ type: 'configUpdated', serverUrl });
   });
 
   const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,8 +34,8 @@ export function activate(context: vscode.ExtensionContext) {
         onConversationId: (id) => context.workspaceState.update('openhands.conversationId', id),
       });
       const settings = await new SettingsManager(new VscodeSettingsAdapter(context)).get();
-      connection.setSettings(settings);
       const savedId = context.workspaceState.get<string>('openhands.conversationId');
+      connection.setSettings(settings);
       if (savedId) connection.restoreConversation(savedId);
     }
 
@@ -159,7 +159,7 @@ export function activate(context: vscode.ExtensionContext) {
       llm: { usageId: usageId || undefined, model: llmModel || undefined, baseUrl: llmBaseUrl || undefined },
       agent: {
         enableSecurityAnalyzer: enableSec ? enableSec === 'Yes' : existing.agent.enableSecurityAnalyzer,
-        filterToolsRegex: filterRegex ?? null
+        filterToolsRegex: filterRegex || null
       },
       secrets: { llmApiKey: llmApiKey || undefined, sessionApiKey: sessionApiKey || undefined }
     }, 'workspace');

--- a/src/settings/SettingsAdapter.ts
+++ b/src/settings/SettingsAdapter.ts
@@ -1,0 +1,24 @@
+export interface SettingsAdapter {
+  // Config
+  get<T = unknown>(key: string, defaultValue?: T): T | undefined;
+  update<T = unknown>(key: string, value: T, target?: 'workspace' | 'global'): Promise<void>;
+
+  // Secrets
+  getSecret(key: string): Promise<string | undefined>;
+  storeSecret(key: string, value: string | undefined): Promise<void>;
+}
+
+export type LLMSettings = {
+  usageId?: string;
+  model?: string;
+  baseUrl?: string;
+};
+
+export type ServerSettings = {
+  serverUrl: string;
+};
+
+export type AgentSettings = {
+  enableSecurityAnalyzer?: boolean;
+  filterToolsRegex?: string | null;
+};

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -42,31 +42,33 @@ export class SettingsManager {
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
+    const ops: Promise<any>[] = [];
     if (partial.serverUrl !== undefined) {
-      await this.adapter.update('openhands.serverUrl', partial.serverUrl, target);
+      ops.push(this.adapter.update('openhands.serverUrl', partial.serverUrl, target));
     }
     if (partial.llm) {
-      if (partial.llm.usageId !== undefined) await this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target);
-      if (partial.llm.model !== undefined) await this.adapter.update('openhands.llm.model', partial.llm.model, target);
-      if (partial.llm.baseUrl !== undefined) await this.adapter.update('openhands.llm.baseUrl', partial.llm.baseUrl, target);
+      if (partial.llm.usageId !== undefined) ops.push(this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target));
+      if (partial.llm.model !== undefined) ops.push(this.adapter.update('openhands.llm.model', partial.llm.model, target));
+      if (partial.llm.baseUrl !== undefined) ops.push(this.adapter.update('openhands.llm.baseUrl', partial.llm.baseUrl, target));
     }
     if (partial.agent) {
-      if (partial.agent.enableSecurityAnalyzer !== undefined) await this.adapter.update('openhands.agent.enableSecurityAnalyzer', partial.agent.enableSecurityAnalyzer, target);
-      if (partial.agent.filterToolsRegex !== undefined) await this.adapter.update('openhands.agent.filterToolsRegex', partial.agent.filterToolsRegex, target);
+      if (partial.agent.enableSecurityAnalyzer !== undefined) ops.push(this.adapter.update('openhands.agent.enableSecurityAnalyzer', partial.agent.enableSecurityAnalyzer, target));
+      if (partial.agent.filterToolsRegex !== undefined) ops.push(this.adapter.update('openhands.agent.filterToolsRegex', partial.agent.filterToolsRegex, target));
     }
     if (partial.secrets) {
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'sessionApiKey')) {
-        await this.adapter.storeSecret('openhands.sessionApiKey', partial.secrets.sessionApiKey);
+        ops.push(this.adapter.storeSecret('openhands.sessionApiKey', partial.secrets.sessionApiKey));
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'llmApiKey')) {
-        await this.adapter.storeSecret('openhands.llmApiKey', partial.secrets.llmApiKey);
+        ops.push(this.adapter.storeSecret('openhands.llmApiKey', partial.secrets.llmApiKey));
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsAccessKeyId')) {
-        await this.adapter.storeSecret('openhands.awsAccessKeyId', partial.secrets.awsAccessKeyId);
+        ops.push(this.adapter.storeSecret('openhands.awsAccessKeyId', partial.secrets.awsAccessKeyId));
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsSecretAccessKey')) {
-        await this.adapter.storeSecret('openhands.awsSecretAccessKey', partial.secrets.awsSecretAccessKey);
+        ops.push(this.adapter.storeSecret('openhands.awsSecretAccessKey', partial.secrets.awsSecretAccessKey));
       }
     }
+    await Promise.all(ops);
   }
 }

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,0 +1,72 @@
+import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings } from './SettingsAdapter';
+
+export type OpenHandsSettings = ServerSettings & {
+  llm: LLMSettings;
+  agent: AgentSettings;
+  secrets: {
+    sessionApiKey?: string;
+    llmApiKey?: string;
+    awsAccessKeyId?: string;
+    awsSecretAccessKey?: string;
+  };
+};
+
+const DEFAULTS: OpenHandsSettings = {
+  serverUrl: 'http://localhost:3000',
+  llm: { usageId: 'default-llm', model: 'claude-sonnet-4-20250514' },
+  agent: { enableSecurityAnalyzer: false, filterToolsRegex: null },
+  secrets: {}
+};
+
+export class SettingsManager {
+  constructor(private adapter: SettingsAdapter) {}
+
+  async get(): Promise<OpenHandsSettings> {
+    const serverUrl = this.adapter.get<string>('openhands.serverUrl', DEFAULTS.serverUrl) ?? DEFAULTS.serverUrl;
+    const llm: LLMSettings = {
+      usageId: this.adapter.get<string>('openhands.llm.usageId', DEFAULTS.llm.usageId) ?? DEFAULTS.llm.usageId,
+      model: this.adapter.get<string>('openhands.llm.model', DEFAULTS.llm.model) ?? DEFAULTS.llm.model,
+      baseUrl: this.adapter.get<string>('openhands.llm.baseUrl', DEFAULTS.llm.baseUrl) ?? DEFAULTS.llm.baseUrl,
+    };
+    const agent: AgentSettings = {
+      enableSecurityAnalyzer: this.adapter.get<boolean>('openhands.agent.enableSecurityAnalyzer', DEFAULTS.agent.enableSecurityAnalyzer) ?? DEFAULTS.agent.enableSecurityAnalyzer,
+      filterToolsRegex: this.adapter.get<string | null>('openhands.agent.filterToolsRegex', DEFAULTS.agent.filterToolsRegex) ?? DEFAULTS.agent.filterToolsRegex,
+    };
+    const secrets = {
+      sessionApiKey: await this.adapter.getSecret('openhands.sessionApiKey'),
+      llmApiKey: await this.adapter.getSecret('openhands.llmApiKey'),
+      awsAccessKeyId: await this.adapter.getSecret('openhands.awsAccessKeyId'),
+      awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
+    };
+    return { serverUrl, llm, agent, secrets };
+  }
+
+  async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
+    if (partial.serverUrl !== undefined) {
+      await this.adapter.update('openhands.serverUrl', partial.serverUrl, target);
+    }
+    if (partial.llm) {
+      if (partial.llm.usageId !== undefined) await this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target);
+      if (partial.llm.model !== undefined) await this.adapter.update('openhands.llm.model', partial.llm.model, target);
+      if (partial.llm.baseUrl !== undefined) await this.adapter.update('openhands.llm.baseUrl', partial.llm.baseUrl, target);
+    }
+    if (partial.agent) {
+      if (partial.agent.enableSecurityAnalyzer !== undefined) await this.adapter.update('openhands.agent.enableSecurityAnalyzer', partial.agent.enableSecurityAnalyzer, target);
+      if (partial.agent.filterToolsRegex !== undefined) await this.adapter.update('openhands.agent.filterToolsRegex', partial.agent.filterToolsRegex, target);
+    }
+    if (partial.secrets) {
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'sessionApiKey')) {
+        await this.adapter.storeSecret('openhands.sessionApiKey', partial.secrets.sessionApiKey);
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'llmApiKey')) {
+        await this.adapter.storeSecret('openhands.llmApiKey', partial.secrets.llmApiKey);
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsAccessKeyId')) {
+        await this.adapter.storeSecret('openhands.awsAccessKeyId', partial.secrets.awsAccessKeyId);
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsSecretAccessKey')) {
+        await this.adapter.storeSecret('openhands.awsSecretAccessKey', partial.secrets.awsSecretAccessKey);
+      }
+    }
+  }
+}

--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -1,0 +1,26 @@
+import * as vscode from 'vscode';
+import type { SettingsAdapter } from './SettingsAdapter';
+
+export class VscodeSettingsAdapter implements SettingsAdapter {
+  constructor(private context: vscode.ExtensionContext) {}
+
+  get<T = unknown>(key: string, defaultValue?: T): T | undefined {
+    return vscode.workspace.getConfiguration().get<T>(key, defaultValue as any);
+  }
+
+  async update<T = unknown>(key: string, value: T, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
+    await vscode.workspace.getConfiguration().update(key, value, target === 'workspace' ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global);
+  }
+
+  async getSecret(key: string): Promise<string | undefined> {
+    return await this.context.secrets.get(key) ?? undefined;
+  }
+
+  async storeSecret(key: string, value: string | undefined): Promise<void> {
+    if (value === undefined || value === '') {
+      await this.context.secrets.delete(key);
+    } else {
+      await this.context.secrets.store(key, value);
+    }
+  }
+}

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { SettingsManager } from '../SettingsManager';
+import type { SettingsAdapter } from '../SettingsAdapter';
+
+class MemoryAdapter implements SettingsAdapter {
+  cfg = new Map<string, any>();
+  secrets = new Map<string, string>();
+  get<T>(key: string, def?: T): T | undefined { return this.cfg.has(key) ? this.cfg.get(key) : def; }
+  async update<T>(key: string, value: T): Promise<void> { this.cfg.set(key, value as any); }
+  async getSecret(key: string): Promise<string | undefined> { return this.secrets.get(key); }
+  async storeSecret(key: string, value: string | undefined): Promise<void> {
+    if (!value) this.secrets.delete(key); else this.secrets.set(key, value);
+  }
+}
+
+describe('SettingsManager', () => {
+  it('returns defaults when unset', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+    const s = await mgr.get();
+    expect(s.serverUrl).toBe('http://localhost:3000');
+    expect(s.llm.usageId).toBe('default-llm');
+    expect(s.agent.enableSecurityAnalyzer).toBe(false);
+  });
+
+  it('updates and persists config and secrets', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+    await mgr.update({
+      serverUrl: 'http://example:1234',
+      llm: { usageId: 'my-usage', model: 'foo', baseUrl: 'https://api.example.com' },
+      agent: { enableSecurityAnalyzer: true, filterToolsRegex: '^(BashTool)$' },
+      secrets: { sessionApiKey: 'sess', llmApiKey: 'key' }
+    });
+    const s = await mgr.get();
+    expect(s.serverUrl).toBe('http://example:1234');
+    expect(s.llm.usageId).toBe('my-usage');
+    expect(s.llm.model).toBe('foo');
+    expect(s.llm.baseUrl).toBe('https://api.example.com');
+    expect(s.agent.enableSecurityAnalyzer).toBe(true);
+    expect(s.agent.filterToolsRegex).toBe('^(BashTool)$');
+    expect(s.secrets.sessionApiKey).toBe('sess');
+    expect(s.secrets.llmApiKey).toBe('key');
+  });
+
+  it('clears secret when undefined is provided', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+    await mgr.update({ secrets: { llmApiKey: 'abc' } });
+    let s = await mgr.get();
+    expect(s.secrets.llmApiKey).toBe('abc');
+    await mgr.update({ secrets: { llmApiKey: undefined } });
+    s = await mgr.get();
+    expect(s.secrets.llmApiKey).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Summary
This PR implements a robust, extensible Settings architecture for the OpenHands-Tab VS Code extension aligned with the agent-sdk server.

Key changes
- Settings architecture
  - Added framework-agnostic SettingsManager with a pluggable SettingsAdapter
  - Implemented VscodeSettingsAdapter using VS Code Configuration and SecretStorage
  - Clear separation of Server, LLM, and Agent settings, with secrets handled securely
- VS Code Configure flow
  - Enhanced multi-step Configure command covering: Server URL, LLM (usageId/model/baseUrl), LLM API key (secret), Agent options, and Session API key (secret)
  - Applies changes immediately to the active ConnectionManager and Webview
- ConnectionManager integration
  - Accepts OpenHandsSettings and uses usage_id over legacy service_id
  - Sends X-Session-API-Key header for HTTP and session_api_key in WS query string
  - Sends LLM config and API key in conversation start payload; supports security analyzer and tool filtering
- Extension activation
  - Loads settings using SettingsManager and applies to ConnectionManager on activation/restore
- Configuration schema
  - package.json contributes.configuration updated with non-secret settings:
    - openhands.serverUrl
    - openhands.llm.usageId, openhands.llm.model, openhands.llm.baseUrl
    - openhands.agent.enableSecurityAnalyzer, openhands.agent.filterToolsRegex
- Tests
  - Added unit tests for SettingsManager covering defaults, updates, and secret clearing
  - Existing unit tests pass locally (8/8)

Why this design
- Decoupled SettingsManager allows reuse and easier testing, minimizing VS Code API coupling
- Single source of truth for settings; secrets are isolated via SecretStorage
- Mirrors agent-sdk structures and prefers usage_id as per current server contract

How it maps to agent-sdk
- startNewConversation payload includes llm.usage_id/model/base_url/api_key and agent flags
- Session API key carried via header and WS query param

Notes
- E2E tests require libgtk on the runner; unit tests cover the logic introduced here
- No runtime deps added; uses existing VS Code APIs and dev tooling

Closes #24


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4a7bfcb84bf24c298c083d191df7c751)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM options: usage ID, model selection, and optional base URL.
  * Agent options: security analyzer toggle and tool-filtering regex.
  * Multi-step configuration flow with pre-filled values and optional session API key.
  * Secure secret storage with workspace/global scope.

* **Refactor**
  * Centralized runtime settings management and applied settings during activation/configuration.

* **Tests**
  * Unit tests for defaults, updates, and secret handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->