### PR TITLE
Add streaming LLM client layer to agent SDK

### DIFF
--- a/packages/agent-sdk-ts/src/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/llm.orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { AgentOrchestrator } from '../runtime';
-import { OpenAICompatibleClient, LLMFactory } from '../llm';
+import { OpenAICompatibleClient, LLMFactory, LLMCredentialProvider } from '../llm';
 import type { ChatCompletionRequest, LLMConfiguration } from '../llm';
 import { ConversationState, EventLog } from '../runtime';
 
@@ -78,6 +78,16 @@ describe('OpenAICompatibleClient streaming', () => {
 });
 
 describe('LLMFactory integration', () => {
+  it('uses inline apiKey without registry lookup', async () => {
+    const spy = vi.spyOn(LLMCredentialProvider.prototype, 'getApiKey');
+    const factory = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', apiKey: 'sk-inline' });
+
+    const client = await factory.createClient();
+
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
   const maybeIt = process.env.OPENAI_API_KEY ? it : it.skip;
 
   maybeIt('streams from OpenAI with real credentials', async () => {

--- a/packages/agent-sdk-ts/src/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/llm.orchestrator.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { AgentOrchestrator } from '../runtime';
+import { OpenAICompatibleClient, LLMFactory } from '../llm';
+import type { ChatCompletionRequest, LLMConfiguration } from '../llm';
+import { ConversationState, EventLog } from '../runtime';
+
+const encoder = new TextEncoder();
+
+const createStreamResponse = (payload: string, status = 200): Response =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(payload));
+        controller.close();
+      },
+    }),
+    { status, headers: { 'content-type': 'text/event-stream' } },
+  );
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OpenAICompatibleClient streaming', () => {
+  const baseConfig: LLMConfiguration = { model: 'gpt-4o-mini', provider: 'openai', nativeToolCalling: true };
+
+  const buildRequest = (): ChatCompletionRequest => ({
+    systemPrompt: 'you are a test harness',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+    tools: [{ type: 'function', function: { name: 'ping' } }],
+  });
+
+  it('streams text, tool calls, and updates state', async () => {
+    const sse = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Hello"}]}}]}',
+      'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1","function":{"name":"ping","arguments":"{\\"ok\\":tru"}}]}}]}',
+      'data: {"choices":[{"delta":{"tool_calls":[{"id":"call_1","function":{"arguments":"e}"}}]}},"usage":{"prompt_tokens":5,"completion_tokens":2}}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+    const state = new ConversationState(new EventLog());
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key');
+    const orchestrator = new AgentOrchestrator(client, { state });
+
+    const response = await orchestrator.runChat(buildRequest());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(response.message.content[0]).toEqual({ type: 'text', text: 'Hello' });
+    expect(response.message.tool_calls?.[0].function.arguments).toContain('ok');
+    expect(state.snapshot.values.llm_stream).toBe('Hello');
+    expect(state.snapshot.values.llm_tool_call).toBe('call_1');
+  });
+
+  it('retries on server errors', async () => {
+    const stream = 'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Hi"}]},"finish_reason":"stop"}]}' + '\n' + 'data: [DONE]';
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(createStreamResponse('failed', 500))
+      .mockResolvedValueOnce(createStreamResponse(stream));
+
+    const client = new OpenAICompatibleClient({ ...baseConfig, timeoutSeconds: 1 }, 'retry-key');
+    const orchestrator = new AgentOrchestrator(client);
+    const response = await orchestrator.runChat(buildRequest());
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(response.message.content[0].type).toBe('text');
+  });
+
+  it('propagates failure after retries', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse('error', 500));
+    const client = new OpenAICompatibleClient(baseConfig, 'bad-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    await expect(orchestrator.runChat(buildRequest())).rejects.toThrow(/LLM request failed/);
+  });
+});
+
+describe('LLMFactory integration', () => {
+  const maybeIt = process.env.OPENAI_API_KEY ? it : it.skip;
+
+  maybeIt('streams from OpenAI with real credentials', async () => {
+    const factory = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', maxOutputTokens: 8 });
+    const client = await factory.createClient();
+    const orchestrator = new AgentOrchestrator(client);
+
+    const result = await orchestrator.runChat({
+      systemPrompt: 'You are a concise bot',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'Say hello in one short sentence.' }] }],
+    });
+
+    expect(result.message.content[0].type).toBe('text');
+    expect(result.message.content[0].text.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agent-sdk-ts/src/index.ts
+++ b/packages/agent-sdk-ts/src/index.ts
@@ -2,3 +2,4 @@ export * from './types';
 export * from './workspace';
 export * from './tools';
 export * from './runtime';
+export * from './llm';

--- a/packages/agent-sdk-ts/src/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/llm/anthropic.ts
@@ -9,6 +9,36 @@ interface AnthropicMessage {
   name?: string;
 }
 
+type AnthropicEventName = 'message_start' | 'content_block_delta' | 'message_delta' | (string & {});
+
+interface AnthropicMessageStartEvent {
+  message?: {
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      cache_creation_input_tokens?: number;
+      cache_read_input_tokens?: number;
+    };
+  };
+}
+
+interface AnthropicContentDeltaEvent {
+  delta?: { type?: string; text?: string };
+}
+
+interface AnthropicMessageDeltaEvent {
+  delta?: { stop_reason?: string };
+}
+
+const isMessageStartEvent = (data: unknown): data is AnthropicMessageStartEvent =>
+  typeof data === 'object' && data !== null && 'message' in data;
+
+const isContentDeltaEvent = (data: unknown): data is AnthropicContentDeltaEvent =>
+  typeof data === 'object' && data !== null && 'delta' in data;
+
+const isMessageDeltaEvent = (data: unknown): data is AnthropicMessageDeltaEvent =>
+  typeof data === 'object' && data !== null && 'delta' in data;
+
 const toAnthropicMessages = (request: ChatCompletionRequest): AnthropicMessage[] =>
   request.messages
     .filter((message) => message.role === 'user' || message.role === 'assistant')
