### PR TITLE
feat: align extension with agent-server 1.1 API

### DIFF
--- a/package.json
+++ b/package.json
@@ -254,8 +254,5 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "ws": "^8.18.3"
-  },
-  "bundledDependencies": [
-    "ws"
-  ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "onCommand:openhands.reconnect",
     "onCommand:openhands.pauseCurrentRun",
     "onCommand:openhands.resumeCurrentRun",
-    "onView:openhands.quickActions"
+    "onView:openhands.quickActions",
+    "onStartupFinished"
   ],
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "onCommand:openhands.configure",
     "onCommand:openhands.reconnect",
     "onCommand:openhands.pauseCurrentRun",
-    "onCommand:openhands.resumeCurrentRun"
+    "onCommand:openhands.resumeCurrentRun",
+    "onView:openhands.quickActions"
   ],
   "contributes": {
     "commands": [

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "onCommand:openhands.reconnect",
     "onCommand:openhands.pauseCurrentRun",
     "onCommand:openhands.resumeCurrentRun",
-    "onView:openhands.quickActions",
-    "onStartupFinished"
+    "onView:openhands.quickActions"
   ],
   "contributes": {
     "commands": [

--- a/scripts/dump-settings.ts
+++ b/scripts/dump-settings.ts
@@ -1,0 +1,10 @@
+import * as vscode from 'vscode';
+
+export async function activate(): Promise<void> {
+  const config = vscode.workspace.getConfiguration('openhands');
+  console.log('openhands.llm.model:', config.get('llm.model'));
+  console.log('openhands.llm.usageId:', config.get('llm.usageId'));
+  console.log('explicit model:', config.inspect('llm.model')?.workspaceValue ?? config.inspect('llm.model')?.globalValue);
+}
+
+export function deactivate(): void {}

--- a/src/connection/ConnectionManager.ts
+++ b/src/connection/ConnectionManager.ts
@@ -67,12 +67,17 @@ export class ConnectionManager {
       if (model) llm.model = model;
       if (baseUrl) llm.base_url = baseUrl;
       if (apiVersion) llm.api_version = apiVersion;
-      if (s?.llm.timeout != null) llm.timeout = s.llm.timeout;
-      if (s?.llm.temperature != null) llm.temperature = s.llm.temperature;
-      if (s?.llm.topP != null) llm.top_p = s.llm.topP;
-      if (s?.llm.topK != null) llm.top_k = s.llm.topK;
-      if (s?.llm.maxInputTokens != null) llm.max_input_tokens = s.llm.maxInputTokens;
-      if (s?.llm.maxOutputTokens != null) llm.max_output_tokens = s.llm.maxOutputTokens;
+      const assignIf = (value: unknown, setter: (n: number) => void, predicate: (n: number) => boolean = (n) => Number.isFinite(n)) => {
+        if (value === null || value === undefined) return;
+        const num = Number(value);
+        if (Number.isFinite(num) && predicate(num)) setter(num);
+      };
+      assignIf(s?.llm.timeout, (n) => { llm.timeout = n; }, (n) => n > 0);
+      assignIf(s?.llm.temperature, (n) => { llm.temperature = n; });
+      assignIf(s?.llm.topP, (n) => { llm.top_p = n; }, (n) => n > 0 && n <= 1);
+      assignIf(s?.llm.topK, (n) => { llm.top_k = n; }, (n) => n > 0);
+      assignIf(s?.llm.maxInputTokens, (n) => { llm.max_input_tokens = n; }, (n) => n > 0);
+      assignIf(s?.llm.maxOutputTokens, (n) => { llm.max_output_tokens = n; }, (n) => n > 0);
       if (s?.llm.nativeToolCalling != null) llm.native_tool_calling = s.llm.nativeToolCalling;
       if (s?.llm.reasoningEffort != null) llm.reasoning_effort = s.llm.reasoningEffort;
       if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;

--- a/src/connection/ConnectionManager.ts
+++ b/src/connection/ConnectionManager.ts
@@ -67,17 +67,12 @@ export class ConnectionManager {
       if (model) llm.model = model;
       if (baseUrl) llm.base_url = baseUrl;
       if (apiVersion) llm.api_version = apiVersion;
-      const assignIf = (value: unknown, setter: (n: number) => void, predicate: (n: number) => boolean = (n) => Number.isFinite(n)) => {
-        if (value === null || value === undefined) return;
-        const num = Number(value);
-        if (Number.isFinite(num) && predicate(num)) setter(num);
-      };
-      assignIf(s?.llm.timeout, (n) => { llm.timeout = n; }, (n) => n > 0);
-      assignIf(s?.llm.temperature, (n) => { llm.temperature = n; });
-      assignIf(s?.llm.topP, (n) => { llm.top_p = n; }, (n) => n > 0 && n <= 1);
-      assignIf(s?.llm.topK, (n) => { llm.top_k = n; }, (n) => n > 0);
-      assignIf(s?.llm.maxInputTokens, (n) => { llm.max_input_tokens = n; }, (n) => n > 0);
-      assignIf(s?.llm.maxOutputTokens, (n) => { llm.max_output_tokens = n; }, (n) => n > 0);
+      if (s?.llm.timeout != null) llm.timeout = s.llm.timeout;
+      if (s?.llm.temperature != null) llm.temperature = s.llm.temperature;
+      if (s?.llm.topP != null) llm.top_p = s.llm.topP;
+      if (s?.llm.topK != null) llm.top_k = s.llm.topK;
+      if (s?.llm.maxInputTokens != null) llm.max_input_tokens = s.llm.maxInputTokens;
+      if (s?.llm.maxOutputTokens != null) llm.max_output_tokens = s.llm.maxOutputTokens;
       if (s?.llm.nativeToolCalling != null) llm.native_tool_calling = s.llm.nativeToolCalling;
       if (s?.llm.reasoningEffort != null) llm.reasoning_effort = s.llm.reasoningEffort;
       if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;

--- a/src/connection/ConnectionManager.ts
+++ b/src/connection/ConnectionManager.ts
@@ -385,7 +385,7 @@ export class ConnectionManager {
         const data = JSON.parse(str) as unknown;
         // Validate event structure before propagating to UI
         if (isAgentEvent(data)) this.events.onEvent(data);
-        else this.events.onError(new Error('Invalid event payload'));
+        else this.events.onError(new Error(`Invalid event payload: ${JSON.stringify(data)}`));
       } catch (e) {
         this.events.onError(e);
       }

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -22,6 +22,12 @@ const DEFAULTS: OpenHandsSettings = {
   secrets: {}
 };
 
+const sanitizePositiveInteger = (value: number | null | undefined): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  const int = Math.trunc(value);
+  return int > 0 ? int : undefined;
+};
+
 export class SettingsManager {
   constructor(private adapter: SettingsAdapter) {}
 
@@ -37,8 +43,8 @@ export class SettingsManager {
       temperature: this.adapter.get<number | null>('openhands.llm.temperature', DEFAULTS.llm.temperature) ?? DEFAULTS.llm.temperature,
       topP: this.adapter.get<number | null>('openhands.llm.topP', DEFAULTS.llm.topP) ?? DEFAULTS.llm.topP,
       topK: this.adapter.get<number | null>('openhands.llm.topK', DEFAULTS.llm.topK) ?? DEFAULTS.llm.topK,
-      maxInputTokens: this.adapter.get<number | null>('openhands.llm.maxInputTokens', DEFAULTS.llm.maxInputTokens) ?? DEFAULTS.llm.maxInputTokens,
-      maxOutputTokens: this.adapter.get<number | null>('openhands.llm.maxOutputTokens', DEFAULTS.llm.maxOutputTokens) ?? DEFAULTS.llm.maxOutputTokens,
+      maxInputTokens: sanitizePositiveInteger(this.adapter.get<number | null>('openhands.llm.maxInputTokens', null) ?? undefined),
+      maxOutputTokens: sanitizePositiveInteger(this.adapter.get<number | null>('openhands.llm.maxOutputTokens', null) ?? undefined),
       nativeToolCalling: this.adapter.get<boolean | null>('openhands.llm.nativeToolCalling', DEFAULTS.llm.nativeToolCalling) ?? DEFAULTS.llm.nativeToolCalling,
       reasoningEffort: this.adapter.get<'low' | 'medium' | 'high' | 'none' | null>('openhands.llm.reasoningEffort', DEFAULTS.llm.reasoningEffort) ?? DEFAULTS.llm.reasoningEffort,
     };

--- a/src/types/agent-sdk.ts
+++ b/src/types/agent-sdk.ts
@@ -116,6 +116,8 @@ export interface ConversationStateUpdateEvent extends EventBase {
   type: 'ConversationStateUpdateEvent';
   agent_status?: string;
   iteration?: number;
+  key?: string;
+  value?: unknown;
 }
 
 export type Event =


### PR DESCRIPTION
## Summary
- align StartConversation requests, resume flow, and message fallbacks with agent-server 1.1 contract
- remove legacy BashTool payloads and document new tool identifiers
- ensure quick actions view activates extension and tidy auth header logic

## Testing
- npm run lint
- npm test
- npx ts-node --transpile-only (manual smoke)