### PR TITLE
Add comprehensive confirmation mode tests (backend+frontend); fix UI flow; closes #61

### DIFF
--- a/src/connection/__tests__/ConnectionManager.confirmation.test.ts
+++ b/src/connection/__tests__/ConnectionManager.confirmation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
 
 // Mock 'ws' BEFORE importing the module under test
 let wsInstances: any[] = [];

--- a/src/connection/__tests__/ConnectionManager.confirmation.test.ts
+++ b/src/connection/__tests__/ConnectionManager.confirmation.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock 'ws' BEFORE importing the module under test
+let wsInstances: any[] = [];
+vi.mock('ws', () => {
+  class MockWS {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+
+    url: string;
+    handlers: Record<string, Function[]> = {};
+    readyState = MockWS.CONNECTING;
+    sent: string[] = [];
+    closed = false;
+
+    constructor(url: string) {
+      this.url = url;
+      wsInstances.push(this);
+    }
+    on(ev: string, cb: Function) {
+      this.handlers[ev] = this.handlers[ev] || [];
+      this.handlers[ev].push(cb);
+      return this as any;
+    }
+    emit(ev: string, ...args: any[]) { (this.handlers[ev] || []).forEach(fn => fn(...args)); }
+    open() { this.readyState = MockWS.OPEN; this.emit('open'); }
+    message(data: any) { this.emit('message', Buffer.from(typeof data === 'string' ? data : JSON.stringify(data))); }
+    error(err: any) { this.emit('error', err); }
+    close() { this.readyState = MockWS.CLOSED; this.closed = true; this.emit('close'); }
+    send(data: string) { this.sent.push(data); }
+  }
+  return { default: MockWS };
+});
+
+const importCM = async () => import('../ConnectionManager');
+
+describe('ConnectionManager - Confirmation Mode', () => {
+  let events: { onStatus: any; onEvent: any; onError: any; onConversationId: any };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    wsInstances = [];
+    (globalThis as any).fetch = undefined as any;
+  });
+  afterEach(() => { vi.useRealTimers(); });
+
+  const setupManager = async () => {
+    const { ConnectionManager } = await importCM();
+    events = { onStatus: vi.fn(), onEvent: vi.fn(), onError: vi.fn(), onConversationId: vi.fn() };
+    const cm = new ConnectionManager('http://localhost:3000', events);
+    // simulate restored conversation to avoid creating a new one in tests
+    cm.restoreConversation('c-confirm');
+    return cm;
+  };
+
+  it('approveAction posts accept=true to confirmation endpoint (HTTP)', async () => {
+    const cm = await setupManager();
+    const fetchSpy = vi.fn(async (url: string, init?: any) => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    await cm.approveAction();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toMatch(/\/api\/conversations\/c-confirm\/events\/respond_to_confirmation$/);
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ accept: true });
+  });
+
+  it('approveAction includes X-Session-API-Key header when configured', async () => {
+    const cm = await setupManager();
+    // set settings to include session key
+    (cm as any).setSettings({ secrets: { sessionApiKey: 'sess-123' } } as any);
+    const fetchSpy = vi.fn(async (url: string, init?: any) => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    await cm.approveAction();
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers['X-Session-API-Key']).toBe('sess-123');
+  });
+
+  it('approveAction uses HTTP regardless of WebSocket availability (fallback behavior)', async () => {
+    const cm = await setupManager();
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    // If a WS exists and is open, approval should still be sent via HTTP endpoint
+    const ws: any = (cm as any).ws || null;
+    await cm.approveAction();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // ensure no .send was called on ws mock (if any)
+    if (ws) expect(ws.sent.length).toBe(0);
+  });
+
+
+  it('rejectAction uses HTTP regardless of WebSocket availability (fallback behavior)', async () => {
+    const cm = await setupManager();
+    const fetchSpy = vi.fn(async () => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    const ws: any = (cm as any).ws || null;
+    await cm.rejectAction('nope');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    if (ws) expect(ws.sent.length).toBe(0);
+  });
+
+  it('rejectAction posts accept=false', async () => {
+    const cm = await setupManager();
+    const fetchSpy = vi.fn(async (url: string, init?: any) => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    await cm.rejectAction();
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body.accept).toBe(false);
+    // reason should be omitted when not provided
+    expect('reason' in body).toBe(false);
+  });
+
+  it('rejectAction includes rejection reason when provided', async () => {
+    const cm = await setupManager();
+    const fetchSpy = vi.fn(async (url: string, init?: any) => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    await cm.rejectAction('Too risky');
+
+    const [, init] = fetchSpy.mock.calls[0];
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ accept: false, reason: 'Too risky' });
+  });
+
+  it('rejectAction includes X-Session-API-Key header when configured', async () => {
+    const cm = await setupManager();
+    (cm as any).setSettings({ secrets: { sessionApiKey: 'sess-xyz' } } as any);
+    const fetchSpy = vi.fn(async (url: string, init?: any) => ({ ok: true, status: 200 })) as any;
+    (globalThis as any).fetch = fetchSpy;
+
+    await cm.rejectAction('r');
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(init.headers['X-Session-API-Key']).toBe('sess-xyz');
+  });
+
+  it('emits error when no active conversation (approve)', async () => {
+    const { ConnectionManager } = await importCM();
+    events = { onStatus: vi.fn(), onEvent: vi.fn(), onError: vi.fn(), onConversationId: vi.fn() };
+    const cm = new ConnectionManager('http://localhost:3000', events);
+    const fetchSpy = vi.fn();
+    (globalThis as any).fetch = fetchSpy;
+
+    await cm.approveAction();
+    expect(events.onError).toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('handles network errors gracefully by emitting onError', async () => {
+    const cm = await setupManager();
+    const err = new Error('network down');
+    (globalThis as any).fetch = vi.fn(async () => { throw err; });
+
+    await cm.rejectAction('any');
+
+    expect(events.onError).toHaveBeenCalledWith(err);
+  });
+
+  it('emits error event on HTTP failure status', async () => {
+    const cm = await setupManager();
+    (globalThis as any).fetch = vi.fn(async () => ({ ok: false, status: 500, text: async () => 'boom' })) as any;
+
+    await cm.approveAction();
+
+    expect(events.onError).toHaveBeenCalled();
+  });
+});

