### PR TITLE
Implement LocalConversation agent loop

### DIFF
--- a/packages/agent-sdk-ts/src/__tests__/local.conversation.test.ts
+++ b/packages/agent-sdk-ts/src/__tests__/local.conversation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { LocalConversation } from '../conversation/LocalConversation';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
+import { isActionEvent, isMessageEvent, isObservationEvent, type Event } from '../types';
+import type { OpenHandsSettings } from '../types/settings';
+
+class FakeStreamingLLM implements LLMClient {
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    const last = request.messages[request.messages.length - 1];
+    if (last.role === 'user') {
+      yield { type: 'text', text: 'Planning…' };
+      yield {
+        type: 'tool_call_delta',
+        id: 'call_1',
+        name: 'task_tracker',
+        arguments: '{"action":"create","title":"demo"}',
+      };
+      yield { type: 'finish' };
+      return;
+    }
+
+    yield { type: 'text', text: 'Task created' };
+    yield { type: 'finish' };
+  }
+}
+
+describe('LocalConversation', () => {
+  const settings: OpenHandsSettings = {
+    llm: { model: 'fake-model' },
+    agent: {},
+    conversation: { maxIterations: 5 },
+    confirmation: { policy: 'never' },
+    secrets: {},
+  };
+
+  it('runs agent loop with tool execution and observations', async () => {
+    const conversation = new LocalConversation({ settings, llmClient: new FakeStreamingLLM() });
+    const events: Event[] = [];
+    conversation.on('event', (event) => events.push(event));
+
+    await conversation.startNewConversation();
+    await conversation.sendUserMessage('start');
+
+    const actionEvents = events.filter(isActionEvent);
+    const observationEvents = events.filter(isObservationEvent);
+    const assistantMessages = events.filter(isMessageEvent).filter((event) => event.source === 'agent');
+
+    expect(actionEvents).toHaveLength(1);
+    expect(observationEvents).toHaveLength(1);
+    expect(assistantMessages.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/conversation/LocalConversation.ts
@@ -1,23 +1,95 @@
 import EventEmitter from 'events';
-import type { BashEvent, Event } from '../types';
+import { randomUUID } from 'crypto';
+import type { SecretStorage } from 'vscode';
+import { AgentOrchestrator, ConversationState, EventLog, SecretRegistry } from '../runtime';
+import { LLMFactory } from '../llm';
+import type { LLMClient, LLMToolDefinition } from '../llm';
+import type {
+  ActionEvent,
+  BashEvent,
+  ConversationStateUpdateEvent,
+  Event,
+  MessageEvent,
+  ObservationEvent,
+  ToolCall,
+  UserRejectObservation,
+} from '../types';
+import { isTextContent } from '../types';
+import type { Message } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
+import { BrowserTool, FileEditorTool, TaskTrackerTool, TerminalTool, type ToolHandler } from '../tools';
+import type { TerminalResult } from '../tools/TerminalTool';
+import { LocalWorkspace } from '../workspace/LocalWorkspace';
+import type { ToolContext } from '../tools/types';
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
 export interface LocalConversationOptions {
   settings: OpenHandsSettings;
+  workspaceRoot?: string;
+  storage?: SecretStorage;
   conversationId?: string;
+  llmClient?: LLMClient; // primarily for tests
 }
+
+type PendingAction = {
+  actionEvent: ActionEvent;
+  handler: ToolHandler<unknown, unknown>;
+  args: unknown;
+  toolCall: ToolCall;
+};
 
 export class LocalConversation extends EventEmitter {
   private status: ConversationStatus = 'offline';
   private conversationId?: string;
   private settings: OpenHandsSettings;
+  private readonly workspace: LocalWorkspace;
+  private readonly secrets: SecretRegistry;
+  private readonly storage?: SecretStorage;
+  private readonly events: EventLog;
+  private readonly state: ConversationState;
+  private orchestrator?: AgentOrchestrator;
+  private readonly toolContext: ToolContext;
+  private readonly tools: Record<string, ToolHandler<unknown, unknown>>;
+  private readonly toolDefinitions: LLMToolDefinition[];
+  private readonly messages: Message[] = [];
+  private pendingActions: PendingAction[] = [];
+  private awaitingConfirmation = false;
+  private paused = false;
+  private runningPromise: Promise<void> | null = null;
+  private readonly iterationLimit: number;
+  private readonly systemPrompt =
+    'You are OpenHands running locally inside VS Code. Use the available tools to complete tasks. Return concise updates when no action is needed.';
 
   constructor(options: LocalConversationOptions) {
     super();
     this.settings = options.settings;
     this.conversationId = options.conversationId;
+    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.secrets = new SecretRegistry(options.storage);
+    this.storage = options.storage;
+    this.events = new EventLog();
+    this.state = new ConversationState(this.events);
+    this.toolContext = { workspace: this.workspace, events: this.events, secrets: this.secrets };
+    if (this.settings.secrets?.llmApiKey) this.secrets.register('LLM_API_KEY', this.settings.secrets.llmApiKey);
+    if (this.settings.secrets?.awsAccessKeyId) this.secrets.register('AWS_ACCESS_KEY_ID', this.settings.secrets.awsAccessKeyId);
+    if (this.settings.secrets?.awsSecretAccessKey) {
+      this.secrets.register('AWS_SECRET_ACCESS_KEY', this.settings.secrets.awsSecretAccessKey);
+    }
+    this.tools = {
+      terminal: new TerminalTool(),
+      file_editor: new FileEditorTool(),
+      task_tracker: new TaskTrackerTool(),
+      browser: new BrowserTool(),
+    };
+    this.toolDefinitions = this.buildToolDefinitions();
+    this.iterationLimit = this.clampIterations(options.settings.conversation?.maxIterations);
+
+    if (options.llmClient) {
+      this.orchestrator = new AgentOrchestrator(options.llmClient, { events: this.events, state: this.state });
+    }
+
+    this.events.on((event) => this.emit('event', event));
     this.setStatus('online');
   }
 
@@ -31,13 +103,15 @@ export class LocalConversation extends EventEmitter {
     this.settings = settings;
   }
 
-  startNewConversation(): Promise<string | undefined> {
+  async startNewConversation(): Promise<string | undefined> {
+    this.resetConversation();
     this.conversationId = this.conversationId ?? `local-${Date.now().toString(36)}`;
     this.emit('conversationStarted', this.conversationId);
-    return Promise.resolve(this.conversationId);
+    return this.conversationId;
   }
 
   restoreConversation(id: string) {
+    this.resetConversation();
     this.conversationId = id;
     this.emit('conversationStarted', id);
   }
@@ -46,24 +120,66 @@ export class LocalConversation extends EventEmitter {
     if (!this.conversationId) {
       await this.startNewConversation();
     }
-    const event: Event = {
+
+    const userMessage: Message = { role: 'user', content: [{ type: 'text', text }] };
+    this.messages.push(userMessage);
+    this.pushEvent({
       type: 'MessageEvent',
       source: 'user',
-      llm_message: { role: 'user', content: [{ type: 'text', text }] },
-    } as Event;
-    this.emit('event', event);
+      llm_message: userMessage,
+    });
+
+    await this.runAgentLoop();
   }
 
-  pause(): Promise<void> {
-    this.emit('event', { type: 'PauseEvent', source: 'user' } as Event);
-    return Promise.resolve();
+  async pause(): Promise<void> {
+    if (this.paused) return;
+    this.paused = true;
+    this.state.setStatus('paused');
+    this.pushEvent({ type: 'PauseEvent', source: 'user' });
   }
 
-  resume(): Promise<void> { return Promise.resolve(); /* local resume no-op */ }
+  async resume(): Promise<void> {
+    if (!this.paused) return;
+    this.paused = false;
+    this.state.setStatus('running');
+    await this.runAgentLoop();
+  }
 
-  approveAction(): Promise<void> { return Promise.resolve(); /* local approve no-op */ }
+  async approveAction(): Promise<void> {
+    if (!this.awaitingConfirmation || this.pendingActions.length === 0) return;
+    const actions = [...this.pendingActions];
+    this.pendingActions = [];
+    this.awaitingConfirmation = false;
 
-  rejectAction(_reason?: string): Promise<void> { return Promise.resolve(); /* local reject no-op */ }
+    for (const pending of actions) {
+      await this.executeToolCall(pending.handler, pending.args, pending.toolCall, pending.actionEvent);
+    }
+
+    await this.runAgentLoop();
+  }
+
+  async rejectAction(reason = 'User rejected the action'): Promise<void> {
+    if (!this.awaitingConfirmation || this.pendingActions.length === 0) return;
+    const actions = [...this.pendingActions];
+    this.pendingActions = [];
+    this.awaitingConfirmation = false;
+
+    for (const pending of actions) {
+      const rejection: UserRejectObservation = {
+        type: 'UserRejectObservation',
+        source: 'environment',
+        rejection_reason: reason,
+        tool_name: pending.actionEvent.tool_name,
+        tool_call_id: pending.actionEvent.tool_call_id,
+        action_id: pending.actionEvent.id ?? pending.actionEvent.tool_call_id,
+      };
+      this.pushEvent(rejection);
+      this.appendToolMessage(pending.toolCall.id, { error: reason });
+    }
+
+    await this.runAgentLoop();
+  }
 
   disconnect() {
     this.setStatus('offline');
@@ -76,6 +192,346 @@ export class LocalConversation extends EventEmitter {
   private setStatus(status: ConversationStatus) {
     this.status = status;
     this.emit('status', status);
+  }
+
+  private pushEvent(event: Event): Event | ConversationStateUpdateEvent {
+    try {
+      return this.events.push(event);
+    } catch (err) {
+      this.emit('error', err);
+      throw err;
+    }
+  }
+
+  private resetConversation() {
+    this.messages.splice(0, this.messages.length);
+    this.pendingActions = [];
+    this.awaitingConfirmation = false;
+    this.paused = false;
+  }
+
+  private clampIterations(raw?: number | null): number {
+    const n = typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : 50;
+    return Math.min(500, Math.max(1, n));
+  }
+
+  private buildToolDefinitions(): LLMToolDefinition[] {
+    return [
+      {
+        type: 'function',
+        function: {
+          name: 'terminal',
+          description: 'Execute a shell command in the workspace and return stdout/stderr.',
+          parameters: {
+            type: 'object',
+            properties: {
+              command: { type: 'string' },
+              cwd: { type: 'string' },
+              timeoutMs: { type: 'number' },
+            },
+            required: ['command'],
+            additionalProperties: false,
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'file_editor',
+          description: 'Write or append content to a file relative to the workspace root.',
+          parameters: {
+            type: 'object',
+            properties: {
+              path: { type: 'string' },
+              content: { type: 'string' },
+              append: { type: 'boolean' },
+            },
+            required: ['path', 'content'],
+            additionalProperties: false,
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'task_tracker',
+          description: 'Track tasks by creating, updating, completing, or listing them.',
+          parameters: {
+            type: 'object',
+            properties: {
+              action: { type: 'string', enum: ['create', 'update', 'complete', 'list'] },
+              id: { type: 'string' },
+              title: { type: 'string' },
+              notes: { type: 'string' },
+              completed: { type: 'boolean' },
+            },
+            required: ['action'],
+            additionalProperties: false,
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'browser',
+          description: 'Perform simple HTTP requests to read web content.',
+          parameters: {
+            type: 'object',
+            properties: {
+              url: { type: 'string' },
+              method: { type: 'string', enum: ['GET', 'POST'] },
+              body: { type: 'string' },
+              maxBytes: { type: 'number' },
+            },
+            required: ['url'],
+            additionalProperties: false,
+          },
+        },
+      },
+    ];
+  }
+
+  private async ensureOrchestrator(): Promise<AgentOrchestrator> {
+    if (this.orchestrator) return this.orchestrator;
+
+    const llmConfig = this.settings.llm;
+    if (!llmConfig?.model) {
+      throw new Error('LLM model is required to run a local conversation');
+    }
+
+    const factory = new LLMFactory(
+      {
+        provider: llmConfig.provider ?? undefined,
+        model: llmConfig.model,
+        baseUrl: llmConfig.baseUrl ?? undefined,
+        apiVersion: llmConfig.apiVersion ?? undefined,
+        timeoutSeconds: llmConfig.timeout ?? undefined,
+        temperature: llmConfig.temperature ?? undefined,
+        topP: llmConfig.topP ?? undefined,
+        topK: llmConfig.topK ?? undefined,
+        maxInputTokens: llmConfig.maxInputTokens ?? undefined,
+        maxOutputTokens: llmConfig.maxOutputTokens ?? undefined,
+        nativeToolCalling: llmConfig.nativeToolCalling ?? undefined,
+        reasoningEffort: llmConfig.reasoningEffort ?? undefined,
+        apiKey: this.settings.secrets?.llmApiKey,
+        headers: this.settings.secrets?.sessionApiKey
+          ? { 'x-session-api-key': this.settings.secrets.sessionApiKey }
+          : undefined,
+      },
+      { storage: this.storage },
+    );
+
+    const llm = await factory.createClient();
+    this.orchestrator = new AgentOrchestrator(llm, { events: this.events, state: this.state });
+    return this.orchestrator;
+  }
+
+  private async runAgentLoop(): Promise<void> {
+    if (this.runningPromise) return this.runningPromise;
+
+    this.runningPromise = this.innerRunLoop()
+      .catch((err) => this.emit('error', err))
+      .finally(() => {
+        this.runningPromise = null;
+      });
+
+    return this.runningPromise;
+  }
+
+  private async innerRunLoop(): Promise<void> {
+    const orchestrator = await this.ensureOrchestrator();
+    this.state.setStatus('running');
+
+    while (!this.paused && !this.awaitingConfirmation && this.state.snapshot.iteration < this.iterationLimit) {
+      const response = await orchestrator.runChat({
+        systemPrompt: this.systemPrompt,
+        messages: [...this.messages],
+        tools: this.toolDefinitions,
+      });
+
+      const assistantMessage: Message = { ...response.message, role: 'assistant' };
+      this.messages.push(assistantMessage);
+      const messageEvent = this.pushEvent({
+        type: 'MessageEvent',
+        source: 'agent',
+        llm_message: assistantMessage,
+        activated_skills: assistantMessage.activated_skills,
+        activated_microagents: assistantMessage.activated_microagents,
+      }) as MessageEvent;
+
+      this.state.incrementIteration();
+
+      const toolCalls = assistantMessage.tool_calls ?? [];
+      if (!toolCalls.length) {
+        break;
+      }
+
+      const llmResponseId = assistantMessage.id ?? randomUUID();
+      for (const call of toolCalls) {
+        const handler = this.tools[call.function.name];
+        if (!handler) {
+          this.pushEvent({
+            type: 'AgentErrorEvent',
+            source: 'agent',
+            error: `Unknown tool: ${call.function.name}`,
+            tool_name: call.function.name,
+            tool_call_id: call.id,
+          });
+          this.appendToolMessage(call.id, { error: `Unknown tool ${call.function.name}` });
+          continue;
+        }
+
+        let parsedArgs: unknown;
+        try {
+          parsedArgs = handler.validate(JSON.parse(call.function.arguments || '{}'));
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.pushEvent({
+            type: 'AgentErrorEvent',
+            source: 'agent',
+            error: message,
+            tool_name: call.function.name,
+            tool_call_id: call.id,
+          });
+          this.appendToolMessage(call.id, { error: message });
+          continue;
+        }
+
+        const actionEvent = this.createActionEvent(call, parsedArgs, messageEvent.llm_message.reasoning_content, llmResponseId);
+        this.pushEvent(actionEvent);
+
+        if (this.requiresConfirmation()) {
+          this.awaitingConfirmation = true;
+          this.pendingActions.push({ actionEvent, handler, args: parsedArgs, toolCall: call });
+          this.state.setStatus('waiting_for_confirmation');
+          break;
+        }
+
+        await this.executeToolCall(handler, parsedArgs, call, actionEvent);
+      }
+    }
+
+    if (!this.paused && !this.awaitingConfirmation) {
+      this.state.setStatus('idle');
+    }
+  }
+
+  private requiresConfirmation(): boolean {
+    const policy = this.settings.confirmation?.policy ?? 'never';
+    return policy === 'always' || policy === 'risky';
+  }
+
+  private createActionEvent(
+    toolCall: ToolCall,
+    args: unknown,
+    reasoning: string | undefined,
+    llmResponseId: string,
+  ): ActionEvent {
+    const thoughtContent = this.messages[this.messages.length - 1]?.content
+      .filter(isTextContent)
+      .map((item) => ({ type: 'text', text: item.text }));
+
+    return {
+      type: 'ActionEvent',
+      source: 'agent',
+      thought: thoughtContent ?? [],
+      reasoning_content: reasoning,
+      action: typeof args === 'object' && args !== null ? (args as Record<string, unknown>) : null,
+      tool_name: toolCall.function.name,
+      tool_call_id: toolCall.id,
+      tool_call: toolCall,
+      llm_response_id: llmResponseId,
+    };
+  }
+
+  private async executeToolCall(
+    handler: ToolHandler<unknown, unknown>,
+    args: unknown,
+    toolCall: ToolCall,
+    actionEvent: ActionEvent,
+  ): Promise<void> {
+    try {
+      const commandId = handler.name === 'terminal' ? this.emitTerminalEvents(toolCall, args) : undefined;
+
+      const result = await handler.execute(args as never, this.toolContext);
+      const observation: ObservationEvent = {
+        type: 'ObservationEvent',
+        source: 'environment',
+        observation: result as Record<string, unknown>,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+        action_id: actionEvent.id ?? toolCall.id,
+      };
+      this.pushEvent(observation);
+      if (handler.name === 'terminal') {
+        this.emitTerminalOutputEvents(result as TerminalResult, commandId);
+      }
+      this.appendToolMessage(toolCall.id, result);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.pushEvent({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: message,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+      });
+      this.appendToolMessage(toolCall.id, { error: message });
+    }
+  }
+
+  private appendToolMessage(toolCallId: string, payload: unknown) {
+    const content = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    const message: Message = {
+      role: 'tool',
+      tool_call_id: toolCallId,
+      content: [{ type: 'text', text: content }],
+    };
+    this.messages.push(message);
+  }
+
+  private emitTerminalEvents(toolCall: ToolCall, args: unknown): string {
+    const commandId = toolCall.id || randomUUID();
+    const now = new Date().toISOString();
+    const parsed = typeof args === 'object' && args !== null ? (args as { command?: string; cwd?: string }) : {};
+
+    const command: BashEvent = {
+      type: 'BashCommand',
+      id: randomUUID(),
+      timestamp: now,
+      command_id: commandId,
+      order: 0,
+      command: parsed.command ?? toolCall.function.arguments,
+    } as BashEvent;
+    this.emit('terminal', command);
+    return commandId;
+  }
+
+  private emitTerminalOutputEvents(result: TerminalResult, commandId?: string) {
+    const now = new Date().toISOString();
+    const cid = commandId ?? randomUUID();
+    const output: BashEvent = {
+      type: 'BashOutput',
+      id: randomUUID(),
+      timestamp: now,
+      command_id: cid,
+      order: 1,
+      exit_code: result.exitCode ?? null,
+      stdout: result.stdout ?? '',
+      stderr: result.stderr ?? '',
+    } as BashEvent;
+
+    const exit: BashEvent = {
+      type: 'BashExit',
+      id: randomUUID(),
+      timestamp: now,
+      command_id: cid,
+      order: 2,
+      exit_code: result.exitCode,
+    } as BashEvent;
+
+    this.emit('terminal', output);
+    this.emit('terminal', exit);
   }
 }
 

--- a/packages/agent-sdk-ts/src/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/conversation/index.ts
@@ -22,7 +22,11 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
       conversationId: options.conversationId,
     }) as ConversationInstance;
   }
-  return new LocalConversation({ settings: options.settings, conversationId: options.conversationId }) as ConversationInstance;
+  return new LocalConversation({
+    settings: options.settings,
+    conversationId: options.conversationId,
+    workspaceRoot: options.workspaceRoot,
+  }) as ConversationInstance;
 }
 
 export { LocalConversation, RemoteConversation };


### PR DESCRIPTION
## Summary
- implement local agent orchestration in `LocalConversation`, wiring LLM streaming, tools, confirmation handling, and terminal events
- route workspace root into local conversations and register configured secrets for tool/LLM access
- add a local conversation test exercising tool execution and observation emission with a fake LLM

## Testing
- npm test -w @openhands/agent-sdk-ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b0b0357e88320985f708ce775edb3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `sendUserMessage()` method to trigger agent responses within conversations.
  * Enhanced LocalConversation with workspace root configuration support.
  * Introduced asynchronous control flow for pause, resume, approve, and reject actions.
  * Added terminal I/O event emission for improved runtime visibility.

* **Tests**
  * Added test coverage for conversation streaming with mock LLM interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->