### PR TITLE
feat(agent-sdk-ts): add vscode workspace runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12309,6 +12309,7 @@
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.18.6",
+        "@types/vscode": "^1.104.0",
         "@typescript-eslint/eslint-plugin": "^8.44.1",
         "@typescript-eslint/parser": "^8.44.1",
         "eslint": "^9.36.0",

--- a/packages/agent-sdk-ts/eslint.config.js
+++ b/packages/agent-sdk-ts/eslint.config.js
@@ -2,6 +2,7 @@
 const eslint = require('@eslint/js');
 const tseslint = require('@typescript-eslint/eslint-plugin');
 const tsparser = require('@typescript-eslint/parser');
+const globals = require('globals');
 
 module.exports = [
   {
@@ -18,6 +19,7 @@ module.exports = [
         project: ['./tsconfig.json'],
         tsconfigRootDir: __dirname,
       },
+      globals: globals.node,
     },
     plugins: {
       '@typescript-eslint': tseslint,
@@ -40,6 +42,7 @@ module.exports = [
         ecmaVersion: 2022,
         sourceType: 'module',
       },
+      globals: globals.node,
     },
     plugins: {
       '@typescript-eslint': tseslint,

--- a/packages/agent-sdk-ts/package.json
+++ b/packages/agent-sdk-ts/package.json
@@ -25,6 +25,7 @@
     "prepare": "npm run build"
   },
   "devDependencies": {
+    "@types/vscode": "^1.104.0",
     "@types/node": "^22.18.6",
     "@typescript-eslint/eslint-plugin": "^8.44.1",
     "@typescript-eslint/parser": "^8.44.1",

--- a/packages/agent-sdk-ts/package.json
+++ b/packages/agent-sdk-ts/package.json
@@ -8,9 +8,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "browser": {
+        "types": "./dist/browser.d.ts",
+        "import": "./dist/browser.mjs",
+        "require": "./dist/browser.cjs"
+      },
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.cjs",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [

--- a/packages/agent-sdk-ts/src/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/local.workspace.test.ts
@@ -1,0 +1,43 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { LocalWorkspace } from '../workspace';
+
+const makeWorkspace = async (register: (dir: string) => void) => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-'));
+  register(dir);
+  return { dir, workspace: new LocalWorkspace(dir) };
+};
+
+describe('LocalWorkspace', () => {
+  const created: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(created.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
+    created.length = 0;
+  });
+
+  describe('file operations', () => {
+    it('writes and reads files inside the sandbox', async () => {
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      await workspace.writeFile('test.txt', 'hello');
+      const content = await workspace.readFile('test.txt');
+      expect(content).toBe('hello');
+    });
+
+    it('blocks traversal outside the sandbox', async () => {
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      expect(() => workspace.resolvePath('../etc/passwd')).toThrowError();
+    });
+  });
+
+  describe('commands', () => {
+    it('runs commands rooted in the workspace', async () => {
+      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+      const result = await workspace.runCommand('pwd');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe(dir);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/local.workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, afterEach } from 'vitest';
 import { LocalWorkspace } from '../workspace';
 
 const makeWorkspace = async (register: (dir: string) => void) => {

--- a/packages/agent-sdk-ts/src/__tests__/runtime.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/runtime.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { ConversationState, EventLog, SecretRegistry, AsyncLock, StuckDetector } from '../runtime';
+import { isConversationStateUpdateEvent } from '../types';
+
+describe('EventLog and ConversationState', () => {
+  it('records state updates', () => {
+    const log = new EventLog();
+    const state = new ConversationState(log);
+    state.setStatus('running');
+    state.incrementIteration();
+
+    const events = log.list();
+    expect(events.length).toBe(2);
+    expect(events.every(isConversationStateUpdateEvent)).toBe(true);
+  });
+});
+
+describe('SecretRegistry', () => {
+  it('prefers registered secrets', async () => {
+    const registry = new SecretRegistry();
+    registry.register('token', 'abc');
+    await expect(registry.get('token')).resolves.toBe('abc');
+  });
+});
+
+describe('AsyncLock', () => {
+  it('serializes tasks', async () => {
+    const lock = new AsyncLock();
+    const order: number[] = [];
+
+    await Promise.all([
+      lock.acquire(async () => {
+        order.push(1);
+      }),
+      lock.acquire(async () => {
+        order.push(2);
+      }),
+    ]);
+
+    expect(order).toEqual([1, 2]);
+  });
+});
+
+describe('StuckDetector', () => {
+  it('flags idle sessions', () => {
+    const log = new EventLog();
+    const detector = new StuckDetector(log, 1);
+    const result = detector.evaluate();
+    expect(result.stuck).toBe(false);
+    // simulate old event
+    log.push({ type: 'PauseEvent', source: 'user', timestamp: '2000-01-01T00:00:00Z' });
+    const stuck = detector.evaluate(Date.parse('2000-01-01T00:01:00Z'));
+    expect(stuck.stuck).toBe(true);
+  });
+});

--- a/packages/agent-sdk-ts/src/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/tools.test.ts
@@ -26,6 +26,16 @@ describe('TerminalTool', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout.trim()).toBe('hello');
   });
+
+  it('times out long-running commands', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+    const start = Date.now();
+    const result = await tool.execute(tool.validate({ command: 'sleep 2', timeoutMs: 200 }), { workspace });
+    expect(Date.now() - start).toBeLessThan(2000);
+    expect(result.exitCode).not.toBe(0);
+  });
 });
 
 describe('FileEditorTool', () => {

--- a/packages/agent-sdk-ts/src/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/tools.test.ts
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, afterEach } from 'vitest';
+import { BrowserTool, FileEditorTool, TaskTrackerTool, TerminalTool } from '../tools';
+import { LocalWorkspace } from '../workspace';
+
+const makeWorkspace = async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-tools-'));
+  return { dir, workspace: new LocalWorkspace(dir) };
+};
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+describe('TerminalTool', () => {
+  it('executes a simple command', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+    const result = await tool.execute(tool.validate({ command: 'echo hello' }), { workspace });
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe('hello');
+  });
+});
+
+describe('FileEditorTool', () => {
+  it('writes content', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+    const args = tool.validate({ path: 'note.txt', content: 'first line' });
+    const result = await tool.execute(args, { workspace });
+    expect(result.bytesWritten).toBeGreaterThan(0);
+    const saved = await workspace.readFile('note.txt');
+    expect(saved).toContain('first line');
+  });
+});
+
+describe('TaskTrackerTool', () => {
+  it('creates and completes tasks', async () => {
+    const tool = new TaskTrackerTool();
+    const createdTasks = await tool.execute(tool.validate({ action: 'create', title: 'Do work' }), {
+      workspace: new LocalWorkspace(process.cwd()),
+    });
+    expect(createdTasks.tasks).toHaveLength(1);
+    const taskId = createdTasks.tasks[0].id;
+
+    const updated = await tool.execute(tool.validate({ action: 'complete', id: taskId }), {
+      workspace: new LocalWorkspace(process.cwd()),
+    });
+    expect(updated.tasks[0].completed).toBe(true);
+  });
+});
+
+describe('BrowserTool', () => {
+  it('rejects unsupported protocols', async () => {
+    const tool = new BrowserTool();
+    expect(() => tool.validate({ url: 'file:///etc/passwd' })).toThrowError();
+  });
+});

--- a/packages/agent-sdk-ts/src/browser.ts
+++ b/packages/agent-sdk-ts/src/browser.ts
@@ -1,0 +1,3 @@
+// Browser-targeted entry that exposes only pure data models and type guards
+// to avoid bundling Node-specific workspace and tool implementations.
+export * from './types';

