### PR TITLE
Rename to ToolDefinition; document parity

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -536,7 +536,7 @@ const agent = new Agent({
     confirmation: { policy: 'always' },
     secrets: {},
   },
-  tools: [/* ToolHandler instances */],
+  tools: [/* ToolDefinition instances */],
   events: new EventLog(),
   workspaceRoot: '/workspace',
 });

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -258,6 +258,61 @@ classDiagram
   - Keyword/task triggers
   - Auto `/name` trigger for task skills
   - MCP tool metadata
+## Tool and event parity
+
+### Python tool architecture
+
+In Python, tools are modeled as `ToolDefinition[ActionT, ObservationT]` with a few key components:
+
+- `Action` and `Observation` are Pydantic models (see `openhands.sdk.tool.schema`) that define the structured input/output for a tool.
+- A `ToolDefinition` instance carries:
+  - `name`, `description`, `annotations`, `meta`
+  - `action_type` and `observation_type` (the concrete `Action`/`Observation` subclasses)
+  - a runtime-only `executor: ToolExecutor[ActionT, ObservationT] | None` which performs the side effects
+- `ToolExecutor.__call__(self, action: ActionT, conversation: LocalConversation | None) -> ObservationT` is responsible for executing the tool logic. For example, the Terminal tool uses an executor that runs shell commands in the workspace and returns an `ExecuteBashObservation`.
+- The `Agent` never calls tools directly with raw args. Instead, the flow is:
+  1. LLM produces a tool call (function name + JSON arguments).
+  2. `_get_action_event` parses/validates arguments into an `Action` instance (e.g., `ExecuteBashAction`) and emits an `ActionEvent`.
+  3. `_execute_action_event` looks up the corresponding `ToolDefinition`, invokes its `executor(action, conversation)`, and receives an `Observation`.
+  4. The `Observation` is wrapped in an `ObservationEvent` and appended to the conversation.
+- The `ConversationState` ties everything together by tracking events (including `ActionEvent`/`ObservationEvent`) and execution status.
+
+### TypeScript tool architecture today
+
+In TypeScript, the core tool abstraction is `ToolHandler<TArgs, TResult>` (see `src/sdk/types/tools.ts`):
+
+- `ToolHandler` defines:
+  - `name`, optional `description` and `parameters` (for schema)
+  - `validate(input: unknown): TArgs` to coerce LLM arguments into a concrete args object
+  - `execute(args: TArgs, context: ToolContext): Promise<TResult>` which performs the side effects and returns a result
+  - an optional `getToolDefinition()` to expose an LLM-facing tool schema (`LLMToolDefinition`).
+- Tools like `TerminalTool`, `FileEditorTool`, etc. currently implement `execute()` directly and return a simple result object (`TerminalResult`, `FileEditorResult`, ...). There are no explicit `Action`/`Observation` classes.
+- The `Agent` loop (`src/sdk/runtime/Agent.ts`) handles tool calls by:
+  1. Parsing `tool_call.arguments` as JSON.
+  2. Validating arguments via `tool.validate()`.
+  3. Emitting an `ActionEvent` (using the validated args as a plain record, not a typed `Action` subclass).
+  4. Executing `tool.execute(args, context)` once confirmation policy allows.
+  5. Wrapping the returned result in an `ObservationEvent` where `observation` is a plain JSON object.
+- Event interfaces in `src/sdk/types/index.ts` mirror the Python wire format: `ActionEvent` and `ObservationEvent` are present, but they carry raw records (`Record<string, unknown>`) instead of strongly-typed `Action`/`Observation` models.
+
+### Gaps and intended direction
+
+- The TS runtime currently has **ActionEvent/ObservationEvent types but no first-class Action/Observation classes**. The Python stack uses Pydantic models for validation, kind resolution, and serialization; TS simply forwards validated args/results as plain JSON.
+- There is no `ToolDefinition`/`ToolExecutor` split in TS. `ToolHandler.execute` is both the definition and executor. This is enough for VS Code usage but diverges from Python, where the executor can be swapped or wrapped (e.g., for remote execution, observability, or sandboxing).
+- The Python Agent works in terms of `ActionEvent`→`ToolExecutor`→`ObservationEvent`. TS mirrors the **event shapes** but shortcuts the intermediate typed models.
+
+**Practical parity goal for now:**
+
+Rather than fully re-implementing Pydantic-style action/observation classes in TS, the near-term goal is:
+
+- Keep the event wire format aligned (ActionEvent/ObservationEvent shapes stay compatible with Python).
+- Ensure each tool has a well-defined input/result schema and that the Agent loop always:
+  - emits an `ActionEvent` when the LLM calls a tool;
+  - executes the corresponding tool;
+  - emits an `ObservationEvent` with the structured result.
+
+`TerminalTool` is the first place where we validate this end-to-end behavior for a “real” environment-interacting tool.
+
   - Input validation helpers (`requires_user_input`)
   - Third-party aliasing
 - **TypeScript `Skill`**

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -279,9 +279,9 @@ In Python, tools are modeled as `ToolDefinition[ActionT, ObservationT]` with a f
 
 ### TypeScript tool architecture today
 
