### PR TITLE
Review persistence feature and tests

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -122,7 +122,11 @@ interface ConversationInstance {
 - Manages tool execution with `LocalWorkspace`
 - Terminal events for VS Code integrated terminal
 - Full conversation state management
+- **Conversation persistence** - save and restore conversations using `FileStore`
 - No external server required (but still VS Code-bound)
+
+**Persistence Support**:
+LocalConversation supports persistent conversations through the `persistenceDir` or `persistence` options. When configured, all events and state are automatically saved to disk and can be restored later. See [Persistence](#persistence) section for details.
 
 **Note**: LocalConversation remains **VS Code-bound** (uses VS Code SecretStorage, IntegratedTerminalRunner, etc.). "Local mode" means running the agent in VS Code without an external server, not running as a standalone CLI.
 
@@ -635,6 +639,268 @@ const lock = new AsyncLock();
 await lock.acquire(async () => {
   // Critical section - only one execution at a time
   await performCriticalOperation();
+});
+```
+
+### Persistence
+
+**Purpose**: Enable conversation state and event history to be saved to disk and restored across sessions.
+
+**Files**: `src/sdk/runtime/persistence.ts`
+
+**Key Components**:
+
+#### ConversationPersistence Interface
+
+Defines the contract for persistence implementations:
+
+```typescript
+interface ConversationPersistence {
+  conversationId: string;
+  appendEvent(event: Event): void;
+  readEvents(): Event[];
+  writeState(state: AgentState): void;
+  readState(): AgentState | undefined;
+}
+```
+
+#### FileStore Implementation
+
+**Purpose**: File-based persistence using JSONL for events and JSON for state.
+
+**Storage Structure**:
+```
+{rootDir}/
+  {conversationId}/
+    events.jsonl     # Append-only event log (one JSON object per line)
+    state.json       # Latest state snapshot
+```
+
+**Default Location**: `.openhands/conversations/` in the current working directory
+
+**Features**:
+- **Event Storage**: Append-only JSONL format for efficient event streaming
+- **State Snapshots**: JSON format for quick state restoration
+- **Corruption Tolerance**: Skips corrupted lines in events.jsonl
+- **Error Handling**: Gracefully handles missing or malformed state files
+- **Auto-creation**: Automatically creates conversation directories
+
+**API**:
+```typescript
+class FileStore implements ConversationPersistence {
+  constructor(options: FileStoreOptions);
+  appendEvent(event: Event): void;
+  readEvents(): Event[];
+  writeState(state: AgentState): void;
+  readState(): AgentState | undefined;
+  static listConversations(rootDir?: string): string[];
+}
+
+interface FileStoreOptions {
+  rootDir?: string;           // Defaults to .openhands/conversations
+  conversationId: string;
+}
+```
+
+**Usage Example**:
+```typescript
+import { FileStore, EventLog, ConversationState } from '@openhands/agent-sdk-ts';
+
+// Create persistence
+const persistence = new FileStore({
+  rootDir: '/path/to/conversations',
+  conversationId: 'conv-123'
+});
+
+// Use with EventLog
+const eventLog = new EventLog({ persistence });
+eventLog.push({
+  kind: 'MessageEvent',
+  source: 'user',
+  llm_message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] }
+});
+// Event is automatically persisted to events.jsonl
+
+// Use with ConversationState
+const state = new ConversationState({ eventLog, persistence });
+state.setValue('iteration', 1);
+// State is automatically persisted to state.json
+
+// List all conversations
+const conversations = FileStore.listConversations('/path/to/conversations');
+console.log(conversations); // ['conv-123', 'conv-456', ...]
+```
+
+**Integration with LocalConversation**:
+
+LocalConversation automatically manages persistence when configured:
+
+```typescript
+import { LocalConversation } from '@openhands/agent-sdk-ts';
+
+// Option 1: Use persistenceDir (FileStore created automatically)
+const conversation = new LocalConversation({
+  settings: { /* ... */ },
+  workspaceRoot: '/workspace',
+  persistenceDir: '.openhands/conversations',  // Relative or absolute path
+});
+
+await conversation.startNewConversation();
+// Conversation state and events are automatically persisted
+
+// Option 2: Provide custom persistence implementation
+const customPersistence = new FileStore({
+  rootDir: '/custom/path',
+  conversationId: 'my-conversation'
+});
+
+const conversation2 = new LocalConversation({
+  settings: { /* ... */ },
+  workspaceRoot: '/workspace',
+  persistence: customPersistence,
+});
+```
+
+**Restoring Conversations**:
+
+```typescript
+import { LocalConversation, FileStore } from '@openhands/agent-sdk-ts';
+
+// List available conversations
+const conversations = FileStore.listConversations('.openhands/conversations');
+console.log('Available conversations:', conversations);
+
+// Restore a specific conversation
+const conversation = new LocalConversation({
+  settings: { /* ... */ },
+  workspaceRoot: '/workspace',
+  persistenceDir: '.openhands/conversations',
+});
+
+conversation.restoreConversation('conv-123');
+// Events and state are loaded from disk
+// You can continue the conversation from where it left off
+
+await conversation.sendUserMessage('Continue from where we left off');
+```
+
+**Restoration Process**:
+
+When restoring a conversation, the system:
+1. Reads all events from `events.jsonl`
+2. Replays events through EventLog (emitted to listeners)
+3. Attempts to restore state from `state.json` snapshot
+4. If no snapshot exists, rebuilds state from events
+5. Emits 'conversationStarted' event with the conversation ID
+
+**Error Handling**:
+
+The persistence layer handles various error scenarios gracefully:
+
+```typescript
+// Corrupted event line - skipped with console.error
+// [FileStore] Skipping corrupted event line: <error>
+
+// Corrupted state file - returns undefined, state rebuilt from events
+// [FileStore] Could not read or parse state file: <error>
+
+// Missing persistence configuration
+conversation.on('error', (err) => {
+  console.error('Persistence error:', err);
+});
+
+try {
+  conversation.restoreConversation('conv-123');
+} catch (error) {
+  // Handle restoration errors
+}
+```
+
+**File Format Examples**:
+
+events.jsonl:
+```jsonl
+{"id":"evt-1","kind":"MessageEvent","source":"user","timestamp":"2025-11-18T10:00:00Z","llm_message":{"role":"user","content":[{"type":"text","text":"Hello"}]}}
+{"id":"evt-2","kind":"MessageEvent","source":"agent","timestamp":"2025-11-18T10:00:01Z","llm_message":{"role":"assistant","content":[{"type":"text","text":"Hi!"}]}}
+{"id":"evt-3","kind":"ConversationStateUpdateEvent","source":"agent","timestamp":"2025-11-18T10:00:02Z","iteration":1}
+```
+
+state.json:
+```json
+{
+  "status": "running",
+  "iteration": 1,
+  "values": {
+    "llm_usage": {
+      "input": 100,
+      "output": 50
+    }
+  }
+}
+```
+
+**Attach Persistence After Initialization**:
+
+For advanced use cases, persistence can be attached after EventLog or ConversationState creation:
+
+```typescript
+const eventLog = new EventLog();
+const state = new ConversationState({ eventLog });
+
+// Later, attach persistence
+const persistence = new FileStore({
+  rootDir: '.openhands/conversations',
+  conversationId: 'conv-123'
+});
+
+eventLog.attachPersistence(persistence);
+state.attachPersistence(persistence);
+
+// Future events and state changes will be persisted
+```
+
+**Custom Persistence Implementation**:
+
+You can implement custom persistence backends by implementing the `ConversationPersistence` interface:
+
+```typescript
+import type { ConversationPersistence, AgentState, Event } from '@openhands/agent-sdk-ts';
+
+class DatabasePersistence implements ConversationPersistence {
+  conversationId: string;
+
+  constructor(conversationId: string, private db: Database) {
+    this.conversationId = conversationId;
+  }
+
+  appendEvent(event: Event): void {
+    this.db.query('INSERT INTO events (conversation_id, data) VALUES (?, ?)',
+      [this.conversationId, JSON.stringify(event)]);
+  }
+
+  readEvents(): Event[] {
+    const rows = this.db.query('SELECT data FROM events WHERE conversation_id = ?',
+      [this.conversationId]);
+    return rows.map(row => JSON.parse(row.data));
+  }
+
+  writeState(state: AgentState): void {
+    this.db.query('INSERT OR REPLACE INTO states (conversation_id, data) VALUES (?, ?)',
+      [this.conversationId, JSON.stringify(state)]);
+  }
+
+  readState(): AgentState | undefined {
+    const row = this.db.queryOne('SELECT data FROM states WHERE conversation_id = ?',
+      [this.conversationId]);
+    return row ? JSON.parse(row.data) : undefined;
+  }
+}
+
+// Use custom persistence
+const persistence = new DatabasePersistence('conv-123', myDatabase);
+const conversation = new LocalConversation({
+  settings: { /* ... */ },
+  persistence,
 });
 ```
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -98,4 +98,188 @@ describe('LocalConversation persistence', () => {
     expect(restoredState.iteration).toBe(initialState.iteration);
     expect(restoredState.values.llm_usage).toEqual(initialState.values.llm_usage);
   });
+
+  it('continues conversation after restoration', async () => {
+    const dir = makeTempDir('local-continuation-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const llm = new MockLLM([
+      { type: 'text', text: 'first response' },
+      { type: 'finish' },
+      { type: 'text', text: 'second response' },
+      { type: 'finish' },
+    ]);
+
+    // Start conversation and send first message
+    const conversation = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+
+    const id = await conversation.startNewConversation();
+    await conversation.sendUserMessage('first message');
+
+    // Restore and continue
+    const restored = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+    restored.restoreConversation(id!);
+
+    const messagesBefore = (restored as unknown as { events: EventLog }).events.list().length;
+    await restored.sendUserMessage('second message');
+    const messagesAfter = (restored as unknown as { events: EventLog }).events.list().length;
+
+    expect(messagesAfter).toBeGreaterThan(messagesBefore);
+  });
+});
+
+describe('FileStore advanced features', () => {
+  it('lists all conversations in a directory', () => {
+    const dir = makeTempDir('list-conversations-');
+
+    // Create multiple conversations
+    new FileStore({ rootDir: dir, conversationId: 'conv-1' });
+    new FileStore({ rootDir: dir, conversationId: 'conv-2' });
+    new FileStore({ rootDir: dir, conversationId: 'conv-3' });
+
+    const conversations = FileStore.listConversations(dir);
+    expect(conversations).toContain('conv-1');
+    expect(conversations).toContain('conv-2');
+    expect(conversations).toContain('conv-3');
+    expect(conversations).toHaveLength(3);
+  });
+
+  it('returns empty array when directory does not exist', () => {
+    const conversations = FileStore.listConversations('/nonexistent-directory-12345');
+    expect(conversations).toEqual([]);
+  });
+
+  it('handles corrupted state file gracefully', () => {
+    const dir = makeTempDir('corrupted-state-');
+    const persistence = new FileStore({ rootDir: dir, conversationId: 'conv-corrupted' });
+
+    // Write valid state first
+    persistence.writeState({ status: 'running', iteration: 1, values: {} });
+
+    // Corrupt the state file
+    const stateFile = path.join(dir, 'conv-corrupted', 'state.json');
+    fs.writeFileSync(stateFile, '{ invalid json }', 'utf8');
+
+    // Should return undefined and not throw
+    const state = persistence.readState();
+    expect(state).toBeUndefined();
+  });
+
+  it('tolerates corrupted event lines', () => {
+    const dir = makeTempDir('corrupted-events-');
+    const persistence = new FileStore({ rootDir: dir, conversationId: 'conv-events' });
+
+    // Add valid events
+    const event1: Event = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    };
+    const event2: Event = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'bye' }] },
+    };
+    persistence.appendEvent(event1);
+    persistence.appendEvent(event2);
+
+    // Corrupt the events file by adding invalid JSON
+    const eventsFile = path.join(dir, 'conv-events', 'events.jsonl');
+    fs.appendFileSync(eventsFile, '{ invalid json line }\n', 'utf8');
+
+    // Should skip corrupted line and return valid events
+    const events = persistence.readEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].llm_message).toBeDefined();
+    expect(events[1].llm_message).toBeDefined();
+  });
+
+  it('handles multiple conversations in the same root directory', () => {
+    const dir = makeTempDir('multi-conversation-');
+
+    const persistence1 = new FileStore({ rootDir: dir, conversationId: 'conv-a' });
+    const persistence2 = new FileStore({ rootDir: dir, conversationId: 'conv-b' });
+
+    const event1: Event = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'message A' }] },
+    };
+    const event2: Event = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'message B' }] },
+    };
+
+    persistence1.appendEvent(event1);
+    persistence2.appendEvent(event2);
+
+    const events1 = persistence1.readEvents();
+    const events2 = persistence2.readEvents();
+
+    expect(events1).toHaveLength(1);
+    expect(events2).toHaveLength(1);
+    expect((events1[0] as any).llm_message.content[0].text).toBe('message A');
+    expect((events2[0] as any).llm_message.content[0].text).toBe('message B');
+  });
+});
+
+describe('Persistence attachment', () => {
+  it('attaches persistence to EventLog after creation', () => {
+    const dir = makeTempDir('attach-eventlog-');
+    const log = new EventLog();
+
+    // Push event without persistence
+    log.push({
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'before' }] },
+    } as Event);
+
+    // Attach persistence
+    const persistence = new FileStore({ rootDir: dir, conversationId: 'conv-attach' });
+    log.attachPersistence(persistence);
+
+    // Push event with persistence
+    log.push({
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'after' }] },
+    } as Event);
+
+    // Only the second event should be persisted
+    const events = persistence.readEvents();
+    expect(events).toHaveLength(1);
+    expect((events[0] as any).llm_message.content[0].text).toBe('after');
+  });
+
+  it('attaches persistence to ConversationState after creation', () => {
+    const dir = makeTempDir('attach-state-');
+    const log = new EventLog();
+    const state = new ConversationState({ eventLog: log });
+
+    // Set value without persistence
+    state.setValue('key1', 'value1');
+
+    // Attach persistence
+    const persistence = new FileStore({ rootDir: dir, conversationId: 'conv-state' });
+    state.attachPersistence(persistence);
+
+    // Set value with persistence
+    state.setValue('key2', 'value2');
+
+    // State should have both values
+    const snapshot = persistence.readState();
+    expect(snapshot?.values.key1).toBe('value1');
+    expect(snapshot?.values.key2).toBe('value2');
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -121,17 +121,19 @@ describe('LocalConversation persistence', () => {
     await conversation.sendUserMessage('first message');
 
     // Restore and continue
+    const restoredEvents: Event[] = [];
     const restored = new LocalConversation({
       settings: baseSettings,
       workspaceRoot,
       llmClient: llm,
       persistenceDir: dir,
     });
+    restored.on('event', (e) => restoredEvents.push(e));
     restored.restoreConversation(id!);
 
-    const messagesBefore = (restored as unknown as { events: EventLog }).events.list().length;
+    const messagesBefore = restoredEvents.length;
     await restored.sendUserMessage('second message');
-    const messagesAfter = (restored as unknown as { events: EventLog }).events.list().length;
+    const messagesAfter = restoredEvents.length;
 
     expect(messagesAfter).toBeGreaterThan(messagesBefore);
   });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { LocalConversation } from '../conversation';
 import { ConversationState, EventLog, FileStore } from '../runtime';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
-import type { Event } from '../types';
+import type { Event, MessageEvent, TextContent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 
 class MockLLM implements LLMClient {
@@ -230,8 +230,8 @@ describe('FileStore advanced features', () => {
 
     expect(events1).toHaveLength(1);
     expect(events2).toHaveLength(1);
-    expect((events1[0] as any).llm_message.content[0].text).toBe('message A');
-    expect((events2[0] as any).llm_message.content[0].text).toBe('message B');
+    expect(((events1[0] as MessageEvent).llm_message.content[0] as TextContent).text).toBe('message A');
+    expect(((events2[0] as MessageEvent).llm_message.content[0] as TextContent).text).toBe('message B');
   });
 });
 
@@ -261,7 +261,7 @@ describe('Persistence attachment', () => {
     // Only the second event should be persisted
     const events = persistence.readEvents();
     expect(events).toHaveLength(1);
-    expect((events[0] as any).llm_message.content[0].text).toBe('after');
+    expect(((events[0] as MessageEvent).llm_message.content[0] as TextContent).text).toBe('after');
   });
 
   it('attaches persistence to ConversationState after creation', () => {


### PR DESCRIPTION
Documentation:
- Add detailed Persistence section to agent-sdk-architecture.md in Layer 2: Runtime
- Document ConversationPersistence interface and FileStore implementation
- Include usage examples for basic usage, LocalConversation integration, and restoration
- Document file formats (events.jsonl and state.json), error handling, and custom implementations
- Add persistence support note to LocalConversation section

Tests:
- Add test for continuing conversation after restoration (full workflow)
- Add test for FileStore.listConversations() method
- Add test for corrupted state file handling
- Add test for corrupted event lines tolerance
- Add test for multiple conversations in same root directory
- Add tests for attachPersistence() on EventLog and ConversationState

The new tests cover previously untested functionality and edge cases, improving overall test coverage for the persistence feature.