### PR TITLE
Implement local conversation orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ The SDK provides a TypeScript implementation used by the VS Code extension for b
 
 **Conversation Layer** (Primary API):
 - `Conversation()` - Factory function that creates local or remote conversation instances
-- `LocalConversation` - In-memory agent execution stub (not yet fully implemented)
+- `LocalConversation` - In-memory agent execution for VS Code with workspace tools
 - `RemoteConversation` - WebSocket-based remote agent communication with auto-reconnect
 - Event-driven API: `.on('event', ...)`, `.on('status', ...)`, `.on('error', ...)`
 - Dual mode support: Automatically selects local or remote based on serverUrl
-- **Note**: Currently requires agent-server (localhost or remote) for functional agent execution
+- Local mode runs directly inside VS Code; remote mode requires an agent-server
 
 **Runtime Layer**:
 - `AgentOrchestrator` - LLM orchestration with streaming support

--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -114,9 +114,9 @@ interface ConversationInstance {
 
 **Purpose**: In-memory agent execution within VS Code without an external agent-server.
 
-**Current Status**: ⚠️ **STUB IMPLEMENTATION** - Currently only emits events without actual agent orchestration. Full implementation tracked in issue [to be created].
+**Status**: Local execution path that runs the full agent loop directly inside VS Code using `AgentOrchestrator`, built-in tools, and `LocalWorkspace`.
 
-**Intended Features** (when implemented):
+**Features**:
 - Runs agent orchestration locally using `AgentOrchestrator`
 - EventEmitter-based event dispatching
 - Manages tool execution with `LocalWorkspace`
@@ -124,7 +124,7 @@ interface ConversationInstance {
 - Full conversation state management
 - No external server required (but still VS Code-bound)
 
-**Note**: Even when fully implemented, LocalConversation will be **VS Code-bound** (uses VS Code SecretStorage, IntegratedTerminalRunner, etc.). "Local mode" means running the agent in VS Code without an external server, not running as a standalone CLI.
+**Note**: LocalConversation remains **VS Code-bound** (uses VS Code SecretStorage, IntegratedTerminalRunner, etc.). "Local mode" means running the agent in VS Code without an external server, not running as a standalone CLI.
 
 ### RemoteConversation
 

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
 import { LocalConversation } from './LocalConversation';
 import type { Event, MessageEvent } from '../types';
-import { isActionEvent, isMessageEvent, isObservationEvent } from '../types';
+import { isActionEvent, isAgentErrorEvent, isMessageEvent, isObservationEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 
 class FakeLLM implements LLMClient {
@@ -12,7 +12,7 @@ class FakeLLM implements LLMClient {
     this.responses = responses;
   }
 
-  // eslint-disable-next-line require-await
+  // eslint-disable-next-line @typescript-eslint/require-await
   async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
     const next = this.responses.shift() ?? [];
     for (const chunk of next) {
@@ -35,7 +35,7 @@ describe('LocalConversation', () => {
     const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
 
     const events: Event[] = [];
-    conversation.on('event', (e) => events.push(e));
+    conversation.on('event', (e: Event) => events.push(e));
 
     await conversation.sendUserMessage('hi');
 
@@ -57,7 +57,7 @@ describe('LocalConversation', () => {
 
     const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
     const events: Event[] = [];
-    conversation.on('event', (e) => events.push(e));
+    conversation.on('event', (e: Event) => events.push(e));
 
     await conversation.sendUserMessage('list tasks');
 
@@ -71,5 +71,66 @@ describe('LocalConversation', () => {
       .filter((e): e is MessageEvent => isMessageEvent(e) && e.source === 'agent')
       .pop();
     expect(finalAssistant?.llm_message.content[0]).toEqual({ type: 'text', text: 'Tasks listed' });
+  });
+
+  it('records AgentErrorEvents when tool args JSON is invalid', async () => {
+    const llm = new FakeLLM([
+      [
+        { type: 'tool_call_delta', id: 'tool_bad', name: 'task_tracker', arguments: '{"action":"list"' },
+        { type: 'finish' },
+      ],
+      [{ type: 'text', text: 'Recovered' }, { type: 'finish' }],
+    ]);
+
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
+    const events: Event[] = [];
+    conversation.on('event', (e: Event) => events.push(e));
+
+    await conversation.sendUserMessage('do something');
+
+    const errors = events.filter(isAgentErrorEvent);
+    expect(errors.some((e) => e.error.includes('Invalid tool arguments'))).toBe(true);
+    const finalAssistant = events
+      .filter((e): e is MessageEvent => isMessageEvent(e) && e.source === 'agent')
+      .pop();
+    expect(finalAssistant?.llm_message.content[0]).toEqual({ type: 'text', text: 'Recovered' });
+  });
+
+  it('emits AgentErrorEvent for unknown tools', async () => {
+    const llm = new FakeLLM([
+      [
+        { type: 'tool_call_delta', id: 'tool_unknown', name: 'nonexistent', arguments: '{"any":"value"}' },
+        { type: 'finish' },
+      ],
+      [{ type: 'text', text: 'Handled' }, { type: 'finish' }],
+    ]);
+
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
+    const events: Event[] = [];
+    conversation.on('event', (e: Event) => events.push(e));
+
+    await conversation.sendUserMessage('call bad tool');
+
+    const error = events.find(isAgentErrorEvent);
+    expect(error?.error).toContain('Unknown tool');
+  });
+
+  it('captures tool execution failures as AgentErrorEvents', async () => {
+    const llm = new FakeLLM([
+      [
+        { type: 'tool_call_delta', id: 'tool_fail', name: 'task_tracker', arguments: '{"action":"complete"}' },
+        { type: 'finish' },
+      ],
+      [{ type: 'text', text: 'Done' }, { type: 'finish' }],
+    ]);
+
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
+    const events: Event[] = [];
+    conversation.on('event', (e: Event) => events.push(e));
+
+    await conversation.sendUserMessage('complete unknown task');
+
+    const error = events.find(isAgentErrorEvent);
+    expect(error?.error).toContain('id is required');
   });
 });

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.test.ts
@@ -12,6 +12,7 @@ class FakeLLM implements LLMClient {
     this.responses = responses;
   }
 
+  // eslint-disable-next-line require-await
   async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
     const next = this.responses.shift() ?? [];
     for (const chunk of next) {

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
+import { LocalConversation } from './LocalConversation';
+import type { Event, MessageEvent } from '../types';
+import { isActionEvent, isMessageEvent, isObservationEvent } from '../types';
+import type { OpenHandsSettings } from '../types/settings';
+
+class FakeLLM implements LLMClient {
+  private readonly responses: LLMStreamChunk[][];
+
+  constructor(responses: LLMStreamChunk[][]) {
+    this.responses = responses;
+  }
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    const next = this.responses.shift() ?? [];
+    for (const chunk of next) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 5 },
+  confirmation: {},
+  secrets: {},
+};
+
+describe('LocalConversation', () => {
+  it('emits assistant messages when LLM responds without tools', async () => {
+    const llm = new FakeLLM([[{ type: 'text', text: 'Hello world' }, { type: 'finish' }]]);
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
+
+    const events: Event[] = [];
+    conversation.on('event', (e) => events.push(e));
+
+    await conversation.sendUserMessage('hi');
+
+    const assistantMessage = events.find(
+      (e): e is MessageEvent => isMessageEvent(e) && e.source === 'agent',
+    );
+    expect(assistantMessage?.llm_message.content[0]).toEqual({ type: 'text', text: 'Hello world' });
+  });
+
+  it('executes tool calls and emits observations', async () => {
+    const llm = new FakeLLM([
+      [
+        { type: 'text', text: 'Working' },
+        { type: 'tool_call_delta', id: 'tool_1', name: 'task_tracker', arguments: '{"action":"list"}' },
+        { type: 'finish' },
+      ],
+      [{ type: 'text', text: 'Tasks listed' }, { type: 'finish' }],
+    ]);
+
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
+    const events: Event[] = [];
+    conversation.on('event', (e) => events.push(e));
+
+    await conversation.sendUserMessage('list tasks');
+
+    const actionEvent = events.find((e) => isActionEvent(e) && e.tool_name === 'task_tracker');
+    expect(actionEvent).toBeDefined();
+
+    const observationEvent = events.find((e) => isObservationEvent(e) && e.tool_name === 'task_tracker');
+    expect(observationEvent).toBeDefined();
+
+    const finalAssistant = events
+      .filter((e): e is MessageEvent => isMessageEvent(e) && e.source === 'agent')
+      .pop();
+    expect(finalAssistant?.llm_message.content[0]).toEqual({ type: 'text', text: 'Tasks listed' });
+  });
+});

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
@@ -1,23 +1,61 @@
 import EventEmitter from 'events';
-import type { BashEvent, Event } from '../types';
+import { randomUUID } from 'crypto';
+import type { SecretStorage } from 'vscode';
+import { AgentOrchestrator, AsyncLock, ConversationState, EventLog, SecretRegistry } from '../runtime';
+import { LLMFactory } from '../llm';
+import type { LLMClient, LLMConfiguration, LLMToolDefinition } from '../llm';
+import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
+import { isTextContent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
+import { BrowserTool, FileEditorTool, TaskTrackerTool, TerminalTool, type ToolHandler } from '../tools';
+import { LocalWorkspace } from '../workspace/LocalWorkspace';
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
 export interface LocalConversationOptions {
   settings: OpenHandsSettings;
   conversationId?: string;
+  workspaceRoot?: string;
+  llmClient?: LLMClient;
+  secretStorage?: SecretStorage;
+  tools?: ToolHandler<unknown, unknown>[];
 }
 
 export class LocalConversation extends EventEmitter {
   private status: ConversationStatus = 'offline';
   private conversationId?: string;
   private settings: OpenHandsSettings;
+  private readonly workspace: LocalWorkspace;
+  private readonly events: EventLog;
+  private readonly state: ConversationState;
+  private readonly secrets: SecretRegistry;
+  private readonly tools: Map<string, ToolHandler<unknown, unknown>>;
+  private readonly lock = new AsyncLock();
+  private orchestratorPromise?: Promise<AgentOrchestrator>;
+  private paused = false;
+  private pendingAction?: { toolCall: ToolCall; actionEvent: ActionEvent; args: unknown };
+  private readonly customLlmClient?: LLMClient;
+  private readonly secretStorage?: SecretStorage;
 
   constructor(options: LocalConversationOptions) {
     super();
     this.settings = options.settings;
     this.conversationId = options.conversationId;
+    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.events = new EventLog();
+    this.state = new ConversationState(this.events);
+    this.secretStorage = options.secretStorage;
+    this.customLlmClient = options.llmClient;
+    this.secrets = new SecretRegistry(options.secretStorage);
+    const providedTools = options.tools ?? [
+      new TerminalTool(),
+      new FileEditorTool(),
+      new TaskTrackerTool(),
+      new BrowserTool(),
+    ];
+    this.tools = new Map(providedTools.map((tool) => [tool.name, tool as ToolHandler<unknown, unknown>]));
+
+    this.events.on((event) => this.emit('event', event));
     this.setStatus('online');
   }
 
@@ -43,27 +81,62 @@ export class LocalConversation extends EventEmitter {
   }
 
   async sendUserMessage(text: string) {
-    if (!this.conversationId) {
-      await this.startNewConversation();
-    }
-    const event: Event = {
-      type: 'MessageEvent',
-      source: 'user',
-      llm_message: { role: 'user', content: [{ type: 'text', text }] },
-    } as Event;
-    this.emit('event', event);
+    await this.lock.acquire(async () => {
+      if (!this.conversationId) {
+        await this.startNewConversation();
+      }
+
+      const userEvent: MessageEvent = {
+        type: 'MessageEvent',
+        source: 'user',
+        llm_message: { role: 'user', content: [{ type: 'text', text }] },
+      };
+      this.events.push(userEvent);
+
+      await this.runAgentLoop();
+    });
   }
 
   pause(): Promise<void> {
-    this.emit('event', { type: 'PauseEvent', source: 'user' } as Event);
+    this.paused = true;
+    this.events.push({ type: 'PauseEvent', source: 'user' } as Event);
+    this.state.setStatus('PAUSED');
     return Promise.resolve();
   }
 
-  resume(): Promise<void> { return Promise.resolve(); /* local resume no-op */ }
+  resume(): Promise<void> {
+    this.paused = false;
+    this.state.setStatus('RUNNING');
+    return this.runAgentLoop();
+  }
 
-  approveAction(): Promise<void> { return Promise.resolve(); /* local approve no-op */ }
+  approveAction(): Promise<void> {
+    if (!this.pendingAction) return Promise.resolve();
+    return this.lock.acquire(async () => {
+      const { toolCall, actionEvent, args } = this.pendingAction!;
+      this.pendingAction = undefined;
+      this.state.setStatus('RUNNING');
+      await this.executeTool(toolCall, actionEvent, args);
+      await this.runAgentLoop();
+    });
+  }
 
-  rejectAction(_reason?: string): Promise<void> { return Promise.resolve(); /* local reject no-op */ }
+  rejectAction(reason?: string): Promise<void> {
+    if (!this.pendingAction) return Promise.resolve();
+    const { actionEvent } = this.pendingAction;
+    this.pendingAction = undefined;
+    const rejection = {
+      type: 'UserRejectObservation',
+      source: 'environment',
+      rejection_reason: reason ?? 'User rejected the action',
+      tool_name: actionEvent.tool_name,
+      tool_call_id: actionEvent.tool_call_id,
+      action_id: actionEvent.id!,
+    } as Event;
+    this.events.push(rejection);
+    this.state.setStatus('IDLE');
+    return Promise.resolve();
+  }
 
   disconnect() {
     this.setStatus('offline');
@@ -76,6 +149,223 @@ export class LocalConversation extends EventEmitter {
   private setStatus(status: ConversationStatus) {
     this.status = status;
     this.emit('status', status);
+  }
+
+  private async runAgentLoop(): Promise<void> {
+    if (this.paused || this.pendingAction) {
+      return;
+    }
+
+    const maxIterations = this.clampMaxIterations();
+    const orchestrator = await this.getOrchestrator();
+
+    while (!this.paused && !this.pendingAction && this.state.snapshot.iteration < maxIterations) {
+      this.state.setStatus('RUNNING');
+      const request = this.buildChatRequest();
+      const response = await orchestrator.runChat(request);
+
+      const assistantEvent: MessageEvent = {
+        type: 'MessageEvent',
+        source: 'agent',
+        llm_message: response.message,
+      };
+      this.events.push(assistantEvent);
+      this.state.incrementIteration();
+
+      const toolCalls = response.message.tool_calls ?? [];
+      if (!toolCalls.length) {
+        this.state.setStatus('IDLE');
+        break;
+      }
+
+      for (const toolCall of toolCalls) {
+        const parsedArgs = this.parseToolArgs(toolCall.function.arguments);
+        const actionEvent = this.createActionEvent(response.message, toolCall, parsedArgs);
+        const recordedAction = this.events.push(actionEvent) as ActionEvent;
+
+        if (this.requiresConfirmation()) {
+          this.pendingAction = { toolCall, actionEvent: recordedAction, args: parsedArgs };
+          this.state.setStatus('WAITING_FOR_CONFIRMATION');
+          return;
+        }
+
+        await this.executeTool(toolCall, recordedAction, parsedArgs);
+      }
+    }
+  }
+
+  private clampMaxIterations(): number {
+    const raw = this.settings?.conversation?.maxIterations;
+    const n = typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : 50;
+    return Math.min(500, Math.max(1, n));
+  }
+
+  private buildChatRequest() {
+    const systemPrompt = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
+    const messages = this.events
+      .list()
+      .filter((event): event is MessageEvent => event.type === 'MessageEvent')
+      .map((event) => event.llm_message);
+    const tools = this.getToolDefinitions();
+    return { systemPrompt, messages, tools };
+  }
+
+  private getToolDefinitions(): LLMToolDefinition[] {
+    return Array.from(this.tools.values()).map((tool) => ({
+      type: 'function',
+      function: { name: tool.name },
+    }));
+  }
+
+  private async getOrchestrator(): Promise<AgentOrchestrator> {
+    if (!this.orchestratorPromise) {
+      this.orchestratorPromise = (async () => {
+        const client = this.customLlmClient ?? (await this.createLlmClientFromSettings());
+        return new AgentOrchestrator(client, { events: this.events, state: this.state });
+      })();
+    }
+
+    return this.orchestratorPromise;
+  }
+
+  private createLlmClientFromSettings(): Promise<LLMClient> {
+    if (!this.settings.llm?.model) {
+      return Promise.reject(new Error('LLM model is not configured'));
+    }
+    const s = this.settings;
+    const config: LLMConfiguration = {
+      model: s.llm.model ?? '',
+      baseUrl: s.llm.baseUrl ?? undefined,
+      apiKey: s.secrets?.llmApiKey ?? undefined,
+      apiVersion: s.llm.apiVersion ?? undefined,
+      timeoutSeconds: s.llm.timeout ?? undefined,
+      temperature: s.llm.temperature ?? undefined,
+      topP: s.llm.topP ?? undefined,
+      topK: s.llm.topK ?? undefined,
+      maxInputTokens: s.llm.maxInputTokens ?? undefined,
+      maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
+      nativeToolCalling: s.llm.nativeToolCalling ?? undefined,
+      reasoningEffort: s.llm.reasoningEffort ?? undefined,
+    };
+    const factory = new LLMFactory(config, { storage: this.secretStorage });
+    return factory.createClient();
+  }
+
+  private parseToolArgs(raw: string | undefined): unknown {
+    if (!raw) return {};
+    try {
+      return JSON.parse(raw);
+    } catch (e) {
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: `Invalid tool arguments: ${e instanceof Error ? e.message : String(e)}`,
+        tool_name: 'unknown',
+        tool_call_id: randomUUID(),
+      } as Event);
+      return {};
+    }
+  }
+
+  private requiresConfirmation(): boolean {
+    const policy = this.settings?.confirmation?.policy ?? 'never';
+    return policy !== 'never';
+  }
+
+  private createActionEvent(message: Message, toolCall: ToolCall, args: unknown): ActionEvent {
+    const thought = message.content.filter(isTextContent);
+    return {
+      type: 'ActionEvent',
+      source: 'agent',
+      thought,
+      reasoning_content: message.reasoning_content,
+      action: typeof args === 'object' ? (args as Record<string, unknown>) : null,
+      tool_name: toolCall.function.name,
+      tool_call_id: toolCall.id,
+      tool_call: toolCall,
+      llm_response_id: message.id ?? randomUUID(),
+    };
+  }
+
+  private async executeTool(toolCall: ToolCall, actionEvent: ActionEvent, args: unknown): Promise<void> {
+    const tool = this.tools.get(toolCall.function.name);
+    if (!tool) {
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: `Unknown tool: ${toolCall.function.name}`,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+      } as Event);
+      return;
+    }
+
+    try {
+      const validated = tool.validate(args);
+      const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
+      const result = await tool.execute(validated as never, context);
+
+      if (toolCall.function.name === 'terminal') {
+        this.emitTerminalEvents(toolCall, result);
+      }
+
+      const observation = {
+        type: 'ObservationEvent',
+        source: 'environment',
+        observation: result as Record<string, unknown>,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+        action_id: actionEvent.id ?? randomUUID(),
+      } as Event;
+      this.events.push(observation);
+
+      const toolMessage: MessageEvent = {
+        type: 'MessageEvent',
+        source: 'environment',
+        llm_message: {
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          name: toolCall.function.name,
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+        },
+      };
+      this.events.push(toolMessage);
+    } catch (e) {
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: e instanceof Error ? e.message : String(e),
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+      } as Event);
+    }
+  }
+
+  private emitTerminalEvents(toolCall: ToolCall, result: unknown): void {
+    const payload = result as { command?: string; stdout?: string; stderr?: string; exitCode?: number };
+    const commandId = toolCall.id;
+    const timestamp = new Date().toISOString();
+    const events: BashEvent[] = [
+      {
+        id: randomUUID(),
+        type: 'BashCommand',
+        timestamp,
+        command_id: commandId,
+        order: 0,
+        command: payload.command ?? toolCall.function.arguments,
+      },
+      {
+        id: randomUUID(),
+        type: 'BashOutput',
+        timestamp,
+        command_id: commandId,
+        order: 1,
+        exit_code: payload.exitCode ?? 0,
+        stdout: payload.stdout ?? null,
+        stderr: payload.stderr ?? null,
+      },
+    ];
+    events.forEach((evt) => this.emit('terminal', evt));
   }
 }
 

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
@@ -303,7 +303,7 @@ export class LocalConversation extends EventEmitter {
     try {
       const validated = tool.validate(args);
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
-      const result = await tool.execute(validated as never, context);
+      const result = await tool.execute(validated, context);
 
       if (toolCall.function.name === 'terminal') {
         this.emitTerminalEvents(toolCall, result);

--- a/packages/agent-sdk-ts/src/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/conversation/index.ts
@@ -22,7 +22,11 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
       conversationId: options.conversationId,
     }) as ConversationInstance;
   }
-  return new LocalConversation({ settings: options.settings, conversationId: options.conversationId }) as ConversationInstance;
+  return new LocalConversation({
+    settings: options.settings,
+    conversationId: options.conversationId,
+    workspaceRoot: options.workspaceRoot,
+  }) as ConversationInstance;
 }
 
 export { LocalConversation, RemoteConversation };


### PR DESCRIPTION
## Summary
- add full LocalConversation orchestration with LLM streaming, tool execution, and conversation state management
- expose workspace root to local conversation creation and emit terminal/tool events for VS Code
- document local mode availability and add unit coverage for local execution paths

## Testing
- npm test -w @openhands/agent-sdk-ts -- LocalConversation

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0b0357e88320985f708ce775edb3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LocalConversation now fully supports local agent execution directly within VS Code with built-in tools and customizable LLM integration.
  * Added agent approval workflow for tool execution control.

* **Documentation**
  * Updated README and architecture documentation to reflect LocalConversation as a complete implementation with in-IDE execution capabilities.

* **Tests**
  * Added comprehensive test coverage for LocalConversation event handling and tool execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->