--- a/src/connection/__tests__/ConnectionManager.confirmation.test.ts
+++ b/src/connection/__tests__/ConnectionManager.confirmation.test.ts
@@ -37,7 +37,7 @@ vi.mock('ws', () => {
 const importCM = async () => import('../ConnectionManager');
 
 describe('ConnectionManager - Confirmation Mode', () => {
-  let events: { onStatus: any; onEvent: any; onError: any; onConversationId: any };
+  let events: { onStatus: Mock; onEvent: Mock; onError: Mock; onConversationId: Mock };
 
   beforeEach(() => {
     vi.resetModules();

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -168,7 +168,7 @@ describe('App - Confirmation Flow', () => {
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-timeout' }) });
 
-    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    const approveBtn = (await screen.findByRole('button', { name: /approve/i }));
     await userEvent.click(approveBtn);
     expect(approveBtn).toBeDisabled();
 

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, cleanup, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { App } from '../components/App';
+import type { ActionEvent, ConversationStateUpdateEvent } from '../../types/agent-sdk';
+
+function postToWindow(payload: any) {
+  window.postMessage(payload, '*');
+}
+
+describe('App - Confirmation Flow', () => {
+  const mockApi = { postMessage: vi.fn() } as any;
+
+  beforeEach(() => {
+    // mock VS Code API
+    // @ts-expect-error
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+  afterEach(() => { vi.useRealTimers(); cleanup(); });
+
+  const mkAction = (over: Partial<ActionEvent> = {}): ActionEvent => ({
+    type: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'Consider running bash' }],
+    action: { tool: 'BashTool', args: { command: 'echo 1' } },
+    tool_name: 'BashTool',
+    tool_call_id: 'call-1',
+    tool_call: { id: 'call-1', type: 'function', function: { name: 'BashTool', arguments: '{}' } },
+    llm_response_id: 'resp-1',
+    security_risk: 'HIGH',
+    ...over,
+  });
+
+  const setWaitingForConfirmation = () => {
+    const state: ConversationStateUpdateEvent = { type: 'ConversationStateUpdateEvent', agent_status: 'WAITING_FOR_CONFIRMATION' } as any;
+    postToWindow({ type: 'event', event: state });
+  };
+
+  const renderAppAndWaitReady = async () => {
+    const res = render(<App />);
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    });
+    return res;
+  };
+
+  it('shows confirmation prompt for confirmable action and displays details', async () => {
+    const res = await renderAppAndWaitReady();
+    const q = within(res.baseElement);
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction() });
+
+    const prompt = await q.findByText(/Action Confirmation Required/);
+    const container = prompt.closest('div') as HTMLElement;
+    expect(container).toBeInTheDocument();
+    const scope = within(container.parentElement as HTMLElement);
+    expect(scope.getAllByText(/Tool:/).length).toBeGreaterThanOrEqual(1);
+    expect(scope.getByText(/Risk: HIGH/)).toBeInTheDocument();
+    expect(scope.getByText(/Thought:/)).toBeInTheDocument();
+  });
+
+  it('hides prompt when no actions are pending', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    // no action posted -> prompt should not render
+    await waitFor(() => {
+      expect(screen.queryByText(/Action Confirmation Required/)).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not show prompt if not waiting for confirmation even with pending action', async () => {
+    await renderAppAndWaitReady();
+    // Post action without setting WAITING_FOR_CONFIRMATION
+    postToWindow({ type: 'event', event: mkAction() });
+    await waitFor(() => {
+      expect(screen.queryByText(/Action Confirmation Required/)).not.toBeInTheDocument();
+    });
+  });
+
+  it('Approve sends command approveAction and disables button while submitting', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction() });
+
+    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    await userEvent.click(approveBtn);
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'approveAction' });
+    // while submitting, buttons are disabled
+    expect(approveBtn).toBeDisabled();
+  });
+
+  it('prevents double-submit for approve', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-dbl' }) });
+    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    await userEvent.click(approveBtn);
+    await userEvent.click(approveBtn);
+    // only first click should dispatch
+    const approveCalls = mockApi.postMessage.mock.calls.filter((c: any[]) => c[0]?.command === 'approveAction');
+    expect(approveCalls.length).toBe(1);
+  });
+
+  it('Reject toggles input and sends command with reason', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction() });
+
+    const rejectBtn = (await screen.findAllByRole('button', { name: /reject/i }))[0];
+    await userEvent.click(rejectBtn);
+    const input = await screen.findByPlaceholderText(/Reason for rejection/);
+    await userEvent.type(input, 'Too risky');
+    const confirmReject = await screen.findByRole('button', { name: /confirm reject/i });
+    await userEvent.click(confirmReject);
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'rejectAction', reason: 'Too risky' });
+  });
+
+  it('prevents double-submit for reject', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-dbl-rej' }) });
+
+    const rejectBtn = (await screen.findAllByRole('button', { name: /reject/i }))[0];
+    await userEvent.click(rejectBtn);
+    const confirmReject = await screen.findByRole('button', { name: /confirm reject/i });
+    await userEvent.click(confirmReject);
+    await userEvent.click(confirmReject);
+
+    const rejectCalls = mockApi.postMessage.mock.calls.filter((c: any[]) => c[0]?.command === 'rejectAction');
+    expect(rejectCalls.length).toBe(1);
+  });
+
+  it('clears pending action after approval when ObservationEvent arrives', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-clear' }) });
+    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    await userEvent.click(approveBtn);
+
+    // send observation for that tool_call_id; should clear prompt
+    postToWindow({ type: 'event', event: { type: 'ObservationEvent', source: 'environment', observation: { ok: true }, tool_name: 'BashTool', tool_call_id: 'call-clear', action_id: 'a1' } });
+    await waitFor(() => {
+      expect(screen.queryByText(/Action Confirmation Required/)).not.toBeInTheDocument();
+    });
+  });
+
+  it('clears pending action after rejection when UserRejectObservation arrives', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-rej' }) });
+    const rejectBtn = await screen.findByRole('button', { name: /reject/i });
+    await userEvent.click(rejectBtn);
+    const confirmReject = await screen.findByRole('button', { name: /confirm reject/i });
+    await userEvent.click(confirmReject);
+
+    postToWindow({ type: 'event', event: { type: 'UserRejectObservation', source: 'environment', rejection_reason: 'no', tool_name: 'BashTool', tool_call_id: 'call-rej', action_id: 'a2' } });
+    await waitFor(() => {
+      expect(screen.queryByText(/Action Confirmation Required/)).not.toBeInTheDocument();
+    });
+  });
+
+  it('sets isSubmitting=true when approval sent, and resets after 30s timeout', async () => {
+    await renderAppAndWaitReady();
+    // Spy on setTimeout so we can trigger the scheduled reset callback without relying on fake timers
+    const stSpy = vi.spyOn(global, 'setTimeout');
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-timeout' }) });
+
+    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    await userEvent.click(approveBtn);
+    expect(approveBtn).toBeDisabled();
+
+    // Ensure a 30s timeout was scheduled and manually invoke its callback
+    const idx = stSpy.mock.calls.findIndex((c: any[]) => c[1] === 30000);
+    expect(idx).toBeGreaterThan(-1);
+    const cb = stSpy.mock.calls[idx][0] as Function;
+    await act(async () => { (cb as any)(); });
+    stSpy.mockRestore();
+
+    const approveBtnAfter = screen.getAllByRole('button', { name: /approve/i })[0];
+    expect(approveBtnAfter).not.toBeDisabled();
+  });
+
+  it('resets isSubmitting=false and re-enables buttons on AgentErrorEvent', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-err' }) });
+
+    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    await userEvent.click(approveBtn);
+    expect(approveBtn).toBeDisabled();
+
+    // Send AgentErrorEvent which should reset isSubmitting
+    postToWindow({ type: 'event', event: { type: 'AgentErrorEvent', source: 'agent', error: 'oops', tool_name: 'BashTool', tool_call_id: 'call-err' } });
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+  });
+
+  it('renders action JSON details in prompt', async () => {
+    const res = await renderAppAndWaitReady();
+    const q = within(res.baseElement);
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkAction() });
+    expect(await q.findByText(/Action Details:/)).toBeInTheDocument();
+    // Use getAllBy to avoid ambiguity (tool name appears in multiple places)
+    expect(q.getAllByText(/BashTool/).length).toBeGreaterThan(0);
+  });
+});

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -136,7 +136,7 @@ describe('App - Confirmation Flow', () => {
     await renderAppAndWaitReady();
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-clear' }) });
-    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    const approveBtn = await screen.findByRole('button', { name: /approve/i });
     await userEvent.click(approveBtn);
 
     // send observation for that tool_call_id; should clear prompt

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -84,7 +84,7 @@ describe('App - Confirmation Flow', () => {
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkAction() });
 
-    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    const approveBtn = await screen.findByRole('button', { name: /approve/i });
     await userEvent.click(approveBtn);
     expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'approveAction' });
     // while submitting, buttons are disabled

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -188,7 +188,7 @@ describe('App - Confirmation Flow', () => {
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-err' }) });
 
-    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+const approveBtn = await screen.findByRole('button', { name: /approve/i });
     await userEvent.click(approveBtn);
     expect(approveBtn).toBeDisabled();
 

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -95,7 +95,7 @@ describe('App - Confirmation Flow', () => {
     await renderAppAndWaitReady();
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkAction({ tool_call_id: 'call-dbl' }) });
-    const approveBtn = (await screen.findAllByRole('button', { name: /approve/i }))[0];
+    const approveBtn = await screen.findByRole('button', { name: /approve/i });
     await userEvent.click(approveBtn);
     await userEvent.click(approveBtn);
     // only first click should dispatch


### PR DESCRIPTION
Summary
- Add full test coverage for confirmation mode across backend ConnectionManager and frontend App webview.
- Implement UI guards and state handling fixes to meet acceptance criteria.

What’s changed
Backend (ConnectionManager)
- Added src/connection/__tests__/ConnectionManager.confirmation.test.ts with 10 tests:
  - approveAction(): HTTP path, payload {accept:true}, includes X-Session-API-Key header when set, uses HTTP regardless of WS
  - rejectAction(): HTTP path, payload {accept:false[, reason]}, includes X-Session-API-Key header when set, uses HTTP regardless of WS
  - Error handling: emits error when no active conversation, handles network errors, emits error on HTTP failure

Frontend (Webview App)
- Added src/webview-src/__tests__/App.confirmation.test.tsx with 12 tests:
  - Prompt display: shows only when agent_status is WAITING_FOR_CONFIRMATION AND a pending ActionEvent exists; hides otherwise; displays tool/thought/security risk; renders "Action Details:"
  - Approve flow: posts command approveAction, disables while submitting, prevents double-click submits
  - Reject flow: toggles input, posts command rejectAction with optional reason, prevents double-click submits
  - Clearing state: clears pending action and resets submitting on ObservationEvent and UserRejectObservation for matching tool_call_id
  - Timeout: sets isSubmitting true on click, and resets to false after 30 seconds (test triggers scheduled callback)
  - Error: resets isSubmitting on AgentErrorEvent

Implementation fixes in App.tsx
- Gate ConfirmationPrompt rendering on agentStatus === 'WAITING_FOR_CONFIRMATION' AND pendingActions.length > 0
- Add double-submit guards in approve/reject handlers using isSubmitting
- On ObservationEvent/UserRejectObservation: remove matching pending action and clear submitting/timeout
- On AgentErrorEvent: clear submitting/timeout
- Ensure heading label "Action Details:" is present

Motivation and Context
- Confirmation mode is a core security feature. These tests prevent regressions and validate both HTTP confirmation responses and UI state transitions, including timeout and error recovery. Closes #61.

Testing
- All unit tests pass locally: 60/60.
- Frontend tests exercise UI interactions via @testing-library/react with React 19; timeout behavior verified by invoking scheduled callback.

Checklist
- [x] Unit tests added/updated
- [x] CI unit tests should run via existing workflow
- [x] No build artifacts or secrets committed

Notes
- No changes to extension activation or packaging.
- No changes to e2e tests; unit coverage focused on confirmation flow.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9169ca143d874ca984e300f9d9e393f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for confirmation workflows in the connection manager and application component, including approval/rejection flows, error handling, and timeout behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->