### PR TITLE
Add agent execution loop to TS SDK

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -298,6 +298,39 @@ applyStateUpdate(chunk) → updates ConversationState
 return { message, usage }
 ```
 
+### Agent (TS SDK)
+
+**Purpose**: Elevates `AgentOrchestrator` into a full agent loop that mirrors the Python SDK's local execution flow.
+
+**Key Responsibilities**:
+- Emit `SystemPromptEvent` up front with tool definitions
+- Manage the full step loop (LLM sampling → action selection → tool execution → observation)
+- Enforce confirmation policies (`never | always | risky`) and surface `PauseEvent` when waiting for approval
+- Pause/resume/cancel runs while keeping `ConversationState` and `EventLog` in sync
+- Execute registered tools against `LocalWorkspace` and emit `ObservationEvent` + tool `MessageEvent` payloads
+
+**Usage Example**:
+```typescript
+import { Agent, EventLog } from '@openhands/agent-sdk-ts';
+
+const agent = new Agent({
+  settings: {
+    llm: { model: 'gpt-4o-mini' },
+    agent: {},
+    conversation: { maxIterations: 10 },
+    confirmation: { policy: 'always' },
+    secrets: {},
+  },
+  tools: [/* ToolHandler instances */],
+  events: new EventLog(),
+  workspaceRoot: '/workspace',
+});
+
+await agent.run('List files');
+// -> ActionEvent + PauseEvent are emitted, then approve:
+await agent.approveAction();
+```
+
 ### EventLog
 
 **Purpose**: Maintains an ordered log of all events in a conversation.

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -5,15 +5,16 @@ import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent } from 
 import type { ToolHandler } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
 
-class MockLLM implements LLMClient {
-  constructor(private readonly chunks: LLMStreamChunk[]) {}
+  class MockLLM implements LLMClient {
+    constructor(private readonly chunks: LLMStreamChunk[]) {}
 
-  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
-    for (const chunk of this.chunks) {
-      yield chunk;
+    async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+      void _request;
+      for (const chunk of this.chunks) {
+        yield chunk;
+      }
     }
   }
-}
 
 const baseSettings: OpenHandsSettings = {
   llm: { model: 'test-model' },

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -100,4 +100,28 @@ describe('Agent loop control', () => {
     expect(events.some(isActionEvent)).toBe(false);
     expect(events.some(isObservationEvent)).toBe(false);
   });
+
+  it('handles JSON primitives in tool arguments by emitting agent error', async () => {
+    const log = new EventLog();
+    const tool: ToolHandler<Record<string, unknown>, { echoed: boolean }> = {
+      name: 'echo',
+      validate: (input) => input,
+      execute: async (args) => ({ echoed: Boolean(args.value) }),
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Calling tool' },
+      { type: 'tool_call_delta', id: 'call_primitive', name: 'echo', arguments: '42' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/workspace', llmClient: llm, tools: [tool] });
+    await agent.run('bad args');
+
+    const events = log.list();
+    const agentErrors = events.filter((event) => event.type === 'AgentErrorEvent');
+    expect(agentErrors).toHaveLength(1);
+    expect((agentErrors[0] as { tool_call_id?: string }).tool_call_id).toBe('call_primitive');
+    expect(events.some(isActionEvent)).toBe(false);
+    expect(events.some(isObservationEvent)).toBe(false);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -19,7 +19,7 @@ import type { OpenHandsSettings } from '../types/settings';
 const baseSettings: OpenHandsSettings = {
   llm: { model: 'test-model' },
   agent: {},
-  conversation: {},
+  conversation: { maxIterations: 1 },
   confirmation: {},
   secrets: {},
 };
@@ -75,5 +75,29 @@ describe('Agent loop control', () => {
     expect(eventsAfterApproval.some(isObservationEvent)).toBe(true);
     const toolMessages = eventsAfterApproval.filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'tool');
     expect(toolMessages.length).toBe(1);
+  });
+
+  it('records agent error when tool arguments are not objects', async () => {
+    const log = new EventLog();
+    const tool: ToolHandler<Record<string, unknown>, { echoed: boolean }> = {
+      name: 'echo',
+      validate: (input) => input,
+      execute: async (args) => ({ echoed: Boolean(args.value) }),
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Calling tool' },
+      { type: 'tool_call_delta', id: 'call_invalid', name: 'echo', arguments: 'false' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/workspace', llmClient: llm, tools: [tool] });
+    await agent.run('bad args');
+
+    const events = log.list();
+    const agentErrors = events.filter((event) => event.type === 'AgentErrorEvent');
+    expect(agentErrors).toHaveLength(1);
+    expect((agentErrors[0] as { tool_call_id?: string }).tool_call_id).toBe('call_invalid');
+    expect(events.some(isActionEvent)).toBe(false);
+    expect(events.some(isObservationEvent)).toBe(false);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, EventLog } from '../runtime';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
+import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
+import type { ToolHandler } from '../types/tools';
+import type { OpenHandsSettings } from '../types/settings';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: {},
+  confirmation: {},
+  secrets: {},
+};
+
+describe('Agent loop control', () => {
+  it('emits system prompt and stops when no tool calls', async () => {
+    const log = new EventLog();
+    const llm = new MockLLM([
+      { type: 'text', text: 'Hello' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/workspace', llmClient: llm });
+
+    await agent.run('hi there');
+
+    const events = log.list();
+    expect(events.some((event) => event.type === 'SystemPromptEvent')).toBe(true);
+    const messages = events.filter(isMessageEvent);
+    expect(messages.length).toBeGreaterThanOrEqual(2); // user + assistant
+    expect(agent.state.snapshot.iteration).toBe(1);
+  });
+
+  it('honors confirmation policy and executes tool on approval', async () => {
+    const log = new EventLog();
+    const tool: ToolHandler<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, confirmation: { policy: 'always' } },
+      events: log,
+      workspaceRoot: '/workspace',
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run tool');
+    const eventsAfterRun = log.list();
+    expect(eventsAfterRun.some(isActionEvent)).toBe(true);
+    expect(eventsAfterRun.some(isPauseEvent)).toBe(true);
+    expect(eventsAfterRun.some(isObservationEvent)).toBe(false);
+
+    await agent.approveAction();
+    const eventsAfterApproval = log.list();
+    expect(eventsAfterApproval.some(isObservationEvent)).toBe(true);
+    const toolMessages = eventsAfterApproval.filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'tool');
+    expect(toolMessages.length).toBe(1);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { Agent, EventLog } from '../runtime';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
@@ -5,16 +8,16 @@ import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent } from 
 import type { ToolHandler } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
 
-  class MockLLM implements LLMClient {
-    constructor(private readonly chunks: LLMStreamChunk[]) {}
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
 
-    async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
-      void _request;
-      for (const chunk of this.chunks) {
-        yield chunk;
-      }
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
     }
   }
+}
 
 const baseSettings: OpenHandsSettings = {
   llm: { model: 'test-model' },
@@ -24,6 +27,8 @@ const baseSettings: OpenHandsSettings = {
   secrets: {},
 };
 
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-workspace-'));
+
 describe('Agent loop control', () => {
   it('emits system prompt and stops when no tool calls', async () => {
     const log = new EventLog();
@@ -32,7 +37,7 @@ describe('Agent loop control', () => {
       { type: 'finish' },
     ]);
 
-    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/workspace', llmClient: llm });
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: createWorkspaceRoot(), llmClient: llm });
 
     await agent.run('hi there');
 
@@ -59,7 +64,7 @@ describe('Agent loop control', () => {
     const agent = new Agent({
       settings: { ...baseSettings, confirmation: { policy: 'always' } },
       events: log,
-      workspaceRoot: '/workspace',
+      workspaceRoot: createWorkspaceRoot(),
       llmClient: llm,
       tools: [tool],
     });
@@ -90,7 +95,13 @@ describe('Agent loop control', () => {
       { type: 'finish' },
     ]);
 
-    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/workspace', llmClient: llm, tools: [tool] });
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
     await agent.run('bad args');
 
     const events = log.list();
@@ -114,7 +125,13 @@ describe('Agent loop control', () => {
       { type: 'finish' },
     ]);
 
-    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/workspace', llmClient: llm, tools: [tool] });
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
     await agent.run('bad args');
 
     const events = log.list();

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
@@ -3,7 +3,7 @@ import { BrowserTool, FileEditorTool, TaskTrackerTool, TerminalTool } from '../.
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
 import { LocalConversation } from './LocalConversation';
 import type { Event, MessageEvent } from '../types';
-import { isActionEvent, isAgentErrorEvent, isMessageEvent, isObservationEvent } from '../types';
+import { isActionEvent, isAgentErrorEvent, isConversationErrorEvent, isMessageEvent, isObservationEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 
 class FakeLLM implements LLMClient {
@@ -118,7 +118,7 @@ describe('LocalConversation', () => {
     expect(error?.error).toContain('Unknown tool');
   });
 
-  it('captures tool execution failures as AgentErrorEvents', async () => {
+  it('captures tool execution failures as ConversationErrorEvents', async () => {
     const llm = new FakeLLM([
       [
         { type: 'tool_call_delta', id: 'tool_fail', name: 'task_tracker', arguments: '{"action":"complete"}' },
@@ -133,7 +133,7 @@ describe('LocalConversation', () => {
 
     await conversation.sendUserMessage('complete unknown task');
 
-    const error = events.find(isAgentErrorEvent);
-    expect(error?.error).toContain('id is required');
+    const error = events.find(isConversationErrorEvent);
+    expect(error?.detail).toContain('id is required');
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -53,6 +53,7 @@ export class LocalConversation extends EventEmitter {
 
   setSettings(settings: OpenHandsSettings) {
     this.settings = settings;
+    // TODO: when settings change, should we just recreate the Agent
     this.agent = this.createAgent();
   }
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -81,8 +81,8 @@ export class LocalConversation extends EventEmitter {
     return Promise.resolve();
   }
 
-  resume(): Promise<void> {
-    return this.agent.resume().then(() => undefined);
+  async resume(): Promise<void> {
+    await this.agent.resume();
   }
 
   approveAction(): Promise<void> {

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -1,10 +1,7 @@
 import EventEmitter from 'events';
-import { randomUUID } from 'crypto';
-import { AgentOrchestrator, AsyncLock, ConversationState, EventLog, SecretRegistry } from '../runtime';
-import { LLMFactory } from '../llm';
-import type { LLMClient, LLMConfiguration, LLMToolDefinition } from '../llm';
-import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
-import { isTextContent } from '../types';
+import { Agent, AsyncLock, ConversationState, EventLog, SecretRegistry } from '../runtime';
+import type { LLMClient } from '../llm';
+import type { BashEvent, Event } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolHandler } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
@@ -27,12 +24,10 @@ export class LocalConversation extends EventEmitter {
   private readonly events: EventLog;
   private readonly state: ConversationState;
   private readonly secrets: SecretRegistry;
-  private readonly tools: Map<string, ToolHandler<unknown, unknown>>;
   private readonly lock = new AsyncLock();
-  private orchestratorPromise?: Promise<AgentOrchestrator>;
-  private paused = false;
-  private pendingAction?: { toolCall: ToolCall; actionEvent: ActionEvent; args: unknown };
   private readonly customLlmClient?: LLMClient;
+  private readonly tools: ToolHandler<unknown, unknown>[];
+  private agent: Agent;
 
   constructor(options: LocalConversationOptions) {
     super();
@@ -42,9 +37,9 @@ export class LocalConversation extends EventEmitter {
     this.events = new EventLog();
     this.state = new ConversationState(this.events);
     this.customLlmClient = options.llmClient;
+    this.tools = options.tools ?? [];
     this.secrets = new SecretRegistry();
-    const providedTools = options.tools ?? [];
-    this.tools = new Map<string, ToolHandler<unknown, unknown>>(providedTools.map((tool) => [tool.name, tool]));
+    this.agent = this.createAgent();
 
     this.events.on((event) => this.emit('event', event));
     this.setStatus('online');
@@ -58,6 +53,7 @@ export class LocalConversation extends EventEmitter {
 
   setSettings(settings: OpenHandsSettings) {
     this.settings = settings;
+    this.agent = this.createAgent();
   }
 
   startNewConversation(): Promise<string | undefined> {
@@ -76,56 +72,25 @@ export class LocalConversation extends EventEmitter {
       if (!this.conversationId) {
         await this.startNewConversation();
       }
-
-      const userEvent: MessageEvent = {
-        type: 'MessageEvent',
-        source: 'user',
-        llm_message: { role: 'user', content: [{ type: 'text', text }] },
-      };
-      this.events.push(userEvent);
-
-      await this.runAgentLoop();
+      await this.agent.run(text);
     });
   }
 
   pause(): Promise<void> {
-    this.paused = true;
-    this.events.push({ type: 'PauseEvent', source: 'user' } as Event);
-    this.state.setStatus('PAUSED');
+    this.agent.pause();
     return Promise.resolve();
   }
 
   resume(): Promise<void> {
-    this.paused = false;
-    this.state.setStatus('RUNNING');
-    return this.runAgentLoop();
+    return this.agent.resume().then(() => undefined);
   }
 
   approveAction(): Promise<void> {
-    if (!this.pendingAction) return Promise.resolve();
-    return this.lock.acquire(async () => {
-      const { toolCall, actionEvent, args } = this.pendingAction!;
-      this.pendingAction = undefined;
-      this.state.setStatus('RUNNING');
-      await this.executeTool(toolCall, actionEvent, args);
-      await this.runAgentLoop();
-    });
+    return this.agent.approveAction();
   }
 
   rejectAction(reason?: string): Promise<void> {
-    if (!this.pendingAction) return Promise.resolve();
-    const { actionEvent } = this.pendingAction;
-    this.pendingAction = undefined;
-    const rejection = {
-      type: 'UserRejectObservation',
-      source: 'environment',
-      rejection_reason: reason ?? 'User rejected the action',
-      tool_name: actionEvent.tool_name,
-      tool_call_id: actionEvent.tool_call_id,
-      action_id: actionEvent.id!,
-    } as Event;
-    this.events.push(rejection);
-    this.state.setStatus('IDLE');
+    this.agent.rejectAction(reason);
     return Promise.resolve();
   }
 
@@ -142,221 +107,17 @@ export class LocalConversation extends EventEmitter {
     this.emit('status', status);
   }
 
-  private async runAgentLoop(): Promise<void> {
-    if (this.paused || this.pendingAction) {
-      return;
-    }
-
-    const maxIterations = this.clampMaxIterations();
-    const orchestrator = await this.getOrchestrator();
-
-    while (!this.paused && !this.pendingAction && this.state.snapshot.iteration < maxIterations) {
-      this.state.setStatus('RUNNING');
-      const request = this.buildChatRequest();
-      const response = await orchestrator.runChat(request);
-
-      const assistantEvent: MessageEvent = {
-        type: 'MessageEvent',
-        source: 'agent',
-        llm_message: response.message,
-      };
-      this.events.push(assistantEvent);
-      this.state.incrementIteration();
-
-      const toolCalls = response.message.tool_calls ?? [];
-      if (!toolCalls.length) {
-        this.state.setStatus('IDLE');
-        break;
-      }
-
-      for (const toolCall of toolCalls) {
-        const parsedArgs = this.parseToolArgs(toolCall.function.arguments);
-        const actionEvent = this.createActionEvent(response.message, toolCall, parsedArgs);
-        const recordedAction = this.events.push(actionEvent) as ActionEvent;
-
-        if (this.requiresConfirmation()) {
-          this.pendingAction = { toolCall, actionEvent: recordedAction, args: parsedArgs };
-          this.state.setStatus('WAITING_FOR_CONFIRMATION');
-          return;
-        }
-
-        await this.executeTool(toolCall, recordedAction, parsedArgs);
-      }
-    }
-  }
-
-  private clampMaxIterations(): number {
-    const raw = this.settings?.conversation?.maxIterations;
-    const n = typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : 50;
-    return Math.min(500, Math.max(1, n));
-  }
-
-  private buildChatRequest() {
-    const systemPrompt = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
-    const messages = this.events
-      .list()
-      .filter((event): event is MessageEvent => event.type === 'MessageEvent')
-      .map((event) => event.llm_message);
-    const tools = this.getToolDefinitions();
-    return { systemPrompt, messages, tools };
-  }
-
-  private getToolDefinitions(): LLMToolDefinition[] {
-    return Array.from(this.tools.values()).map((tool) => ({
-      type: 'function',
-      function: { name: tool.name },
-    }));
-  }
-
-  private async getOrchestrator(): Promise<AgentOrchestrator> {
-    if (!this.orchestratorPromise) {
-      this.orchestratorPromise = (async () => {
-        const client = this.customLlmClient ?? (await this.createLlmClientFromSettings());
-        return new AgentOrchestrator(client, { events: this.events, state: this.state });
-      })();
-    }
-
-    return this.orchestratorPromise;
-  }
-
-  private createLlmClientFromSettings(): Promise<LLMClient> {
-    if (!this.settings.llm?.model) {
-      return Promise.reject(new Error('LLM model is not configured'));
-    }
-    const s = this.settings;
-    const config: LLMConfiguration = {
-      model: s.llm.model ?? '',
-      baseUrl: s.llm.baseUrl ?? undefined,
-      apiKey: s.secrets?.llmApiKey ?? undefined,
-      apiVersion: s.llm.apiVersion ?? undefined,
-      timeoutSeconds: s.llm.timeout ?? undefined,
-      temperature: s.llm.temperature ?? undefined,
-      topP: s.llm.topP ?? undefined,
-      topK: s.llm.topK ?? undefined,
-      maxInputTokens: s.llm.maxInputTokens ?? undefined,
-      maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
-      nativeToolCalling: s.llm.nativeToolCalling ?? undefined,
-      reasoningEffort: s.llm.reasoningEffort ?? undefined,
-    };
-    const factory = new LLMFactory(config, { secrets: this.secrets });
-    return factory.createClient();
-  }
-
-  private parseToolArgs(raw: string | undefined): unknown {
-    if (!raw) return {};
-    try {
-      return JSON.parse(raw);
-    } catch (e) {
-      this.events.push({
-        type: 'AgentErrorEvent',
-        source: 'agent',
-        error: `Invalid tool arguments: ${e instanceof Error ? e.message : String(e)}`,
-        tool_name: 'unknown',
-        tool_call_id: randomUUID(),
-      } as Event);
-      return {};
-    }
-  }
-
-  private requiresConfirmation(): boolean {
-    const policy = this.settings?.confirmation?.policy ?? 'never';
-    return policy !== 'never';
-  }
-
-  private createActionEvent(message: Message, toolCall: ToolCall, args: unknown): ActionEvent {
-    const thought = message.content.filter(isTextContent);
-    return {
-      type: 'ActionEvent',
-      source: 'agent',
-      thought,
-      reasoning_content: message.reasoning_content,
-      action: typeof args === 'object' ? (args as Record<string, unknown>) : null,
-      tool_name: toolCall.function.name,
-      tool_call_id: toolCall.id,
-      tool_call: toolCall,
-      llm_response_id: message.id ?? randomUUID(),
-    };
-  }
-
-  private async executeTool(toolCall: ToolCall, actionEvent: ActionEvent, args: unknown): Promise<void> {
-    const tool = this.tools.get(toolCall.function.name);
-    if (!tool) {
-      this.events.push({
-        type: 'AgentErrorEvent',
-        source: 'agent',
-        error: `Unknown tool: ${toolCall.function.name}`,
-        tool_name: toolCall.function.name,
-        tool_call_id: toolCall.id,
-      } as Event);
-      return;
-    }
-
-    try {
-      const validated = tool.validate(args);
-      const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
-      const result = await tool.execute(validated, context);
-
-      if (toolCall.function.name === 'terminal') {
-        this.emitTerminalEvents(toolCall, result);
-      }
-
-      const observation = {
-        type: 'ObservationEvent',
-        source: 'environment',
-        observation: result as Record<string, unknown>,
-        tool_name: toolCall.function.name,
-        tool_call_id: toolCall.id,
-        action_id: actionEvent.id ?? randomUUID(),
-      } as Event;
-      this.events.push(observation);
-
-      const toolMessage: MessageEvent = {
-        type: 'MessageEvent',
-        source: 'environment',
-        llm_message: {
-          role: 'tool',
-          tool_call_id: toolCall.id,
-          name: toolCall.function.name,
-          content: [{ type: 'text', text: JSON.stringify(result) }],
-        },
-      };
-      this.events.push(toolMessage);
-    } catch (e) {
-      this.events.push({
-        type: 'AgentErrorEvent',
-        source: 'agent',
-        error: e instanceof Error ? e.message : String(e),
-        tool_name: toolCall.function.name,
-        tool_call_id: toolCall.id,
-      } as Event);
-    }
-  }
-
-  private emitTerminalEvents(toolCall: ToolCall, result: unknown): void {
-    const payload = result as { command?: string; stdout?: string; stderr?: string; exitCode?: number };
-    const commandId = toolCall.id;
-    const timestamp = new Date().toISOString();
-    const events: BashEvent[] = [
-      {
-        id: randomUUID(),
-        type: 'BashCommand',
-        timestamp,
-        command_id: commandId,
-        order: 0,
-        command: payload.command ?? toolCall.function.arguments,
-      },
-      {
-        id: randomUUID(),
-        type: 'BashOutput',
-        timestamp,
-        command_id: commandId,
-        order: 1,
-        exit_code: payload.exitCode ?? 0,
-        stdout: payload.stdout ?? null,
-        stderr: payload.stderr ?? null,
-      },
-    ];
-    events.forEach((evt) => this.emit('terminal', evt));
+  private createAgent(): Agent {
+    return new Agent({
+      settings: this.settings,
+      workspaceRoot: this.workspace.root,
+      llmClient: this.customLlmClient,
+      tools: this.tools,
+      events: this.events,
+      state: this.state,
+      secrets: this.secrets,
+      onTerminalEvent: (event) => this.emit('terminal', event),
+    });
   }
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -168,8 +168,14 @@ export class Agent extends EventEmitter {
         break;
       }
 
+      let toolExecutionFailed = false;
       for (const toolCall of toolCalls) {
-        const { args, securityRisk } = this.parseToolArgs(toolCall.function.arguments);
+        const parsedArgs = this.parseToolArgs(toolCall);
+        if (!parsedArgs) {
+          toolExecutionFailed = true;
+          break;
+        }
+        const { args, securityRisk } = parsedArgs;
         const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
         const recordedAction = this.events.push(actionEvent) as ActionEvent;
 
@@ -180,7 +186,17 @@ export class Agent extends EventEmitter {
           return lastAssistantMessage;
         }
 
-        await this.executeTool(toolCall, recordedAction, args);
+        try {
+          await this.executeTool(toolCall, recordedAction, args);
+        } catch {
+          toolExecutionFailed = true;
+          break;
+        }
+      }
+
+      if (toolExecutionFailed) {
+        this.state.setStatus('IDLE');
+        continue;
       }
     }
 
@@ -267,7 +283,8 @@ export class Agent extends EventEmitter {
     this.events.push(event);
   }
 
-  private parseToolArgs(raw: string | undefined): { args: Record<string, unknown>; securityRisk?: SecurityRisk } {
+  private parseToolArgs(toolCall: ToolCall): { args: Record<string, unknown>; securityRisk?: SecurityRisk } | undefined {
+    const raw = toolCall.function.arguments;
     if (!raw) return { args: {} };
     try {
       const parsed: unknown = JSON.parse(raw);
@@ -281,10 +298,10 @@ export class Agent extends EventEmitter {
         type: 'AgentErrorEvent',
         source: 'agent',
         error: `Invalid tool arguments: ${e instanceof Error ? e.message : String(e)}`,
-        tool_name: 'unknown',
-        tool_call_id: randomUUID(),
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
       } as Event);
-      return { args: {} };
+      return undefined;
     }
   }
 
@@ -383,6 +400,7 @@ export class Agent extends EventEmitter {
         detail: e instanceof Error ? e.message : String(e),
         code: 'tool_execution_failed',
       } as Event);
+      throw e;
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -4,7 +4,7 @@ import { AgentOrchestrator } from './AgentOrchestrator';
 import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
-import type { LLMClient } from '../llm';
+import type { LLMClient, LLMToolDefinition } from '../llm';
 import { LLMFactory } from '../llm';
 import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
 import { isTextContent, type SecurityRisk } from '../types';
@@ -52,6 +52,7 @@ export class Agent extends EventEmitter {
     this.workspace = new LocalWorkspace(options.workspaceRoot);
     this.events = options.events ?? new EventLog();
     this.state = options.state ?? new ConversationState(this.events);
+    this.state.attachEventLog(this.events);
     this.secrets = options.secrets ?? new SecretRegistry();
     const providedTools = options.tools ?? [];
     this.tools = new Map(providedTools.map((tool) => [tool.name, tool]));
@@ -71,7 +72,7 @@ export class Agent extends EventEmitter {
   async run(input: AgentRunInput): Promise<Message | undefined> {
     this.cancelled = false;
     return this.lock.acquire(async () => {
-      await this.ensureSystemPrompt();
+      this.ensureSystemPrompt();
       this.pushUserMessage(input);
       return this.runLoop();
     });
@@ -201,11 +202,15 @@ export class Agent extends EventEmitter {
     return { systemPrompt: SYSTEM_PROMPT, messages, tools };
   }
 
-  private getToolDefinitions() {
+  private getToolDefinitions(): LLMToolDefinition[] {
     return Array.from(this.tools.values()).map((tool) => ({
       type: 'function',
       function: { name: tool.name },
     }));
+  }
+
+  private getToolDefinitionsForEvent(): Record<string, unknown>[] {
+    return this.getToolDefinitions().map((tool) => tool as unknown as Record<string, unknown>);
   }
 
   private async getOrchestrator(): Promise<AgentOrchestrator> {
@@ -249,7 +254,7 @@ export class Agent extends EventEmitter {
       type: 'SystemPromptEvent',
       source: 'agent',
       system_prompt: { type: 'text', text: SYSTEM_PROMPT },
-      tools: this.getToolDefinitions(),
+      tools: this.getToolDefinitionsForEvent(),
     } as Event);
   }
 
@@ -265,12 +270,12 @@ export class Agent extends EventEmitter {
   private parseToolArgs(raw: string | undefined): { args: Record<string, unknown>; securityRisk?: SecurityRisk } {
     if (!raw) return { args: {} };
     try {
-      const parsed = JSON.parse(raw);
-      if (parsed && typeof parsed === 'object') {
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         const { security_risk, ...rest } = parsed as Record<string, unknown>;
         return { args: rest, securityRisk: security_risk as SecurityRisk | undefined };
       }
-      return { args: {} };
+      throw new Error('Tool arguments must be a JSON object.');
     } catch (e) {
       this.events.push({
         type: 'AgentErrorEvent',
@@ -328,8 +333,21 @@ export class Agent extends EventEmitter {
       return;
     }
 
+    let validated;
     try {
-      const validated = tool.validate(args);
+      validated = tool.validate(args);
+    } catch (e) {
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: `Tool validation failed: ${e instanceof Error ? e.message : String(e)}`,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+      } as Event);
+      return;
+    }
+
+    try {
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
       const result = await tool.execute(validated, context);
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1,0 +1,398 @@
+import EventEmitter from 'events';
+import { randomUUID } from 'crypto';
+import { AgentOrchestrator } from './AgentOrchestrator';
+import { AsyncLock } from './AsyncLock';
+import { ConversationState } from './ConversationState';
+import { EventLog } from './EventLog';
+import type { LLMClient } from '../llm';
+import { LLMFactory } from '../llm';
+import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
+import { isTextContent, type SecurityRisk } from '../types';
+import type { OpenHandsSettings } from '../types/settings';
+import type { ToolHandler } from '../types/tools';
+import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import { SecretRegistry } from './SecretRegistry';
+
+export type AgentRunInput = string | Message;
+
+export interface ConfirmationPolicy {
+  policy?: 'never' | 'always' | 'risky';
+  riskyThreshold?: SecurityRisk;
+  confirmUnknown?: boolean;
+}
+
+export interface AgentOptions {
+  settings: OpenHandsSettings;
+  workspaceRoot?: string;
+  llmClient?: LLMClient;
+  tools?: ToolHandler<unknown, unknown>[];
+  events?: EventLog;
+  state?: ConversationState;
+  secrets?: SecretRegistry;
+  onTerminalEvent?: (event: BashEvent) => void;
+}
+
+const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
+
+export class Agent extends EventEmitter {
+  private readonly workspace: LocalWorkspace;
+  private readonly events: EventLog;
+  readonly state: ConversationState;
+  private readonly secrets: SecretRegistry;
+  private readonly tools: Map<string, ToolHandler<unknown, unknown>>;
+  private readonly confirmation: ConfirmationPolicy;
+  private readonly lock = new AsyncLock();
+  private orchestratorPromise?: Promise<AgentOrchestrator>;
+  private paused = false;
+  private cancelled = false;
+  private pendingAction?: { toolCall: ToolCall; actionEvent: ActionEvent; args: Record<string, unknown> };
+
+  constructor(private readonly options: AgentOptions) {
+    super();
+    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.events = options.events ?? new EventLog();
+    this.state = options.state ?? new ConversationState(this.events);
+    this.secrets = options.secrets ?? new SecretRegistry();
+    const providedTools = options.tools ?? [];
+    this.tools = new Map(providedTools.map((tool) => [tool.name, tool]));
+    this.confirmation = {
+      policy: options.settings?.confirmation?.policy ?? 'never',
+      riskyThreshold: options.settings?.confirmation?.riskyThreshold ?? 'MEDIUM',
+      confirmUnknown: options.settings?.confirmation?.confirmUnknown ?? true,
+    };
+
+    this.events.on((event) => this.emit('event', event));
+  }
+
+  get pendingActionId(): string | undefined {
+    return this.pendingAction?.actionEvent.id;
+  }
+
+  async run(input: AgentRunInput): Promise<Message | undefined> {
+    this.cancelled = false;
+    return this.lock.acquire(async () => {
+      await this.ensureSystemPrompt();
+      this.pushUserMessage(input);
+      return this.runLoop();
+    });
+  }
+
+  pause(): void {
+    if (this.paused) return;
+    this.paused = true;
+    const pause: Event = { type: 'PauseEvent', source: 'user' } as Event;
+    this.events.push(pause);
+    this.state.setStatus('PAUSED');
+  }
+
+  resume(): Promise<Message | undefined> {
+    if (!this.paused) return Promise.resolve(undefined);
+    this.paused = false;
+    this.state.setStatus('RUNNING');
+    return this.lock.acquire(async () => this.runLoop());
+  }
+
+  cancel(): void {
+    this.cancelled = true;
+    this.pendingAction = undefined;
+    this.state.setStatus('CANCELLED');
+  }
+
+  async approveAction(): Promise<void> {
+    if (!this.pendingAction) return;
+    await this.lock.acquire(async () => {
+      const pending = this.pendingAction!;
+      this.pendingAction = undefined;
+      this.state.setStatus('RUNNING');
+      await this.executeTool(pending.toolCall, pending.actionEvent, pending.args);
+      await this.runLoop();
+    });
+  }
+
+  rejectAction(reason?: string): void {
+    if (!this.pendingAction) return;
+    const { actionEvent, toolCall } = this.pendingAction;
+    this.pendingAction = undefined;
+    this.events.push({
+      type: 'UserRejectObservation',
+      source: 'environment',
+      rejection_reason: reason ?? 'User rejected the action',
+      tool_name: actionEvent.tool_name,
+      tool_call_id: toolCall.id,
+      action_id: actionEvent.id!,
+    } as Event);
+    this.state.setStatus('IDLE');
+  }
+
+  private async runLoop(): Promise<Message | undefined> {
+    if (this.paused || this.pendingAction || this.cancelled) {
+      return undefined;
+    }
+
+    const maxIterations = this.clampMaxIterations();
+    const orchestrator = await this.getOrchestrator();
+    let lastAssistantMessage: Message | undefined;
+
+    while (!this.paused && !this.pendingAction && !this.cancelled && this.state.snapshot.iteration < maxIterations) {
+      this.state.setStatus('RUNNING');
+      const request = this.buildChatRequest();
+      let response;
+      try {
+        response = await orchestrator.runChat(request);
+      } catch (error) {
+        this.events.push({
+          type: 'ConversationErrorEvent',
+          source: 'agent',
+          detail: error instanceof Error ? error.message : String(error),
+        } as Event);
+        this.state.setStatus('IDLE');
+        break;
+      }
+
+      const assistantEvent: MessageEvent = {
+        type: 'MessageEvent',
+        source: 'agent',
+        llm_message: response.message,
+      };
+      this.events.push(assistantEvent);
+      if (response.usage) {
+        this.state.setValue('llm_usage', response.usage);
+      }
+      this.state.incrementIteration();
+      lastAssistantMessage = response.message;
+
+      const toolCalls = response.message.tool_calls ?? [];
+      if (!toolCalls.length) {
+        this.state.setStatus('IDLE');
+        break;
+      }
+
+      for (const toolCall of toolCalls) {
+        const { args, securityRisk } = this.parseToolArgs(toolCall.function.arguments);
+        const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
+        const recordedAction = this.events.push(actionEvent) as ActionEvent;
+
+        if (this.requiresConfirmation(recordedAction)) {
+          this.pendingAction = { toolCall, actionEvent: recordedAction, args };
+          this.state.setStatus('WAITING_FOR_CONFIRMATION');
+          this.events.push({ type: 'PauseEvent', source: 'user' } as Event);
+          return lastAssistantMessage;
+        }
+
+        await this.executeTool(toolCall, recordedAction, args);
+      }
+    }
+
+    return lastAssistantMessage;
+  }
+
+  private clampMaxIterations(): number {
+    const raw = this.options.settings?.conversation?.maxIterations;
+    const n = typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : 50;
+    return Math.min(500, Math.max(1, n));
+  }
+
+  private buildChatRequest() {
+    const messages = this.events
+      .list()
+      .filter((event): event is MessageEvent => event.type === 'MessageEvent')
+      .map((event) => event.llm_message);
+    const tools = this.getToolDefinitions();
+    return { systemPrompt: SYSTEM_PROMPT, messages, tools };
+  }
+
+  private getToolDefinitions() {
+    return Array.from(this.tools.values()).map((tool) => ({
+      type: 'function',
+      function: { name: tool.name },
+    }));
+  }
+
+  private async getOrchestrator(): Promise<AgentOrchestrator> {
+    if (!this.orchestratorPromise) {
+      this.orchestratorPromise = (async () => {
+        const client = this.options.llmClient ?? (await this.createLlmClientFromSettings());
+        return new AgentOrchestrator(client, { events: this.events, state: this.state });
+      })();
+    }
+
+    return this.orchestratorPromise;
+  }
+
+  private createLlmClientFromSettings(): Promise<LLMClient> {
+    if (!this.options.settings.llm?.model) {
+      return Promise.reject(new Error('LLM model is not configured'));
+    }
+    const s = this.options.settings;
+    const config = {
+      model: s.llm.model ?? '',
+      baseUrl: s.llm.baseUrl ?? undefined,
+      apiKey: s.secrets?.llmApiKey ?? undefined,
+      apiVersion: s.llm.apiVersion ?? undefined,
+      timeoutSeconds: s.llm.timeout ?? undefined,
+      temperature: s.llm.temperature ?? undefined,
+      topP: s.llm.topP ?? undefined,
+      topK: s.llm.topK ?? undefined,
+      maxInputTokens: s.llm.maxInputTokens ?? undefined,
+      maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
+      nativeToolCalling: s.llm.nativeToolCalling ?? undefined,
+      reasoningEffort: s.llm.reasoningEffort ?? undefined,
+    };
+    const factory = new LLMFactory(config, { secrets: this.secrets });
+    return factory.createClient();
+  }
+
+  private ensureSystemPrompt() {
+    const existing = this.events.list().find((event) => event.type === 'SystemPromptEvent');
+    if (existing) return;
+    this.events.push({
+      type: 'SystemPromptEvent',
+      source: 'agent',
+      system_prompt: { type: 'text', text: SYSTEM_PROMPT },
+      tools: this.getToolDefinitions(),
+    } as Event);
+  }
+
+  private pushUserMessage(input: AgentRunInput) {
+    const message: Message =
+      typeof input === 'string'
+        ? { role: 'user', content: [{ type: 'text', text: input }] }
+        : input;
+    const event: MessageEvent = { type: 'MessageEvent', source: 'user', llm_message: message };
+    this.events.push(event);
+  }
+
+  private parseToolArgs(raw: string | undefined): { args: Record<string, unknown>; securityRisk?: SecurityRisk } {
+    if (!raw) return { args: {} };
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        const { security_risk, ...rest } = parsed as Record<string, unknown>;
+        return { args: rest, securityRisk: security_risk as SecurityRisk | undefined };
+      }
+      return { args: {} };
+    } catch (e) {
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: `Invalid tool arguments: ${e instanceof Error ? e.message : String(e)}`,
+        tool_name: 'unknown',
+        tool_call_id: randomUUID(),
+      } as Event);
+      return { args: {} };
+    }
+  }
+
+  private requiresConfirmation(action: ActionEvent): boolean {
+    const policy = this.confirmation.policy ?? 'never';
+    if (policy === 'never') return false;
+    if (policy === 'always') return true;
+    const risk = action.security_risk;
+    if (!risk) return this.confirmation.confirmUnknown ?? true;
+    const order: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
+    const threshold = this.confirmation.riskyThreshold ?? 'MEDIUM';
+    return order.indexOf(risk) >= order.indexOf(threshold);
+  }
+
+  private createActionEvent(
+    message: Message,
+    toolCall: ToolCall,
+    args: Record<string, unknown>,
+    securityRisk?: SecurityRisk,
+  ): ActionEvent {
+    const thought = message.content.filter(isTextContent);
+    return {
+      type: 'ActionEvent',
+      source: 'agent',
+      thought,
+      reasoning_content: message.reasoning_content,
+      action: args,
+      tool_name: toolCall.function.name,
+      tool_call_id: toolCall.id,
+      tool_call: toolCall,
+      llm_response_id: message.id ?? randomUUID(),
+      security_risk: securityRisk,
+    };
+  }
+
+  private async executeTool(toolCall: ToolCall, actionEvent: ActionEvent, args: Record<string, unknown>): Promise<void> {
+    const tool = this.tools.get(toolCall.function.name);
+    if (!tool) {
+      this.events.push({
+        type: 'AgentErrorEvent',
+        source: 'agent',
+        error: `Unknown tool: ${toolCall.function.name}`,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+      } as Event);
+      return;
+    }
+
+    try {
+      const validated = tool.validate(args);
+      const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
+      const result = await tool.execute(validated, context);
+
+      if (toolCall.function.name === 'terminal') {
+        this.emitTerminalEvents(toolCall, result);
+      }
+
+      const observation = {
+        type: 'ObservationEvent',
+        source: 'environment',
+        observation: result as Record<string, unknown>,
+        tool_name: toolCall.function.name,
+        tool_call_id: toolCall.id,
+        action_id: actionEvent.id ?? randomUUID(),
+      } as Event;
+      this.events.push(observation);
+
+      const toolMessage: MessageEvent = {
+        type: 'MessageEvent',
+        source: 'environment',
+        llm_message: {
+          role: 'tool',
+          tool_call_id: toolCall.id,
+          name: toolCall.function.name,
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+        },
+      };
+      this.events.push(toolMessage);
+    } catch (e) {
+      this.events.push({
+        type: 'ConversationErrorEvent',
+        source: 'environment',
+        detail: e instanceof Error ? e.message : String(e),
+        code: 'tool_execution_failed',
+      } as Event);
+    }
+  }
+
+  private emitTerminalEvents(toolCall: ToolCall, result: unknown): void {
+    if (!this.options.onTerminalEvent) return;
+    const payload = result as { command?: string; stdout?: string; stderr?: string; exitCode?: number };
+    const commandId = toolCall.id;
+    const timestamp = new Date().toISOString();
+    const events: BashEvent[] = [
+      {
+        id: randomUUID(),
+        type: 'BashCommand',
+        timestamp,
+        command_id: commandId,
+        order: 0,
+        command: payload.command ?? toolCall.function.arguments,
+      },
+      {
+        id: randomUUID(),
+        type: 'BashOutput',
+        timestamp,
+        command_id: commandId,
+        order: 1,
+        exit_code: payload.exitCode ?? 0,
+        stdout: payload.stdout ?? null,
+        stderr: payload.stderr ?? null,
+      },
+    ];
+    events.forEach((evt) => this.options.onTerminalEvent?.(evt));
+  }
+}

--- a/packages/agent-sdk-ts/src/sdk/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/index.ts
@@ -3,4 +3,5 @@ export * from './ConversationState';
 export * from './SecretRegistry';
 export * from './AsyncLock';
 export * from './StuckDetector';
+export * from './Agent';
 export * from './AgentOrchestrator';


### PR DESCRIPTION
## Summary
- add an Agent runtime that manages the full local conversation loop with confirmation, pause/resume, and tool execution
- update LocalConversation to delegate to the new Agent and align error handling and event emission
- document the Agent runtime and add coverage for confirmation flow and local tool execution

## Testing
- npm test -w @openhands/agent-sdk-ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4fc5fc3c8320bfffe53546b22613)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Autonomous agent workflow with full lifecycle controls (pause, resume, cancel)
  * Action approval and rejection system with configurable confirmation policies (never/always/risky)

* **Bug Fixes**
  * Improved error handling and validation for tool execution failures

* **Documentation**
  * Added comprehensive Agent SDK architecture documentation

* **Tests**
  * Expanded test coverage for agent loop behavior and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->