@@ -18,7 +48,7 @@ const toAnthropicMessages = (request: ChatCompletionRequest): AnthropicMessage[]
       name: message.name,
     }));
 
-const parseAnthropicStream = async function* (response: Response): AsyncGenerator<{ event?: string; data?: any }> {
+const parseAnthropicStream = async function* (response: Response): AsyncGenerator<{ event?: AnthropicEventName; data?: unknown }> {
   const reader = response.body?.getReader();
   if (!reader) return;
 
@@ -67,7 +97,7 @@ export class AnthropicClient implements LLMClient {
       if (!data) continue;
       switch (event) {
         case 'message_start':
-          if (data.message?.usage) {
+          if (isMessageStartEvent(data) && data.message?.usage) {
             yield {
               type: 'usage',
               inputTokens: data.message.usage.input_tokens,
@@ -78,12 +108,12 @@ export class AnthropicClient implements LLMClient {
           }
           break;
         case 'content_block_delta':
-          if (data.delta?.type === 'text_delta' && data.delta.text) {
+          if (isContentDeltaEvent(data) && data.delta?.type === 'text_delta' && data.delta.text) {
             yield { type: 'text', text: data.delta.text };
           }
           break;
         case 'message_delta':
-          if (data.delta?.stop_reason) {
+          if (isMessageDeltaEvent(data) && data.delta?.stop_reason) {
             yield { type: 'finish', finishReason: data.delta.stop_reason };
           }
           break;

--- a/packages/agent-sdk-ts/src/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/llm/anthropic.ts
@@ -1,0 +1,166 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions } from './types';
+
+const decoder = new TextDecoder();
+
+interface AnthropicMessage {
+  role: 'user' | 'assistant';
+  content: Array<{ type: 'text'; text: string }>;
+  name?: string;
+}
+
+const toAnthropicMessages = (request: ChatCompletionRequest): AnthropicMessage[] =>
+  request.messages
+    .filter((message) => message.role === 'user' || message.role === 'assistant')
+    .map((message) => ({
+      role: message.role as AnthropicMessage['role'],
+      content: [{ type: 'text', text: reduceTextContent(message) }],
+      name: message.name,
+    }));
+
+const parseAnthropicStream = async function* (response: Response): AsyncGenerator<{ event?: string; data?: any }> {
+  const reader = response.body?.getReader();
+  if (!reader) return;
+
+  let buffer = '';
+  let currentEvent: string | undefined;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex = buffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (line.startsWith('event:')) {
+        currentEvent = line.slice(6).trim();
+      }
+      if (line.startsWith('data:')) {
+        const payload = line.slice(5).trim();
+        if (payload) {
+          try {
+            yield { event: currentEvent, data: JSON.parse(payload) };
+          } catch {
+            yield { event: currentEvent };
+          }
+        }
+      }
+      newlineIndex = buffer.indexOf('\n');
+    }
+  }
+};
+
+export class AnthropicClient implements LLMClient {
+  private readonly config: LLMConfiguration;
+  private readonly apiKey: string;
+  private readonly retry: RetryOptions;
+
+  constructor(config: LLMConfiguration, apiKey: string, retry: RetryOptions = DEFAULT_RETRY_OPTIONS) {
+    this.config = config;
+    this.apiKey = apiKey;
+    this.retry = retry;
+  }
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    const response = await this.fetchWithRetry(request);
+    for await (const { event, data } of parseAnthropicStream(response)) {
+      if (!data) continue;
+      switch (event) {
+        case 'message_start':
+          if (data.message?.usage) {
+            yield {
+              type: 'usage',
+              inputTokens: data.message.usage.input_tokens,
+              outputTokens: data.message.usage.output_tokens,
+              cacheWriteTokens: data.message.usage.cache_creation_input_tokens,
+              cacheReadTokens: data.message.usage.cache_read_input_tokens,
+            };
+          }
+          break;
+        case 'content_block_delta':
+          if (data.delta?.type === 'text_delta' && data.delta.text) {
+            yield { type: 'text', text: data.delta.text };
+          }
+          break;
+        case 'message_delta':
+          if (data.delta?.stop_reason) {
+            yield { type: 'finish', finishReason: data.delta.stop_reason };
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  private async fetchWithRetry(request: ChatCompletionRequest): Promise<Response> {
+    let attempt = 0;
+    let delayMs = this.retry.baseDelayMs;
+    let lastError: Error | undefined;
+
+    while (attempt <= this.retry.maxRetries) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), (this.config.timeoutSeconds ?? (DEFAULT_TIMEOUT_MS / 1000)) * 1000);
+        const response = await fetch(this.requestUrl(), {
+          method: 'POST',
+          headers: this.requestHeaders(),
+          body: JSON.stringify(this.requestBody(request)),
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+          if (this.retry.retryOn(response.status) && attempt < this.retry.maxRetries) {
+            await delay(delayMs);
+            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
+            attempt += 1;
+            continue;
+          }
+
+          const message = await response.text();
+          throw new Error(`Anthropic request failed (${response.status}): ${message}`);
+        }
+
+        return response;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt >= this.retry.maxRetries) break;
+        await delay(delayMs);
+        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
+        attempt += 1;
+      }
+    }
+
+    throw lastError ?? new Error('Anthropic request failed after retries');
+  }
+
+  private requestUrl(): string {
+    const base = this.config.baseUrl || 'https://api.anthropic.com/v1';
+    const normalized = base.endsWith('/') ? base.slice(0, -1) : base;
+    return `${normalized}/messages`;
+  }
+
+  private requestHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      'x-api-key': this.apiKey,
+      'anthropic-version': this.config.apiVersion || '2023-06-01',
+      ...this.config.headers,
+    };
+  }
+
+  private requestBody(request: ChatCompletionRequest): Record<string, unknown> {
+    return {
+      model: this.config.model,
+      max_tokens: this.config.maxOutputTokens ?? 1024,
+      temperature: this.config.temperature ?? 0,
+      system: [{ type: 'text', text: request.systemPrompt }],
+      messages: toAnthropicMessages(request),
+      stream: true,
+      thinking: this.config.reasoningEffort && this.config.reasoningEffort !== 'none'
+        ? { type: 'enabled', budget_tokens: this.config.maxOutputTokens ?? undefined }
+        : undefined,
+    };
+  }
+}

--- a/packages/agent-sdk-ts/src/llm/credentials.ts
+++ b/packages/agent-sdk-ts/src/llm/credentials.ts
@@ -1,0 +1,33 @@
+import type { SecretStorage } from 'vscode';
+import { SecretRegistry } from '../runtime/SecretRegistry';
+
+const FALLBACK_KEY_ORDER = [
+  'openhands.llmApiKey',
+  'OPENAI_API_KEY',
+  'OPENROUTER_API_KEY',
+  'LITELLM_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'LLM_API_KEY',
+];
+
+export class LLMCredentialProvider {
+  private readonly registry: SecretRegistry;
+
+  constructor(storage?: SecretStorage) {
+    this.registry = new SecretRegistry(storage);
+  }
+
+  async getApiKey(preferredKeys?: string | string[]): Promise<string | undefined> {
+    const orderedKeys = Array.isArray(preferredKeys)
+      ? [...preferredKeys, ...FALLBACK_KEY_ORDER]
+      : preferredKeys
+        ? [preferredKeys, ...FALLBACK_KEY_ORDER]
+        : [...FALLBACK_KEY_ORDER];
+
+    for (const key of orderedKeys) {
+      const value = await this.registry.get(key);
+      if (value) return value;
+    }
+    return undefined;
+  }
+}

--- a/packages/agent-sdk-ts/src/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/llm/factory.ts
@@ -19,9 +19,15 @@ export class LLMFactory {
   }
 
   async createClient(): Promise<LLMClient> {
-    const apiKey = await this.credentialProvider.getApiKey(
-      this.config.apiKey ?? this.preferredKeys ?? this.getDefaultApiKeyName(),
-    );
+    const inlineApiKey =
+      typeof this.config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(this.config.apiKey)
+        ? this.config.apiKey
+        : undefined;
+    const apiKey =
+      inlineApiKey ??
+      (await this.credentialProvider.getApiKey(
+        this.config.apiKey ?? this.preferredKeys ?? this.getDefaultApiKeyName(),
+      ));
     if (!apiKey) {
       throw new Error('Missing API key for LLM provider');
     }

--- a/packages/agent-sdk-ts/src/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/llm/factory.ts
@@ -1,0 +1,59 @@
+import type { SecretStorage } from 'vscode';
+import { LLMCredentialProvider } from './credentials';
+import { AnthropicClient } from './anthropic';
+import { OpenAICompatibleClient } from './openai-compatible';
+import type { ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
+
+export interface LLMFactoryOptions {
+  storage?: SecretStorage;
+  preferredApiKeys?: string | string[];
+}
+
+export class LLMFactory {
+  private readonly credentialProvider: LLMCredentialProvider;
+  private readonly preferredKeys?: string | string[];
+
+  constructor(private readonly config: LLMConfiguration, options: LLMFactoryOptions = {}) {
+    this.credentialProvider = new LLMCredentialProvider(options.storage);
+    this.preferredKeys = options.preferredApiKeys;
+  }
+
+  async createClient(): Promise<LLMClient> {
+    const apiKey = await this.credentialProvider.getApiKey(
+      this.config.apiKey ?? this.preferredKeys ?? this.getDefaultApiKeyName(),
+    );
+    if (!apiKey) {
+      throw new Error('Missing API key for LLM provider');
+    }
+
+    if (this.config.provider === 'anthropic') {
+      return new AnthropicClient(this.config, apiKey);
+    }
+
+    const provider = this.config.provider ?? this.detectProviderFromBaseUrl();
+    return new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
+  }
+
+  requestFromDefaults(messages: ChatCompletionRequest['messages'], systemPrompt: string): ChatCompletionRequest {
+    return { systemPrompt, messages };
+  }
+
+  private detectProviderFromBaseUrl(): LLMProvider {
+    if (this.config.baseUrl?.includes('openrouter.ai')) return 'openrouter';
+    if (this.config.baseUrl?.includes('litellm')) return 'litellm_proxy';
+    return 'openai';
+  }
+
+  private getDefaultApiKeyName(): string {
+    switch (this.config.provider) {
+      case 'openrouter':
+        return 'OPENROUTER_API_KEY';
+      case 'litellm_proxy':
+        return 'LITELLM_API_KEY';
+      case 'anthropic':
+        return 'ANTHROPIC_API_KEY';
+      default:
+        return 'OPENAI_API_KEY';
+    }
+  }
+}

--- a/packages/agent-sdk-ts/src/llm/index.ts
+++ b/packages/agent-sdk-ts/src/llm/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './credentials';
+export * from './openai-compatible';
+export * from './anthropic';
+export * from './factory';

--- a/packages/agent-sdk-ts/src/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/llm/openai-compatible.ts
@@ -1,0 +1,253 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions, type ToolCallAccumulator } from './types';
+
+const decoder = new TextDecoder();
+
+const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
+  ...(base ?? {}),
+  ...(overrides ?? {}),
+});
+
+const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number]): any => {
+  const contentText = reduceTextContent(message);
+  const base: Record<string, unknown> = {
+    role: message.role,
+    content: contentText,
+  };
+  if (message.name) base.name = message.name;
+  if (message.tool_call_id) base.tool_call_id = message.tool_call_id;
+  if (message.role === 'assistant' && message.tool_calls) base.tool_calls = message.tool_calls;
+  return base;
+};
+
+const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest) => ({
+  model: config.model,
+  messages: [
+    {
+      role: 'system',
+      content: request.systemPrompt,
+    },
+    ...request.messages.map(toOpenAIMessage),
+  ],
+  stream: true,
+  stream_options: { include_usage: true },
+  temperature: config.temperature ?? undefined,
+  top_p: config.topP ?? undefined,
+  top_k: config.topK ?? undefined,
+  max_tokens: config.maxOutputTokens ?? undefined,
+  reasoning_effort: config.reasoningEffort && config.reasoningEffort !== 'none' ? config.reasoningEffort : undefined,
+  tools: config.nativeToolCalling ? request.tools : undefined,
+  tool_choice: config.nativeToolCalling && request.tools?.length ? 'auto' : undefined,
+});
+
+const defaultBaseUrls: Record<string, string> = {
+  openai: 'https://api.openai.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+  litellm_proxy: 'http://localhost:4000',
+};
+
+const parseSseLines = async function* (response: Response): AsyncGenerator<string> {
+  const reader = response.body?.getReader();
+  if (!reader) return;
+
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let newlineIndex = buffer.indexOf('\n');
+    while (newlineIndex !== -1) {
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (line.startsWith('data:')) {
+        const payload = line.slice(5).trim();
+        if (payload) {
+          yield payload;
+        }
+      }
+      newlineIndex = buffer.indexOf('\n');
+    }
+  }
+  if (buffer.length) {
+    const payload = buffer.replace(/^data:/, '').trim();
+    if (payload) yield payload;
+  }
+};
+
+class OpenAIToolCallAccumulator implements ToolCallAccumulator {
+  complete = [] as ToolCallAccumulator['complete'];
+  private readonly partial = new Map<string, { id: string; name?: string; arguments: string }>();
+
+  applyDelta(delta: { id: string; name?: string; arguments?: string }): ToolCallAccumulator['complete'] {
+    const existing = this.partial.get(delta.id) ?? { id: delta.id, name: delta.name, arguments: '' };
+    this.partial.set(delta.id, {
+      id: delta.id,
+      name: delta.name ?? existing.name,
+      arguments: `${existing.arguments}${delta.arguments ?? ''}`,
+    });
+
+    this.complete = Array.from(this.partial.values()).map((value) => ({
+      id: value.id,
+      type: 'function',
+      function: { name: value.name ?? '', arguments: value.arguments },
+    }));
+    return this.complete;
+  }
+}
+
+const mapChunkToStream = (chunk: any, accumulator: OpenAIToolCallAccumulator): LLMStreamChunk[] => {
+  const choice = chunk?.choices?.[0];
+  if (!choice) return [];
+  const deltas: LLMStreamChunk[] = [];
+
+  const delta = choice.delta ?? {};
+  const content = delta.content as any;
+  if (typeof content === 'string') {
+    deltas.push({ type: 'text', text: content });
+  } else if (Array.isArray(content)) {
+    for (const part of content) {
+      if (part?.type === 'text' && typeof part.text === 'string') {
+        deltas.push({ type: 'text', text: part.text });
+      }
+    }
+  }
+
+  if (Array.isArray(delta.tool_calls)) {
+    for (const call of delta.tool_calls) {
+      const acc = accumulator.applyDelta({
+        id: call.id ?? call.index?.toString() ?? 'tool_call',
+        name: call.function?.name,
+        arguments: call.function?.arguments,
+      });
+      const current = acc.find((item) => item.id === (call.id ?? call.index?.toString() ?? 'tool_call'));
+      if (current) {
+        deltas.push({
+          type: 'tool_call_delta',
+          id: current.id,
+          name: current.function.name,
+          arguments: current.function.arguments,
+        });
+      }
+    }
+  }
+
+  if (delta.reasoning_content) {
+    const reasoning = Array.isArray(delta.reasoning_content)
+      ? delta.reasoning_content.map((entry: any) => entry.text ?? '').join('')
+      : String(delta.reasoning_content ?? '');
+    if (reasoning) deltas.push({ type: 'reasoning', reasoning });
+  }
+
+  if (chunk.usage) {
+    deltas.push({
+      type: 'usage',
+      inputTokens: chunk.usage.prompt_tokens,
+      outputTokens: chunk.usage.completion_tokens,
+      cacheReadTokens: chunk.usage.prompt_tokens_details?.cached_tokens,
+    });
+  }
+
+  if (choice.finish_reason) {
+    deltas.push({ type: 'finish', finishReason: choice.finish_reason });
+  }
+
+  return deltas;
+};
+
+export class OpenAICompatibleClient implements LLMClient {
+  private readonly config: LLMConfiguration;
+  private readonly apiKey: string;
+  private readonly retry: RetryOptions;
+
+  constructor(config: LLMConfiguration, apiKey: string, retry: RetryOptions = DEFAULT_RETRY_OPTIONS) {
+    this.config = config;
+    this.apiKey = apiKey;
+    this.retry = retry;
+  }
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    const response = await this.fetchWithRetry(request);
+    const accumulator = new OpenAIToolCallAccumulator();
+
+    for await (const payload of parseSseLines(response)) {
+      if (payload === '[DONE]') {
+        yield { type: 'finish' };
+        break;
+      }
+
+      try {
+        const json = JSON.parse(payload);
+        const mapped = mapChunkToStream(json, accumulator);
+        for (const item of mapped) {
+          yield item;
+        }
+      } catch (error) {
+        yield { type: 'finish', finishReason: (error as Error).message };
+        break;
+      }
+    }
+  }
+
+  private async fetchWithRetry(request: ChatCompletionRequest): Promise<Response> {
+    let attempt = 0;
+    let delayMs = this.retry.baseDelayMs;
+    let lastError: Error | undefined;
+
+    while (attempt <= this.retry.maxRetries) {
+      try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), (this.config.timeoutSeconds ?? (DEFAULT_TIMEOUT_MS / 1000)) * 1000);
+        const response = await fetch(this.requestUrl(), {
+          method: 'POST',
+          headers: this.requestHeaders(),
+          body: JSON.stringify(toRequestBody(this.config, request)),
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+          if (this.retry.retryOn(response.status) && attempt < this.retry.maxRetries) {
+            await delay(delayMs);
+            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
+            attempt += 1;
+            continue;
+          }
+
+          const message = await response.text();
+          throw new Error(`LLM request failed (${response.status}): ${message}`);
+        }
+
+        return response;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt >= this.retry.maxRetries) break;
+        await delay(delayMs);
+        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
+        attempt += 1;
+      }
+    }
+
+    throw lastError ?? new Error('LLM request failed after retries');
+  }
+
+  private requestUrl(): string {
+    const providerBase = this.config.baseUrl || defaultBaseUrls[this.config.provider ?? 'openai'] || defaultBaseUrls.openai;
+    const normalized = providerBase.endsWith('/') ? providerBase.slice(0, -1) : providerBase;
+    const apiVersionSegment = this.config.apiVersion ? `?api-version=${encodeURIComponent(this.config.apiVersion)}` : '';
+    return `${normalized}/chat/completions${apiVersionSegment}`;
+  }
+
+  private requestHeaders(): Record<string, string> {
+    const baseHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+
+    if (this.config.provider === 'openrouter') {
+      baseHeaders['HTTP-Referer'] = 'https://openhands.io';
+      baseHeaders['X-Title'] = 'OpenHands';
+    }
+
+    return mergeHeaders(baseHeaders, this.config.headers);
+  }
+}

