### PR TITLE
fix: address delayed PR review comments

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -305,9 +305,10 @@ interface ConfirmationPromptProps {
   actions: ActionEvent[];
   onApprove: () => void;
   onReject: (reason?: string) => void;
+  isSubmitting: boolean;
 }
 
-function ConfirmationPrompt({ actions, onApprove, onReject }: ConfirmationPromptProps) {
+function ConfirmationPrompt({ actions, onApprove, onReject, isSubmitting }: ConfirmationPromptProps) {
   const [showRejectInput, setShowRejectInput] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
 
@@ -324,7 +325,7 @@ function ConfirmationPrompt({ actions, onApprove, onReject }: ConfirmationPrompt
       <div className="font-bold mb-3 text-[var(--vscode-foreground)] text-lg">
         ⚠️ Action Confirmation Required
       </div>
-      {actions.map((action, idx) => (
+      {actions.map((action) => (
         <div key={action.tool_call_id} className="mb-3 pb-3 border-b border-[rgba(128,128,128,0.2)] last:border-b-0">
           <div className="mb-2">
             <span className="font-semibold">Tool: </span>
@@ -360,26 +361,32 @@ function ConfirmationPrompt({ actions, onApprove, onReject }: ConfirmationPrompt
 
       <div className="flex gap-2 items-center mt-3">
         <button
+          type="button"
           onClick={onApprove}
+          disabled={isSubmitting}
           className="px-3 py-1.5 rounded text-sm font-medium"
           style={{
             background: 'var(--vscode-button-background)',
             color: 'var(--vscode-button-foreground)',
             border: 'none',
-            cursor: 'pointer'
+            cursor: isSubmitting ? 'not-allowed' : 'pointer',
+            opacity: isSubmitting ? 0.6 : 1
           }}
         >
           ✓ Approve
         </button>
         {!showRejectInput ? (
           <button
+            type="button"
             onClick={() => setShowRejectInput(true)}
+            disabled={isSubmitting}
             className="px-3 py-1.5 rounded text-sm font-medium"
             style={{
               background: 'var(--vscode-button-secondaryBackground)',
               color: 'var(--vscode-button-secondaryForeground)',
               border: 'none',
-              cursor: 'pointer'
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              opacity: isSubmitting ? 0.6 : 1
             }}
           >
             ✗ Reject
@@ -390,30 +397,37 @@ function ConfirmationPrompt({ actions, onApprove, onReject }: ConfirmationPrompt
               type="text"
               value={rejectReason}
               onChange={(e) => setRejectReason(e.target.value)}
+              disabled={isSubmitting}
               placeholder="Reason for rejection (optional)"
               className="flex-1 px-2 py-1 border border-gray-300 rounded text-sm"
               style={{ background: 'var(--vscode-input-background)', color: 'var(--vscode-input-foreground)', borderColor: 'var(--vscode-input-border)' }}
             />
             <button
+              type="button"
               onClick={handleReject}
+              disabled={isSubmitting}
               className="px-3 py-1.5 rounded text-sm font-medium"
               style={{
                 background: 'var(--vscode-button-secondaryBackground)',
                 color: 'var(--vscode-button-secondaryForeground)',
                 border: 'none',
-                cursor: 'pointer'
+                cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                opacity: isSubmitting ? 0.6 : 1
               }}
             >
               Confirm Reject
             </button>
             <button
+              type="button"
               onClick={() => setShowRejectInput(false)}
+              disabled={isSubmitting}
               className="px-3 py-1.5 rounded text-sm font-medium"
               style={{
                 background: 'var(--vscode-button-secondaryBackground)',
                 color: 'var(--vscode-button-secondaryForeground)',
                 border: 'none',
-                cursor: 'pointer'
+                cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                opacity: isSubmitting ? 0.6 : 1
               }}
             >
               Cancel
@@ -449,6 +463,8 @@ export function App() {
   const eventId = useRef(1);
   const endRef = useRef<HTMLDivElement | null>(null);
   const lastStatusRef = useRef<'online' | 'offline' | 'connecting' | null>(null);
+  const lastAgentStatusRef = useRef<string | undefined>(undefined);
+  const confirmInFlightRef = useRef(false);
 
   // Message handler: processes incoming messages from extension host
   useEffect(() => {
@@ -499,28 +515,37 @@ export function App() {
     if (isConversationStateUpdateEvent(e)) {
       if (e.agent_status) {
         setAgentStatus(e.agent_status);
-        // Show toast when entering confirmation mode
-        if (e.agent_status === 'WAITING_FOR_CONFIRMATION') {
+        // Show toast only when transitioning INTO confirmation mode (not on repeated updates)
+        if (e.agent_status === 'WAITING_FOR_CONFIRMATION' && lastAgentStatusRef.current !== 'WAITING_FOR_CONFIRMATION') {
           toastDebounced('warning', 'Agent is waiting for confirmation');
         }
+        lastAgentStatusRef.current = e.agent_status;
       }
       // Don't render state update events in the UI
       return;
     }
 
     // Track pending actions (actions awaiting confirmation or execution)
+    // Deduplicate by tool_call_id to prevent duplicate cards on reconnection or retries
     if (isActionEvent(e)) {
-      setPendingActions((prev) => [...prev, e]);
+      setPendingActions((prev) => {
+        const exists = prev.some((a) => a.tool_call_id === e.tool_call_id);
+        return exists ? prev : [...prev, e];
+      });
     }
 
     // Clear pending action when we receive its observation
+    // Also reset in-flight flag to allow new confirmations
     if (isObservationEvent(e) || isUserRejectObservation(e)) {
       setPendingActions((prev) => prev.filter((a) => a.tool_call_id !== e.tool_call_id));
+      confirmInFlightRef.current = false;
     }
 
     // Show toast notifications for certain events
     if (isAgentErrorEvent(e)) {
       toastDebounced('error', e.error);
+      // Reset in-flight flag on error to allow recovery
+      confirmInFlightRef.current = false;
     } else if (isPauseEvent(e)) {
       toastDebounced('warning', 'Conversation paused');
     }
@@ -545,15 +570,23 @@ export function App() {
   };
 
   const handleApprove = () => {
+    // Prevent double-submit: return early if confirmation already in flight
+    if (confirmInFlightRef.current) return;
+    confirmInFlightRef.current = true;
     postMessage({ type: 'command', command: 'approveAction' });
-    toastDebounced('success', 'Action approved');
-    // Server will send ObservationEvent which clears pending actions via handleEvent
+    // Use "submitted" (pending state) instead of "approved" (implies success)
+    toastDebounced('info', 'Approval submitted');
+    // Server will send ObservationEvent which clears pending actions and resets flag via handleEvent
   };
 
   const handleReject = (reason?: string) => {
+    // Prevent double-submit: return early if confirmation already in flight
+    if (confirmInFlightRef.current) return;
+    confirmInFlightRef.current = true;
     postMessage({ type: 'command', command: 'rejectAction', reason });
-    toastDebounced('info', 'Action rejected');
-    // Server will send UserRejectObservation which clears pending actions via handleEvent
+    // Use "submitted" (pending state) instead of "rejected" (implies success)
+    toastDebounced('info', 'Rejection submitted');
+    // Server will send UserRejectObservation which clears pending actions and resets flag via handleEvent
   };
 
   return (
@@ -589,6 +622,7 @@ export function App() {
               actions={pendingActions}
               onApprove={handleApprove}
               onReject={handleReject}
+              isSubmitting={confirmInFlightRef.current}
             />
           )}
           <div ref={endRef} />

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -364,13 +364,10 @@ function ConfirmationPrompt({ actions, onApprove, onReject, isSubmitting }: Conf
           type="button"
           onClick={onApprove}
           disabled={isSubmitting}
-          className="px-3 py-1.5 rounded text-sm font-medium"
+          className="px-3 py-1.5 rounded text-sm font-medium border-0 disabled:opacity-60 disabled:cursor-not-allowed"
           style={{
             background: 'var(--vscode-button-background)',
-            color: 'var(--vscode-button-foreground)',
-            border: 'none',
-            cursor: isSubmitting ? 'not-allowed' : 'pointer',
-            opacity: isSubmitting ? 0.6 : 1
+            color: 'var(--vscode-button-foreground)'
           }}
         >
           ✓ Approve
@@ -380,13 +377,10 @@ function ConfirmationPrompt({ actions, onApprove, onReject, isSubmitting }: Conf
             type="button"
             onClick={() => setShowRejectInput(true)}
             disabled={isSubmitting}
-            className="px-3 py-1.5 rounded text-sm font-medium"
+            className="px-3 py-1.5 rounded text-sm font-medium border-0 disabled:opacity-60 disabled:cursor-not-allowed"
             style={{
               background: 'var(--vscode-button-secondaryBackground)',
-              color: 'var(--vscode-button-secondaryForeground)',
-              border: 'none',
-              cursor: isSubmitting ? 'not-allowed' : 'pointer',
-              opacity: isSubmitting ? 0.6 : 1
+              color: 'var(--vscode-button-secondaryForeground)'
             }}
           >
             ✗ Reject
@@ -406,13 +400,10 @@ function ConfirmationPrompt({ actions, onApprove, onReject, isSubmitting }: Conf
               type="button"
               onClick={handleReject}
               disabled={isSubmitting}
-              className="px-3 py-1.5 rounded text-sm font-medium"
+              className="px-3 py-1.5 rounded text-sm font-medium border-0 disabled:opacity-60 disabled:cursor-not-allowed"
               style={{
                 background: 'var(--vscode-button-secondaryBackground)',
-                color: 'var(--vscode-button-secondaryForeground)',
-                border: 'none',
-                cursor: isSubmitting ? 'not-allowed' : 'pointer',
-                opacity: isSubmitting ? 0.6 : 1
+                color: 'var(--vscode-button-secondaryForeground)'
               }}
             >
               Confirm Reject
@@ -421,13 +412,10 @@ function ConfirmationPrompt({ actions, onApprove, onReject, isSubmitting }: Conf
               type="button"
               onClick={() => setShowRejectInput(false)}
               disabled={isSubmitting}
-              className="px-3 py-1.5 rounded text-sm font-medium"
+              className="px-3 py-1.5 rounded text-sm font-medium border-0 disabled:opacity-60 disabled:cursor-not-allowed"
               style={{
                 background: 'var(--vscode-button-secondaryBackground)',
-                color: 'var(--vscode-button-secondaryForeground)',
-                border: 'none',
-                cursor: isSubmitting ? 'not-allowed' : 'pointer',
-                opacity: isSubmitting ? 0.6 : 1
+                color: 'var(--vscode-button-secondaryForeground)'
               }}
             >
               Cancel
@@ -464,7 +452,8 @@ export function App() {
   const endRef = useRef<HTMLDivElement | null>(null);
   const lastStatusRef = useRef<'online' | 'offline' | 'connecting' | null>(null);
   const lastAgentStatusRef = useRef<string | undefined>(undefined);
-  const confirmInFlightRef = useRef(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submissionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
   // Message handler: processes incoming messages from extension host
   useEffect(() => {
@@ -538,14 +527,22 @@ export function App() {
     // Also reset in-flight flag to allow new confirmations
     if (isObservationEvent(e) || isUserRejectObservation(e)) {
       setPendingActions((prev) => prev.filter((a) => a.tool_call_id !== e.tool_call_id));
-      confirmInFlightRef.current = false;
+      if (submissionTimeoutRef.current) {
+        clearTimeout(submissionTimeoutRef.current);
+        submissionTimeoutRef.current = null;
+      }
+      setIsSubmitting(false);
     }
 
     // Show toast notifications for certain events
     if (isAgentErrorEvent(e)) {
       toastDebounced('error', e.error);
       // Reset in-flight flag on error to allow recovery
-      confirmInFlightRef.current = false;
+      if (submissionTimeoutRef.current) {
+        clearTimeout(submissionTimeoutRef.current);
+        submissionTimeoutRef.current = null;
+      }
+      setIsSubmitting(false);
     } else if (isPauseEvent(e)) {
       toastDebounced('warning', 'Conversation paused');
     }
@@ -571,8 +568,16 @@ export function App() {
 
   const handleApprove = () => {
     // Prevent double-submit: return early if confirmation already in flight
-    if (confirmInFlightRef.current) return;
-    confirmInFlightRef.current = true;
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
+    // Set 30-second timeout to prevent permanent lockout if backend doesn't respond
+    submissionTimeoutRef.current = setTimeout(() => {
+      setIsSubmitting(false);
+      submissionTimeoutRef.current = null;
+      toastDebounced('warning', 'Confirmation timed out - please try again');
+    }, 30000);
+
     postMessage({ type: 'command', command: 'approveAction' });
     // Use "submitted" (pending state) instead of "approved" (implies success)
     toastDebounced('info', 'Approval submitted');
@@ -581,8 +586,16 @@ export function App() {
 
   const handleReject = (reason?: string) => {
     // Prevent double-submit: return early if confirmation already in flight
-    if (confirmInFlightRef.current) return;
-    confirmInFlightRef.current = true;
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
+    // Set 30-second timeout to prevent permanent lockout if backend doesn't respond
+    submissionTimeoutRef.current = setTimeout(() => {
+      setIsSubmitting(false);
+      submissionTimeoutRef.current = null;
+      toastDebounced('warning', 'Confirmation timed out - please try again');
+    }, 30000);
+
     postMessage({ type: 'command', command: 'rejectAction', reason });
     // Use "submitted" (pending state) instead of "rejected" (implies success)
     toastDebounced('info', 'Rejection submitted');
@@ -622,7 +635,7 @@ export function App() {
               actions={pendingActions}
               onApprove={handleApprove}
               onReject={handleReject}
-              isSubmitting={confirmInFlightRef.current}
+              isSubmitting={isSubmitting}
             />
           )}
           <div ref={endRef} />


### PR DESCRIPTION
Four improvements to confirmation mode UI:

1. Toast gating: Track previous agent status to avoid duplicate 'waiting for confirmation' toasts on repeated status updates

2. Pending actions deduplication: Check tool_call_id before adding to pending actions array to prevent duplicate cards on reconnect

3. Double-submit prevention (CRITICAL): Add confirmInFlightRef guard to prevent rapid clicking from sending duplicate approve/reject requests. Reset flag on observation/error events for recovery.
   - Added disabled states to all buttons when isSubmitting
   - Changed toast messages from 'approved/rejected' to 'submitted'
   - Added type='button' to prevent form submission
   - Added visual feedback (opacity, cursor) for disabled state

4. Code cleanup: Remove unused idx parameter from map callback

Fixes issues identified in post-merge review of PR #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate submissions and duplicate action cards on reconnection.
  * Clears pending actions and reliably resets in-flight state on errors or related events.
  * Recovers from stalled submissions with a timeout to avoid hanging UI.

* **New Features**
  * Submission UI disables controls during processing and shows visual disabled states.
  * Shows “Approval submitted” / “Rejection submitted” toasts while awaiting final confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->