### PR TITLE
Improve remote conversation history replay

### DIFF
--- a/packages/agent-sdk-ts/findings.md
+++ b/packages/agent-sdk-ts/findings.md
@@ -1,0 +1,24 @@
+# agent-sdk-ts investigation log
+
+## Setup checklist
+- Cloned the Python agent-sdk repository (`enyst/agent-sdk`) into `/workspace/agent-sdk` for side-by-side comparison.
+- Attempted to clone `agent-sdk-ts` from GitHub for reference; repository prompted for authentication, so the existing package in this monorepo is the working copy.
+- Read repository guidelines in `AGENTS.md` and the SDK-specific guidance in `packages/agent-sdk-ts/AGENTS.md`.
+- Reviewed `docs/agent-sdk-architecture.md` for the intended TypeScript SDK architecture.
+
+## Initial observations
+- `@openhands/agent-sdk-ts` currently exposes conversation, runtime, LLM, tools, and workspace layers aimed at VS Code usage.
+- LocalConversation implements an in-process orchestration loop with tools and event logging; RemoteConversation proxies to the agent-server over WebSocket/HTTP.
+
+(Will append detailed gap analysis and follow-up actions as investigation continues.)
+
+## Gaps vs Python agent-sdk (so far)
+- **Remote conversation history**: Python `RemoteConversation` fetches existing events via `RemoteEventsList` and appends them to a local cache before streaming new ones. The TS `RemoteConversation.restoreConversation()` only opens WebSockets and never replays past events, so restoring a saved conversation yields an empty UI until new events arrive.
+- **WebSocket resend support**: The agent-server supports `resend_all` on the events WebSocket to replay stored events; the TS client never requests it or performs deduplication, so there is no history when reconnecting.
+
+Next steps: investigate how to pull history (HTTP search vs WS resend) without duplicating live events, then update SDK and tests.
+- **Missing conversationStarted signal on restore**: LocalConversation emits `conversationStarted` when restoring an ID; RemoteConversation currently just sets `conversationId` and connects, so the extension never re-sends the active ID to the webview after reload.
+
+## Implemented fixes
+- Added conversation history replay for remote sessions via REST `/events/search` with pagination and event-type validation.
+- Ensured `RemoteConversation` emits `conversationStarted` when restoring or constructed with an ID, clears dedup state per conversation, and deduplicates events using server-provided IDs (covers `resend_all` WS replays and HTTP history fetch).

--- a/packages/agent-sdk-ts/findings.md
+++ b/packages/agent-sdk-ts/findings.md
@@ -22,3 +22,4 @@ Next steps: investigate how to pull history (HTTP search vs WS resend) without d
 ## Implemented fixes
 - Added conversation history replay for remote sessions via REST `/events/search` with pagination and event-type validation.
 - Ensured `RemoteConversation` emits `conversationStarted` when restoring or constructed with an ID, clears dedup state per conversation, and deduplicates events using server-provided IDs (covers `resend_all` WS replays and HTTP history fetch).
+- Deferred remote socket reconnection until after history replay completes and now surface errors from the replay promise rather than silently failing during constructor-based restores.

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -3,6 +3,8 @@ import type { Event } from '../types';
 
 let wsInstances: MockWS[] = [];
 
