### PR TITLE
Align tool prompt with Python agent SDK

### DIFF
--- a/packages/agent-sdk-ts/LOCAL_FINDINGS.md
+++ b/packages/agent-sdk-ts/LOCAL_FINDINGS.md
@@ -1,0 +1,9 @@
+# agent-sdk-ts parity notes
+
+- Read enyst/agent-sdk README for Python SDK goals and local/remote conversation factory behavior.
+- Reviewed OpenHands-Tab docs/agent-sdk-architecture.md for expected layers and noted LocalConversation is still stubbed.
+- Current TypeScript LocalConversation only emits status/events for user messages; it does not orchestrate agents, run tools, or use LocalWorkspace/LLM clients. Local mode in VS Code therefore cannot execute actions or show terminal events.
+- LocalConversation also ignores the VS Code workspace root and lacks confirmation handling/state updates compared to Python Conversation.
+- Local tool system exists (TerminalTool, FileEditorTool, TaskTrackerTool) but is unused in conversation flow; Terminal events are never emitted in local mode, unlike Python terminal tool streaming.
+- Implemented LocalConversation orchestration that builds LLM requests with tool schemas, runs terminal/file/task tools through LocalWorkspace, and emits both agent events and bash output so the VS Code UI mirrors the Python SDK behavior in local mode.
+- Tools prompt sent to the LLM now reuses the Python agent-sdk function-calling suffix (tools/parameters descriptions rendered via the same template) instead of a simplified bullet list.

--- a/packages/agent-sdk-ts/src/__tests__/local.conversation.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/local.conversation.test.ts
@@ -80,4 +80,38 @@ describe('LocalConversation', () => {
     expect(bashEvents.some((event) => event.type === 'BashCommand')).toBe(true);
     expect(bashEvents.some((event) => event.type === 'BashExit')).toBe(true);
   });
+
+  it('provides a final assistant response when hitting the iteration cap', async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), 'local-conv-cap-'));
+    const llm = new FakeLLM([
+      [
+        { type: 'tool_call_delta', id: 'call_3', name: 'terminal', arguments: '{"command":"pwd"}' },
+        { type: 'finish', finishReason: 'tool_calls' },
+      ],
+      [
+        { type: 'tool_call_delta', id: 'call_4', name: 'terminal', arguments: '{"command":"pwd"}' },
+        { type: 'finish', finishReason: 'tool_calls' },
+      ],
+      [
+        { type: 'text', text: 'Done after limit' },
+        { type: 'finish', finishReason: 'stop' },
+      ],
+    ]);
+
+    const settings: OpenHandsSettings = {
+      ...baseSettings,
+      conversation: { maxIterations: 2 },
+    };
+
+    const conversation = new LocalConversation({ settings, workspaceRoot: tmp, llmClient: llm });
+    const events: Event[] = [];
+    conversation.on('event', (event) => events.push(event));
+
+    await conversation.sendUserMessage('check cwd twice then summarize');
+
+    const agentMessages = events.filter((event) => event.type === 'MessageEvent' && event.source === 'agent');
+    expect(agentMessages.length).toBe(3);
+    const finalMessage = agentMessages.at(-1);
+    expect(finalMessage?.llm_message.content?.[0]).toMatchObject({ type: 'text', text: 'Done after limit' });
+  });
 });

