### PR TITLE
Review and improve test coverage

### DIFF
--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -59,4 +59,145 @@ describe('SettingsManager', () => {
     s = await mgr.get();
     expect(s.secrets.llmApiKey).toBeUndefined();
   });
+
+  it('updates AWS credentials', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+
+    await mgr.update({
+      secrets: {
+        awsAccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        awsSecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      }
+    });
+
+    const s = await mgr.get();
+    expect(s.secrets.awsAccessKeyId).toBe('AKIAIOSFODNN7EXAMPLE');
+    expect(s.secrets.awsSecretAccessKey).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+  });
+
+  it('clears AWS credentials when undefined is provided', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+
+    await mgr.update({
+      secrets: {
+        awsAccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        awsSecretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      }
+    });
+
+    let s = await mgr.get();
+    expect(s.secrets.awsAccessKeyId).toBe('AKIAIOSFODNN7EXAMPLE');
+    expect(s.secrets.awsSecretAccessKey).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY');
+
+    await mgr.update({
+      secrets: {
+        awsAccessKeyId: undefined,
+        awsSecretAccessKey: undefined
+      }
+    });
+
+    s = await mgr.get();
+    expect(s.secrets.awsAccessKeyId).toBeUndefined();
+    expect(s.secrets.awsSecretAccessKey).toBeUndefined();
+  });
+
+  it('updates all optional LLM fields', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+
+    await mgr.update({
+      llm: {
+        apiVersion: '2024-01-01',
+        timeout: 120,
+        temperature: 0.7,
+        topP: 0.9,
+        topK: 50,
+        maxInputTokens: 4096,
+        maxOutputTokens: 2048,
+        nativeToolCalling: true,
+        reasoningEffort: 'high'
+      }
+    });
+
+    const s = await mgr.get();
+    expect(s.llm.apiVersion).toBe('2024-01-01');
+    expect(s.llm.timeout).toBe(120);
+    expect(s.llm.temperature).toBe(0.7);
+    expect(s.llm.topP).toBe(0.9);
+    expect(s.llm.topK).toBe(50);
+    expect(s.llm.maxInputTokens).toBe(4096);
+    expect(s.llm.maxOutputTokens).toBe(2048);
+    expect(s.llm.nativeToolCalling).toBe(true);
+    expect(s.llm.reasoningEffort).toBe('high');
+  });
+
+  it('handles sanitizePositiveInteger with invalid inputs', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+
+    // Test with invalid maxInputTokens and maxOutputTokens
+    await mgr.update({
+      llm: {
+        maxInputTokens: -100 as any, // Should be filtered out
+        maxOutputTokens: 0 as any, // Should be filtered out
+      }
+    });
+
+    const s = await mgr.get();
+    expect(s.llm.maxInputTokens).toBeUndefined();
+    expect(s.llm.maxOutputTokens).toBeUndefined();
+  });
+
+  it('handles sanitizePositiveInteger with fractional numbers', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+
+    await mgr.update({
+      llm: {
+        maxInputTokens: 4096.7 as any, // Should be truncated to 4096
+        maxOutputTokens: 2048.3 as any, // Should be truncated to 2048
+      }
+    });
+
+    const s = await mgr.get();
+    expect(s.llm.maxInputTokens).toBe(4096);
+    expect(s.llm.maxOutputTokens).toBe(2048);
+  });
+
+  it('handles null returns from adapter.get by falling back to defaults', async () => {
+    const a = new MemoryAdapter();
+    // Override get to return null for specific keys
+    const originalGet = a.get.bind(a);
+    a.get = <T>(key: string, def?: T): T | undefined => {
+      if (key === 'openhands.serverUrl') return null as any;
+      if (key === 'openhands.agent.enableSecurityAnalyzer') return null as any;
+      if (key === 'openhands.conversation.maxIterations') return null as any;
+      if (key === 'openhands.confirmation.policy') return null as any;
+      if (key === 'openhands.confirmation.risky.threshold') return null as any;
+      if (key === 'openhands.confirmation.risky.confirmUnknown') return null as any;
+      return originalGet(key, def);
+    };
+
+    const mgr = new SettingsManager(a);
+    const s = await mgr.get();
+
+    expect(s.serverUrl).toBe('http://localhost:3000');
+    expect(s.agent.enableSecurityAnalyzer).toBe(false);
+    expect(s.conversation.maxIterations).toBe(50);
+    expect(s.confirmation.policy).toBe('never');
+    expect(s.confirmation.riskyThreshold).toBe('HIGH');
+    expect(s.confirmation.confirmUnknown).toBe(true);
+  });
+
+  it('updates settings with global target', async () => {
+    const a = new MemoryAdapter();
+    const mgr = new SettingsManager(a);
+
+    await mgr.update({ serverUrl: 'http://global:5000' }, 'global');
+
+    const s = await mgr.get();
+    expect(s.serverUrl).toBe('http://global:5000');
+  });
 });

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { SettingsManager } from '../SettingsManager';
 import type { SettingsAdapter } from '../SettingsAdapter';
 
