### PR TITLE
chore(eslint)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,10 +4,9 @@ const tseslint = require('@typescript-eslint/eslint-plugin');
 const tsparser = require('@typescript-eslint/parser');
 const globals = require('globals');
 
-const reactHooks = require('eslint-plugin-react-hooks');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
 
 module.exports = [
-
   {
     ignores: [
       'dist/**',
@@ -93,7 +92,7 @@ module.exports = [
   {
     files: ['src/webview-src/**/*.tsx'],
     plugins: {
-      'react-hooks': reactHooks,
+      'react-hooks': reactHooksPlugin,
     },
     rules: {
       'react-hooks/rules-of-hooks': 'error',


### PR DESCRIPTION
rename reactHooks var to reactHooksPlugin and tighten formatting in flat config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization improvements to the linting configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->