--- a/packages/agent-sdk-ts/src/__tests__/local.conversation.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/local.conversation.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { LocalConversation } from '../conversation/LocalConversation';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
+import type { BashEvent, Event, OpenHandsSettings } from '../types';
+
+class FakeLLM implements LLMClient {
+  private callIndex = 0;
+
+  constructor(private readonly responses: LLMStreamChunk[][]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    const chunks = this.responses[this.callIndex] ?? [];
+    this.callIndex += 1;
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'gpt-local-test', nativeToolCalling: true },
+  agent: {},
+  conversation: { maxIterations: 3 },
+  confirmation: {},
+  secrets: {},
+  serverUrl: undefined,
+};
+
+describe('LocalConversation', () => {
+  it('executes tools locally and emits observation events', async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), 'local-conv-'));
+    const llm = new FakeLLM([
+      [
+        { type: 'tool_call_delta', id: 'call_1', name: 'file_editor', arguments: '{"path":"note.txt","content":"hello"}' },
+        { type: 'finish', finishReason: 'tool_calls' },
+      ],
+      [
+        { type: 'text', text: 'Wrote the file' },
+        { type: 'finish', finishReason: 'stop' },
+      ],
+    ]);
+
+    const conversation = new LocalConversation({ settings: baseSettings, workspaceRoot: tmp, llmClient: llm });
+    const events: Event[] = [];
+    conversation.on('event', (event) => events.push(event));
+
+    await conversation.sendUserMessage('write a file');
+
+    const content = readFileSync(path.join(tmp, 'note.txt'), 'utf8');
+    expect(content).toContain('hello');
+
+    const observation = events.find((event) => event.type === 'ObservationEvent');
+    expect(observation).toBeDefined();
+    const assistantMessages = events.filter((event) => event.type === 'MessageEvent' && event.source === 'agent');
+    expect(assistantMessages.length).toBeGreaterThan(0);
+  });
+
+  it('emits bash events when terminal tool runs', async () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), 'local-conv-term-'));
+    const llm = new FakeLLM([
+      [
+        { type: 'tool_call_delta', id: 'call_2', name: 'terminal', arguments: '{"command":"pwd"}' },
+        { type: 'finish', finishReason: 'tool_calls' },
+      ],
+      [
+        { type: 'text', text: 'Ran command' },
+        { type: 'finish', finishReason: 'stop' },
+      ],
+    ]);
+
+    const conversation = new LocalConversation({ settings: baseSettings, workspaceRoot: tmp, llmClient: llm });
+    const bashEvents: BashEvent[] = [];
+    conversation.on('terminal', (event) => bashEvents.push(event));
+
+    await conversation.sendUserMessage('run pwd');
+
+    expect(bashEvents.some((event) => event.type === 'BashCommand')).toBe(true);
+    expect(bashEvents.some((event) => event.type === 'BashExit')).toBe(true);
+  });
+});

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
@@ -1,23 +1,58 @@
 import EventEmitter from 'events';