--- a/packages/agent-sdk-ts/src/index.ts
+++ b/packages/agent-sdk-ts/src/index.ts
@@ -1,1 +1,4 @@
 export * from './types';
+export * from './workspace';
+export * from './tools';
+export * from './runtime';

--- a/packages/agent-sdk-ts/src/runtime/AsyncLock.ts
+++ b/packages/agent-sdk-ts/src/runtime/AsyncLock.ts
@@ -1,0 +1,28 @@
+export class AsyncLock {
+  private queue: Promise<void> = Promise.resolve();
+
+  async acquire<T>(fn: () => Promise<T>): Promise<T> {
+    const unlock = this.enqueue();
+    await unlock.start;
+    try {
+      return await fn();
+    } finally {
+      unlock.finish();
+    }
+  }
+
+  private enqueue(): { start: Promise<void>; finish: () => void } {
+    let release: () => void = () => {};
+    const start = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const previous = this.queue;
+    this.queue = previous.then(() => start);
+
+    return {
+      start: previous,
+      finish: release,
+    };
+  }
+}

--- a/packages/agent-sdk-ts/src/runtime/ConversationState.ts
+++ b/packages/agent-sdk-ts/src/runtime/ConversationState.ts
@@ -1,0 +1,53 @@
+import type { ConversationStateUpdateEvent, Event } from '../types';
+import { EventLog } from './EventLog';
+
+export interface AgentState {
+  status: string;
+  iteration: number;
+  values: Record<string, unknown>;
+}
+
+export class ConversationState {
+  private state: AgentState = {
+    status: 'idle',
+    iteration: 0,
+    values: {},
+  };
+
+  constructor(private events: EventLog = new EventLog()) {}
+
+  get snapshot(): AgentState {
+    return { ...this.state, values: { ...this.state.values } };
+  }
+
+  incrementIteration(): AgentState {
+    this.state = { ...this.state, iteration: this.state.iteration + 1 };
+    this.emitUpdate({ iteration: this.state.iteration });
+    return this.snapshot;
+  }
+
+  setStatus(status: string): AgentState {
+    this.state = { ...this.state, status };
+    this.emitUpdate({ agent_status: status });
+    return this.snapshot;
+  }
+
+  setValue(key: string, value: unknown): AgentState {
+    this.state = { ...this.state, values: { ...this.state.values, [key]: value } };
+    this.emitUpdate({ key, value });
+    return this.snapshot;
+  }
+
+  attachEventLog(events: EventLog): void {
+    this.events = events;
+  }
+
+  private emitUpdate(update: Partial<ConversationStateUpdateEvent>): void {
+    const event: ConversationStateUpdateEvent = {
+      type: 'ConversationStateUpdateEvent',
+      source: 'agent',
+      ...update,
+    };
+    this.events.push(event as Event);
+  }
+}

--- a/packages/agent-sdk-ts/src/runtime/ConversationState.ts
+++ b/packages/agent-sdk-ts/src/runtime/ConversationState.ts
@@ -42,11 +42,11 @@ export class ConversationState {
     this.events = events;
   }
 
-  private emitUpdate(update: Partial<ConversationStateUpdateEvent>): void {
+  private emitUpdate(update: Omit<Partial<ConversationStateUpdateEvent>, 'type' | 'source'>): void {
     const event: ConversationStateUpdateEvent = {
+      ...update,
       type: 'ConversationStateUpdateEvent',
       source: 'agent',
-      ...update,
     };
     this.events.push(event);
   }

--- a/packages/agent-sdk-ts/src/runtime/ConversationState.ts
+++ b/packages/agent-sdk-ts/src/runtime/ConversationState.ts
@@ -1,4 +1,4 @@
-import type { ConversationStateUpdateEvent, Event } from '../types';
+import type { ConversationStateUpdateEvent } from '../types';
 import { EventLog } from './EventLog';
 
 export interface AgentState {
@@ -48,6 +48,6 @@ export class ConversationState {
       source: 'agent',
       ...update,
     };
-    this.events.push(event as Event);
+    this.events.push(event);
   }
 }

--- a/packages/agent-sdk-ts/src/runtime/EventLog.ts
+++ b/packages/agent-sdk-ts/src/runtime/EventLog.ts
@@ -1,0 +1,32 @@
+import { randomUUID } from 'crypto';
+import { isEvent, type Event } from '../types';
+
+export type EventListener = (event: Event) => void;
+
+export class EventLog {
+  private readonly events: Event[] = [];
+  private readonly listeners: Set<EventListener> = new Set();
+
+  push(event: Event): Event {
+    if (!isEvent(event)) {
+      throw new Error('Attempted to push invalid event');
+    }
+    const normalized: Event = {
+      ...event,
+      id: event.id ?? randomUUID(),
+      timestamp: event.timestamp ?? new Date().toISOString(),
+    };
+    this.events.push(normalized);
+    this.listeners.forEach((listener) => listener(normalized));
+    return normalized;
+  }
+
+  list(): Event[] {
+    return [...this.events];
+  }
+
+  on(listener: EventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}

--- a/packages/agent-sdk-ts/src/runtime/SecretRegistry.ts
+++ b/packages/agent-sdk-ts/src/runtime/SecretRegistry.ts
@@ -1,0 +1,42 @@
+import type { SecretStorage } from 'vscode';
+
+const loadVscode = (): typeof import('vscode') | null => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+    return require('vscode') as typeof import('vscode');
+  } catch (err) {
+    return null;
+  }
+};
+
+export class SecretRegistry {
+  private readonly secrets: Map<string, string> = new Map();
+  private readonly vscodeApi: typeof import('vscode') | null;
+  private readonly storage?: SecretStorage;
+
+  constructor(storage?: SecretStorage, vscodeModule: typeof import('vscode') | null = loadVscode()) {
+    this.storage = storage;
+    this.vscodeApi = vscodeModule;
+  }
+
+  register(name: string, value: string): void {
+    this.secrets.set(name, value);
+  }
+
+  async get(name: string): Promise<string | undefined> {
+    if (this.secrets.has(name)) {
+      return this.secrets.get(name);
+    }
+
+    const envKey = name.toUpperCase();
+    if (process.env[envKey]) {
+      return process.env[envKey];
+    }
+
+    if (this.storage) {
+      return this.storage.get(name);
+    }
+
+    return undefined;
+  }
+}

--- a/packages/agent-sdk-ts/src/runtime/SecretRegistry.ts
+++ b/packages/agent-sdk-ts/src/runtime/SecretRegistry.ts
@@ -2,9 +2,9 @@ import type { SecretStorage } from 'vscode';
 
 const loadVscode = (): typeof import('vscode') | null => {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('vscode') as typeof import('vscode');
-  } catch (err) {
+  } catch {
     return null;
   }
 };

