### PR TITLE
Refactor ConversationStats to camelCase

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -14,30 +14,30 @@ describe('ConversationStats', () => {
     const llmA = { llm: { usageId: 'a', metrics: makeMetrics(1) } };
     const llmB = { llm: { usageId: 'b', metrics: makeMetrics(2) } };
 
-    stats.register_llm(llmA);
-    stats.register_llm(llmB);
+    stats.registerLlm(llmA);
+    stats.registerLlm(llmB);
 
-    expect(Object.keys(stats.usage_to_metrics)).toEqual(['a', 'b']);
+    expect(Object.keys(stats.usageToMetrics)).toEqual(['a', 'b']);
 
-    const combined = stats.get_combined_metrics().getSnapshot();
+    const combined = stats.getCombinedMetrics().getSnapshot();
     expect(combined.accumulatedTokenUsage?.promptTokens).toBe(3);
   });
 
   it('serializes and restores from JSON', () => {
     const stats = new ConversationStats();
-    stats.register_llm({ llm: { usageId: 'a', metrics: makeMetrics(3) } });
+    stats.registerLlm({ llm: { usageId: 'a', metrics: makeMetrics(3) } });
 
     const json = stats.toJSON();
     const restored = ConversationStats.fromJSON(json);
 
-    const m = restored.get_metrics_for_usage('a');
+    const m = restored.getMetricsForUsage('a');
     expect(m.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(3);
   });
 
   it('restores and merges metrics correctly on re-registration', () => {
     const stats = new ConversationStats();
     const m1 = makeMetrics(5);
-    stats.register_llm({ llm: { usageId: 'persistent', metrics: m1 } });
+    stats.registerLlm({ llm: { usageId: 'persistent', metrics: m1 } });
 
     // Simulate persistence round-trip
     const json = stats.toJSON();
@@ -49,7 +49,7 @@ describe('ConversationStats', () => {
 
     // Re-register the same usageId with a fresh metrics object
     const m2 = new Metrics('m'); // empty initially
-    newStats.register_llm({ llm: { usageId: 'persistent', metrics: m2 } });
+    newStats.registerLlm({ llm: { usageId: 'persistent', metrics: m2 } });
 
     // m2 should now contain the restored metrics (5 tokens)
     expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(5);
@@ -58,12 +58,12 @@ describe('ConversationStats', () => {
     m2.addTokenUsage({ promptTokens: 2, completionTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, contextWindow: 0, responseId: 'new' });
 
     // The stats object should reflect the total (7 tokens)
-    const combined = newStats.get_combined_metrics();
+    const combined = newStats.getCombinedMetrics();
     expect(combined.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(7);
 
-    // Ensure we don't double-count if we register again (though register_llm is usually called once per client init)
+    // Ensure we don't double-count if we register again (though registerLlm is usually called once per client init)
     // But if we did:
-    newStats.register_llm({ llm: { usageId: 'persistent', metrics: m2 } });
+    newStats.registerLlm({ llm: { usageId: 'persistent', metrics: m2 } });
     // Should not merge again because _restored_usage_ids prevents it
     expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(7);
   });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -58,7 +58,7 @@ export class LocalConversation extends EventEmitter {
     this.llmRegistry = new LLMRegistry();
     this.stats = new ConversationStats();
     // connect registry to stats
-    this.llmRegistry.subscribe((event: RegistryEvent) => this.stats.register_llm(event));
+    this.llmRegistry.subscribe((event: RegistryEvent) => this.stats.registerLlm(event));
 
     this.agent = this.createAgent();
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -313,8 +313,8 @@ export class Agent extends EventEmitter {
       onMetricsUpdate: (usageId, metrics) => {
         if (!this.conversationStats) return;
         // ensure entry exists and reference the same metrics
-        if (!this.conversationStats.usage_to_metrics[usageId]) {
-          this.conversationStats.usage_to_metrics[usageId] = metrics;
+        if (!this.conversationStats.usageToMetrics[usageId]) {
+          this.conversationStats.usageToMetrics[usageId] = metrics;
         }
         this.state.setValue('stats', this.conversationStats.toJSON());
       },

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -1,8 +1,8 @@
 import { Metrics } from '../llm/metrics';
 
 export class ConversationStats {
-  usage_to_metrics: Record<string, Metrics> = {};
-  private _restored_usage_ids = new Set<string>();
+  usageToMetrics: Record<string, Metrics> = {};
+  private restoredUsageIds = new Set<string>();
 
   static fromJSON(json: unknown): ConversationStats {
     const stats = new ConversationStats();
@@ -12,47 +12,47 @@ export class ConversationStats {
     if (usage && typeof usage === 'object') {
       const entries = Object.entries(usage as Record<string, unknown>);
       for (const [key, value] of entries) {
-        stats.usage_to_metrics[key] = Metrics.fromJSON(value);
+        stats.usageToMetrics[key] = Metrics.fromJSON(value);
       }
     }
     const restored = obj['_restored_usage_ids'];
-    if (Array.isArray(restored)) restored.forEach((id) => stats._restored_usage_ids.add(String(id)));
+    if (Array.isArray(restored)) restored.forEach((id) => stats.restoredUsageIds.add(String(id)));
     return stats;
   }
 
   toJSON(): Record<string, unknown> {
     return {
-      usage_to_metrics: Object.fromEntries(Object.entries(this.usage_to_metrics).map(([k, v]) => [k, v.toJSON()])),
-      _restored_usage_ids: Array.from(this._restored_usage_ids),
+      usage_to_metrics: Object.fromEntries(Object.entries(this.usageToMetrics).map(([k, v]) => [k, v.toJSON()])),
+      _restored_usage_ids: Array.from(this.restoredUsageIds),
     };
   }
 
   restore(other: ConversationStats): void {
-    this.usage_to_metrics = other.usage_to_metrics;
-    this._restored_usage_ids = new Set(other._restored_usage_ids);
+    this.usageToMetrics = other.usageToMetrics;
+    this.restoredUsageIds = new Set(other.restoredUsageIds);
   }
 
-  get_combined_metrics(): Metrics {
+  getCombinedMetrics(): Metrics {
     const total = new Metrics('combined');
-    for (const m of Object.values(this.usage_to_metrics)) total.merge(m);
+    for (const m of Object.values(this.usageToMetrics)) total.merge(m);
     return total;
   }
 
-  get_metrics_for_usage(usageId: string): Metrics {
-    const metrics = this.usage_to_metrics[usageId];
+  getMetricsForUsage(usageId: string): Metrics {
+    const metrics = this.usageToMetrics[usageId];
     if (!metrics) throw new Error(`LLM usage does not exist ${usageId}`);
     return metrics;
   }
 
-  register_llm(event: { llm: { usageId: string; metrics: Metrics } }): void {
+  registerLlm(event: { llm: { usageId: string; metrics: Metrics } }): void {
     const llm = event.llm;
     const usageId = llm.usageId;
-    if (usageId in this.usage_to_metrics && !this._restored_usage_ids.has(usageId)) {
+    if (usageId in this.usageToMetrics && !this.restoredUsageIds.has(usageId)) {
       // restore existing metrics into llm
-      llm.metrics.merge(this.usage_to_metrics[usageId]);
-      this._restored_usage_ids.add(usageId);
+      llm.metrics.merge(this.usageToMetrics[usageId]);
+      this.restoredUsageIds.add(usageId);
     }
     // Ensure we track the live metrics object
-    this.usage_to_metrics[usageId] = llm.metrics;
+    this.usageToMetrics[usageId] = llm.metrics;
   }
 }


### PR DESCRIPTION
## Summary

Refactors `ConversationStats` and its related usages from snake_case to camelCase to align with TypeScript/JavaScript conventions.

## Changes

- Updated `ConversationStats` members and methods:
  - `usage_to_metrics` -> `usageToMetrics`
  - `_restored_usage_ids` (now private) -> `restoredUsageIds`
  - `get_combined_metrics()` -> `getCombinedMetrics()`
  - `get_metrics_for_usage()` -> `getMetricsForUsage()`
  - `register_llm()` -> `registerLlm()`
- Updated all references to these members/methods:
  - `LocalConversation` now subscribes with `stats.registerLlm(...)`
  - `Agent` runtime now uses `conversationStats.usageToMetrics`
  - `conversation-stats.test.ts` updated to use the new camelCase API
- Kept JSON wire format backwards-compatible by still reading/writing `usage_to_metrics` and `_restored_usage_ids` keys in `fromJSON`/`toJSON`.

## Testing

- Installed dependencies with `npm install`.
- Ran the test suite with `npm test`.
  - `packages/agent-sdk-ts` tests all pass, including `conversation-stats.test.ts`.
  - Root webview/extension tests run; there are known existing failures in the webview/extension suite on the base branch, unrelated to this change (e.g., some `App.*` and `actions.*` tests). The ConversationStats-related tests all pass.

## Related Issues

- Fixes #131

## Additional Notes

This change keeps the external JSON representation stable while bringing the TypeScript interface in line with camelCase conventions used elsewhere in the codebase (e.g., `metrics.ts`).

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1b300a59b3fe4174920adc9d8ca98975)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized public API method and property naming conventions in the agent SDK to use camelCase, replacing previous snake_case naming patterns for improved consistency with TypeScript best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->