@@ -15,9 +15,15 @@ class MemoryAdapter implements SettingsAdapter {
 }
 
 describe('SettingsManager', () => {
+  let a: MemoryAdapter;
+  let mgr: SettingsManager;
+
+  beforeEach(() => {
+    a = new MemoryAdapter();
+    mgr = new SettingsManager(a);
+  });
+
   it('returns defaults when unset', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://localhost:3000');
     expect(s.llm.usageId).toBeUndefined();
@@ -25,8 +31,6 @@ describe('SettingsManager', () => {
   });
 
   it('updates and persists config and secrets', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
     await mgr.update({
       serverUrl: 'http://example:1234',
       llm: { usageId: 'my-usage', model: 'foo', baseUrl: 'https://api.example.com' },
@@ -50,8 +54,6 @@ describe('SettingsManager', () => {
   });
 
   it('clears secret when undefined is provided', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
     await mgr.update({ secrets: { llmApiKey: 'abc' } });
     let s = await mgr.get();
     expect(s.secrets.llmApiKey).toBe('abc');
@@ -61,9 +63,6 @@ describe('SettingsManager', () => {
   });
 
   it('updates AWS credentials', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
-
     await mgr.update({
       secrets: {
         awsAccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
@@ -77,9 +76,6 @@ describe('SettingsManager', () => {
   });
 
   it('clears AWS credentials when undefined is provided', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
-
     await mgr.update({
       secrets: {
         awsAccessKeyId: 'AKIAIOSFODNN7EXAMPLE',
@@ -104,9 +100,6 @@ describe('SettingsManager', () => {
   });
 
   it('updates all optional LLM fields', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
-
     await mgr.update({
       llm: {
         apiVersion: '2024-01-01',
@@ -134,9 +127,6 @@ describe('SettingsManager', () => {
   });
 
   it('handles sanitizePositiveInteger with invalid inputs', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
-
     // Test with invalid maxInputTokens and maxOutputTokens
     await mgr.update({
       llm: {
@@ -151,9 +141,6 @@ describe('SettingsManager', () => {
   });
 
   it('handles sanitizePositiveInteger with fractional numbers', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
-
     await mgr.update({
       llm: {
         maxInputTokens: 4096.7 as any, // Should be truncated to 4096
@@ -167,20 +154,21 @@ describe('SettingsManager', () => {
   });
 
   it('handles null returns from adapter.get by falling back to defaults', async () => {
-    const a = new MemoryAdapter();
     // Override get to return null for specific keys
     const originalGet = a.get.bind(a);
+    const nullKeys = new Set([
+      'openhands.serverUrl',
+      'openhands.agent.enableSecurityAnalyzer',
+      'openhands.conversation.maxIterations',
+      'openhands.confirmation.policy',
+      'openhands.confirmation.risky.threshold',
+      'openhands.confirmation.risky.confirmUnknown',
+    ]);
     a.get = <T>(key: string, def?: T): T | undefined => {
-      if (key === 'openhands.serverUrl') return null as any;
-      if (key === 'openhands.agent.enableSecurityAnalyzer') return null as any;
-      if (key === 'openhands.conversation.maxIterations') return null as any;
-      if (key === 'openhands.confirmation.policy') return null as any;
-      if (key === 'openhands.confirmation.risky.threshold') return null as any;
-      if (key === 'openhands.confirmation.risky.confirmUnknown') return null as any;
+      if (nullKeys.has(key)) return null as any;
       return originalGet(key, def);
     };
 
-    const mgr = new SettingsManager(a);
     const s = await mgr.get();
 
     expect(s.serverUrl).toBe('http://localhost:3000');
@@ -192,9 +180,6 @@ describe('SettingsManager', () => {
   });
 
   it('updates settings with global target', async () => {
-    const a = new MemoryAdapter();
-    const mgr = new SettingsManager(a);
-
     await mgr.update({ serverUrl: 'http://global:5000' }, 'global');
 
     const s = await mgr.get();

--- a/src/sidebar/__tests__/OpenHandsViewProvider.test.ts
+++ b/src/sidebar/__tests__/OpenHandsViewProvider.test.ts
@@ -28,57 +28,53 @@ describe('OpenHandsViewProvider', () => {
       expect(children).toEqual([]);
     });
 
-    it('returns root items when no element is provided', async () => {
-      const children = await provider.getChildren();
+    describe('when no element is provided', () => {
+      let children: vscode.TreeItem[];
 
-      expect(children).toHaveLength(2);
-      expect(children[0].label).toBe('Open Conversation Tab');
-      expect(children[0].command?.command).toBe('openhands.openTab');
-      expect(children[0].command?.title).toBe('OpenHands: Open Tab');
-      expect(children[0].iconPath).toBeInstanceOf(vscode.ThemeIcon);
-
-      expect(children[1].label).toBe('Extension Settings');
-      expect(children[1].command?.command).toBe('workbench.action.openSettings');
-      expect(children[1].command?.title).toBe('Open OpenHands Settings');
-      expect(children[1].command?.arguments).toEqual(['@ext:openhands.openhands-tab']);
-    });
-
-    it('creates tree items with correct icons', async () => {
-      const children = await provider.getChildren();
-
-      const conversationItem = children[0];
-      expect((conversationItem.iconPath as vscode.ThemeIcon).id).toBe('comment-discussion');
-
-      const settingsItem = children[1];
-      expect((settingsItem.iconPath as vscode.ThemeIcon).id).toBe('gear');
-    });
-
-    it('creates non-collapsible tree items', async () => {
-      const children = await provider.getChildren();
-
-      children.forEach(item => {
-        expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+      beforeEach(async () => {
+        children = await provider.getChildren();
       });
-    });
 
-    it('provides correct command structure for Open Conversation Tab item', async () => {
-      const children = await provider.getChildren();
-      const conversationItem = children[0];
-
-      expect(conversationItem.command).toEqual({
-        command: 'openhands.openTab',
-        title: 'OpenHands: Open Tab',
+      it('returns two root items', () => {
+        expect(children).toHaveLength(2);
       });
-    });
 
-    it('provides correct command structure for Extension Settings item with arguments', async () => {
-      const children = await provider.getChildren();
-      const settingsItem = children[1];
+      it('creates a correctly configured "Open Conversation Tab" item', () => {
+        const conversationItem = children[0];
+        expect(conversationItem.label).toBe('Open Conversation Tab');
+        expect(conversationItem.command?.command).toBe('openhands.openTab');
+        expect(conversationItem.command?.title).toBe('OpenHands: Open Tab');
+        expect(conversationItem.iconPath).toBeInstanceOf(vscode.ThemeIcon);
+        expect((conversationItem.iconPath as vscode.ThemeIcon).id).toBe('comment-discussion');
+        expect(conversationItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+      });
 
-      expect(settingsItem.command).toEqual({
-        command: 'workbench.action.openSettings',
-        title: 'Open OpenHands Settings',
-        arguments: ['@ext:openhands.openhands-tab'],
+      it('creates a correctly configured "Extension Settings" item', () => {
+        const settingsItem = children[1];
+        expect(settingsItem.label).toBe('Extension Settings');
+        expect(settingsItem.command?.command).toBe('workbench.action.openSettings');
+        expect(settingsItem.command?.title).toBe('Open OpenHands Settings');
+        expect(settingsItem.command?.arguments).toEqual(['@ext:openhands.openhands-tab']);
+        expect(settingsItem.iconPath).toBeInstanceOf(vscode.ThemeIcon);
+        expect((settingsItem.iconPath as vscode.ThemeIcon).id).toBe('gear');
+        expect(settingsItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+      });
+
+      it('provides correct command structure for Open Conversation Tab item', () => {
+        const conversationItem = children[0];
+        expect(conversationItem.command).toEqual({
+          command: 'openhands.openTab',
+          title: 'OpenHands: Open Tab',
+        });
+      });
+
+      it('provides correct command structure for Extension Settings item with arguments', () => {
+        const settingsItem = children[1];
+        expect(settingsItem.command).toEqual({
+          command: 'workbench.action.openSettings',
+          title: 'Open OpenHands Settings',
+          arguments: ['@ext:openhands.openhands-tab'],
+        });
       });
     });
   });

--- a/src/sidebar/__tests__/OpenHandsViewProvider.test.ts
+++ b/src/sidebar/__tests__/OpenHandsViewProvider.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as vscode from 'vscode';
+import { OpenHandsViewProvider } from '../OpenHandsViewProvider';
+
+describe('OpenHandsViewProvider', () => {
+  let provider: OpenHandsViewProvider;
+
+  beforeEach(() => {
+    provider = new OpenHandsViewProvider();
+  });
+
+  describe('TreeDataProvider implementation', () => {
+    it('provides onDidChangeTreeData event emitter', () => {
+      expect(provider.onDidChangeTreeData).toBeDefined();
+    });
+
+    it('getTreeItem returns the element unchanged', () => {
+      const mockItem = new vscode.TreeItem('Test Item');
+      const result = provider.getTreeItem(mockItem as any);
+      expect(result).toBe(mockItem);
+    });
+  });
+
+  describe('getChildren', () => {
+    it('returns empty array when element is provided (no nested items)', async () => {
+      const mockElement = new vscode.TreeItem('Parent');
+      const children = await provider.getChildren(mockElement as any);
+      expect(children).toEqual([]);
+    });
+
+    it('returns root items when no element is provided', async () => {
+      const children = await provider.getChildren();
+
+      expect(children).toHaveLength(2);
+      expect(children[0].label).toBe('Open Conversation Tab');
+      expect(children[0].command?.command).toBe('openhands.openTab');
+      expect(children[0].command?.title).toBe('OpenHands: Open Tab');
+      expect(children[0].iconPath).toBeInstanceOf(vscode.ThemeIcon);
+
+      expect(children[1].label).toBe('Extension Settings');
+      expect(children[1].command?.command).toBe('workbench.action.openSettings');
+      expect(children[1].command?.title).toBe('Open OpenHands Settings');
+      expect(children[1].command?.arguments).toEqual(['@ext:openhands.openhands-tab']);
+    });
+
+    it('creates tree items with correct icons', async () => {
+      const children = await provider.getChildren();
+
+      const conversationItem = children[0];
+      expect((conversationItem.iconPath as vscode.ThemeIcon).id).toBe('comment-discussion');
+
+      const settingsItem = children[1];
+      expect((settingsItem.iconPath as vscode.ThemeIcon).id).toBe('gear');
+    });
+
+    it('creates non-collapsible tree items', async () => {
+      const children = await provider.getChildren();
+
+      children.forEach(item => {
+        expect(item.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
+      });
+    });
+
+    it('provides correct command structure for Open Conversation Tab item', async () => {
+      const children = await provider.getChildren();
+      const conversationItem = children[0];
+
+      expect(conversationItem.command).toEqual({
+        command: 'openhands.openTab',
+        title: 'OpenHands: Open Tab',
+      });
+    });
+
+    it('provides correct command structure for Extension Settings item with arguments', async () => {
+      const children = await provider.getChildren();
+      const settingsItem = children[1];
+
+      expect(settingsItem.command).toEqual({
+        command: 'workbench.action.openSettings',
+        title: 'Open OpenHands Settings',
+        arguments: ['@ext:openhands.openhands-tab'],
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Add tests for OpenHandsViewProvider (31.25% → 100%)
- Enhance SettingsManager tests for branch coverage (35.48% → 100%)
- Add 15 new tests covering AWS credentials, LLM fields, edge cases
- Overall coverage improved: 85.46% → 87.21% statements, 78.21% → 82.92% branches

Tests added:
- OpenHandsViewProvider: 8 tests for TreeDataProvider, commands, icons
- SettingsManager: 7 tests for AWS secrets, optional LLM fields, sanitization, null handling

All 164 tests passing. Issue #62 related.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for settings management and validation.
  * Added test coverage for sidebar navigation and tree view functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->