--- a/packages/agent-sdk-ts/src/runtime/StuckDetector.ts
+++ b/packages/agent-sdk-ts/src/runtime/StuckDetector.ts
@@ -1,0 +1,37 @@
+import type { Event } from '../types';
+import { isActionEvent, isObservationEvent } from '../types';
+import { EventLog } from './EventLog';
+
+export interface StuckResult {
+  stuck: boolean;
+  reason?: string;
+  lastEvent?: Event;
+}
+
+export class StuckDetector {
+  constructor(private readonly events: EventLog, private readonly thresholdMs = 30_000) {}
+
+  evaluate(now: number = Date.now()): StuckResult {
+    const recorded = this.events.list();
+    if (recorded.length === 0) {
+      return { stuck: false };
+    }
+
+    const last = recorded[recorded.length - 1];
+    const timestamp = last.timestamp ? new Date(last.timestamp).getTime() : now;
+    const idleMs = now - timestamp;
+    if (idleMs > this.thresholdMs) {
+      return { stuck: true, reason: `No events for ${idleMs}ms`, lastEvent: last };
+    }
+
+    // Detect repeated actions without observations
+    const recent = recorded.slice(-5);
+    const actions = recent.filter(isActionEvent);
+    const observations = recent.filter(isObservationEvent);
+    if (actions.length >= 2 && observations.length === 0) {
+      return { stuck: true, reason: 'Actions produced no observations', lastEvent: last };
+    }
+
+    return { stuck: false, lastEvent: last };
+  }
+}

--- a/packages/agent-sdk-ts/src/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/runtime/index.ts
@@ -1,0 +1,5 @@
+export * from './EventLog';
+export * from './ConversationState';
+export * from './SecretRegistry';
+export * from './AsyncLock';
+export * from './StuckDetector';

