### PR TITLE
feat(agent-sdk-ts): LLMRegistry + ConversationStats

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -33,4 +33,38 @@ describe('ConversationStats', () => {
     const m = restored.get_metrics_for_usage('a');
     expect(m.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(3);
   });
+
+  it('restores and merges metrics correctly on re-registration', () => {
+    const stats = new ConversationStats();
+    const m1 = makeMetrics(5);
+    stats.register_llm({ llm: { usageId: 'persistent', metrics: m1 } });
+
+    // Simulate persistence round-trip
+    const json = stats.toJSON();
+    const restoredStats = ConversationStats.fromJSON(json);
+
+    // Create a new stats object and restore state (like LocalConversation)
+    const newStats = new ConversationStats();
+    newStats.restore(restoredStats);
+
+    // Re-register the same usageId with a fresh metrics object
+    const m2 = new Metrics('m'); // empty initially
+    newStats.register_llm({ llm: { usageId: 'persistent', metrics: m2 } });
+
+    // m2 should now contain the restored metrics (5 tokens)
+    expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(5);
+
+    // Add more usage to m2
+    m2.addTokenUsage({ promptTokens: 2, completionTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, contextWindow: 0, responseId: 'new' });
+
+    // The stats object should reflect the total (7 tokens)
+    const combined = newStats.get_combined_metrics();
+    expect(combined.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(7);
+
+    // Ensure we don't double-count if we register again (though register_llm is usually called once per client init)
+    // But if we did:
+    newStats.register_llm({ llm: { usageId: 'persistent', metrics: m2 } });
+    // Should not merge again because _restored_usage_ids prevents it
+    expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(7);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { ConversationStats } from '../runtime/ConversationStats';
+import { Metrics } from '../llm/metrics';
+
+function makeMetrics(token: number): Metrics {
+  const m = new Metrics('m');
+  m.addTokenUsage({ promptTokens: token, completionTokens: token, cacheReadTokens: 0, cacheWriteTokens: 0, contextWindow: 0, responseId: String(token) });
+  return m;
+}
+
+describe('ConversationStats', () => {
+  it('registers llm metrics and combines', () => {
+    const stats = new ConversationStats();
+    const llmA = { llm: { usageId: 'a', metrics: makeMetrics(1) } };
+    const llmB = { llm: { usageId: 'b', metrics: makeMetrics(2) } };
+
+    stats.register_llm(llmA);
+    stats.register_llm(llmB);
+
+    expect(Object.keys(stats.usage_to_metrics)).toEqual(['a', 'b']);
+
+    const combined = stats.get_combined_metrics().getSnapshot();
+    expect(combined.accumulatedTokenUsage?.promptTokens).toBe(3);
+  });
+
+  it('serializes and restores from JSON', () => {
+    const stats = new ConversationStats();
+    stats.register_llm({ llm: { usageId: 'a', metrics: makeMetrics(3) } });
+
+    const json = stats.toJSON();
+    const restored = ConversationStats.fromJSON(json);
+
+    const m = restored.get_metrics_for_usage('a');
+    expect(m.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(3);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
@@ -51,4 +51,13 @@ describe('Metrics', () => {
     expect(snap.accumulatedTokenUsage?.promptTokens).toBe(7);
     expect(snap.accumulatedTokenUsage?.completionTokens).toBe(10);
   });
+
+  it('tracks costs', () => {
+    const m = new Metrics('costly-model');
+    m.addCost(0.05);
+    m.addCost(0.02);
+    expect(m.accumulatedCost).toBeCloseTo(0.07);
+    const snap = m.getSnapshot();
+    expect(snap.accumulatedCost).toBeCloseTo(0.07);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { Metrics } from '../llm/metrics';
+
+describe('Metrics', () => {
+  it('adds token usage and response latency and computes snapshot', () => {
+    const m = new Metrics('gpt-4o');
+    expect(m.getSnapshot()).toMatchObject({
+      modelName: 'gpt-4o',
+      accumulatedCost: 0,
+    });
+
+    m.addTokenUsage({
+      promptTokens: 100,
+      completionTokens: 50,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 5,
+      contextWindow: 0,
+      responseId: 'r1',
+    });
+    m.addResponseLatency(1.25, 'r1');
+
+    const snap = m.getSnapshot();
+    expect(snap.accumulatedTokenUsage).toBeTruthy();
+    expect(snap.accumulatedTokenUsage?.promptTokens).toBe(100);
+    expect(snap.accumulatedTokenUsage?.completionTokens).toBe(50);
+    const json = m.toJSON();
+    expect(Array.isArray(json.responseLatencies)).toBe(true);
+    expect((json.responseLatencies as unknown[]).length).toBe(1);
+  });
+
+  it('serializes and deserializes via JSON', () => {
+    const m = new Metrics('claude-3');
+    m.addTokenUsage({ promptTokens: 1, completionTokens: 2, cacheReadTokens: 0, cacheWriteTokens: 0, contextWindow: 0, responseId: 'x' });
+    m.addResponseLatency(0.5, 'x');
+
+    const json = m.toJSON();
+    const m2 = Metrics.fromJSON(json);
+    expect(m2.modelName).toBe('claude-3');
+    const json2 = m2.toJSON();
+    expect((json2.responseLatencies as unknown[]).length).toBe(1);
+  });
+
+  it('merges metrics', () => {
+    const a = new Metrics('m');
+    const b = new Metrics('m');
+    a.addTokenUsage({ promptTokens: 2, completionTokens: 3, cacheReadTokens: 0, cacheWriteTokens: 1, contextWindow: 0, responseId: 'a' });
+    b.addTokenUsage({ promptTokens: 5, completionTokens: 7, cacheReadTokens: 1, cacheWriteTokens: 0, contextWindow: 0, responseId: 'b' });
+
+    a.merge(b);
+    const snap = a.getSnapshot();
+    expect(snap.accumulatedTokenUsage?.promptTokens).toBe(7);
+    expect(snap.accumulatedTokenUsage?.completionTokens).toBe(10);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LLMRegistry, TrackedLLMClient } from '../llm/registry';
+import type { LLMClient, LLMStreamChunk } from '../llm/types';
+import { Metrics } from '../llm/metrics';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+  async *streamChat(): AsyncGenerator<LLMStreamChunk> {
+    for (const c of this.chunks) yield c;
+  }
+}
+
+describe('LLMRegistry and TrackedLLMClient', () => {
+  it('registers, retrieves and lists usage ids', async () => {
+    const registry = new LLMRegistry();
+    const onUpdate = vi.fn();
+    const metrics = new Metrics('m');
+    const inner = new MockLLM([
+      { type: 'usage', inputTokens: 3, outputTokens: 2 },
+      { type: 'finish', finishReason: 'stop' },
+    ]);
+    const tracked = new TrackedLLMClient({ inner, usageId: 'u1', modelName: 'm', metrics, onMetricsUpdate: onUpdate });
+
+    registry.add(tracked);
+    expect(registry.listUsageIds()).toEqual(['u1']);
+    expect(registry.get('u1')).toBe(tracked);
+
+    const chunks = [] as LLMStreamChunk[];
+    for await (const ch of tracked.streamChat({ systemPrompt: '', messages: [] })) chunks.push(ch);
+
+    expect(onUpdate).toHaveBeenCalled();
+    const json = metrics.toJSON();
+    expect((json.responseLatencies as unknown[]).length).toBe(1);
+  });
+
+  it('notifies subscriber and ConversationStats can register', () => {
+    const registry = new LLMRegistry();
+    const events: string[] = [];
+    registry.subscribe((e) => events.push(e.llm.usageId));
+
+    const t = new TrackedLLMClient({ inner: { async *streamChat() {} }, usageId: 'x', modelName: 'm', metrics: new Metrics('m') });
+    registry.add(t);
+    expect(events).toEqual(['x']);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -31,6 +31,19 @@ describe('LLMRegistry and TrackedLLMClient', () => {
     expect(onUpdate).toHaveBeenCalled();
     const json = metrics.toJSON();
     expect((json.responseLatencies as unknown[]).length).toBe(1);
+    // Verify token usage accumulation
+    const tokenUsages = json.tokenUsages as any[];
+    expect(tokenUsages.length).toBeGreaterThan(0);
+    expect(tokenUsages[0].promptTokens).toBe(3);
+    expect(tokenUsages[0].completionTokens).toBe(2);
+  });
+
+  it('throws on duplicate usageId', () => {
+    const registry = new LLMRegistry();
+    const t1 = new TrackedLLMClient({ inner: { async *streamChat() {} }, usageId: 'dup', modelName: 'm', metrics: new Metrics('m') });
+    const t2 = new TrackedLLMClient({ inner: { async *streamChat() {} }, usageId: 'dup', modelName: 'm', metrics: new Metrics('m') });
+    registry.add(t1);
+    expect(() => registry.add(t2)).toThrow(/already exists/);
   });
 
   it('notifies subscriber and ConversationStats can register', () => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -6,6 +6,7 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { ToolHandler } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
 import { LLMRegistry } from '../llm';
+import type { RegistryEvent } from '../llm/registry';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime/persistence';
 import { AgentContext } from '../context';
@@ -57,7 +58,7 @@ export class LocalConversation extends EventEmitter {
     this.llmRegistry = new LLMRegistry();
     this.stats = new ConversationStats();
     // connect registry to stats
-    this.llmRegistry.subscribe((event) => this.stats.register_llm(event as any));
+    this.llmRegistry.subscribe((event: RegistryEvent) => this.stats.register_llm(event));
 
     this.agent = this.createAgent();
 
@@ -100,7 +101,8 @@ export class LocalConversation extends EventEmitter {
       const snapshot = this.persistence?.readState();
       if (snapshot) {
         this.state.restore(snapshot);
-        const rawStats = (snapshot.values as any)?.stats;
+        const values: Record<string, unknown> = snapshot.values;
+        const rawStats = values['stats'];
         if (rawStats) {
           const restored = ConversationStats.fromJSON(rawStats);
           this.stats.usage_to_metrics = restored.usage_to_metrics;

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -1,10 +1,11 @@
 import EventEmitter from 'events';
-import { Agent, AsyncLock, ConversationState, EventLog, FileStore, SecretRegistry } from '../runtime';
+import { Agent, AsyncLock, ConversationState, EventLog, FileStore, SecretRegistry, ConversationStats } from '../runtime';
 import type { LLMClient } from '../llm';
 import type { BashEvent, Event } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolHandler } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import { LLMRegistry } from '../llm';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime/persistence';
 import { AgentContext } from '../context';
@@ -37,6 +38,8 @@ export class LocalConversation extends EventEmitter {
   private persistence?: ConversationPersistence;
   private readonly agentContext?: AgentContext;
   private agent: Agent;
+  private readonly llmRegistry: LLMRegistry;
+  private readonly stats: ConversationStats;
 
   constructor(options: LocalConversationOptions) {
     super();
@@ -51,6 +54,11 @@ export class LocalConversation extends EventEmitter {
     this.tools = options.tools ?? [];
     this.secrets = new SecretRegistry();
     this.agentContext = options.agentContext;
+    this.llmRegistry = new LLMRegistry();
+    this.stats = new ConversationStats();
+    // connect registry to stats
+    this.llmRegistry.subscribe((event) => this.stats.register_llm(event as any));
+
     this.agent = this.createAgent();
 
     this.events.on((event) => this.emit('event', event));
@@ -92,6 +100,11 @@ export class LocalConversation extends EventEmitter {
       const snapshot = this.persistence?.readState();
       if (snapshot) {
         this.state.restore(snapshot);
+        const rawStats = (snapshot.values as any)?.stats;
+        if (rawStats) {
+          const restored = ConversationStats.fromJSON(rawStats);
+          this.stats.usage_to_metrics = restored.usage_to_metrics;
+        }
       } else {
         this.state.loadEvents(events);
       }
@@ -153,6 +166,8 @@ export class LocalConversation extends EventEmitter {
       secrets: this.secrets,
       agentContext: this.agentContext,
       onTerminalEvent: (event) => this.emit('terminal', event),
+      registry: this.llmRegistry,
+      conversationStats: this.stats,
     });
   }
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -105,7 +105,7 @@ export class LocalConversation extends EventEmitter {
         const rawStats = values['stats'];
         if (rawStats) {
           const restored = ConversationStats.fromJSON(rawStats);
-          this.stats.usage_to_metrics = restored.usage_to_metrics;
+          this.stats.restore(restored);
         }
       } else {
         this.state.loadEvents(events);

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -3,19 +3,27 @@ import { AnthropicClient } from './anthropic';
 import { OpenAICompatibleClient } from './openai-compatible';
 import type { ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
+import { LLMRegistry, TrackedLLMClient } from './registry';
+import { Metrics } from './metrics';
 
 export interface LLMFactoryOptions {
   secrets?: SecretRegistry;
   preferredApiKeys?: string | string[];
+  registry?: LLMRegistry;
+  onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 }
 
 export class LLMFactory {
   private readonly credentialProvider: LLMCredentialProvider;
   private readonly preferredKeys?: string | string[];
+  private readonly registry?: LLMRegistry;
+  private readonly onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 
   constructor(private readonly config: LLMConfiguration, options: LLMFactoryOptions = {}) {
     this.credentialProvider = new LLMCredentialProvider(options.secrets);
     this.preferredKeys = options.preferredApiKeys;
+    this.registry = options.registry;
+    this.onMetricsUpdate = options.onMetricsUpdate;
   }
 
   async createClient(): Promise<LLMClient> {
@@ -32,12 +40,17 @@ export class LLMFactory {
       throw new Error('Missing API key for LLM provider');
     }
 
-    if (this.config.provider === 'anthropic') {
-      return new AnthropicClient(this.config, apiKey);
+    const provider = this.config.provider ?? this.detectProviderFromBaseUrl();
+    const base = provider === 'anthropic' ? new AnthropicClient(this.config, apiKey) : new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
+
+    if (this.config.usageId) {
+      const metrics = new Metrics(this.config.model);
+      const tracked = new TrackedLLMClient({ inner: base, usageId: this.config.usageId, modelName: this.config.model, metrics, onMetricsUpdate: this.onMetricsUpdate });
+      this.registry?.add(tracked);
+      return tracked;
     }
 
-    const provider = this.config.provider ?? this.detectProviderFromBaseUrl();
-    return new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
+    return base;
   }
 
   requestFromDefaults(messages: ChatCompletionRequest['messages'], systemPrompt: string): ChatCompletionRequest {

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -3,3 +3,5 @@ export * from './credentials';
 export * from './openai-compatible';
 export * from './anthropic';
 export * from './factory';
+export * from './metrics';
+export * from './registry';

--- a/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
@@ -1,0 +1,180 @@
+export type MetricsSnapshot = {
+  modelName: string;
+  accumulatedCost: number;
+  maxBudgetPerTask?: number | null;
+  accumulatedTokenUsage?: TokenUsage | null;
+};
+
+export type Cost = { model: string; cost: number; timestamp: number };
+export type ResponseLatency = { model: string; latency: number; responseId: string };
+
+export type TokenUsage = {
+  model: string;
+  promptTokens: number;
+  completionTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  reasoningTokens: number;
+  contextWindow: number;
+  perTurnToken: number;
+  responseId: string;
+};
+
+export class Metrics {
+  modelName: string;
+  accumulatedCost = 0;
+  maxBudgetPerTask: number | null = null;
+  costs: Cost[] = [];
+  responseLatencies: ResponseLatency[] = [];
+  tokenUsages: TokenUsage[] = [];
+  accumulatedTokenUsage: TokenUsage | null = null;
+
+  constructor(modelName = 'default') {
+    this.modelName = modelName;
+  }
+
+  static fromJSON(json: unknown): Metrics {
+    if (!json || typeof json !== 'object') return new Metrics();
+    const obj = json as Record<string, any>;
+    const m = new Metrics(String(obj.modelName ?? obj.model_name ?? 'default'));
+    m.accumulatedCost = Number(obj.accumulatedCost ?? obj.accumulated_cost ?? 0) || 0;
+    m.maxBudgetPerTask = obj.maxBudgetPerTask ?? obj.max_budget_per_task ?? null;
+    m.costs = Array.isArray(obj.costs) ? obj.costs.map((c: any) => ({ model: String(c.model ?? m.modelName), cost: Number(c.cost) || 0, timestamp: Number(c.timestamp) || Date.now() })) : [];
+    m.responseLatencies = Array.isArray(obj.responseLatencies)
+      ? obj.responseLatencies.map((r: any) => ({ model: String(r.model ?? m.modelName), latency: Math.max(0, Number(r.latency) || 0), responseId: String(r.responseId ?? r.response_id ?? '') }))
+      : [];
+    m.tokenUsages = Array.isArray(obj.tokenUsages)
+      ? obj.tokenUsages.map((u: any) => ({
+          model: String(u.model ?? m.modelName),
+          promptTokens: Math.max(0, Number(u.promptTokens ?? u.prompt_tokens) || 0),
+          completionTokens: Math.max(0, Number(u.completionTokens ?? u.completion_tokens) || 0),
+          cacheReadTokens: Math.max(0, Number(u.cacheReadTokens ?? u.cache_read_tokens) || 0),
+          cacheWriteTokens: Math.max(0, Number(u.cacheWriteTokens ?? u.cache_write_tokens) || 0),
+          reasoningTokens: Math.max(0, Number(u.reasoningTokens ?? u.reasoning_tokens) || 0),
+          contextWindow: Math.max(0, Number(u.contextWindow ?? u.context_window) || 0),
+          perTurnToken: Math.max(0, Number(u.perTurnToken ?? u.per_turn_token) || 0),
+          responseId: String(u.responseId ?? u.response_id ?? ''),
+        }))
+      : [];
+    const acc = obj.accumulatedTokenUsage ?? obj.accumulated_token_usage;
+    m.accumulatedTokenUsage = acc
+      ? {
+          model: String(acc.model ?? acc.model_name ?? m.modelName),
+          promptTokens: Math.max(0, Number(acc.promptTokens ?? acc.prompt_tokens) || 0),
+          completionTokens: Math.max(0, Number(acc.completionTokens ?? acc.completion_tokens) || 0),
+          cacheReadTokens: Math.max(0, Number(acc.cacheReadTokens ?? acc.cache_read_tokens) || 0),
+          cacheWriteTokens: Math.max(0, Number(acc.cacheWriteTokens ?? acc.cache_write_tokens) || 0),
+          reasoningTokens: Math.max(0, Number(acc.reasoningTokens ?? acc.reasoning_tokens) || 0),
+          contextWindow: Math.max(0, Number(acc.contextWindow ?? acc.context_window) || 0),
+          perTurnToken: Math.max(0, Number(acc.perTurnToken ?? acc.per_turn_token) || 0),
+          responseId: String(acc.responseId ?? acc.response_id ?? ''),
+        }
+      : null;
+    return m;
+  }
+
+  getSnapshot(): MetricsSnapshot {
+    return {
+      modelName: this.modelName,
+      accumulatedCost: this.accumulatedCost,
+      maxBudgetPerTask: this.maxBudgetPerTask,
+      accumulatedTokenUsage: this.accumulatedTokenUsage ? { ...this.accumulatedTokenUsage } : null,
+    };
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      modelName: this.modelName,
+      accumulatedCost: this.accumulatedCost,
+      maxBudgetPerTask: this.maxBudgetPerTask,
+      accumulatedTokenUsage: this.accumulatedTokenUsage,
+      costs: this.costs,
+      responseLatencies: this.responseLatencies,
+      tokenUsages: this.tokenUsages,
+    };
+  }
+
+  addCost(value: number): void {
+    if (value < 0) return;
+    this.accumulatedCost += value;
+    this.costs.push({ model: this.modelName, cost: value, timestamp: Date.now() });
+  }
+
+  addResponseLatency(seconds: number, responseId: string): void {
+    const latency = Math.max(0, seconds);
+    this.responseLatencies.push({ model: this.modelName, latency, responseId });
+  }
+
+  addTokenUsage(params: {
+    promptTokens?: number;
+    completionTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+    contextWindow?: number;
+    responseId?: string;
+    reasoningTokens?: number;
+  }): void {
+    const usage: TokenUsage = {
+      model: this.modelName,
+      promptTokens: Math.max(0, params.promptTokens ?? 0),
+      completionTokens: Math.max(0, params.completionTokens ?? 0),
+      cacheReadTokens: Math.max(0, params.cacheReadTokens ?? 0),
+      cacheWriteTokens: Math.max(0, params.cacheWriteTokens ?? 0),
+      reasoningTokens: Math.max(0, params.reasoningTokens ?? 0),
+      contextWindow: Math.max(0, params.contextWindow ?? 0),
+      perTurnToken: Math.max(0, (params.promptTokens ?? 0) + (params.completionTokens ?? 0)),
+      responseId: String(params.responseId ?? ''),
+    };
+    this.tokenUsages.push(usage);
+
+    const add = {
+      model: this.modelName,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
+      cacheReadTokens: usage.cacheReadTokens,
+      cacheWriteTokens: usage.cacheWriteTokens,
+      reasoningTokens: usage.reasoningTokens,
+      contextWindow: usage.contextWindow,
+      perTurnToken: usage.perTurnToken,
+      responseId: '',
+    };
+
+    if (this.accumulatedTokenUsage == null) {
+      this.accumulatedTokenUsage = add;
+    } else {
+      this.accumulatedTokenUsage = {
+        ...this.accumulatedTokenUsage,
+        promptTokens: this.accumulatedTokenUsage.promptTokens + add.promptTokens,
+        completionTokens: this.accumulatedTokenUsage.completionTokens + add.completionTokens,
+        cacheReadTokens: this.accumulatedTokenUsage.cacheReadTokens + add.cacheReadTokens,
+        cacheWriteTokens: this.accumulatedTokenUsage.cacheWriteTokens + add.cacheWriteTokens,
+        reasoningTokens: this.accumulatedTokenUsage.reasoningTokens + add.reasoningTokens,
+        contextWindow: Math.max(this.accumulatedTokenUsage.contextWindow, add.contextWindow),
+        perTurnToken: add.perTurnToken,
+      };
+    }
+  }
+
+  merge(other: Metrics): void {
+    this.accumulatedCost += other.accumulatedCost;
+    if (this.maxBudgetPerTask == null && other.maxBudgetPerTask != null) this.maxBudgetPerTask = other.maxBudgetPerTask;
+    this.costs.push(...other.costs);
+    this.responseLatencies.push(...other.responseLatencies);
+    this.tokenUsages.push(...other.tokenUsages);
+
+    if (!this.accumulatedTokenUsage) {
+      this.accumulatedTokenUsage = other.accumulatedTokenUsage ? { ...other.accumulatedTokenUsage } : null;
+    } else if (other.accumulatedTokenUsage) {
+      this.accumulatedTokenUsage = {
+        ...this.accumulatedTokenUsage,
+        promptTokens: this.accumulatedTokenUsage.promptTokens + other.accumulatedTokenUsage.promptTokens,
+        completionTokens: this.accumulatedTokenUsage.completionTokens + other.accumulatedTokenUsage.completionTokens,
+        cacheReadTokens: this.accumulatedTokenUsage.cacheReadTokens + other.accumulatedTokenUsage.cacheReadTokens,
+        cacheWriteTokens: this.accumulatedTokenUsage.cacheWriteTokens + other.accumulatedTokenUsage.cacheWriteTokens,
+        reasoningTokens: this.accumulatedTokenUsage.reasoningTokens + other.accumulatedTokenUsage.reasoningTokens,
+        contextWindow: Math.max(this.accumulatedTokenUsage.contextWindow, other.accumulatedTokenUsage.contextWindow),
+        perTurnToken: other.accumulatedTokenUsage.perTurnToken,
+      };
+    }
+  }
+}

--- a/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
@@ -34,42 +34,93 @@ export class Metrics {
   }
 
   static fromJSON(json: unknown): Metrics {
-    if (!json || typeof json !== 'object') return new Metrics();
-    const obj = json as Record<string, any>;
-    const m = new Metrics(String(obj.modelName ?? obj.model_name ?? 'default'));
-    m.accumulatedCost = Number(obj.accumulatedCost ?? obj.accumulated_cost ?? 0) || 0;
-    m.maxBudgetPerTask = obj.maxBudgetPerTask ?? obj.max_budget_per_task ?? null;
-    m.costs = Array.isArray(obj.costs) ? obj.costs.map((c: any) => ({ model: String(c.model ?? m.modelName), cost: Number(c.cost) || 0, timestamp: Number(c.timestamp) || Date.now() })) : [];
-    m.responseLatencies = Array.isArray(obj.responseLatencies)
-      ? obj.responseLatencies.map((r: any) => ({ model: String(r.model ?? m.modelName), latency: Math.max(0, Number(r.latency) || 0), responseId: String(r.responseId ?? r.response_id ?? '') }))
-      : [];
-    m.tokenUsages = Array.isArray(obj.tokenUsages)
-      ? obj.tokenUsages.map((u: any) => ({
-          model: String(u.model ?? m.modelName),
-          promptTokens: Math.max(0, Number(u.promptTokens ?? u.prompt_tokens) || 0),
-          completionTokens: Math.max(0, Number(u.completionTokens ?? u.completion_tokens) || 0),
-          cacheReadTokens: Math.max(0, Number(u.cacheReadTokens ?? u.cache_read_tokens) || 0),
-          cacheWriteTokens: Math.max(0, Number(u.cacheWriteTokens ?? u.cache_write_tokens) || 0),
-          reasoningTokens: Math.max(0, Number(u.reasoningTokens ?? u.reasoning_tokens) || 0),
-          contextWindow: Math.max(0, Number(u.contextWindow ?? u.context_window) || 0),
-          perTurnToken: Math.max(0, Number(u.perTurnToken ?? u.per_turn_token) || 0),
-          responseId: String(u.responseId ?? u.response_id ?? ''),
-        }))
-      : [];
-    const acc = obj.accumulatedTokenUsage ?? obj.accumulated_token_usage;
-    m.accumulatedTokenUsage = acc
-      ? {
-          model: String(acc.model ?? acc.model_name ?? m.modelName),
-          promptTokens: Math.max(0, Number(acc.promptTokens ?? acc.prompt_tokens) || 0),
-          completionTokens: Math.max(0, Number(acc.completionTokens ?? acc.completion_tokens) || 0),
-          cacheReadTokens: Math.max(0, Number(acc.cacheReadTokens ?? acc.cache_read_tokens) || 0),
-          cacheWriteTokens: Math.max(0, Number(acc.cacheWriteTokens ?? acc.cache_write_tokens) || 0),
-          reasoningTokens: Math.max(0, Number(acc.reasoningTokens ?? acc.reasoning_tokens) || 0),
-          contextWindow: Math.max(0, Number(acc.contextWindow ?? acc.context_window) || 0),
-          perTurnToken: Math.max(0, Number(acc.perTurnToken ?? acc.per_turn_token) || 0),
-          responseId: String(acc.responseId ?? acc.response_id ?? ''),
+    const isRecord = (x: unknown): x is Record<string, unknown> => !!x && typeof x === 'object';
+    if (!isRecord(json)) return new Metrics();
+    const obj = json;
+
+    const getStr = (v: unknown, fallback = ''): string => (typeof v === 'string' ? v : fallback);
+    const getNum = (v: unknown, fallback = 0): number => {
+      const n = typeof v === 'number' ? v : Number(v ?? fallback);
+      return Number.isFinite(n) ? n : fallback;
+    };
+
+    const m = new Metrics(getStr(obj['modelName'] ?? obj['model_name'], 'default'));
+    m.accumulatedCost = getNum(obj['accumulatedCost'] ?? obj['accumulated_cost'], 0);
+    const mbptA = obj['maxBudgetPerTask'];
+    const mbptB = obj['max_budget_per_task'];
+    if (typeof mbptA === 'number' || mbptA === null) {
+      m.maxBudgetPerTask = mbptA as number | null; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+    } else if (typeof mbptB === 'number' || mbptB === null) {
+      m.maxBudgetPerTask = mbptB as number | null; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+    } else {
+      m.maxBudgetPerTask = null;
+    }
+
+    const costs = obj['costs'];
+    if (Array.isArray(costs)) {
+      m.costs = [];
+      for (const raw of costs) {
+        if (isRecord(raw)) {
+          m.costs.push({
+            model: getStr(raw['model'], m.modelName),
+            cost: getNum(raw['cost'], 0),
+            timestamp: getNum(raw['timestamp'], Date.now()),
+          });
         }
-      : null;
+      }
+    }
+
+    const lats = obj['responseLatencies'];
+    if (Array.isArray(lats)) {
+      m.responseLatencies = [];
+      for (const raw of lats) {
+        if (isRecord(raw)) {
+          m.responseLatencies.push({
+            model: getStr(raw['model'], m.modelName),
+            latency: Math.max(0, getNum(raw['latency'], 0)),
+            responseId: getStr(raw['responseId'] ?? raw['response_id'], ''),
+          });
+        }
+      }
+    }
+
+    const usages = obj['tokenUsages'];
+    if (Array.isArray(usages)) {
+      m.tokenUsages = [];
+      for (const raw of usages) {
+        if (isRecord(raw)) {
+          m.tokenUsages.push({
+            model: getStr(raw['model'], m.modelName),
+            promptTokens: Math.max(0, getNum(raw['promptTokens'] ?? raw['prompt_tokens'], 0)),
+            completionTokens: Math.max(0, getNum(raw['completionTokens'] ?? raw['completion_tokens'], 0)),
+            cacheReadTokens: Math.max(0, getNum(raw['cacheReadTokens'] ?? raw['cache_read_tokens'], 0)),
+            cacheWriteTokens: Math.max(0, getNum(raw['cacheWriteTokens'] ?? raw['cache_write_tokens'], 0)),
+            reasoningTokens: Math.max(0, getNum(raw['reasoningTokens'] ?? raw['reasoning_tokens'], 0)),
+            contextWindow: Math.max(0, getNum(raw['contextWindow'] ?? raw['context_window'], 0)),
+            perTurnToken: Math.max(0, getNum(raw['perTurnToken'] ?? raw['per_turn_token'], 0)),
+            responseId: getStr(raw['responseId'] ?? raw['response_id'], ''),
+          });
+        }
+      }
+    }
+
+    const accRaw = obj['accumulatedTokenUsage'] ?? obj['accumulated_token_usage'];
+    if (isRecord(accRaw)) {
+      m.accumulatedTokenUsage = {
+        model: getStr(accRaw['model'] ?? accRaw['model_name'], m.modelName),
+        promptTokens: Math.max(0, getNum(accRaw['promptTokens'] ?? accRaw['prompt_tokens'], 0)),
+        completionTokens: Math.max(0, getNum(accRaw['completionTokens'] ?? accRaw['completion_tokens'], 0)),
+        cacheReadTokens: Math.max(0, getNum(accRaw['cacheReadTokens'] ?? accRaw['cache_read_tokens'], 0)),
+        cacheWriteTokens: Math.max(0, getNum(accRaw['cacheWriteTokens'] ?? accRaw['cache_write_tokens'], 0)),
+        reasoningTokens: Math.max(0, getNum(accRaw['reasoningTokens'] ?? accRaw['reasoning_tokens'], 0)),
+        contextWindow: Math.max(0, getNum(accRaw['contextWindow'] ?? accRaw['context_window'], 0)),
+        perTurnToken: Math.max(0, getNum(accRaw['perTurnToken'] ?? accRaw['per_turn_token'], 0)),
+        responseId: getStr(accRaw['responseId'] ?? accRaw['response_id'], ''),
+      };
+    } else {
+      m.accumulatedTokenUsage = null;
+    }
+
     return m;
   }
 
@@ -139,7 +190,7 @@ export class Metrics {
       responseId: '',
     };
 
-    if (this.accumulatedTokenUsage == null) {
+    if (this.accumulatedTokenUsage === null) {
       this.accumulatedTokenUsage = add;
     } else {
       this.accumulatedTokenUsage = {
@@ -157,7 +208,7 @@ export class Metrics {
 
   merge(other: Metrics): void {
     this.accumulatedCost += other.accumulatedCost;
-    if (this.maxBudgetPerTask == null && other.maxBudgetPerTask != null) this.maxBudgetPerTask = other.maxBudgetPerTask;
+    if (this.maxBudgetPerTask === null && other.maxBudgetPerTask !== null) this.maxBudgetPerTask = other.maxBudgetPerTask;
     this.costs.push(...other.costs);
     this.responseLatencies.push(...other.responseLatencies);
     this.tokenUsages.push(...other.tokenUsages);

--- a/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
@@ -49,9 +49,10 @@ export class Metrics {
     const mbptA = obj['maxBudgetPerTask'];
     const mbptB = obj['max_budget_per_task'];
     if (typeof mbptA === 'number' || mbptA === null) {
-      m.maxBudgetPerTask = mbptA as number | null; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+      m.maxBudgetPerTask = mbptA;
     } else if (typeof mbptB === 'number' || mbptB === null) {
-      m.maxBudgetPerTask = mbptB as number | null; // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion
+      m.maxBudgetPerTask = mbptB;
+
     } else {
       m.maxBudgetPerTask = null;
     }

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -53,7 +53,7 @@ export class TrackedLLMClient implements LLMClient {
 
   async *streamChat(request: import('./types').ChatCompletionRequest): AsyncGenerator<import('./types').LLMStreamChunk> {
     const start = Date.now();
-    let responseId = '';
+    const responseId = `${this.usageId}-${start}`;
     try {
       for await (const chunk of this.inner.streamChat(request)) {
         if (chunk.type === 'usage') {
@@ -69,7 +69,6 @@ export class TrackedLLMClient implements LLMClient {
         }
         if (chunk.type === 'finish') {
           const seconds = (Date.now() - start) / 1000;
-          responseId = responseId || `${this.usageId}-${start}`;
           this.metrics.addResponseLatency(seconds, responseId);
           this.onMetricsUpdate?.(this.usageId, this.metrics);
         }

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -1,0 +1,82 @@
+import type { LLMClient } from './types';
+import type { Metrics } from './metrics';
+
+export type RegistryEvent = { llm: TrackedLLMClient };
+
+export class LLMRegistry {
+  readonly registryId: string;
+  private usageToLLM = new Map<string, TrackedLLMClient>();
+  private subscriber?: (event: RegistryEvent) => void;
+
+  constructor() {
+    this.registryId = Math.random().toString(36).slice(2);
+  }
+
+  subscribe(cb: (event: RegistryEvent) => void): void {
+    this.subscriber = cb;
+  }
+
+  notify(event: RegistryEvent): void {
+    try { this.subscriber?.(event); } catch { /* noop */ }
+  }
+
+  add(llm: TrackedLLMClient): void {
+    const id = llm.usageId;
+    if (this.usageToLLM.has(id)) throw new Error(`Usage ID '${id}' already exists in registry`);
+    this.usageToLLM.set(id, llm);
+    this.notify({ llm });
+  }
+
+  get(usageId: string): TrackedLLMClient {
+    const llm = this.usageToLLM.get(usageId);
+    if (!llm) throw new Error(`Usage ID '${usageId}' not found in registry`);
+    return llm;
+  }
+
+  listUsageIds(): string[] { return Array.from(this.usageToLLM.keys()); }
+}
+
+export class TrackedLLMClient implements LLMClient {
+  readonly inner: LLMClient;
+  readonly usageId: string;
+  readonly modelName: string;
+  readonly metrics: Metrics;
+  private readonly onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
+
+  constructor(params: { inner: LLMClient; usageId: string; modelName: string; metrics: Metrics; onMetricsUpdate?: (usageId: string, metrics: Metrics) => void }) {
+    this.inner = params.inner;
+    this.usageId = params.usageId;
+    this.modelName = params.modelName;
+    this.metrics = params.metrics;
+    this.onMetricsUpdate = params.onMetricsUpdate;
+  }
+
+  async *streamChat(request: import('./types').ChatCompletionRequest): AsyncGenerator<import('./types').LLMStreamChunk> {
+    const start = Date.now();
+    let responseId = '';
+    try {
+      for await (const chunk of this.inner.streamChat(request)) {
+        if (chunk.type === 'usage') {
+          this.metrics.addTokenUsage({
+            promptTokens: chunk.inputTokens ?? 0,
+            completionTokens: chunk.outputTokens ?? 0,
+            cacheReadTokens: chunk.cacheReadTokens ?? 0,
+            cacheWriteTokens: chunk.cacheWriteTokens ?? 0,
+            contextWindow: 0,
+            responseId,
+          });
+          this.onMetricsUpdate?.(this.usageId, this.metrics);
+        }
+        if (chunk.type === 'finish') {
+          const seconds = (Date.now() - start) / 1000;
+          responseId = responseId || `${this.usageId}-${start}`;
+          this.metrics.addResponseLatency(seconds, responseId);
+          this.onMetricsUpdate?.(this.usageId, this.metrics);
+        }
+        yield chunk;
+      }
+    } finally {
+      // no-op
+    }
+  }
+}

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -14,6 +14,7 @@ export interface LLMToolDefinition {
 export interface LLMConfiguration {
   provider?: LLMProvider;
   model: string;
+  usageId?: string | null;
   baseUrl?: string | null;
   apiKey?: string;
   apiVersion?: string | null;
@@ -26,6 +27,8 @@ export interface LLMConfiguration {
   nativeToolCalling?: boolean | null;
   reasoningEffort?: 'low' | 'medium' | 'high' | 'none' | null;
   headers?: Record<string, string>;
+  inputCostPerToken?: number | null;
+  outputCostPerToken?: number | null;
 }
 
 export interface ChatCompletionRequest {

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -27,7 +27,9 @@ export interface LLMConfiguration {
   nativeToolCalling?: boolean | null;
   reasoningEffort?: 'low' | 'medium' | 'high' | 'none' | null;
   headers?: Record<string, string>;
+  /** Cost per input token in USD (or base currency). */
   inputCostPerToken?: number | null;
+  /** Cost per output token in USD (or base currency). */
   outputCostPerToken?: number | null;
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -32,6 +32,8 @@ export interface AgentOptions {
   secrets?: SecretRegistry;
   agentContext?: AgentContext;
   onTerminalEvent?: (event: BashEvent) => void;
+  registry?: import('../llm').LLMRegistry;
+  conversationStats?: import('./ConversationStats').ConversationStats;
 }
 
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
@@ -50,6 +52,8 @@ export class Agent extends EventEmitter {
   private pendingAction?: { toolCall: ToolCall; actionEvent: ActionEvent; args: Record<string, unknown> };
   private readonly agentContext?: AgentContext;
   private readonly activatedSkillNames: string[] = [];
+  private readonly registry?: import('../llm').LLMRegistry;
+  private readonly conversationStats?: import('./ConversationStats').ConversationStats;
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -60,6 +64,8 @@ export class Agent extends EventEmitter {
     this.secrets = options.secrets ?? new SecretRegistry();
     const providedTools = options.tools ?? [];
     this.tools = new Map(providedTools.map((tool) => [tool.name, tool]));
+    this.registry = options.registry;
+    this.conversationStats = options.conversationStats;
     this.confirmation = {
       policy: options.settings?.confirmation?.policy ?? 'never',
       riskyThreshold: options.settings?.confirmation?.riskyThreshold ?? 'MEDIUM',
@@ -286,6 +292,7 @@ export class Agent extends EventEmitter {
     const s = this.options.settings;
     const config = {
       model: s.llm.model ?? '',
+      usageId: s.llm.usageId ?? undefined,
       baseUrl: s.llm.baseUrl ?? undefined,
       apiKey: s.secrets?.llmApiKey ?? undefined,
       apiVersion: s.llm.apiVersion ?? undefined,
@@ -297,8 +304,21 @@ export class Agent extends EventEmitter {
       maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
       nativeToolCalling: s.llm.nativeToolCalling ?? undefined,
       reasoningEffort: s.llm.reasoningEffort ?? undefined,
+      inputCostPerToken: s.llm.inputCostPerToken ?? undefined,
+      outputCostPerToken: s.llm.outputCostPerToken ?? undefined,
     };
-    const factory = new LLMFactory(config, { secrets: this.secrets });
+    const factory = new LLMFactory(config, {
+      secrets: this.secrets,
+      registry: this.registry,
+      onMetricsUpdate: (usageId, metrics) => {
+        if (!this.conversationStats) return;
+        // ensure entry exists and reference the same metrics
+        if (!this.conversationStats.usage_to_metrics[usageId]) {
+          this.conversationStats.usage_to_metrics[usageId] = metrics;
+        }
+        this.state.setValue('stats', this.conversationStats.toJSON());
+      },
+    });
     return factory.createClient();
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -47,8 +47,7 @@ export class ConversationStats {
       llm.metrics.merge(this.usage_to_metrics[usageId]);
       this._restored_usage_ids.add(usageId);
     }
-    if (!(usageId in this.usage_to_metrics)) {
-      this.usage_to_metrics[usageId] = llm.metrics;
-    }
+    // Ensure we track the live metrics object
+    this.usage_to_metrics[usageId] = llm.metrics;
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -1,4 +1,4 @@
-import type { Metrics } from '../llm/metrics';
+import { Metrics } from '../llm/metrics';
 
 export class ConversationStats {
   usage_to_metrics: Record<string, Metrics> = {};
@@ -7,14 +7,16 @@ export class ConversationStats {
   static fromJSON(json: unknown): ConversationStats {
     const stats = new ConversationStats();
     if (!json || typeof json !== 'object') return stats;
-    const obj = json as Record<string, any>;
-    const usage = obj.usage_to_metrics ?? obj.service_to_metrics ?? {};
-    for (const [key, value] of Object.entries(usage)) {
-      const { Metrics } = require('../llm/metrics') as { Metrics: typeof import('../llm/metrics').Metrics };
-      stats.usage_to_metrics[key] = Metrics.fromJSON(value);
+    const obj = json as Record<string, unknown>;
+    const usage = obj['usage_to_metrics'] ?? obj['service_to_metrics'];
+    if (usage && typeof usage === 'object') {
+      const entries = Object.entries(usage as Record<string, unknown>);
+      for (const [key, value] of entries) {
+        stats.usage_to_metrics[key] = Metrics.fromJSON(value);
+      }
     }
-    const restored = obj._restored_usage_ids as string[] | undefined;
-    if (Array.isArray(restored)) restored.forEach((id) => stats._restored_usage_ids.add(id));
+    const restored = obj['_restored_usage_ids'];
+    if (Array.isArray(restored)) restored.forEach((id) => stats._restored_usage_ids.add(String(id)));
     return stats;
   }
 
@@ -26,7 +28,6 @@ export class ConversationStats {
   }
 
   get_combined_metrics(): Metrics {
-    const { Metrics } = require('../llm/metrics') as { Metrics: typeof import('../llm/metrics').Metrics };
     const total = new Metrics('combined');
     for (const m of Object.values(this.usage_to_metrics)) total.merge(m);
     return total;

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -27,6 +27,11 @@ export class ConversationStats {
     };
   }
 
+  restore(other: ConversationStats): void {
+    this.usage_to_metrics = other.usage_to_metrics;
+    this._restored_usage_ids = new Set(other._restored_usage_ids);
+  }
+
   get_combined_metrics(): Metrics {
     const total = new Metrics('combined');
     for (const m of Object.values(this.usage_to_metrics)) total.merge(m);

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -1,0 +1,53 @@
+import type { Metrics } from '../llm/metrics';
+
+export class ConversationStats {
+  usage_to_metrics: Record<string, Metrics> = {};
+  private _restored_usage_ids = new Set<string>();
+
+  static fromJSON(json: unknown): ConversationStats {
+    const stats = new ConversationStats();
+    if (!json || typeof json !== 'object') return stats;
+    const obj = json as Record<string, any>;
+    const usage = obj.usage_to_metrics ?? obj.service_to_metrics ?? {};
+    for (const [key, value] of Object.entries(usage)) {
+      const { Metrics } = require('../llm/metrics') as { Metrics: typeof import('../llm/metrics').Metrics };
+      stats.usage_to_metrics[key] = Metrics.fromJSON(value);
+    }
+    const restored = obj._restored_usage_ids as string[] | undefined;
+    if (Array.isArray(restored)) restored.forEach((id) => stats._restored_usage_ids.add(id));
+    return stats;
+  }
+
+  toJSON(): Record<string, unknown> {
+    return {
+      usage_to_metrics: Object.fromEntries(Object.entries(this.usage_to_metrics).map(([k, v]) => [k, v.toJSON()])),
+      _restored_usage_ids: Array.from(this._restored_usage_ids),
+    };
+  }
+
+  get_combined_metrics(): Metrics {
+    const { Metrics } = require('../llm/metrics') as { Metrics: typeof import('../llm/metrics').Metrics };
+    const total = new Metrics('combined');
+    for (const m of Object.values(this.usage_to_metrics)) total.merge(m);
+    return total;
+  }
+
+  get_metrics_for_usage(usageId: string): Metrics {
+    const metrics = this.usage_to_metrics[usageId];
+    if (!metrics) throw new Error(`LLM usage does not exist ${usageId}`);
+    return metrics;
+  }
+
+  register_llm(event: { llm: { usageId: string; metrics: Metrics } }): void {
+    const llm = event.llm;
+    const usageId = llm.usageId;
+    if (usageId in this.usage_to_metrics && !this._restored_usage_ids.has(usageId)) {
+      // restore existing metrics into llm
+      llm.metrics.merge(this.usage_to_metrics[usageId]);
+      this._restored_usage_ids.add(usageId);
+    }
+    if (!(usageId in this.usage_to_metrics)) {
+      this.usage_to_metrics[usageId] = llm.metrics;
+    }
+  }
+}

--- a/packages/agent-sdk-ts/src/sdk/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/index.ts
@@ -5,3 +5,4 @@ export * from './AsyncLock';
 export * from './Agent';
 export * from './AgentOrchestrator';
 export * from './persistence';
+export * from './ConversationStats';

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -11,6 +11,8 @@ export type LLMSettings = {
   maxOutputTokens?: number | null;
   nativeToolCalling?: boolean | null;
   reasoningEffort?: 'low' | 'medium' | 'high' | 'none' | null;
+  inputCostPerToken?: number | null;
+  outputCostPerToken?: number | null;
 };
 
 export type ServerSettings = {


### PR DESCRIPTION
This PR adds LLMRegistry and ConversationStats parity with the Python agent-sdk and wires metrics into the local conversation flow.

Fix #127 

- New: sdk/llm/metrics.ts, sdk/llm/registry.ts
- New: sdk/runtime/ConversationStats.ts
- Types: extend LLMConfiguration/LLMSettings with usageId and cost hints
- Factory: wrap client with TrackedLLMClient when usageId present; registry events
- Agent/LocalConversation: wire registry and stats, persist stats in state under 'stats'

Notes
- No backward-compat constraints; implementation is straightforward and focused on TS extension needs.
- Remote stats fetching can be layered later if required.

Co-authored-by: openhands <openhands@all-hands.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics tracking for LLMs: token usage, response latency, and cost accounting with per-LLM aggregation and JSON round-trip support
  * Central LLM registry to register/observe LLM instances and emit usage events; tracked LLMs report metrics during streaming
  * Aggregated conversation statistics that persist/restore across sessions and combine per-LLM metrics
  * New LLM configuration: usage IDs and per-token cost overrides

* **Tests**
  * Added tests covering metrics, registry/tracked LLM behavior, conversation statistics, serialization, merging, and updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->