--- a/packages/agent-sdk-ts/src/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/llm/openai-compatible.ts
@@ -8,9 +8,48 @@ const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, 
   ...(overrides ?? {}),
 });
 
-const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number]): any => {
+type OpenAIChatMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  name?: string;
+  tool_call_id?: string;
+  tool_calls?: ChatCompletionRequest['messages'][number]['tool_calls'];
+};
+
+type OpenAIContentPart = { type: 'text'; text?: string };
+
+type OpenAIToolCallDelta = {
+  id?: string;
+  index?: number;
+  function?: { name?: string; arguments?: string };
+};
+
+type OpenAIChoiceDelta = {
+  content?: string | OpenAIContentPart[];
+  tool_calls?: OpenAIToolCallDelta[];
+  reasoning_content?: string | { text?: string }[];
+};
+
+type OpenAIChoice = {
+  delta?: OpenAIChoiceDelta;
+  finish_reason?: string | null;
+};
+
+type OpenAIStreamChunk = {
+  choices?: OpenAIChoice[];
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+    prompt_tokens_details?: { cached_tokens?: number };
+  };
+};
+
+const isOpenAIStreamChunk = (value: unknown): value is OpenAIStreamChunk =>
+  typeof value === 'object' && value !== null && ('choices' in value || 'usage' in value);
+
+const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number]): OpenAIChatMessage => {
   const contentText = reduceTextContent(message);
-  const base: Record<string, unknown> = {
+  const base: OpenAIChatMessage = {
     role: message.role,
     content: contentText,
   };
@@ -95,13 +134,13 @@ class OpenAIToolCallAccumulator implements ToolCallAccumulator {
   }
 }
 
-const mapChunkToStream = (chunk: any, accumulator: OpenAIToolCallAccumulator): LLMStreamChunk[] => {
+const mapChunkToStream = (chunk: OpenAIStreamChunk, accumulator: OpenAIToolCallAccumulator): LLMStreamChunk[] => {
   const choice = chunk?.choices?.[0];
   if (!choice) return [];
   const deltas: LLMStreamChunk[] = [];
 
   const delta = choice.delta ?? {};
-  const content = delta.content as any;
+  const content = delta.content;
   if (typeof content === 'string') {
     deltas.push({ type: 'text', text: content });
   } else if (Array.isArray(content)) {
@@ -114,12 +153,13 @@ const mapChunkToStream = (chunk: any, accumulator: OpenAIToolCallAccumulator): L
 
   if (Array.isArray(delta.tool_calls)) {
     for (const call of delta.tool_calls) {
+      const toolId = call.id ?? call.index?.toString() ?? 'tool_call';
       const acc = accumulator.applyDelta({
-        id: call.id ?? call.index?.toString() ?? 'tool_call',
+        id: toolId,
         name: call.function?.name,
         arguments: call.function?.arguments,
       });
-      const current = acc.find((item) => item.id === (call.id ?? call.index?.toString() ?? 'tool_call'));
+      const current = acc.find((item) => item.id === toolId);
       if (current) {
         deltas.push({
           type: 'tool_call_delta',
@@ -133,7 +173,7 @@ const mapChunkToStream = (chunk: any, accumulator: OpenAIToolCallAccumulator): L
 
   if (delta.reasoning_content) {
     const reasoning = Array.isArray(delta.reasoning_content)
-      ? delta.reasoning_content.map((entry: any) => entry.text ?? '').join('')
+      ? delta.reasoning_content.map((entry) => entry?.text ?? '').join('')
       : String(delta.reasoning_content ?? '');
     if (reasoning) deltas.push({ type: 'reasoning', reasoning });
   }
@@ -176,7 +216,8 @@ export class OpenAICompatibleClient implements LLMClient {
       }
 
       try {
-        const json = JSON.parse(payload);
+        const json = JSON.parse(payload) as unknown;
+        if (!isOpenAIStreamChunk(json)) continue;
         const mapped = mapChunkToStream(json, accumulator);
         for (const item of mapped) {
           yield item;

--- a/packages/agent-sdk-ts/src/llm/types.ts
+++ b/packages/agent-sdk-ts/src/llm/types.ts
@@ -1,0 +1,83 @@
+import type { Message, ToolCall } from '../types';
+
+export type LLMProvider = 'openai' | 'litellm_proxy' | 'openrouter' | 'anthropic';
+
+export interface LLMToolDefinition {
+  type: 'function';
+  function: {
+    name: string;
+    description?: string;
+    parameters?: unknown;
+  };
+}
+
+export interface LLMConfiguration {
+  provider?: LLMProvider;
+  model: string;
+  baseUrl?: string | null;
+  apiKey?: string;
+  apiVersion?: string | null;
+  timeoutSeconds?: number | null;
+  temperature?: number | null;
+  topP?: number | null;
+  topK?: number | null;
+  maxInputTokens?: number | null;
+  maxOutputTokens?: number | null;
+  nativeToolCalling?: boolean | null;
+  reasoningEffort?: 'low' | 'medium' | 'high' | 'none' | null;
+  headers?: Record<string, string>;
+}
+
+export interface ChatCompletionRequest {
+  systemPrompt: string;
+  messages: Message[];
+  tools?: LLMToolDefinition[];
+}
+
+export type LLMStreamChunk =
+  | { type: 'text'; text: string }
+  | { type: 'reasoning'; reasoning: string }
+  | { type: 'tool_call_delta'; id: string; name?: string; arguments?: string }
+  | { type: 'usage'; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number }
+  | { type: 'finish'; finishReason?: string };
+
+export interface LLMResponse {
+  message: Message;
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+}
+
+export interface LLMClient {
+  streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk>;
+}
+
+export interface RetryOptions {
+  maxRetries: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+  retryOn: (status: number) => boolean;
+}
+
+export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
+  maxRetries: 2,
+  baseDelayMs: 250,
+  maxDelayMs: 2000,
+  retryOn: (status: number): boolean => [408, 409, 425, 429, 500, 502, 503, 504].includes(status),
+};
+
+export const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface ToolCallAccumulator {
+  complete: ToolCall[];
+  applyDelta(delta: { id: string; name?: string; arguments?: string }): ToolCall[];
+}
+
+export const reduceTextContent = (message: Message): string =>
+  message.content
+    .filter((item) => item.type === 'text')
+    .map((item) => item.text)
+    .join('\n');

--- a/packages/agent-sdk-ts/src/runtime/AgentOrchestrator.ts
+++ b/packages/agent-sdk-ts/src/runtime/AgentOrchestrator.ts
@@ -1,0 +1,92 @@
+import { EventLog } from './EventLog';
+import { ConversationState } from './ConversationState';
+import type { ChatCompletionRequest, LLMClient, LLMResponse, LLMStreamChunk } from '../llm';
+import type { Message, ToolCall } from '../types';
+
+export interface AgentOrchestratorOptions {
+  events?: EventLog;
+  state?: ConversationState;
+}
+
+export class AgentOrchestrator {
+  private readonly events: EventLog;
+  private readonly state: ConversationState;
+
+  constructor(private readonly llm: LLMClient, options: AgentOrchestratorOptions = {}) {
+    this.events = options.events ?? new EventLog();
+    this.state = options.state ?? new ConversationState(this.events);
+    this.state.attachEventLog(this.events);
+  }
+
+  async runChat(request: ChatCompletionRequest): Promise<LLMResponse> {
+    const message: Message = { role: 'assistant', content: [] };
+    const toolCalls: Record<string, ToolCall> = {};
+    let usage: LLMResponse['usage'];
+
+    for await (const chunk of this.llm.streamChat(request)) {
+      this.applyStateUpdate(chunk);
+      switch (chunk.type) {
+        case 'text': {
+          const existingText = message.content.find((item) => item.type === 'text');
+          if (existingText) {
+            existingText.text += chunk.text;
+          } else {
+            message.content.push({ type: 'text', text: chunk.text });
+          }
+          break;
+        }
+        case 'reasoning':
+          message.reasoning_content = (message.reasoning_content ?? '') + chunk.reasoning;
+          break;
+        case 'tool_call_delta': {
+          const current = toolCalls[chunk.id] ?? { id: chunk.id, type: 'function', function: { name: chunk.name ?? '', arguments: '' } };
+          current.function = {
+            name: chunk.name ?? current.function.name,
+            arguments: `${current.function.arguments}${chunk.arguments ?? ''}`,
+          };
+          toolCalls[chunk.id] = current;
+          break;
+        }
+        case 'usage':
+          usage = {
+            inputTokens: chunk.inputTokens ?? usage?.inputTokens,
+            outputTokens: chunk.outputTokens ?? usage?.outputTokens,
+            cacheReadTokens: chunk.cacheReadTokens ?? usage?.cacheReadTokens,
+            cacheWriteTokens: chunk.cacheWriteTokens ?? usage?.cacheWriteTokens,
+          };
+          break;
+        case 'finish':
+          break;
+        default:
+          break;
+      }
+    }
+
+    if (Object.keys(toolCalls).length) {
+      message.tool_calls = Object.values(toolCalls);
+    }
+
+    return { message, usage };
+  }
+
+  private applyStateUpdate(chunk: LLMStreamChunk): void {
+    switch (chunk.type) {
+      case 'text':
+        this.state.setValue('llm_stream', chunk.text);
+        break;
+      case 'tool_call_delta':
+        this.state.setValue('llm_tool_call', chunk.id);
+        break;
+      case 'usage':
+        this.state.setValue('llm_usage', {
+          input: chunk.inputTokens,
+          output: chunk.outputTokens,
+          cacheRead: chunk.cacheReadTokens,
+          cacheWrite: chunk.cacheWriteTokens,
+        });
+        break;
+      default:
+        break;
+    }
+  }
+}

--- a/packages/agent-sdk-ts/src/runtime/AgentOrchestrator.ts
+++ b/packages/agent-sdk-ts/src/runtime/AgentOrchestrator.ts
@@ -72,7 +72,10 @@ export class AgentOrchestrator {
   private applyStateUpdate(chunk: LLMStreamChunk): void {
     switch (chunk.type) {
       case 'text':
-        this.state.setValue('llm_stream', chunk.text);
+        this.state.setValue(
+          'llm_stream',
+          `${typeof this.state.snapshot.values.llm_stream === 'string' ? this.state.snapshot.values.llm_stream : ''}${chunk.text}`,
+        );
         break;
       case 'tool_call_delta':
         this.state.setValue('llm_tool_call', chunk.id);

--- a/packages/agent-sdk-ts/src/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/runtime/index.ts
@@ -3,3 +3,4 @@ export * from './ConversationState';
 export * from './SecretRegistry';
 export * from './AsyncLock';
 export * from './StuckDetector';
+export * from './AgentOrchestrator';


### PR DESCRIPTION
## Summary
- add a new llm module with OpenAI-compatible and Anthropic streaming clients plus credential resolution
- wire agent orchestration to consume the llm layer and stream token/tool updates into conversation state
- add mocked and optional integration tests to cover success, retry, and failure paths

## Testing
- npm test -w @openhands/agent-sdk-ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ab806b7c48320a342081dc8093849)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM integration with OpenAI-compatible and Anthropic providers, including streaming chat, tool/function calling, and provider detection
  * Factory for creating LLM clients and a credential provider for API key management
  * Public orchestrator to manage streaming interactions, state updates, and usage aggregation
* **Tests**
  * End-to-end and streaming tests covering streaming behavior, retries, and failure propagation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->