### PR TITLE
docs: sync with develop — Conversation layer, local mode, and bash events updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The extension connects to an [OpenHands agent-server](https://github.com/All-Han
 
 - Visual Studio Code 1.104.0 or higher
 - Node.js 22.x or higher
-- Python 3.12+ (for agent-sdk backend)
+- Python 3.12+ (optional; only needed when using a remote agent-server)
 - Access to an LLM provider (OpenAI, Anthropic, or self-hosted)
 
 ### Installation
@@ -189,6 +189,6 @@ Detailed documentation is available in the [docs/](docs/) directory:
 - **[PRD.md](docs/PRD.md)** - Product requirements and architecture overview
 - **[IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)** - Implementation phases and progress
 - **[settings_prd.md](docs/settings_prd.md)** - Settings system architecture and LLM configuration
-- **[bash_events.md](docs/bash_events.md)** - Bash events live terminal integration
+- Bash events live terminal integration is now handled by LocalConversation in local mode; the previous docs/bash_events.md has been removed.
 - **[e2e_testing.md](docs/e2e_testing.md)** - End-to-end testing guide
 - **[vscode_remote_setup.md](docs/vscode_remote_setup.md)** - Headless VS Code setup for AI agents

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ Detailed documentation is available in the [docs/](docs/) directory:
 - **[PRD.md](docs/PRD.md)** - Product requirements and architecture overview
 - **[IMPLEMENTATION_PLAN.md](docs/IMPLEMENTATION_PLAN.md)** - Implementation phases and progress
 - **[settings_prd.md](docs/settings_prd.md)** - Settings system architecture and LLM configuration
-- Bash events live terminal integration is now handled by LocalConversation in local mode; the previous docs/bash_events.md has been removed.
+- **Bash Events** - Live terminal integration is now handled by `LocalConversation` in local mode; the previous `docs/bash_events.md` has been removed.
 - **[e2e_testing.md](docs/e2e_testing.md)** - End-to-end testing guide
 - **[vscode_remote_setup.md](docs/vscode_remote_setup.md)** - Headless VS Code setup for AI agents

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -283,10 +283,10 @@ Confirmation policy
   - Surface WAITING_FOR_CONFIRMATION state; list pending actions; Approve/Reject flow
   - Policies selectable when starting a conversation (NeverConfirm, AlwaysConfirm, ConfirmRisky)
   - Security risk indicators (LOW/MEDIUM/HIGH) in action events
-- Live Bash Events Terminal ✓ IMPLEMENTED
-  - Stream bash command output to VS Code integrated terminal via /sockets/bash-events
+- Live Bash Events Terminal ✓ IMPLEMENTED (local mode)
+  - In local mode, the SDK emits bash events which are rendered in the VS Code integrated terminal
   - Configurable via openhands.bashEvents.enabled setting
-  - See bash_events.md for full feature specification
+  - The legacy /sockets/bash-events client and docs/bash_events.md were removed
 - Activity Bar Integration ✓ IMPLEMENTED
   - Custom activity bar icon and view
   - Quick action shortcuts for opening tab and settings


### PR DESCRIPTION
This PR updates documentation to align with recent changes merged into `develop`:

- Introduced Conversation layer as primary SDK API with local/remote modes
- Deprecated and removed legacy Bash Events client and docs

Changes:
- README
  - Python prerequisite now marked optional (only for remote agent-server usage)
  - Remove dead link to docs/bash_events.md and note that bash events are handled in local mode
- docs/PRD.md
  - Update "Live Bash Events Terminal" to reflect local mode handling and removal of legacy /sockets/bash-events client and docs

Notes:
- No code changes; docs only
- Verified consistency with docs/agent-sdk-architecture.md and packages/agent-sdk-ts/AGENTS.md

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b2a4977bfc494620a14c682b4df2415a)