### PR TITLE
set LLM API key 

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
         "title": "OpenHands: Configure"
       },
       {
+        "command": "openhands.setApiKey",
+        "title": "OpenHands: Set API Key"
+      },
+      {
         "command": "openhands.reconnect",
         "title": "OpenHands: Reconnect"
       },
@@ -120,6 +124,12 @@
         "openhands.llm.baseUrl": {
           "type": "string",
           "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
+        },
+        "openhands.llm.apiKey": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
         },
         "openhands.llm.apiVersion": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -331,31 +331,36 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const setApiKey = vscode.commands.registerCommand('openhands.setApiKey', async () => {
-    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-    const existing = await settingsMgr.get();
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      const existing = await settingsMgr.get();
 
-    const llmApiKey = await vscode.window.showInputBox({
-      title: 'LLM API Key',
-      value: existing.secrets.llmApiKey,
-      password: true,
-      prompt: 'Enter your LLM API key. It will be stored securely in VS Code SecretStorage.',
-      placeHolder: 'sk-...'
-    });
+      const llmApiKey = await vscode.window.showInputBox({
+        title: 'LLM API Key',
+        value: existing.secrets.llmApiKey,
+        password: true,
+        prompt: 'Enter your LLM API key. It will be stored securely in VS Code SecretStorage.',
+        placeHolder: 'sk-...'
+      });
 
-    if (llmApiKey === undefined) {
-      // User cancelled
-      return;
+      if (llmApiKey === undefined) {
+        // User cancelled
+        return;
+      }
+
+      await settingsMgr.update({
+        secrets: { llmApiKey: llmApiKey || undefined }
+      }, 'workspace');
+
+      vscode.window.showInformationMessage('LLM API Key saved securely.');
+
+      // Apply to connection
+      const newSettings = await settingsMgr.get();
+      connection?.setSettings(newSettings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to save API Key: ${message}`);
     }
-
-    await settingsMgr.update({
-      secrets: { llmApiKey: llmApiKey || undefined }
-    }, 'workspace');
-
-    vscode.window.showInformationMessage('LLM API Key saved securely.');
-
-    // Apply to connection
-    const newSettings = await settingsMgr.get();
-    connection?.setSettings(newSettings);
   });
 
   const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -330,6 +330,34 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
+  const setApiKey = vscode.commands.registerCommand('openhands.setApiKey', async () => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const existing = await settingsMgr.get();
+
+    const llmApiKey = await vscode.window.showInputBox({
+      title: 'LLM API Key',
+      value: existing.secrets.llmApiKey,
+      password: true,
+      prompt: 'Enter your LLM API key. It will be stored securely in VS Code SecretStorage.',
+      placeHolder: 'sk-...'
+    });
+
+    if (llmApiKey === undefined) {
+      // User cancelled
+      return;
+    }
+
+    await settingsMgr.update({
+      secrets: { llmApiKey: llmApiKey || undefined }
+    }, 'workspace');
+
+    vscode.window.showInformationMessage('LLM API Key saved securely.');
+
+    // Apply to connection
+    const newSettings = await settingsMgr.get();
+    connection?.setSettings(newSettings);
+  });
+
   const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {
     await ensurePanelAndConnection();
     connection?.reconnect();
@@ -374,7 +402,7 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  context.subscriptions.push(openTab, diag, sendTestEvent, queryRenderedEvents, injectBashEvent, queryBashEvents, startNew, configure, reconnect, pause, resume);
+  context.subscriptions.push(openTab, diag, sendTestEvent, queryRenderedEvents, injectBashEvent, queryBashEvents, startNew, configure, setApiKey, reconnect, pause, resume);
 }
 
 export function deactivate() {


### PR DESCRIPTION
Add a discoverable way to set LLM API key from VS Code Settings:

- Add `openhands.llm.apiKey` setting entry with inline button link
- Add "OpenHands: Set API Key" command for quick access
- API key stored securely in VS Code SecretStorage (not settings.json)
- Settings UI displays clickable link: "🔑 Configure API Key"
- Automatically applies updated key to active connection

This improves UX by making API key configuration visible in Settings instead of requiring users to discover the multi-step configure wizard.

Resolves user feedback about API key discoverability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new VS Code command to set your LLM API key securely.
  * Added a new configuration property for storing your LLM API key.
  * Users can now configure API keys through VS Code settings or the dedicated command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->