--- a/packages/agent-sdk-ts/src/tools/BrowserTool.ts
+++ b/packages/agent-sdk-ts/src/tools/BrowserTool.ts
@@ -42,7 +42,12 @@ export class BrowserTool implements ToolHandler<BrowserArgs, BrowserResult> {
     const maxBytes = args.maxBytes ?? DEFAULT_MAX_BYTES;
     let bytesRead = 0;
 
-    const response = await fetch(parsed, {
+    const fetchFn = globalThis.fetch;
+    if (!fetchFn) {
+      throw new Error('Global fetch API is unavailable in this runtime');
+    }
+
+    const response = await fetchFn(parsed, {
       method: args.method ?? 'GET',
       body: args.body,
       signal: controller.signal,

--- a/packages/agent-sdk-ts/src/tools/BrowserTool.ts
+++ b/packages/agent-sdk-ts/src/tools/BrowserTool.ts
@@ -1,0 +1,72 @@
+import type { ToolContext, ToolHandler } from './types';
+import { requireObject, requireString, optionalString, optionalNumber } from './validation';
+
+export interface BrowserArgs {
+  url: string;
+  method?: 'GET' | 'POST';
+  body?: string;
+  maxBytes?: number;
+}
+
+export interface BrowserResult {
+  url: string;
+  status: number;
+  content: string;
+}
+
+const DEFAULT_MAX_BYTES = 256 * 1024;
+
+export class BrowserTool implements ToolHandler<BrowserArgs, BrowserResult> {
+  readonly name = 'browser';
+
+  validate(input: unknown): BrowserArgs {
+    const obj = requireObject(input, 'browser args');
+    const url = requireString(obj.url, 'url');
+    const method = (optionalString(obj.method, 'method') ?? 'GET').toUpperCase();
+    if (!['GET', 'POST'].includes(method)) {
+      throw new Error('Unsupported HTTP method');
+    }
+    const body = optionalString(obj.body, 'body');
+    const maxBytes = optionalNumber(obj.maxBytes, 'maxBytes');
+    const parsed = new URL(url);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error('Only http and https URLs are allowed');
+    }
+    return { url: parsed.toString(), method: method as BrowserArgs['method'], body, maxBytes };
+  }
+
+  async execute(args: BrowserArgs, _context: ToolContext): Promise<BrowserResult> {
+    const parsed = new URL(args.url);
+
+    const controller = new AbortController();
+    const maxBytes = args.maxBytes ?? DEFAULT_MAX_BYTES;
+    let bytesRead = 0;
+
+    const response = await fetch(parsed, {
+      method: args.method ?? 'GET',
+      body: args.body,
+      signal: controller.signal,
+    });
+
+    const reader = response.body?.getReader();
+    const chunks: string[] = [];
+    if (reader) {
+      // Stream chunks while enforcing the maxBytes limit
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          bytesRead += value.byteLength;
+          if (bytesRead > maxBytes) {
+            controller.abort();
+            throw new Error(`Response exceeded limit of ${maxBytes} bytes`);
+          }
+          chunks.push(new TextDecoder().decode(value));
+        }
+      }
+    }
+
+    const content = chunks.join('');
+    return { url: parsed.toString(), status: response.status, content };
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,6 +1,7 @@
 import path from 'path';
+import { Buffer } from 'buffer';
 import type { ToolContext, ToolHandler } from './types';
-import { requireBoolean, requireObject, requireString, optionalString } from './validation';
+import { requireBoolean, requireObject, requireString } from './validation';
 
 export interface FileEditorArgs {
   path: string;
@@ -19,7 +20,11 @@ export class FileEditorTool implements ToolHandler<FileEditorArgs, FileEditorRes
   validate(input: unknown): FileEditorArgs {
     const obj = requireObject(input, 'file editor args');
     const filePath = requireString(obj.path, 'path');
-    const content = optionalString(obj.content, 'content') ?? '';
+    const rawContent = obj.content;
+    if (rawContent !== undefined && typeof rawContent !== 'string') {
+      throw new Error('content must be a string');
+    }
+    const content = (rawContent as string | undefined) ?? '';
     const append = obj.append === undefined ? false : requireBoolean(obj.append, 'append');
     return { path: filePath, content, append };
   }
@@ -29,7 +34,11 @@ export class FileEditorTool implements ToolHandler<FileEditorArgs, FileEditorRes
     const dir = path.dirname(resolved);
     await context.workspace.ensureDirectory(dir);
 
-    const writeMethod = args.append ? context.workspace.readFile(args.path).catch(() => '') : Promise.resolve('');
+    const writeMethod = args.append
+      ? context.workspace
+          .readFile(args.path)
+          .catch((err: NodeJS.ErrnoException) => (err?.code === 'ENOENT' ? '' : Promise.reject(err)))
+      : Promise.resolve('');
     const existing = await writeMethod;
     const newContent = args.append ? `${existing}${existing ? '\n' : ''}${args.content}` : args.content;
     await context.workspace.writeFile(args.path, newContent);

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -24,7 +24,7 @@ export class FileEditorTool implements ToolHandler<FileEditorArgs, FileEditorRes
     if (rawContent !== undefined && typeof rawContent !== 'string') {
       throw new Error('content must be a string');
     }
-    const content = (rawContent as string | undefined) ?? '';
+    const content = rawContent ?? '';
     const append = obj.append === undefined ? false : requireBoolean(obj.append, 'append');
     return { path: filePath, content, append };
   }
@@ -37,7 +37,13 @@ export class FileEditorTool implements ToolHandler<FileEditorArgs, FileEditorRes
     const writeMethod = args.append
       ? context.workspace
           .readFile(args.path)
-          .catch((err: NodeJS.ErrnoException) => (err?.code === 'ENOENT' ? '' : Promise.reject(err)))
+          .catch((err: unknown) => {
+            if (err && typeof err === 'object' && 'code' in err && (err as { code?: string }).code === 'ENOENT') {
+              return '';
+            }
+            const error = err instanceof Error ? err : new Error(String(err));
+            return Promise.reject(error);
+          })
       : Promise.resolve('');
     const existing = await writeMethod;
     const newContent = args.append ? `${existing}${existing ? '\n' : ''}${args.content}` : args.content;

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import type { ToolContext, ToolHandler } from './types';
+import { requireBoolean, requireObject, requireString, optionalString } from './validation';
+
+export interface FileEditorArgs {
+  path: string;
+  content: string;
+  append?: boolean;
+}
+
+export interface FileEditorResult {
+  path: string;
+  bytesWritten: number;
+}
+
+export class FileEditorTool implements ToolHandler<FileEditorArgs, FileEditorResult> {
+  readonly name = 'file_editor';
+
+  validate(input: unknown): FileEditorArgs {
+    const obj = requireObject(input, 'file editor args');
+    const filePath = requireString(obj.path, 'path');
+    const content = optionalString(obj.content, 'content') ?? '';
+    const append = obj.append === undefined ? false : requireBoolean(obj.append, 'append');
+    return { path: filePath, content, append };
+  }
+
+  async execute(args: FileEditorArgs, context: ToolContext): Promise<FileEditorResult> {
+    const resolved = context.workspace.resolvePath(args.path);
+    const dir = path.dirname(resolved);
+    await context.workspace.ensureDirectory(dir);
+
+    const writeMethod = args.append ? context.workspace.readFile(args.path).catch(() => '') : Promise.resolve('');
+    const existing = await writeMethod;
+    const newContent = args.append ? `${existing}${existing ? '\n' : ''}${args.content}` : args.content;
+    await context.workspace.writeFile(args.path, newContent);
+
+    return { path: resolved, bytesWritten: Buffer.byteLength(newContent) };
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -6,9 +6,9 @@ import type { LocalWorkspace } from '../workspace/LocalWorkspace';
 
 const loadVscode = (): typeof import('vscode') | null => {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     return require('vscode') as typeof import('vscode');
-  } catch (err) {
+  } catch {
     return null;
   }
 };
@@ -51,7 +51,7 @@ export class IntegratedTerminalRunner {
     let exitCode = 0;
     let timedOut = false;
     let aborted = false;
-    let timeout: NodeJS.Timeout | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const timeoutMs = options.timeoutMs;
 
     let childProcess: ReturnType<typeof spawn> | null = null;
@@ -84,13 +84,13 @@ export class IntegratedTerminalRunner {
           options.signal.addEventListener('abort', abortHandler);
         }
 
-        childProcess.stdout?.on('data', (data) => {
+        childProcess.stdout?.on('data', (data: Buffer | string) => {
           const chunk = data.toString();
           stdout += chunk;
           writeEmitter.fire(chunk);
         });
 
-        childProcess.stderr?.on('data', (data) => {
+        childProcess.stderr?.on('data', (data: Buffer | string) => {
           const chunk = data.toString();
           stderr += chunk;
           writeEmitter.fire(chunk);
@@ -167,11 +167,11 @@ export class IntegratedTerminalRunner {
         options.signal.addEventListener('abort', abortHandler);
       }
 
-      child.stdout?.on('data', (data) => {
+      child.stdout?.on('data', (data: Buffer | string) => {
         stdout += data.toString();
       });
 
-      child.stderr?.on('data', (data) => {
+      child.stderr?.on('data', (data: Buffer | string) => {
         stderr += data.toString();
       });
 

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -17,6 +17,7 @@ export interface TerminalRunOptions {
   cwd?: string;
   timeoutMs?: number;
   terminalName?: string;
+  signal?: AbortSignal;
 }
 
 export class IntegratedTerminalRunner {
@@ -30,16 +31,16 @@ export class IntegratedTerminalRunner {
     const workingDirectory = options.cwd ? this.workspace.resolvePath(options.cwd) : this.workspace.root;
     const terminalName = options.terminalName ?? 'OpenHands Agent';
     if (this.vscodeApi) {
-      return this.runWithPseudoterminal(command, workingDirectory, terminalName, options.timeoutMs);
+      return this.runWithPseudoterminal(command, workingDirectory, terminalName, options);
     }
-    return this.spawnDirect(command, workingDirectory, options.timeoutMs);
+    return this.spawnDirect(command, workingDirectory, options);
   }
 
   private async runWithPseudoterminal(
     command: string,
     cwd: string,
     terminalName: string,
-    timeoutMs?: number,
+    options: TerminalRunOptions,
   ): Promise<CommandResult> {
     const vscode = this.vscodeApi!;
     const writeEmitter = new vscode.EventEmitter<string>();
@@ -49,9 +50,15 @@ export class IntegratedTerminalRunner {
     let stderr = '';
     let exitCode = 0;
     let timedOut = false;
+    let aborted = false;
     let timeout: NodeJS.Timeout | undefined;
+    const timeoutMs = options.timeoutMs;
 
     let childProcess: ReturnType<typeof spawn> | null = null;
+    const abortHandler = () => {
+      aborted = true;
+      childProcess?.kill('SIGTERM');
+    };
 
     const pty: Pseudoterminal = {
       onDidWrite: writeEmitter.event,
@@ -70,6 +77,13 @@ export class IntegratedTerminalRunner {
           }, timeoutMs);
         }
 
+        if (options.signal) {
+          if (options.signal.aborted) {
+            abortHandler();
+          }
+          options.signal.addEventListener('abort', abortHandler);
+        }
+
         childProcess.stdout?.on('data', (data) => {
           const chunk = data.toString();
           stdout += chunk;
@@ -86,13 +100,20 @@ export class IntegratedTerminalRunner {
           if (timeout) {
             clearTimeout(timeout);
           }
-          exitCode = timedOut ? code ?? -1 : code ?? 0;
+          if (options.signal) {
+            options.signal.removeEventListener('abort', abortHandler);
+          }
+          const cancelled = timedOut || aborted;
+          exitCode = cancelled ? code ?? -1 : code ?? 0;
           closeEmitter.fire();
         });
       },
       close: () => {
         if (timeout) {
           clearTimeout(timeout);
+        }
+        if (options.signal) {
+          options.signal.removeEventListener('abort', abortHandler);
         }
         childProcess?.kill();
         closeEmitter.fire();
@@ -115,7 +136,7 @@ export class IntegratedTerminalRunner {
     });
   }
 
-  private spawnDirect(command: string, cwd: string, timeoutMs?: number): Promise<CommandResult> {
+  private spawnDirect(command: string, cwd: string, options: TerminalRunOptions): Promise<CommandResult> {
     return new Promise<CommandResult>((resolve) => {
       const child = spawn(command, {
         cwd,
@@ -126,12 +147,25 @@ export class IntegratedTerminalRunner {
       let stdout = '';
       let stderr = '';
       let timedOut = false;
-      const timeout = timeoutMs
+      let aborted = false;
+      const timeout = options.timeoutMs
         ? setTimeout(() => {
             timedOut = true;
             child.kill('SIGTERM');
-          }, timeoutMs)
+          }, options.timeoutMs)
         : null;
+
+      const abortHandler = () => {
+        aborted = true;
+        child.kill('SIGTERM');
+      };
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          abortHandler();
+        }
+        options.signal.addEventListener('abort', abortHandler);
+      }
 
       child.stdout?.on('data', (data) => {
         stdout += data.toString();
@@ -145,12 +179,15 @@ export class IntegratedTerminalRunner {
         if (timeout) {
           clearTimeout(timeout);
         }
+        if (options.signal) {
+          options.signal.removeEventListener('abort', abortHandler);
+        }
         resolve({
           command,
           cwd,
           stdout,
           stderr,
-          exitCode: timedOut ? code ?? -1 : code ?? 0,
+          exitCode: timedOut || aborted ? code ?? -1 : code ?? 0,
         });
       });
     });

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -1,0 +1,125 @@
+import { spawn } from 'child_process';
+import os from 'os';
+import type { Pseudoterminal } from 'vscode';
+import type { CommandResult } from '../workspace/LocalWorkspace';
+import type { LocalWorkspace } from '../workspace/LocalWorkspace';
+
+const loadVscode = (): typeof import('vscode') | null => {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+    return require('vscode') as typeof import('vscode');
+  } catch (err) {
+    return null;
+  }
+};
+
+export class IntegratedTerminalRunner {
+  private readonly vscodeApi: typeof import('vscode') | null;
+
+  constructor(private readonly workspace: LocalWorkspace, vscodeModule: typeof import('vscode') | null = loadVscode()) {
+    this.vscodeApi = vscodeModule;
+  }
+
+  async execute(command: string, cwd?: string, terminalName = 'OpenHands Agent'): Promise<CommandResult> {
+    const workingDirectory = cwd ? this.workspace.resolvePath(cwd) : this.workspace.root;
+    if (this.vscodeApi) {
+      return this.runWithPseudoterminal(command, workingDirectory, terminalName);
+    }
+    return this.spawnDirect(command, workingDirectory);
+  }
+
+  private async runWithPseudoterminal(
+    command: string,
+    cwd: string,
+    terminalName: string,
+  ): Promise<CommandResult> {
+    const vscode = this.vscodeApi!;
+    const writeEmitter = new vscode.EventEmitter<string>();
+    const closeEmitter = new vscode.EventEmitter<void>();
+
+    let stdout = '';
+    let stderr = '';
+    let exitCode = 0;
+
+    let childProcess: ReturnType<typeof spawn> | null = null;
+
+    const pty: Pseudoterminal = {
+      onDidWrite: writeEmitter.event,
+      onDidClose: closeEmitter.event,
+      open: () => {
+        childProcess = spawn(command, {
+          cwd,
+          env: process.env,
+          shell: os.platform() === 'win32' ? undefined : '/bin/bash',
+        });
+
+        childProcess.stdout?.on('data', (data) => {
+          const chunk = data.toString();
+          stdout += chunk;
+          writeEmitter.fire(chunk);
+        });
+
+        childProcess.stderr?.on('data', (data) => {
+          const chunk = data.toString();
+          stderr += chunk;
+          writeEmitter.fire(chunk);
+        });
+
+        childProcess.on('close', (code) => {
+          exitCode = code ?? 0;
+          closeEmitter.fire();
+        });
+      },
+      close: () => {
+        childProcess?.kill();
+        closeEmitter.fire();
+      },
+    };
+
+    const terminal = vscode.window.createTerminal({ name: terminalName, pty });
+    terminal.show(true);
+
+    return new Promise<CommandResult>((resolve) => {
+      closeEmitter.event(() => {
+        resolve({
+          command,
+          cwd,
+          stdout,
+          stderr,
+          exitCode,
+        });
+      });
+    });
+  }
+
+  private spawnDirect(command: string, cwd: string): Promise<CommandResult> {
+    return new Promise<CommandResult>((resolve) => {
+      const child = spawn(command, {
+        cwd,
+        env: process.env,
+        shell: os.platform() === 'win32' ? undefined : '/bin/bash',
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout?.on('data', (data) => {
+        stdout += data.toString();
+      });
+
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code) => {
+        resolve({
+          command,
+          cwd,
+          stdout,
+          stderr,
+          exitCode: code ?? 0,
+        });
+      });
+    });
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -13,6 +13,12 @@ const loadVscode = (): typeof import('vscode') | null => {
   }
 };
 
+export interface TerminalRunOptions {
+  cwd?: string;
+  timeoutMs?: number;
+  terminalName?: string;
+}
+
 export class IntegratedTerminalRunner {
   private readonly vscodeApi: typeof import('vscode') | null;
 
@@ -20,18 +26,20 @@ export class IntegratedTerminalRunner {
     this.vscodeApi = vscodeModule;
   }
 
-  async execute(command: string, cwd?: string, terminalName = 'OpenHands Agent'): Promise<CommandResult> {
-    const workingDirectory = cwd ? this.workspace.resolvePath(cwd) : this.workspace.root;
+  async execute(command: string, options: TerminalRunOptions = {}): Promise<CommandResult> {
+    const workingDirectory = options.cwd ? this.workspace.resolvePath(options.cwd) : this.workspace.root;
+    const terminalName = options.terminalName ?? 'OpenHands Agent';
     if (this.vscodeApi) {
-      return this.runWithPseudoterminal(command, workingDirectory, terminalName);
+      return this.runWithPseudoterminal(command, workingDirectory, terminalName, options.timeoutMs);
     }
-    return this.spawnDirect(command, workingDirectory);
+    return this.spawnDirect(command, workingDirectory, options.timeoutMs);
   }
 
   private async runWithPseudoterminal(
     command: string,
     cwd: string,
     terminalName: string,
+    timeoutMs?: number,
   ): Promise<CommandResult> {
     const vscode = this.vscodeApi!;
     const writeEmitter = new vscode.EventEmitter<string>();
@@ -40,6 +48,8 @@ export class IntegratedTerminalRunner {
     let stdout = '';
     let stderr = '';
     let exitCode = 0;
+    let timedOut = false;
+    let timeout: NodeJS.Timeout | undefined;
 
     let childProcess: ReturnType<typeof spawn> | null = null;
 
@@ -52,6 +62,13 @@ export class IntegratedTerminalRunner {
           env: process.env,
           shell: os.platform() === 'win32' ? undefined : '/bin/bash',
         });
+
+        if (timeoutMs && timeoutMs > 0) {
+          timeout = setTimeout(() => {
+            timedOut = true;
+            childProcess?.kill('SIGTERM');
+          }, timeoutMs);
+        }
 
         childProcess.stdout?.on('data', (data) => {
           const chunk = data.toString();
@@ -66,11 +83,17 @@ export class IntegratedTerminalRunner {
         });
 
         childProcess.on('close', (code) => {
-          exitCode = code ?? 0;
+          if (timeout) {
+            clearTimeout(timeout);
+          }
+          exitCode = timedOut ? code ?? -1 : code ?? 0;
           closeEmitter.fire();
         });
       },
       close: () => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
         childProcess?.kill();
         closeEmitter.fire();
       },
@@ -92,7 +115,7 @@ export class IntegratedTerminalRunner {
     });
   }
 
-  private spawnDirect(command: string, cwd: string): Promise<CommandResult> {
+  private spawnDirect(command: string, cwd: string, timeoutMs?: number): Promise<CommandResult> {
     return new Promise<CommandResult>((resolve) => {
       const child = spawn(command, {
         cwd,
@@ -102,6 +125,13 @@ export class IntegratedTerminalRunner {
 
       let stdout = '';
       let stderr = '';
+      let timedOut = false;
+      const timeout = timeoutMs
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill('SIGTERM');
+          }, timeoutMs)
+        : null;
 
       child.stdout?.on('data', (data) => {
         stdout += data.toString();
@@ -112,12 +142,15 @@ export class IntegratedTerminalRunner {
       });
 
       child.on('close', (code) => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
         resolve({
           command,
           cwd,
           stdout,
           stderr,
-          exitCode: code ?? 0,
+          exitCode: timedOut ? code ?? -1 : code ?? 0,
         });
       });
     });

--- a/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
@@ -50,7 +50,11 @@ export class TaskTrackerTool implements ToolHandler<TaskTrackerArgs, TaskTracker
         break;
       case 'update':
         if (!args.id) throw new Error('id is required to update a task');
-        this.updateTask(args.id, { title: args.title, notes: args.notes, completed: args.completed });
+        this.updateTask(args.id, {
+          ...(args.title !== undefined ? { title: args.title } : {}),
+          ...(args.notes !== undefined ? { notes: args.notes } : {}),
+          ...(args.completed !== undefined ? { completed: args.completed } : {}),
+        });
         break;
       case 'list':
       default:

--- a/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'crypto';
+import type { ToolContext, ToolHandler } from './types';
+import { requireBoolean, requireObject, requireString, optionalString } from './validation';
+
+interface TaskRecord {
+  id: string;
+  title: string;
+  completed: boolean;
+  notes?: string;
+}
+
+export interface TaskTrackerArgs {
+  action: 'create' | 'complete' | 'list' | 'update';
+  id?: string;
+  title?: string;
+  notes?: string;
+  completed?: boolean;
+}
+
+export interface TaskTrackerResult {
+  tasks: TaskRecord[];
+}
+
+export class TaskTrackerTool implements ToolHandler<TaskTrackerArgs, TaskTrackerResult> {
+  readonly name = 'task_tracker';
+  private readonly tasks: Map<string, TaskRecord> = new Map();
+
+  validate(input: unknown): TaskTrackerArgs {
+    const obj = requireObject(input, 'task tracker args');
+    const action = requireString(obj.action, 'action');
+    if (!['create', 'complete', 'list', 'update'].includes(action)) {
+      throw new Error('Unsupported task tracker action');
+    }
+
+    const id = optionalString(obj.id, 'id');
+    const title = optionalString(obj.title, 'title');
+    const notes = optionalString(obj.notes, 'notes');
+    const completed = obj.completed === undefined ? undefined : requireBoolean(obj.completed, 'completed');
+    return { action: action as TaskTrackerArgs['action'], id, title, notes, completed };
+  }
+
+  async execute(args: TaskTrackerArgs, _context: ToolContext): Promise<TaskTrackerResult> {
+    switch (args.action) {
+      case 'create':
+        this.createTask(args.title ?? 'Untitled task', args.notes);
+        break;
+      case 'complete':
+        if (!args.id) throw new Error('id is required to complete a task');
+        this.updateTask(args.id, { completed: true });
+        break;
+      case 'update':
+        if (!args.id) throw new Error('id is required to update a task');
+        this.updateTask(args.id, { title: args.title, notes: args.notes, completed: args.completed });
+        break;
+      case 'list':
+      default:
+        break;
+    }
+
+    return { tasks: Array.from(this.tasks.values()) };
+  }
+
+  private createTask(title: string, notes?: string): TaskRecord {
+    const task: TaskRecord = { id: randomUUID(), title, completed: false, notes };
+    this.tasks.set(task.id, task);
+    return task;
+  }
+
+  private updateTask(id: string, updates: Partial<TaskRecord>): void {
+    const existing = this.tasks.get(id);
+    if (!existing) {
+      throw new Error('Task not found');
+    }
+    const updated: TaskRecord = { ...existing, ...updates };
+    this.tasks.set(id, updated);
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
@@ -39,7 +39,7 @@ export class TaskTrackerTool implements ToolHandler<TaskTrackerArgs, TaskTracker
     return { action: action as TaskTrackerArgs['action'], id, title, notes, completed };
   }
 
-  async execute(args: TaskTrackerArgs, _context: ToolContext): Promise<TaskTrackerResult> {
+  execute(args: TaskTrackerArgs, _context: ToolContext): Promise<TaskTrackerResult> {
     switch (args.action) {
       case 'create':
         this.createTask(args.title ?? 'Untitled task', args.notes);
@@ -61,7 +61,7 @@ export class TaskTrackerTool implements ToolHandler<TaskTrackerArgs, TaskTracker
         break;
     }
 
-    return { tasks: Array.from(this.tasks.values()) };
+    return Promise.resolve({ tasks: Array.from(this.tasks.values()) });
   }
 
   private createTask(title: string, notes?: string): TaskRecord {

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -27,11 +27,25 @@ export class TerminalTool implements ToolHandler<TerminalArgs, TerminalResult> {
 
   async execute(args: TerminalArgs, context: ToolContext): Promise<TerminalResult> {
     const runner = new IntegratedTerminalRunner(context.workspace);
-    const result = await runner.execute(args.command, { cwd: args.cwd, timeoutMs: args.timeoutMs });
-    return {
-      stdout: result.stdout,
-      stderr: result.stderr,
-      exitCode: result.exitCode,
-    };
+    let timeout: NodeJS.Timeout | undefined;
+    let controller: AbortController | undefined;
+
+    if (args.timeoutMs && args.timeoutMs > 0) {
+      controller = new AbortController();
+      timeout = setTimeout(() => controller?.abort(new Error('Command timed out')), args.timeoutMs);
+    }
+
+    try {
+      const result = await runner.execute(args.command, { cwd: args.cwd, signal: controller?.signal });
+      return {
+        stdout: result.stdout,
+        stderr: controller?.signal.aborted ? result.stderr || 'Command timed out' : result.stderr,
+        exitCode: controller?.signal.aborted ? result.exitCode || -1 : result.exitCode,
+      };
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 }

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -1,0 +1,40 @@
+import { IntegratedTerminalRunner } from './IntegratedTerminalRunner';
+import type { ToolContext, ToolHandler } from './types';
+import { requireObject, requireString, optionalString, optionalNumber } from './validation';
+
+export interface TerminalArgs {
+  command: string;
+  cwd?: string;
+  timeoutMs?: number;
+}
+
+export interface TerminalResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export class TerminalTool implements ToolHandler<TerminalArgs, TerminalResult> {
+  readonly name = 'terminal';
+
+  validate(input: unknown): TerminalArgs {
+    const obj = requireObject(input, 'terminal args');
+    const command = requireString(obj.command, 'command');
+    const cwd = optionalString(obj.cwd, 'cwd');
+    const timeoutMs = optionalNumber(obj.timeoutMs, 'timeoutMs');
+    return { command, cwd, timeoutMs };
+  }
+
+  async execute(args: TerminalArgs, context: ToolContext): Promise<TerminalResult> {
+    const runner = new IntegratedTerminalRunner(context.workspace);
+    const result = await runner.execute(args.command, args.cwd);
+    if (typeof args.timeoutMs === 'number' && args.timeoutMs > 0 && result.exitCode === 0) {
+      // Simple guard to mimic timeout enforcement; runner already cancels via signal when configured
+    }
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    };
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -27,7 +27,7 @@ export class TerminalTool implements ToolHandler<TerminalArgs, TerminalResult> {
 
   async execute(args: TerminalArgs, context: ToolContext): Promise<TerminalResult> {
     const runner = new IntegratedTerminalRunner(context.workspace);
-    let timeout: NodeJS.Timeout | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     let controller: AbortController | undefined;
 
     if (args.timeoutMs && args.timeoutMs > 0) {

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -27,10 +27,7 @@ export class TerminalTool implements ToolHandler<TerminalArgs, TerminalResult> {
 
   async execute(args: TerminalArgs, context: ToolContext): Promise<TerminalResult> {
     const runner = new IntegratedTerminalRunner(context.workspace);
-    const result = await runner.execute(args.command, args.cwd);
-    if (typeof args.timeoutMs === 'number' && args.timeoutMs > 0 && result.exitCode === 0) {
-      // Simple guard to mimic timeout enforcement; runner already cancels via signal when configured
-    }
+    const result = await runner.execute(args.command, { cwd: args.cwd, timeoutMs: args.timeoutMs });
     return {
       stdout: result.stdout,
       stderr: result.stderr,

--- a/packages/agent-sdk-ts/src/tools/index.ts
+++ b/packages/agent-sdk-ts/src/tools/index.ts
@@ -1,0 +1,7 @@
+export * from './IntegratedTerminalRunner';
+export * from './TerminalTool';
+export * from './FileEditorTool';
+export * from './TaskTrackerTool';
+export * from './BrowserTool';
+export * from './types';
+export * from './validation';

--- a/packages/agent-sdk-ts/src/tools/types.ts
+++ b/packages/agent-sdk-ts/src/tools/types.ts
@@ -1,0 +1,15 @@
+import type { EventLog } from '../runtime/EventLog';
+import type { LocalWorkspace } from '../workspace/LocalWorkspace';
+import type { SecretRegistry } from '../runtime/SecretRegistry';
+
+export interface ToolContext {
+  workspace: LocalWorkspace;
+  events?: EventLog;
+  secrets?: SecretRegistry;
+}
+
+export interface ToolHandler<TArgs, TResult> {
+  name: string;
+  validate(input: unknown): TArgs;
+  execute(args: TArgs, context: ToolContext): Promise<TResult>;
+}

--- a/packages/agent-sdk-ts/src/tools/validation.ts
+++ b/packages/agent-sdk-ts/src/tools/validation.ts
@@ -1,0 +1,33 @@
+export const requireObject = (value: unknown, name: string): Record<string, unknown> => {
+  if (!value || typeof value !== 'object') {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+};
+
+export const requireString = (value: unknown, name: string): string => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+};
+
+export const optionalString = (value: unknown, name: string): string | undefined => {
+  if (value === undefined) return undefined;
+  return requireString(value, name);
+};
+
+export const requireBoolean = (value: unknown, name: string): boolean => {
+  if (typeof value !== 'boolean') {
+    throw new Error(`${name} must be a boolean`);
+  }
+  return value;
+};
+
+export const optionalNumber = (value: unknown, name: string): number | undefined => {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    throw new Error(`${name} must be a number`);
+  }
+  return value;
+};

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -2,15 +2,12 @@ import { spawn } from 'child_process';
 import type { SpawnOptions } from 'child_process';
 import * as fs from 'fs';
 import { readFile as readFileAsync, mkdir, writeFile as writeFileAsync, rm, readdir } from 'node:fs/promises';
-import type { Buffer } from 'node:buffer';
-import type { BufferEncoding } from 'node:buffer';
-import type { ProcessEnv } from 'node:process';
 import path from 'path';
 import os from 'os';
 
 export interface CommandOptions {
   cwd?: string;
-  env?: ProcessEnv;
+  env?: NodeJS.ProcessEnv;
   timeoutMs?: number;
   shell?: string;
 }
@@ -107,15 +104,15 @@ export class LocalWorkspace {
 
   async runCommand(command: string, options: CommandOptions = {}): Promise<CommandResult> {
     const cwd = options.cwd ? this.resolvePath(options.cwd) : this.root;
-      return new Promise<CommandResult>((resolve) => {
+    return new Promise<CommandResult>((resolve) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const env: NodeJS.ProcessEnv = { ...process.env, ...(options.env ?? {}) };
+      const spawnOptions: SpawnOptions = {
+        cwd,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const env: ProcessEnv = { ...process.env, ...(options.env ?? {}) };
-        const spawnOptions: SpawnOptions = {
-          cwd,
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-          env,
-          shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
-        };
+        env,
+        shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
+      };
       const child = spawn(command, spawnOptions);
 
       let stdout = '';

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -1,11 +1,16 @@
 import { spawn } from 'child_process';
-import fs from 'fs';
+import type { SpawnOptions } from 'child_process';
+import * as fs from 'fs';
+import { readFile as readFileAsync, mkdir, writeFile as writeFileAsync, rm, readdir } from 'node:fs/promises';
+import type { Buffer } from 'node:buffer';
+import type { BufferEncoding } from 'node:buffer';
+import type { ProcessEnv } from 'node:process';
 import path from 'path';
 import os from 'os';
 
 export interface CommandOptions {
   cwd?: string;
-  env?: NodeJS.ProcessEnv;
+  env?: ProcessEnv;
   timeoutMs?: number;
   shell?: string;
 }
@@ -42,13 +47,13 @@ export class LocalWorkspace {
 
   private static getVsCodeWorkspaceRoot(): string | null {
     try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       const vscode = require('vscode') as typeof import('vscode');
       const folder = vscode.workspace?.workspaceFolders?.[0];
       if (folder?.uri?.scheme === 'file') {
         return folder.uri.fsPath;
       }
-    } catch (err) {
+    } catch {
       return null;
     }
     return null;
@@ -68,23 +73,25 @@ export class LocalWorkspace {
 
   async readFile(targetPath: string, encoding: BufferEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
-    return fs.promises.readFile(resolved, { encoding });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const readOptions: { encoding: BufferEncoding } = { encoding };
+    return readFileAsync(resolved, readOptions);
   }
 
   async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
     const resolved = this.resolvePath(targetPath);
-    await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
-    await fs.promises.writeFile(resolved, content);
+    await mkdir(path.dirname(resolved), { recursive: true });
+    await writeFileAsync(resolved, content);
   }
 
   async remove(targetPath: string): Promise<void> {
     const resolved = this.resolvePath(targetPath);
-    await fs.promises.rm(resolved, { force: true, recursive: true });
+    await rm(resolved, { force: true, recursive: true });
   }
 
   async list(targetPath = '.'): Promise<DirectoryEntry[]> {
     const resolved = this.resolvePath(targetPath);
-    const entries = await fs.promises.readdir(resolved, { withFileTypes: true });
+    const entries = await readdir(resolved, { withFileTypes: true });
     return entries.map((entry) => ({
       name: entry.name,
       path: path.join(targetPath, entry.name),
@@ -94,18 +101,22 @@ export class LocalWorkspace {
 
   async ensureDirectory(targetPath: string): Promise<string> {
     const resolved = this.resolvePath(targetPath);
-    await fs.promises.mkdir(resolved, { recursive: true });
+    await mkdir(resolved, { recursive: true });
     return resolved;
   }
 
   async runCommand(command: string, options: CommandOptions = {}): Promise<CommandResult> {
     const cwd = options.cwd ? this.resolvePath(options.cwd) : this.root;
-    return new Promise<CommandResult>((resolve) => {
-      const child = spawn(command, {
-        cwd,
-        env: { ...process.env, ...options.env },
-        shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
-      });
+      return new Promise<CommandResult>((resolve) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const env: ProcessEnv = { ...process.env, ...(options.env ?? {}) };
+        const spawnOptions: SpawnOptions = {
+          cwd,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          env,
+          shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
+        };
+      const child = spawn(command, spawnOptions);
 
       let stdout = '';
       let stderr = '';
@@ -115,10 +126,10 @@ export class LocalWorkspace {
           }, options.timeoutMs)
         : null;
 
-      child.stdout?.on('data', (data) => {
+      child.stdout?.on('data', (data: Buffer | string) => {
         stdout += data.toString();
       });
-      child.stderr?.on('data', (data) => {
+      child.stderr?.on('data', (data: Buffer | string) => {
         stderr += data.toString();
       });
 

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -145,7 +145,7 @@ export class LocalWorkspace {
     const sanitizedPaths = paths?.map((p) => this.resolvePath(p));
     const relativePaths = sanitizedPaths?.map((p) => path.relative(this.root, p));
     const command = relativePaths?.length
-      ? `git diff HEAD -- ${relativePaths.map((p) => `'${p}'`).join(' ')}`
+      ? `git diff HEAD -- ${relativePaths.map((p) => JSON.stringify(p)).join(' ')}`
       : 'git diff HEAD';
     return this.runCommand(command, { cwd: this.root });
   }

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -5,9 +5,23 @@ import { readFile as readFileAsync, mkdir, writeFile as writeFileAsync, rm, read
 import path from 'path';
 import os from 'os';
 
+type WorkspaceEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf-8'
+  | 'utf16le'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+type EnvVars = Record<string, string | undefined>;
+
 export interface CommandOptions {
   cwd?: string;
-  env?: NodeJS.ProcessEnv;
+  env?: EnvVars;
   timeoutMs?: number;
   shell?: string;
 }
@@ -68,11 +82,9 @@ export class LocalWorkspace {
     throw new Error(`Path escapes workspace root: ${targetPath}`);
   }
 
-  async readFile(targetPath: string, encoding: BufferEncoding = 'utf8'): Promise<string> {
+  async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const readOptions: { encoding: BufferEncoding } = { encoding };
-    return readFileAsync(resolved, readOptions);
+    return readFileAsync(resolved, encoding);
   }
 
   async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
@@ -105,11 +117,16 @@ export class LocalWorkspace {
   async runCommand(command: string, options: CommandOptions = {}): Promise<CommandResult> {
     const cwd = options.cwd ? this.resolvePath(options.cwd) : this.root;
     return new Promise<CommandResult>((resolve) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-      const env: NodeJS.ProcessEnv = { ...process.env, ...(options.env ?? {}) };
+      const env: EnvVars = { ...process.env };
+      if (options.env) {
+        for (const [key, value] of Object.entries(options.env)) {
+          if (typeof value === 'string' || value === undefined) {
+            env[key] = value;
+          }
+        }
+      }
       const spawnOptions: SpawnOptions = {
         cwd,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         env,
         shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
       };

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -1,0 +1,154 @@
+import { spawn } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+export interface CommandOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+  shell?: string;
+}
+
+export interface CommandResult {
+  command: string;
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface DirectoryEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}
+
+export class LocalWorkspace {
+  readonly root: string;
+
+  constructor(root?: string) {
+    const detectedRoot = root ?? LocalWorkspace.getDefaultRoot();
+    this.root = fs.realpathSync(detectedRoot);
+  }
+
+  static getDefaultRoot(): string {
+    const vscodeRoot = LocalWorkspace.getVsCodeWorkspaceRoot();
+    if (vscodeRoot) {
+      return vscodeRoot;
+    }
+    return process.cwd();
+  }
+
+  private static getVsCodeWorkspaceRoot(): string | null {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-unsafe-assignment
+      const vscode = require('vscode') as typeof import('vscode');
+      const folder = vscode.workspace?.workspaceFolders?.[0];
+      if (folder?.uri?.scheme === 'file') {
+        return folder.uri.fsPath;
+      }
+    } catch (err) {
+      return null;
+    }
+    return null;
+  }
+
+  resolvePath(targetPath: string): string {
+    const candidate = path.isAbsolute(targetPath)
+      ? path.resolve(targetPath)
+      : path.resolve(this.root, targetPath);
+    const normalized = fs.existsSync(candidate) ? fs.realpathSync(candidate) : candidate;
+    const relative = path.relative(this.root, normalized);
+    if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+      return normalized;
+    }
+    throw new Error(`Path escapes workspace root: ${targetPath}`);
+  }
+
+  async readFile(targetPath: string, encoding: BufferEncoding = 'utf8'): Promise<string> {
+    const resolved = this.resolvePath(targetPath);
+    return fs.promises.readFile(resolved, { encoding });
+  }
+
+  async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
+    const resolved = this.resolvePath(targetPath);
+    await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.promises.writeFile(resolved, content);
+  }
+
+  async remove(targetPath: string): Promise<void> {
+    const resolved = this.resolvePath(targetPath);
+    await fs.promises.rm(resolved, { force: true, recursive: true });
+  }
+
+  async list(targetPath = '.'): Promise<DirectoryEntry[]> {
+    const resolved = this.resolvePath(targetPath);
+    const entries = await fs.promises.readdir(resolved, { withFileTypes: true });
+    return entries.map((entry) => ({
+      name: entry.name,
+      path: path.join(targetPath, entry.name),
+      isDirectory: entry.isDirectory(),
+    }));
+  }
+
+  async ensureDirectory(targetPath: string): Promise<string> {
+    const resolved = this.resolvePath(targetPath);
+    await fs.promises.mkdir(resolved, { recursive: true });
+    return resolved;
+  }
+
+  async runCommand(command: string, options: CommandOptions = {}): Promise<CommandResult> {
+    const cwd = options.cwd ? this.resolvePath(options.cwd) : this.root;
+    return new Promise<CommandResult>((resolve) => {
+      const child = spawn(command, {
+        cwd,
+        env: { ...process.env, ...options.env },
+        shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
+      });
+
+      let stdout = '';
+      let stderr = '';
+      const timeout = options.timeoutMs
+        ? setTimeout(() => {
+            child.kill('SIGTERM');
+          }, options.timeoutMs)
+        : null;
+
+      child.stdout?.on('data', (data) => {
+        stdout += data.toString();
+      });
+      child.stderr?.on('data', (data) => {
+        stderr += data.toString();
+      });
+
+      child.on('close', (code) => {
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        resolve({
+          command,
+          cwd,
+          stdout,
+          stderr,
+          exitCode: code ?? -1,
+        });
+      });
+    });
+  }
+
+  async gitStatus(): Promise<CommandResult> {
+    return this.runCommand('git status --porcelain', { cwd: this.root });
+  }
+
+  async gitDiff(paths?: string[]): Promise<CommandResult> {
+    const sanitizedPaths = paths?.map((p) => this.resolvePath(p));
+    const relativePaths = sanitizedPaths?.map((p) => path.relative(this.root, p));
+    const command = relativePaths?.length
+      ? `git diff HEAD -- ${relativePaths.map((p) => `'${p}'`).join(' ')}`
+      : 'git diff HEAD';
+    return this.runCommand(command, { cwd: this.root });
+  }
+}
+
+export default LocalWorkspace;

--- a/packages/agent-sdk-ts/src/workspace/index.ts
+++ b/packages/agent-sdk-ts/src/workspace/index.ts
@@ -1,0 +1,1 @@
+export * from './LocalWorkspace';

--- a/packages/agent-sdk-ts/tsup.config.ts
+++ b/packages/agent-sdk-ts/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/browser.ts'],
   format: ['esm', 'cjs'],
   dts: false,
   sourcemap: true,


### PR DESCRIPTION
## Summary
- add a LocalWorkspace sandbox with command execution and git helpers aligned to VS Code roots
- implement VS Code oriented terminal, file editor, browser, and task tracker tools with validation and guards
- add local orchestration utilities (conversation state, event log, secrets, locks, stuck detection) plus matching tests

## Testing
- npm test -w @openhands/agent-sdk-ts
- npm run build -w @openhands/agent-sdk-ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a93e19d948320acf99e35b0c50440)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime utilities: event log, observable conversation state, async lock, secret registry, and stuck-state detection.
  * Workspace: local filesystem ops, secure path resolution, command execution, and Git helpers.
  * Tools: integrated terminal runner, terminal tool, file editor, task tracker, browser fetcher, and validation helpers.
  * Consolidated exports for runtime, tools, and workspace APIs.

* **Tests**
  * Added unit tests covering workspace, runtime, and tools.

* **Chores**
  * Added VS Code type definitions as a dev dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->