-In TypeScript, the core tool abstraction is `ToolHandler<TArgs, TResult>` (see `src/sdk/types/tools.ts`):
+In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (see `src/sdk/types/tools.ts`):
 
-- `ToolHandler` defines:
+- `ToolDefinition` defines:
   - `name`, optional `description` and `parameters` (for schema)
   - `validate(input: unknown): TArgs` to coerce LLM arguments into a concrete args object
   - `execute(args: TArgs, context: ToolContext): Promise<TResult>` which performs the side effects and returns a result
@@ -298,7 +298,7 @@ In TypeScript, the core tool abstraction is `ToolHandler<TArgs, TResult>` (see `
 ### Gaps and intended direction
 
 - The TS runtime currently has **ActionEvent/ObservationEvent types but no first-class Action/Observation classes**. The Python stack uses Pydantic models for validation, kind resolution, and serialization; TS simply forwards validated args/results as plain JSON.
-- There is no `ToolDefinition`/`ToolExecutor` split in TS. `ToolHandler.execute` is both the definition and executor. This is enough for VS Code usage but diverges from Python, where the executor can be swapped or wrapped (e.g., for remote execution, observability, or sandboxing).
+- There is no `ToolDefinition`/`ToolExecutor` split in TS. `ToolDefinition.execute` is both the definition and executor. This is enough for VS Code usage but diverges from Python, where the executor can be swapped or wrapped (e.g., for remote execution, observability, or sandboxing).
 - The Python Agent works in terms of `ActionEvent`→`ToolExecutor`→`ObservationEvent`. TS mirrors the **event shapes** but shortcuts the intermediate typed models.
 
 **Practical parity goal for now:**

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { Agent, EventLog } from '../runtime';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
 import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
-import type { ToolHandler } from '../types/tools';
+import type { ToolDefinition } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
 
 class MockLLM implements LLMClient {
@@ -50,7 +50,7 @@ describe('Agent loop control', () => {
 
   it('honors confirmation policy and executes tool on approval', async () => {
     const log = new EventLog();
-    const tool: ToolHandler<{ value: string }, { echoed: string }> = {
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
       name: 'echo',
       validate: (input) => ({ value: (input as { value: string }).value }),
       execute: async (args) => ({ echoed: args.value }),
@@ -84,7 +84,7 @@ describe('Agent loop control', () => {
 
   it('records agent error when tool arguments are not objects', async () => {
     const log = new EventLog();
-    const tool: ToolHandler<Record<string, unknown>, { echoed: boolean }> = {
+    const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {
       name: 'echo',
       validate: (input) => input,
       execute: async (args) => ({ echoed: Boolean(args.value) }),
@@ -114,7 +114,7 @@ describe('Agent loop control', () => {
 
   it('handles JSON primitives in tool arguments by emitting agent error', async () => {
     const log = new EventLog();
-    const tool: ToolHandler<Record<string, unknown>, { echoed: boolean }> = {
+    const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {
       name: 'echo',
       validate: (input) => input,
       execute: async (args) => ({ echoed: Boolean(args.value) }),

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -3,7 +3,7 @@ import { Agent, AsyncLock, ConversationState, EventLog, FileStore, SecretRegistr
 import type { LLMClient } from '../llm';
 import type { BashEvent, Event } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
-import type { ToolHandler } from '../types/tools';
+import type { ToolDefinition } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime/persistence';
@@ -16,7 +16,7 @@ export interface LocalConversationOptions {
   conversationId?: string;
   workspaceRoot?: string;
   llmClient?: LLMClient;
-  tools?: ToolHandler<unknown, unknown>[];
+  tools?: ToolDefinition<unknown, unknown>[];
   persistenceDir?: string;
   persistence?: ConversationPersistence;
   agentContext?: AgentContext;
@@ -32,7 +32,7 @@ export class LocalConversation extends EventEmitter {
   private readonly secrets: SecretRegistry;
   private readonly lock = new AsyncLock();
   private readonly customLlmClient?: LLMClient;
-  private readonly tools: ToolHandler<unknown, unknown>[];
+  private readonly tools: ToolDefinition<unknown, unknown>[];
   private readonly persistenceDir?: string;
   private persistence?: ConversationPersistence;
   private readonly agentContext?: AgentContext;

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -1,5 +1,5 @@
 import type { OpenHandsSettings } from '../types/settings';
-import type { ToolHandler } from '../types/tools';
+import type { ToolDefinition } from '../types/tools';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
 
@@ -12,7 +12,7 @@ export interface ConversationFactoryOptions {
   settings: OpenHandsSettings;
   workspaceRoot?: string;
   conversationId?: string;
-  tools?: ToolHandler<unknown, unknown>[];
+  tools?: ToolDefinition<unknown, unknown>[];
   persistenceDir?: string;
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -9,7 +9,7 @@ import { LLMFactory } from '../llm';
 import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
 import { isTextContent, isMessageEvent, isSystemPromptEvent, type SecurityRisk } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
-import type { ToolHandler } from '../types/tools';
+import type { ToolDefinition } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
@@ -26,7 +26,7 @@ export interface AgentOptions {
   settings: OpenHandsSettings;
   workspaceRoot?: string;
   llmClient?: LLMClient;
-  tools?: ToolHandler<unknown, unknown>[];
+  tools?: ToolDefinition<unknown, unknown>[];
   events?: EventLog;
   state?: ConversationState;
   secrets?: SecretRegistry;
@@ -41,7 +41,7 @@ export class Agent extends EventEmitter {
   private readonly events: EventLog;
   readonly state: ConversationState;
   private readonly secrets: SecretRegistry;
-  private readonly tools: Map<string, ToolHandler<unknown, unknown>>;
+  private readonly tools: Map<string, ToolDefinition<unknown, unknown>>;
   private readonly confirmation: ConfirmationPolicy;
   private readonly lock = new AsyncLock();
   private orchestratorPromise?: Promise<AgentOrchestrator>;

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -139,7 +139,7 @@ export type Event =
   | Condensation
   | ConversationStateUpdateEvent;
 
-export type { ToolContext, ToolHandler } from './tools';
+export type { ToolContext, ToolDefinition } from './tools';
 
 // Event-level guard
 export const isEvent = (candidate: unknown): candidate is Event => {

--- a/packages/agent-sdk-ts/src/sdk/types/tools.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/tools.ts
@@ -9,7 +9,7 @@ export interface ToolContext {
   secrets?: SecretRegistry;
 }
 
-export interface ToolHandler<TArgs, TResult> {
+export interface ToolDefinition<TArgs, TResult> {
   name: string;
   description?: string;
   parameters?: Record<string, unknown>;

--- a/packages/agent-sdk-ts/src/tools/BrowserTool.ts
+++ b/packages/agent-sdk-ts/src/tools/BrowserTool.ts
@@ -1,4 +1,4 @@
-import type { ToolContext, ToolHandler } from './types';
+import type { ToolContext, ToolDefinition } from './types';
 import { requireObject, requireString, optionalString, optionalNumber } from './validation';
 
 export interface BrowserArgs {
@@ -16,7 +16,7 @@ export interface BrowserResult {
 
 const DEFAULT_MAX_BYTES = 256 * 1024;
 
-export class BrowserTool implements ToolHandler<BrowserArgs, BrowserResult> {
+export class BrowserTool implements ToolDefinition<BrowserArgs, BrowserResult> {
   readonly name = 'browser';
 
   validate(input: unknown): BrowserArgs {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { Buffer } from 'buffer';
-import type { ToolContext, ToolHandler } from './types';
+import type { ToolContext, ToolDefinition } from './types';
 import { requireBoolean, requireObject, requireString } from './validation';
 
 export interface FileEditorArgs {
@@ -14,7 +14,7 @@ export interface FileEditorResult {
   bytesWritten: number;
 }
 
-export class FileEditorTool implements ToolHandler<FileEditorArgs, FileEditorResult> {
+export class FileEditorTool implements ToolDefinition<FileEditorArgs, FileEditorResult> {
   readonly name = 'file_editor';
 
   validate(input: unknown): FileEditorArgs {

--- a/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import type { ToolContext, ToolHandler } from './types';
+import type { ToolContext, ToolDefinition } from './types';
 import { requireBoolean, requireObject, requireString, optionalString } from './validation';
 
 interface TaskRecord {
@@ -21,7 +21,7 @@ export interface TaskTrackerResult {
   tasks: TaskRecord[];
 }
 
-export class TaskTrackerTool implements ToolHandler<TaskTrackerArgs, TaskTrackerResult> {
+export class TaskTrackerTool implements ToolDefinition<TaskTrackerArgs, TaskTrackerResult> {
   readonly name = 'task_tracker';
   private readonly tasks: Map<string, TaskRecord> = new Map();
 

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -1,5 +1,5 @@
 import { IntegratedTerminalRunner } from './IntegratedTerminalRunner';
-import type { ToolContext, ToolHandler } from './types';
+import type { ToolContext, ToolDefinition } from './types';
 import { requireObject, requireString, optionalString, optionalNumber } from './validation';
 
 export interface TerminalArgs {
@@ -14,7 +14,7 @@ export interface TerminalResult {
   exitCode: number;
 }
 
-export class TerminalTool implements ToolHandler<TerminalArgs, TerminalResult> {
+export class TerminalTool implements ToolDefinition<TerminalArgs, TerminalResult> {
   readonly name = 'terminal';
 
   validate(input: unknown): TerminalArgs {

--- a/packages/agent-sdk-ts/src/tools/types.ts
+++ b/packages/agent-sdk-ts/src/tools/types.ts
@@ -1,1 +1,1 @@
-export type { ToolContext, ToolHandler } from '../sdk/types/tools';
+export type { ToolContext, ToolDefinition } from '../sdk/types/tools';

--- a/packages/agent-sdk-ts/src/tools/zod-tool.ts
+++ b/packages/agent-sdk-ts/src/tools/zod-tool.ts
@@ -1,14 +1,14 @@
 import { z, type ZodTypeAny } from 'zod';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import type { LLMToolDefinition } from '../sdk/llm';
-import type { ToolContext, ToolHandler } from './types';
+import type { ToolContext, ToolDefinition } from './types';
 
 export interface ToolMetadata {
   description: string;
   parameters: Record<string, unknown>;
 }
 
-export abstract class ZodTool<TArgs, TResult> implements ToolHandler<TArgs, TResult> {
+export abstract class ZodTool<TArgs, TResult> implements ToolDefinition<TArgs, TResult> {
   abstract readonly name: string;
   abstract readonly schema: ZodTypeAny;
   abstract readonly description: string;


### PR DESCRIPTION
This PR:
- adds documentation to `packages/agent-sdk-ts/docs/python-parity.md` describing how the Python `ToolDefinition`/`ToolExecutor` + `Action`/`Observation` event flow maps onto the current TypeScript `ToolHandler` + `ActionEvent`/`ObservationEvent` model.
- renames ToolHandler to ToolDefinition, the closest for the mental model and for parity with python.

Key points documented:
- Python tools operate via `ToolDefinition[ActionT, ObservationT]` and `ToolExecutor`, with `Agent.step()` converting LLM tool calls into `ActionEvent` and back into `ObservationEvent`.
- TypeScript tools use `ToolHandler(ToolDefinition)<TArgs, TResult>`; the Agent loop validates args, emits `ActionEvent`, calls `execute`, and wraps the result in `ObservationEvent`.
- TS currently lacks first-class `Action`/`Observation` classes and a distinct executor type, but the wire format for events is aligned with Python.
- `TerminalTool` in TS is identified as the first real environment-interacting tool where we exercise the full ActionEvent → tool execution → ObservationEvent path.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d180ad8382704a7d933e90743c8a305f)