### PR TITLE
Add test: getExplicit() returns undefined when all scoped values are undefined

### DIFF
--- a/src/settings/__tests__/VscodeSettingsAdapter.test.ts
+++ b/src/settings/__tests__/VscodeSettingsAdapter.test.ts
@@ -125,17 +125,17 @@ describe('VscodeSettingsAdapter', () => {
       expect(result).toBe(globalValue);
     });
 
-	    it('should return undefined when inspect returns object with all undefined values', () => {
-	      mockConfiguration.inspect.mockReturnValue({
-	        workspaceFolderValue: undefined,
-	        workspaceValue: undefined,
-	        globalValue: undefined,
-	      });
-	
-	      const result = adapter.getExplicit('test.key');
-	
-	      expect(result).toBeUndefined();
-	    });
+    it('should return undefined when inspect returns object with all undefined values', () => {
+      mockConfiguration.inspect.mockReturnValue({
+        workspaceFolderValue: undefined,
+        workspaceValue: undefined,
+        globalValue: undefined,
+      });
+
+      const result = adapter.getExplicit('test.key');
+
+      expect(result).toBeUndefined();
+    });
 
   });
 

--- a/src/settings/__tests__/VscodeSettingsAdapter.test.ts
+++ b/src/settings/__tests__/VscodeSettingsAdapter.test.ts
@@ -124,6 +124,19 @@ describe('VscodeSettingsAdapter', () => {
 
       expect(result).toBe(globalValue);
     });
+
+	    it('should return undefined when inspect returns object with all undefined values', () => {
+	      mockConfiguration.inspect.mockReturnValue({
+	        workspaceFolderValue: undefined,
+	        workspaceValue: undefined,
+	        globalValue: undefined,
+	      });
+	
+	      const result = adapter.getExplicit('test.key');
+	
+	      expect(result).toBeUndefined();
+	    });
+
   });
 
   describe('update()', () => {


### PR DESCRIPTION
This follows up on feedback to expand coverage of getExplicit().

- Adds a unit test for the scenario where configuration.inspect() returns an object but workspaceFolderValue, workspaceValue, and globalValue are all undefined. The test verifies that getExplicit() correctly resolves to undefined in this case.

No changes to runtime code.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ee223fd75014487ea492e925ed8dd335)