+type Handler = (...args: unknown[]) => void;
+
 class MockWS {
   static CONNECTING = 0;
   static OPEN = 1;
@@ -10,7 +12,7 @@ class MockWS {
   static CLOSED = 3;
 
   url: string;
-  handlers: Record<string, Function[]> = {};
+  handlers: Record<string, Handler[]> = {};
   readyState = MockWS.CONNECTING;
   sent: string[] = [];
 
@@ -19,13 +21,13 @@ class MockWS {
     wsInstances.push(this);
   }
 
-  on(ev: string, cb: Function) {
+  on(ev: string, cb: Handler) {
     this.handlers[ev] = this.handlers[ev] || [];
     this.handlers[ev].push(cb);
     return this as any;
   }
 
-  emit(ev: string, ...args: any[]) {
+  emit(ev: string, ...args: unknown[]) {
     (this.handlers[ev] || []).forEach((fn) => fn(...args));
   }
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Event } from '../types';
+
+let wsInstances: MockWS[] = [];
+
+class MockWS {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  url: string;
+  handlers: Record<string, Function[]> = {};
+  readyState = MockWS.CONNECTING;
+  sent: string[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    wsInstances.push(this);
+  }
+
+  on(ev: string, cb: Function) {
+    this.handlers[ev] = this.handlers[ev] || [];
+    this.handlers[ev].push(cb);
+    return this as any;
+  }
+
+  emit(ev: string, ...args: any[]) {
+    (this.handlers[ev] || []).forEach((fn) => fn(...args));
+  }
+
+  open() {
+    this.readyState = MockWS.OPEN;
+    this.emit('open');
+  }
+
+  message(data: any) {
+    const payload = Buffer.from(typeof data === 'string' ? data : JSON.stringify(data));
+    this.emit('message', payload);
+  }
+
+  error(err: any) {
+    this.emit('error', err);
+  }
+
+  close() {
+    this.readyState = MockWS.CLOSED;
+    this.emit('close');
+  }
+
+  removeAllListeners() {
+    this.handlers = {};
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+}
+
+vi.mock('ws', () => ({ default: MockWS }));
+
+const getEventWS = () => wsInstances.find((ws) => ws.url.includes('/sockets/events')) ?? wsInstances[0];
+
+const baseSettings = {
+  llm: { model: 'test-model' },
+  agent: { enableSecurityAnalyzer: false },
+  conversation: { maxIterations: 2 },
+  confirmation: { policy: 'never' as const },
+  secrets: {},
+};
+
+describe('RemoteConversation', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    wsInstances = [];
+    (globalThis as any).fetch = undefined as any;
+  });
+
+  it('replays history on restore and skips duplicate event ids', async () => {
+    const history: Event[] = [
+      {
+        id: 'e-1',
+        type: 'MessageEvent',
+        source: 'user',
+        llm_message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      } as Event,
+      {
+        id: 'e-2',
+        type: 'ActionEvent',
+        source: 'agent',
+        thought: [{ type: 'text', text: 'thinking' }],
+        action: { command: 'pwd' },
+        tool_name: 'terminal',
+        tool_call_id: 'tc-1',
+        tool_call: { id: 'tc-1', type: 'function', function: { name: 'terminal', arguments: '{}' } },
+        llm_response_id: 'r-1',
+      } as Event,
+    ];
+
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain('/events/search');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: history, next_page_id: null }),
+        text: async () => '',
+      } as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    const received: Event[] = [];
+    const started = vi.fn();
+    conversation.on('event', (e) => received.push(e));
+    conversation.on('conversationStarted', started);
+
+    await conversation.restoreConversation('abc');
+
+    expect(started).toHaveBeenCalledWith('abc');
+    expect(received.map((e) => e.id)).toEqual(['e-1', 'e-2']);
+
+    const ws = getEventWS();
+    ws.open();
+    ws.message({ ...history[0] });
+    ws.message({ ...history[1], id: 'e-3' });
+
+    expect(received.map((e) => e.id)).toEqual(['e-1', 'e-2', 'e-3']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -52,11 +52,13 @@ export class RemoteConversation extends EventEmitter {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
       this.emit('conversationStarted', this.conversationId);
-      this.replayHistory().then(() => {
+      void this.replayHistory().then(() => {
         if (this.conversationId === options.conversationId) {
           this.connect();
           this.connectBashEvents();
         }
+      }).catch((err) => {
+        this.emit('error', err instanceof Error ? err : new Error(String(err)));
       });
     }
   }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -26,6 +26,7 @@ export class RemoteConversation extends EventEmitter {
   private settings: OpenHandsSettings;
   private conversationId?: string;
   private status: ConversationStatus = 'offline';
+  private readonly seenEventIds = new Set<string>();
   private ws?: WebSocket;
   private bashWs?: WebSocket;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
@@ -43,6 +44,9 @@ export class RemoteConversation extends EventEmitter {
     this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
     if (options.conversationId) {
       this.conversationId = options.conversationId;
+      this.seenEventIds.clear();
+      this.emit('conversationStarted', this.conversationId);
+      void this.replayHistory();
       this.connect();
       this.connectBashEvents();
     }
@@ -69,6 +73,7 @@ export class RemoteConversation extends EventEmitter {
           this.ws.close();
           this.ws = undefined;
         }
+        this.seenEventIds.clear();
         this.setStatus('connecting');
         const base = this.serverUrl.replace(/\/$/, '');
         const s = this.settings;
@@ -177,8 +182,11 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
-  restoreConversation(id: string) {
+  async restoreConversation(id: string) {
     this.conversationId = id;
+    this.seenEventIds.clear();
+    this.emit('conversationStarted', id);
+    await this.replayHistory();
     this.connect();
     this.connectBashEvents();
   }
@@ -342,8 +350,11 @@ export class RemoteConversation extends EventEmitter {
     if (!this.conversationId) return;
     const base = this.serverUrl.replace(/\/$/, '');
     const sessionKey = this.settings?.secrets.sessionApiKey || '';
-    const qs = sessionKey ? `?session_api_key=${encodeURIComponent(sessionKey)}` : '';
-    const wsUrl = base.replace(/^http/, 'ws') + `/sockets/events/${this.conversationId}${qs}`;
+    const params = new URLSearchParams();
+    if (sessionKey) params.set('session_api_key', sessionKey);
+    params.set('resend_all', 'true');
+    const qs = params.toString();
+    const wsUrl = `${base.replace(/^http/, 'ws')}/sockets/events/${this.conversationId}?${qs}`;
     this.setStatus('connecting');
     const ws = new WebSocket(wsUrl);
     this.ws = ws;
@@ -356,12 +367,52 @@ export class RemoteConversation extends EventEmitter {
         const str = buf.toString('utf8');
         const data = JSON.parse(str) as unknown;
         const normalized = this.normalizeEventPayload(data);
-        if (isAgentEvent(normalized)) this.emit('event', normalized);
+        if (isAgentEvent(normalized)) this.emitIfNewEvent(normalized);
         else this.emit('error', new Error(`Invalid event payload: ${JSON.stringify(normalized)}`));
       } catch (e) {
         this.emit('error', e);
       }
     });
+  }
+
+  private emitIfNewEvent(event: Event) {
+    if (event?.id) {
+      if (this.seenEventIds.has(event.id)) return;
+      this.seenEventIds.add(event.id);
+    }
+    this.emit('event', event);
+  }
+
+  private async replayHistory(): Promise<void> {
+    if (!this.conversationId) return;
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    let pageId: string | undefined;
+    try {
+      while (true) {
+        const params = new URLSearchParams({ limit: '100' });
+        if (pageId) params.set('page_id', pageId);
+        const res = await fetch(`${base}/api/conversations/${this.conversationId}/events/search?${params.toString()}`, { headers });
+        if (!res.ok) {
+          const info = await res.text().catch(() => '');
+          this.emit('error', new Error(`Failed to fetch conversation history (HTTP ${res.status})${info ? `: ${info}` : ''}`));
+          return;
+        }
+        const body = await res.json() as { items?: unknown[]; next_page_id?: string | null };
+        const items = Array.isArray(body.items) ? body.items : [];
+        for (const raw of items) {
+          const normalized = this.normalizeEventPayload(raw);
+          if (isAgentEvent(normalized)) {
+            this.emitIfNewEvent(normalized);
+          }
+        }
+        const next = body.next_page_id;
+        if (!next || typeof next !== 'string') break;
+        pageId = next;
+      }
+    } catch (e) {
+      this.emit('error', e instanceof Error ? e : new Error(String(e)));
+    }
   }
 
   private connectBashEvents() {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -6,6 +6,11 @@ import type { OpenHandsSettings } from '../types/settings';
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
+interface ConversationHistoryPage {
+  items?: unknown[];
+  next_page_id?: string | null;
+}
+
 export interface RemoteConversationOptions {
   serverUrl: string;
   settings: OpenHandsSettings;
@@ -36,6 +41,7 @@ export class RemoteConversation extends EventEmitter {
   private readonly retryBaseMs = 1000;
   private readonly retryMaxMs = 15000;
   private readonly workspaceRoot: string;
+  private static readonly historyPageLimit = 100;
 
   constructor(options: RemoteConversationOptions) {
     super();
@@ -46,9 +52,12 @@ export class RemoteConversation extends EventEmitter {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
       this.emit('conversationStarted', this.conversationId);
-      void this.replayHistory();
-      this.connect();
-      this.connectBashEvents();
+      this.replayHistory().then(() => {
+        if (this.conversationId === options.conversationId) {
+          this.connect();
+          this.connectBashEvents();
+        }
+      });
     }
   }
 
@@ -390,7 +399,7 @@ export class RemoteConversation extends EventEmitter {
     let pageId: string | undefined;
     try {
       while (true) {
-        const params = new URLSearchParams({ limit: '100' });
+        const params = new URLSearchParams({ limit: String(RemoteConversation.historyPageLimit) });
         if (pageId) params.set('page_id', pageId);
         const res = await fetch(`${base}/api/conversations/${this.conversationId}/events/search?${params.toString()}`, { headers });
         if (!res.ok) {
@@ -398,7 +407,7 @@ export class RemoteConversation extends EventEmitter {
           this.emit('error', new Error(`Failed to fetch conversation history (HTTP ${res.status})${info ? `: ${info}` : ''}`));
           return;
         }
-        const body = await res.json() as { items?: unknown[]; next_page_id?: string | null };
+        const body = await res.json() as ConversationHistoryPage;
         const items = Array.isArray(body.items) ? body.items : [];
         for (const raw of items) {
           const normalized = this.normalizeEventPayload(raw);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,12 +232,12 @@ export function activate(context: vscode.ExtensionContext) {
       });
       conversation.on('terminal', (event) => handleTerminalEvent(event));
       if (savedId) {
-        conversation.restoreConversation(savedId);
+        void conversation.restoreConversation(savedId);
       }
     } else if (conversation) {
       conversation.setSettings(settings);
       if (savedId) {
-        conversation.restoreConversation(savedId);
+        void conversation.restoreConversation(savedId);
       }
     } else {
       outputChannel?.appendLine('[warn] Conversation unavailable during settings refresh');


### PR DESCRIPTION
## Summary
- add history replay and event deduplication to RemoteConversation restores, emitting conversationStarted when resuming sessions
- request websocket resend_all and hydrate stored events via the REST search endpoint to keep VS Code UI in sync
- add regression coverage for remote restores and record investigation findings

## Testing
- npm test -w @openhands/agent-sdk-ts


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4de6139c8320b54f79d5e50bce20)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restores conversation history when reopening saved conversations so past messages reappear.
  * Prevents duplicate events after reconnects by deduplicating incoming events.
  * Ensures the extension re-syncs conversation state after reload.

* **Tests**
  * Added comprehensive tests covering conversation restoration, history replay, reconnection, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->