### PR TITLE
Remove sidebar tree items, open tab directly on icon click

### DIFF
--- a/src/sidebar/OpenHandsViewProvider.ts
+++ b/src/sidebar/OpenHandsViewProvider.ts
@@ -16,24 +16,9 @@ export class OpenHandsViewProvider implements vscode.TreeDataProvider<OpenHandsT
     return element;
   }
 
-  getChildren(element?: OpenHandsTreeItem): Thenable<OpenHandsTreeItem[]> {
-    if (element) {
-      return Promise.resolve([]);
-    }
-
-    // Provide quick entry points to the webview and extension settings.
-    const items: OpenHandsTreeItem[] = [
-      new OpenHandsTreeItem('Open Conversation Tab', {
-        command: 'openhands.openTab',
-        title: 'OpenHands: Open Tab',
-      }, 'comment-discussion'),
-      new OpenHandsTreeItem('Extension Settings', {
-        command: 'workbench.action.openSettings',
-        title: 'Open OpenHands Settings',
-        arguments: ['@ext:openhands.openhands-tab'],
-      }, 'gear'),
-    ];
-
-    return Promise.resolve(items);
+  getChildren(_element?: OpenHandsTreeItem): Thenable<OpenHandsTreeItem[]> {
+    // Return empty - clicking the sidebar icon triggers onDidChangeVisibility
+    // which opens the OpenHands Tab directly
+    return Promise.resolve([]);
   }
 }

--- a/src/sidebar/OpenHandsViewProvider.ts
+++ b/src/sidebar/OpenHandsViewProvider.ts
@@ -1,24 +1,15 @@
 import * as vscode from 'vscode';
 
-class OpenHandsTreeItem extends vscode.TreeItem {
-  constructor(label: string, command: vscode.Command | undefined, iconId: string) {
-    super(label, vscode.TreeItemCollapsibleState.None);
-    this.command = command;
-    this.iconPath = new vscode.ThemeIcon(iconId);
-  }
-}
-
-export class OpenHandsViewProvider implements vscode.TreeDataProvider<OpenHandsTreeItem> {
-  private readonly onDidChangeTreeDataEmitter = new vscode.EventEmitter<OpenHandsTreeItem | void>();
-  readonly onDidChangeTreeData = this.onDidChangeTreeDataEmitter.event;
-
-  getTreeItem(element: OpenHandsTreeItem): vscode.TreeItem {
+/**
+ * Empty tree provider - the sidebar icon click triggers onDidChangeVisibility
+ * which opens the OpenHands Tab directly.
+ */
+export class OpenHandsViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;
   }
 
-  getChildren(_element?: OpenHandsTreeItem): Thenable<OpenHandsTreeItem[]> {
-    // Return empty - clicking the sidebar icon triggers onDidChangeVisibility
-    // which opens the OpenHands Tab directly
+  getChildren(): Thenable<vscode.TreeItem[]> {
     return Promise.resolve([]);
   }
 }

--- a/src/sidebar/__tests__/OpenHandsViewProvider.test.ts
+++ b/src/sidebar/__tests__/OpenHandsViewProvider.test.ts
@@ -10,72 +10,15 @@ describe('OpenHandsViewProvider', () => {
   });
 
   describe('TreeDataProvider implementation', () => {
-    it('provides onDidChangeTreeData event emitter', () => {
-      expect(provider.onDidChangeTreeData).toBeDefined();
-    });
-
     it('getTreeItem returns the element unchanged', () => {
       const mockItem = new vscode.TreeItem('Test Item');
-      const result = provider.getTreeItem(mockItem as any);
+      const result = provider.getTreeItem(mockItem);
       expect(result).toBe(mockItem);
     });
-  });
 
-  describe('getChildren', () => {
-    it('returns empty array when element is provided (no nested items)', async () => {
-      const mockElement = new vscode.TreeItem('Parent');
-      const children = await provider.getChildren(mockElement as any);
+    it('getChildren returns empty array', async () => {
+      const children = await provider.getChildren();
       expect(children).toEqual([]);
-    });
-
-    describe('when no element is provided', () => {
-      let children: vscode.TreeItem[];
-
-      beforeEach(async () => {
-        children = await provider.getChildren();
-      });
-
-      it('returns two root items', () => {
-        expect(children).toHaveLength(2);
-      });
-
-      it('creates a correctly configured "Open Conversation Tab" item', () => {
-        const conversationItem = children[0];
-        expect(conversationItem.label).toBe('Open Conversation Tab');
-        expect(conversationItem.command?.command).toBe('openhands.openTab');
-        expect(conversationItem.command?.title).toBe('OpenHands: Open Tab');
-        expect(conversationItem.iconPath).toBeInstanceOf(vscode.ThemeIcon);
-        expect((conversationItem.iconPath as vscode.ThemeIcon).id).toBe('comment-discussion');
-        expect(conversationItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
-      });
-
-      it('creates a correctly configured "Extension Settings" item', () => {
-        const settingsItem = children[1];
-        expect(settingsItem.label).toBe('Extension Settings');
-        expect(settingsItem.command?.command).toBe('workbench.action.openSettings');
-        expect(settingsItem.command?.title).toBe('Open OpenHands Settings');
-        expect(settingsItem.command?.arguments).toEqual(['@ext:openhands.openhands-tab']);
-        expect(settingsItem.iconPath).toBeInstanceOf(vscode.ThemeIcon);
-        expect((settingsItem.iconPath as vscode.ThemeIcon).id).toBe('gear');
-        expect(settingsItem.collapsibleState).toBe(vscode.TreeItemCollapsibleState.None);
-      });
-
-      it('provides correct command structure for Open Conversation Tab item', () => {
-        const conversationItem = children[0];
-        expect(conversationItem.command).toEqual({
-          command: 'openhands.openTab',
-          title: 'OpenHands: Open Tab',
-        });
-      });
-
-      it('provides correct command structure for Extension Settings item with arguments', () => {
-        const settingsItem = children[1];
-        expect(settingsItem.command).toEqual({
-          command: 'workbench.action.openSettings',
-          title: 'Open OpenHands Settings',
-          arguments: ['@ext:openhands.openhands-tab'],
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
The sidebar view no longer shows intermediate options. Clicking the
OpenHands icon now directly opens the OpenHands Tab via the existing
onDidChangeVisibility handler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the OpenHands sidebar tree view provider by removing custom item construction and specialized icon handling functionality
  * Streamlined the component architecture and event management for cleaner code organization
  * Updated tree rendering logic to use simplified, generic components
  * Reduced overall codebase complexity through strategic architectural improvements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->