-import type { BashEvent, Event } from '../types';
+import { randomUUID } from 'crypto';
+import type { ChatCompletionRequest, LLMClient } from '../llm';
+import { LLMFactory } from '../llm';
+import { buildToolsPrompt } from '../llm/toolPrompt';
+import { AgentOrchestrator, AsyncLock, EventLog, SecretRegistry } from '../runtime';
+import { FileEditorTool, TaskTrackerTool, TerminalTool } from '../tools';
+import type { ToolHandler } from '../tools/types';
+import type { BashEvent, Event, Message, ToolCall } from '../types';
+import { isBashEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
+import { LocalWorkspace } from '../workspace';
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
 export interface LocalConversationOptions {
   settings: OpenHandsSettings;
   conversationId?: string;
+  workspaceRoot?: string;
+  /**
+   * Optional client used for testing. When not provided, LLMFactory builds the client
+   * from the supplied settings.
+   */
+  llmClient?: LLMClient;
 }
+
+type ToolMap = Record<string, ToolHandler<unknown, unknown>>;
 
 export class LocalConversation extends EventEmitter {
   private status: ConversationStatus = 'offline';
   private conversationId?: string;
   private settings: OpenHandsSettings;
+  private readonly workspace: LocalWorkspace;
+  private readonly tools: ToolMap;
+  private readonly events = new EventLog();
+  private readonly secrets = new SecretRegistry();
+  private readonly lock = new AsyncLock();
+  private readonly messages: Message[] = [];
+  private readonly providedClient?: LLMClient;
 
   constructor(options: LocalConversationOptions) {
     super();
     this.settings = options.settings;
     this.conversationId = options.conversationId;
+    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.providedClient = options.llmClient;
+    this.tools = {
+      terminal: new TerminalTool(),
+      file_editor: new FileEditorTool(),
+      task_tracker: new TaskTrackerTool(),
+    } as ToolMap;
+
+    this.events.on((event) => {
+      this.emit('event', event);
+    });
     this.setStatus('online');
   }
 
@@ -32,7 +67,8 @@ export class LocalConversation extends EventEmitter {
   }
 
   startNewConversation(): Promise<string | undefined> {
-    this.conversationId = this.conversationId ?? `local-${Date.now().toString(36)}`;
+    this.conversationId = `local-${Date.now().toString(36)}-${Math.floor(Math.random() * 1000)}`;
+    this.messages.length = 0;
     this.emit('conversationStarted', this.conversationId);
     return Promise.resolve(this.conversationId);
   }
@@ -43,19 +79,19 @@ export class LocalConversation extends EventEmitter {
   }
 
   async sendUserMessage(text: string) {
-    if (!this.conversationId) {
-      await this.startNewConversation();
-    }
-    const event: Event = {
-      type: 'MessageEvent',
-      source: 'user',
-      llm_message: { role: 'user', content: [{ type: 'text', text }] },
-    } as Event;
-    this.emit('event', event);
+    await this.lock.acquire(async () => {
+      if (!this.conversationId) {
+        await this.startNewConversation();
+      }
+      const userMessage: Message = { role: 'user', content: [{ type: 'text', text }], id: randomUUID() };
+      this.messages.push(userMessage);
+      this.events.push({ type: 'MessageEvent', source: 'user', llm_message: userMessage });
+      await this.runAgentLoop();
+    });
   }
 
   pause(): Promise<void> {
-    this.emit('event', { type: 'PauseEvent', source: 'user' } as Event);
+    this.events.push({ type: 'PauseEvent', source: 'user' });
     return Promise.resolve();
   }
 
@@ -71,6 +107,244 @@ export class LocalConversation extends EventEmitter {
 
   reconnect() {
     this.setStatus('online');
+  }
+
+  private async runAgentLoop(): Promise<void> {
+    const maxIterations = Math.min(Math.max(this.settings?.conversation.maxIterations ?? 4, 1), 10);
+    for (let i = 0; i < maxIterations; i += 1) {
+      const response = await this.generateAssistantMessage();
+      const assistantMessage = response.message;
+      this.messages.push(assistantMessage);
+      this.events.push({ type: 'MessageEvent', source: 'agent', llm_message: assistantMessage });
+
+      const toolCalls = assistantMessage.tool_calls ?? [];
+      if (!toolCalls.length) {
+        return;
+      }
+
+      await this.handleToolCalls(toolCalls, assistantMessage);
+    }
+  }
+
+  private async generateAssistantMessage() {
+    const llm = this.providedClient ?? (await this.createLlmClient());
+    const orchestrator = new AgentOrchestrator(llm, { events: this.events });
+    const request: ChatCompletionRequest = {
+      systemPrompt: this.buildSystemPrompt(),
+      messages: [...this.messages],
+      tools: this.buildToolSchemas(),
+    };
+    return orchestrator.runChat(request);
+  }
+
+  private async handleToolCalls(toolCalls: ToolCall[], assistantMessage: Message): Promise<void> {
+    for (const call of toolCalls) {
+      const actionId = randomUUID();
+      const args = this.parseToolArgs(call);
+      const thoughtText = assistantMessage.content
+        .filter((c) => c.type === 'text')
+        .map((c) => (c.type === 'text' ? c.text : ''))
+        .join(' ');
+
+      this.events.push({
+        type: 'ActionEvent',
+        source: 'agent',
+        thought: thoughtText ? [{ type: 'text', text: thoughtText }] : [],
+        action: args ?? null,
+        tool_name: call.function.name,
+        tool_call_id: call.id,
+        tool_call: call,
+        llm_response_id: assistantMessage.id ?? randomUUID(),
+      });
+
+      const handler = this.tools[call.function.name];
+      if (!handler) {
+        this.events.push({
+          type: 'AgentErrorEvent',
+          source: 'agent',
+          error: `Unsupported tool: ${call.function.name}`,
+          tool_name: call.function.name,
+          tool_call_id: call.id,
+        });
+        continue;
+      }
+
+      try {
+        const observation = await this.executeTool(handler, args);
+        this.events.push({
+          type: 'ObservationEvent',
+          source: 'environment',
+          observation: observation ?? {},
+          tool_name: call.function.name,
+          tool_call_id: call.id,
+          action_id: actionId,
+        });
+        this.messages.push({
+          role: 'tool',
+          tool_call_id: call.id,
+          name: call.function.name,
+          content: [{ type: 'text', text: JSON.stringify(observation ?? {}) }],
+        });
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err);
+        this.events.push({
+          type: 'AgentErrorEvent',
+          source: 'agent',
+          error,
+          tool_name: call.function.name,
+          tool_call_id: call.id,
+        });
+      }
+    }
+  }
+
+  private parseToolArgs(call: ToolCall): unknown {
+    try {
+      return JSON.parse(call.function.arguments || '{}');
+    } catch (e) {
+      const err = e instanceof Error ? e.message : 'unknown error parsing tool args';
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: `Failed to parse tool arguments: ${err}`,
+        tool_name: call.function.name,
+        tool_call_id: call.id,
+      });
+      return {};
+    }
+  }
+
+  private async executeTool(handler: ToolHandler<unknown, unknown>, args: unknown) {
+    if (handler.name === 'terminal') {
+      const parsed = handler.validate(args) as { command: string; cwd?: string; timeoutMs?: number };
+      const commandId = randomUUID();
+      this.emitBashEvent({
+        type: 'BashCommand',
+        command: parsed.command,
+        command_id: commandId,
+        id: randomUUID(),
+        order: 0,
+        timestamp: new Date().toISOString(),
+      });
+      const result = await handler.execute(parsed, { workspace: this.workspace, events: this.events, secrets: this.secrets });
+      if (typeof result === 'object' && result && 'stdout' in result && 'stderr' in result) {
+        const output = result as { stdout?: string; stderr?: string; exitCode?: number };
+        this.emitBashEvent({
+          type: 'BashOutput',
+          command_id: commandId,
+          id: randomUUID(),
+          order: 1,
+          timestamp: new Date().toISOString(),
+          exit_code: output.exitCode ?? null,
+          stdout: output.stdout ?? null,
+          stderr: output.stderr ?? null,
+        });
+        this.emitBashEvent({
+          type: 'BashExit',
+          command_id: commandId,
+          id: randomUUID(),
+          order: 2,
+          timestamp: new Date().toISOString(),
+          exit_code: output.exitCode ?? -1,
+        });
+      }
+      return result;
+    }
+
+    const validated = handler.validate(args);
+    return handler.execute(validated, { workspace: this.workspace, events: this.events, secrets: this.secrets });
+  }
+
+  private emitBashEvent(event: BashEvent) {
+    if (!isBashEvent(event)) return;
+    this.emit('terminal', event);
+  }
+
+  private buildSystemPrompt(): string {
+    const toolsPrompt = buildToolsPrompt(this.buildToolSchemas());
+    return [
+      'You are OpenHands running locally inside VS Code.',
+      'Use the available tools to inspect and modify files in the workspace when needed.',
+      'Respond concisely and prefer tool calls over guesswork.',
+      toolsPrompt,
+    ].join('\n\n');
+  }
+
+  private buildToolSchemas(): ChatCompletionRequest['tools'] {
+    return [
+      {
+        type: 'function',
+        function: {
+          name: 'terminal',
+          description: 'Execute bash commands inside the workspace',
+          parameters: {
+            type: 'object',
+            properties: {
+              command: { type: 'string', description: 'Shell command to execute' },
+              cwd: { type: 'string', description: 'Working directory relative to workspace' },
+              timeoutMs: { type: 'number', description: 'Timeout in milliseconds' },
+            },
+            required: ['command'],
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'file_editor',
+          description: 'Write or append file contents',
+          parameters: {
+            type: 'object',
+            properties: {
+              path: { type: 'string', description: 'Path of the target file' },
+              content: { type: 'string', description: 'Content to write' },
+              append: { type: 'boolean', description: 'Append instead of overwrite' },
+            },
+            required: ['path', 'content'],
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'task_tracker',
+          description: 'Track tasks completed by the agent',
+          parameters: {
+            type: 'object',
+            properties: {
+              action: { type: 'string', enum: ['create', 'complete', 'list', 'update'] },
+              id: { type: 'string', description: 'Task identifier for updates' },
+              title: { type: 'string' },
+              notes: { type: 'string' },
+              completed: { type: 'boolean' },
+            },
+            required: ['action'],
+          },
+        },
+      },
+    ];
+  }
+
+  private async createLlmClient(): Promise<LLMClient> {
+    const model = this.settings?.llm?.model;
+    if (!model) {
+      throw new Error('Missing LLM model in settings. Set openhands.llm.model in VS Code settings.');
+    }
+    const factory = new LLMFactory({
+      model,
+      provider: this.settings.llm.baseUrl?.includes('anthropic') ? 'anthropic' : undefined,
+      baseUrl: this.settings.llm.baseUrl ?? undefined,
+      apiVersion: this.settings.llm.apiVersion ?? undefined,
+      temperature: this.settings.llm.temperature ?? undefined,
+      topP: this.settings.llm.topP ?? undefined,
+      topK: this.settings.llm.topK ?? undefined,
+      maxInputTokens: this.settings.llm.maxInputTokens ?? undefined,
+      maxOutputTokens: this.settings.llm.maxOutputTokens ?? undefined,
+      nativeToolCalling: this.settings.llm.nativeToolCalling ?? true,
+      reasoningEffort: this.settings.llm.reasoningEffort ?? undefined,
+      apiKey: this.settings.secrets.llmApiKey,
+    });
+    return factory.createClient();
   }
 
   private setStatus(status: ConversationStatus) {

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
@@ -67,7 +67,7 @@ export class LocalConversation extends EventEmitter {
   }
 
   startNewConversation(): Promise<string | undefined> {
-    this.conversationId = `local-${Date.now().toString(36)}-${Math.floor(Math.random() * 1000)}`;
+    this.conversationId = `local-${randomUUID()}`;
     this.messages.length = 0;
     this.emit('conversationStarted', this.conversationId);
     return Promise.resolve(this.conversationId);
@@ -111,9 +111,11 @@ export class LocalConversation extends EventEmitter {
 
   private async runAgentLoop(): Promise<void> {
     const maxIterations = Math.min(Math.max(this.settings?.conversation.maxIterations ?? 4, 1), 10);
+    let lastAssistantMessage: Message | undefined;
     for (let i = 0; i < maxIterations; i += 1) {
       const response = await this.generateAssistantMessage();
       const assistantMessage = response.message;
+      lastAssistantMessage = assistantMessage;
       this.messages.push(assistantMessage);
       this.events.push({ type: 'MessageEvent', source: 'agent', llm_message: assistantMessage });
 
@@ -124,15 +126,22 @@ export class LocalConversation extends EventEmitter {
 
       await this.handleToolCalls(toolCalls, assistantMessage);
     }
+
+    if (lastAssistantMessage?.tool_calls?.length) {
+      const finalResponse = await this.generateAssistantMessage([]);
+      const finalMessage = finalResponse.message;
+      this.messages.push(finalMessage);
+      this.events.push({ type: 'MessageEvent', source: 'agent', llm_message: finalMessage });
+    }
   }
 
-  private async generateAssistantMessage() {
+  private async generateAssistantMessage(tools?: ChatCompletionRequest['tools']) {
     const llm = this.providedClient ?? (await this.createLlmClient());
     const orchestrator = new AgentOrchestrator(llm, { events: this.events });
     const request: ChatCompletionRequest = {
       systemPrompt: this.buildSystemPrompt(),
       messages: [...this.messages],
-      tools: this.buildToolSchemas(),
+      tools: tools ?? this.buildToolSchemas(),
     };
     return orchestrator.runChat(request);
   }
@@ -143,7 +152,7 @@ export class LocalConversation extends EventEmitter {
       const args = this.parseToolArgs(call);
       const thoughtText = assistantMessage.content
         .filter((c) => c.type === 'text')
-        .map((c) => (c.type === 'text' ? c.text : ''))
+        .map((c) => c.text)
         .join(' ');
 
       this.events.push({
@@ -332,7 +341,6 @@ export class LocalConversation extends EventEmitter {
     }
     const factory = new LLMFactory({
       model,
-      provider: this.settings.llm.baseUrl?.includes('anthropic') ? 'anthropic' : undefined,
       baseUrl: this.settings.llm.baseUrl ?? undefined,
       apiVersion: this.settings.llm.apiVersion ?? undefined,
       temperature: this.settings.llm.temperature ?? undefined,

--- a/packages/agent-sdk-ts/src/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/conversation/index.ts
@@ -22,7 +22,11 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
       conversationId: options.conversationId,
     }) as ConversationInstance;
   }
-  return new LocalConversation({ settings: options.settings, conversationId: options.conversationId }) as ConversationInstance;
+  return new LocalConversation({
+    settings: options.settings,
+    conversationId: options.conversationId,
+    workspaceRoot: options.workspaceRoot,
+  }) as ConversationInstance;
 }
 
 export { LocalConversation, RemoteConversation };

--- a/packages/agent-sdk-ts/src/llm/factory.test.ts
+++ b/packages/agent-sdk-ts/src/llm/factory.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { AnthropicClient } from './anthropic';
+import { LLMFactory } from './factory';
+
+describe('LLMFactory', () => {
+  it('detects anthropic provider from baseUrl', async () => {
+    const factory = new LLMFactory({
+      model: 'claude-3-5-sonnet-latest',
+      baseUrl: 'https://api.anthropic.com',
+      apiKey: 'test-key',
+    });
+
+    const client = await factory.createClient();
+    expect(client).toBeInstanceOf(AnthropicClient);
+  });
+});

--- a/packages/agent-sdk-ts/src/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/llm/factory.ts
@@ -32,11 +32,11 @@ export class LLMFactory {
       throw new Error('Missing API key for LLM provider');
     }
 
-    if (this.config.provider === 'anthropic') {
-      return new AnthropicClient(this.config, apiKey);
+    const provider = this.config.provider ?? this.detectProviderFromBaseUrl();
+    if (provider === 'anthropic') {
+      return new AnthropicClient({ ...this.config, provider }, apiKey);
     }
 
-    const provider = this.config.provider ?? this.detectProviderFromBaseUrl();
     return new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
   }
 
@@ -45,6 +45,7 @@ export class LLMFactory {
   }
 
   private detectProviderFromBaseUrl(): LLMProvider {
+    if (this.config.baseUrl?.includes('anthropic')) return 'anthropic';
     if (this.config.baseUrl?.includes('openrouter.ai')) return 'openrouter';
     if (this.config.baseUrl?.includes('litellm')) return 'litellm_proxy';
     return 'openai';

--- a/packages/agent-sdk-ts/src/llm/index.ts
+++ b/packages/agent-sdk-ts/src/llm/index.ts
@@ -3,3 +3,4 @@ export * from './credentials';
 export * from './openai-compatible';
 export * from './anthropic';
 export * from './factory';
+export * from './toolPrompt';

--- a/packages/agent-sdk-ts/src/llm/toolPrompt.test.ts
+++ b/packages/agent-sdk-ts/src/llm/toolPrompt.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import type { LLMToolDefinition } from './types';
+import { buildToolsPrompt, convertToolsToDescription } from './toolPrompt';
+
+describe('toolPrompt', () => {
+  const tools: LLMToolDefinition[] = [
+    {
+      type: 'function',
+      function: {
+        name: 'terminal',
+        description: 'Execute bash commands',
+        parameters: {
+          type: 'object',
+          properties: {
+            command: { type: 'string', description: 'Command to run' },
+            timeout: { type: 'number' },
+          },
+          required: ['command'],
+        },
+      },
+    },
+    {
+      type: 'function',
+      function: {
+        name: 'task_tracker',
+      },
+    },
+  ];
+
+  it('matches the Python tool description format', () => {
+    const description = convertToolsToDescription(tools);
+    const expected = [
+      '---- BEGIN FUNCTION #1: terminal ----',
+      'Description: Execute bash commands',
+      'Parameters:',
+      '  (1) command (string, required): Command to run',
+      '  (2) timeout (number, optional): No description provided',
+      '---- END FUNCTION #1 ----',
+      '',
+      '---- BEGIN FUNCTION #2: task_tracker ----',
+      'No parameters are required for this function.',
+      '---- END FUNCTION #2 ----',
+      '',
+    ].join('\n');
+
+    expect(description).toEqual(expected);
+  });
+
+  it('embeds the tool description in the system suffix template', () => {
+    const prompt = buildToolsPrompt(tools);
+    expect(prompt).toContain('You have access to the following functions:');
+    expect(prompt).toContain('<IMPORTANT>');
+    expect(prompt).toContain('Function calls MUST follow the specified format');
+    expect(prompt).toContain(convertToolsToDescription(tools));
+  });
+});
+

--- a/packages/agent-sdk-ts/src/llm/toolPrompt.ts
+++ b/packages/agent-sdk-ts/src/llm/toolPrompt.ts
@@ -1,0 +1,205 @@
+import type { LLMToolDefinition } from './types';
+
+const SCHEMA_INDENT_STEP = 2;
+const SCHEMA_UNION_KEYS = ['anyOf', 'oneOf', 'allOf'] as const;
+const MISSING_DESCRIPTION_PLACEHOLDER = 'No description provided';
+
+const systemMessageSuffixTemplate = `You have access to the following functions:
+
+{description}
+
+If you choose to call a function ONLY reply in the following format with NO suffix:
+
+<function=example_function_name>
+<parameter=example_parameter_1>value_1</parameter>
+<parameter=example_parameter_2>
+This is the value for the second parameter
+that can span
+multiple lines
+</parameter>
+</function>
+
+<IMPORTANT>
+Reminder:
+- Function calls MUST follow the specified format, start with <function= and end with </function>
+- Required parameters MUST be specified
+- Only call one function at a time
+- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after.
+- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls
+</IMPORTANT>`;
+
+const indent = (spaces: number): string => ' '.repeat(spaces);
+const nestedIndent = (spaces: number, levels = 1): number => spaces + SCHEMA_INDENT_STEP * levels;
+
+const summarizeSchemaType = (schema: unknown): string => {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) {
+    return schema == null ? 'unknown' : String(schema);
+  }
+
+  const typedSchema = schema as Record<string, unknown>;
+  for (const key of SCHEMA_UNION_KEYS) {
+    const options = typedSchema[key];
+    if (Array.isArray(options)) {
+      return options.map((option) => summarizeSchemaType(option)).join(' or ');
+    }
+  }
+
+  const schemaType = typedSchema.type;
+  if (Array.isArray(schemaType)) {
+    return schemaType.map(String).join(' or ');
+  }
+  if (schemaType === 'array') {
+    const items = typedSchema.items;
+    if (Array.isArray(items)) {
+      return `array[${items.map((item) => summarizeSchemaType(item)).join(', ')}]`;
+    }
+    if (items && typeof items === 'object') {
+      return `array[${summarizeSchemaType(items)}]`;
+    }
+    return 'array';
+  }
+  if (schemaType) return String(schemaType);
+  if ('enum' in typedSchema) return 'enum';
+  return 'unknown';
+};
+
+const getDescription = (schema: unknown): string => {
+  if (schema && typeof schema === 'object' && !Array.isArray(schema) && 'description' in (schema as Record<string, unknown>)) {
+    const description = (schema as Record<string, unknown>).description;
+    if (typeof description === 'string' && description.trim()) {
+      return description;
+    }
+  }
+  return MISSING_DESCRIPTION_PLACEHOLDER;
+};
+
+const formatUnionDetails = (schema: Record<string, unknown>, spaces: number): string[] | null => {
+  for (const key of SCHEMA_UNION_KEYS) {
+    const options = schema[key];
+    if (!Array.isArray(options)) continue;
+    const lines = [`${indent(spaces)}${key} options:`];
+    for (const option of options) {
+      const optionType = summarizeSchemaType(option);
+      const optionLine = `${indent(nestedIndent(spaces))}- ${optionType}: ${getDescription(option)}`;
+      lines.push(optionLine);
+      lines.push(...formatSchemaDetail(option, nestedIndent(spaces, 2)));
+    }
+    return lines;
+  }
+  return null;
+};
+
+const formatArrayDetails = (schema: Record<string, unknown>, spaces: number): string[] => {
+  const lines = [`${indent(spaces)}Array details:`];
+  const items = schema.items;
+
+  if (Array.isArray(items)) {
+    lines.push(`${indent(nestedIndent(spaces))}Allowed item types:`);
+    items.forEach((item, idx) => {
+      lines.push(`${indent(nestedIndent(spaces, 2))}${idx + 1}. ${summarizeSchemaType(item)}: ${getDescription(item)}`);
+      lines.push(...formatSchemaDetail(item, nestedIndent(spaces, 3)));
+    });
+  } else if (items && typeof items === 'object') {
+    lines.push(`${indent(nestedIndent(spaces))}Items type: ${summarizeSchemaType(items)}: ${getDescription(items)}`);
+    lines.push(...formatSchemaDetail(items, nestedIndent(spaces, 2)));
+  }
+
+  const minItems = schema.minItems;
+  if (typeof minItems === 'number') {
+    lines.push(`${indent(nestedIndent(spaces))}Minimum items: ${minItems}`);
+  }
+  const maxItems = schema.maxItems;
+  if (typeof maxItems === 'number') {
+    lines.push(`${indent(nestedIndent(spaces))}Maximum items: ${maxItems}`);
+  }
+  return lines;
+};
+
+const formatObjectDetails = (schema: Record<string, unknown>, spaces: number): string[] => {
+  const lines = [`${indent(spaces)}Object details:`];
+  const properties = (schema.properties && typeof schema.properties === 'object' && !Array.isArray(schema.properties))
+    ? schema.properties as Record<string, unknown>
+    : {};
+  const required = new Set(Array.isArray(schema.required) ? (schema.required as unknown[]).map(String) : []);
+
+  Object.entries(properties).forEach(([propName, propSchema], idx) => {
+    const status = required.has(propName) ? 'required' : 'optional';
+    const propType = summarizeSchemaType(propSchema);
+    lines.push(`${indent(nestedIndent(spaces))}${idx + 1}. ${propName} (${propType}, ${status}): ${getDescription(propSchema)}`);
+    lines.push(...formatSchemaDetail(propSchema, nestedIndent(spaces, 2)));
+  });
+
+  if ('additionalProperties' in schema) {
+    const additionalProperties = schema.additionalProperties;
+    if (additionalProperties === false) {
+      lines.push(`${indent(nestedIndent(spaces))}Additional properties: Not allowed`);
+    } else {
+      const additionalType = summarizeSchemaType(additionalProperties);
+      lines.push(`${indent(nestedIndent(spaces))}Additional properties: Allowed (type: ${additionalType})`);
+      lines.push(...formatSchemaDetail(additionalProperties, nestedIndent(spaces, 2)));
+    }
+  }
+  return lines;
+};
+
+const formatSchemaDetail = (schema: unknown, spaces: number): string[] => {
+  if (!schema || typeof schema !== 'object' || Array.isArray(schema)) return [];
+  const typedSchema = schema as Record<string, unknown>;
+
+  const unionLines = formatUnionDetails(typedSchema, spaces);
+  if (unionLines) return unionLines;
+
+  const schemaType = typedSchema.type;
+  if (Array.isArray(schemaType)) {
+    const allowedTypes = schemaType.join(', ');
+    return [`${indent(spaces)}Allowed types: ${allowedTypes}`];
+  }
+  if (schemaType === 'array') {
+    return formatArrayDetails(typedSchema, spaces);
+  }
+  if (schemaType === 'object') {
+    return formatObjectDetails(typedSchema, spaces);
+  }
+  return [];
+};
+
+export const convertToolsToDescription = (tools: LLMToolDefinition[]): string => {
+  let description = '';
+  tools.forEach((tool, index) => {
+    if (tool.type !== 'function') return;
+    const fn = tool.function;
+    if (index > 0) description += '\n';
+    description += `---- BEGIN FUNCTION #${index + 1}: ${fn.name} ----\n`;
+    if ('description' in fn && fn.description) {
+      description += `Description: ${fn.description}\n`;
+    }
+
+    const parameters = (fn as { parameters?: unknown }).parameters;
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const paramsSchema = parameters as { properties?: Record<string, unknown>; required?: string[] };
+      const properties = paramsSchema.properties ?? {};
+      const requiredParams = new Set(paramsSchema.required ?? []);
+      description += 'Parameters:\n';
+      Object.entries(properties).forEach(([paramName, paramInfo], propIndex) => {
+        const isRequired = requiredParams.has(paramName);
+        const paramStatus = isRequired ? 'required' : 'optional';
+        const paramType = summarizeSchemaType(paramInfo);
+        const desc = getDescription(paramInfo);
+        description += `  (${propIndex + 1}) ${paramName} (${paramType}, ${paramStatus}): ${desc}\n`;
+        const detailLines = formatSchemaDetail(paramInfo, 6);
+        if (detailLines.length) {
+          description += `${detailLines.join('\n')}\n`;
+        }
+      });
+    } else {
+      description += 'No parameters are required for this function.\n';
+    }
+
+    description += `---- END FUNCTION #${index + 1} ----\n`;
+  });
+  return description;
+};
+
+export const buildToolsPrompt = (tools: LLMToolDefinition[]): string =>
+  systemMessageSuffixTemplate.replace('{description}', convertToolsToDescription(tools));
+


### PR DESCRIPTION
## Summary
- add a shared tool prompt generator that mirrors the Python agent-sdk function-calling suffix
- update local conversations to embed the Python-style tools prompt and export the helper from the LLM package
- cover the new tools prompt rendering with unit tests and document the parity in LOCAL_FINDINGS

## Testing
- npm test -w @openhands/agent-sdk-ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b09857f7c8320b581ac1376eefb53)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled local tool execution and agent orchestration in conversation workflows.
  * Added public APIs to query and manage conversation state (mode, conversation ID, status, runtime settings).
  * Standardized tool prompt formatting to match existing SDK patterns.

* **Documentation**
  * Added parity notes documenting local conversation capabilities and limitations.

* **Tests**
  * Added tests covering local conversation orchestration, tool execution, and tool-prompt generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->