### PR TITLE
Refactor HistoryView to show title and prompt preview

### DIFF
--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -1,6 +1,10 @@
 import { useRef } from 'react';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
 
+// --- Constants ---
+
+const PROMPT_PREVIEW_MAX_LENGTH = 100;
+
 // --- Types ---
 
 interface Conversation {
@@ -49,10 +53,10 @@ function getPromptPreview(firstMessage?: string): string | null {
   if (!firstMessage) {
     return null;
   }
-  if (firstMessage.length <= 100) {
+  if (firstMessage.length <= PROMPT_PREVIEW_MAX_LENGTH) {
     return firstMessage;
   }
-  return `${firstMessage.slice(0, 100)}…`;
+  return `${firstMessage.slice(0, PROMPT_PREVIEW_MAX_LENGTH)}…`;
 }
 
 /**

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -1,6 +1,8 @@
 import { useRef } from 'react';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
 
+// --- Types ---
+
 interface Conversation {
   id: string;
   title?: string;
@@ -17,6 +19,143 @@ interface HistoryViewProps {
   onSelectConversation: (id: string) => void;
 }
 
+interface ConversationItemProps {
+  conversation: Conversation;
+  isActive: boolean;
+  animationDelay: number;
+  onSelect: () => void;
+}
+
+// --- Utility Functions ---
+
+/**
+ * Generates the display title for a conversation.
+ * Uses the server-provided title if available, otherwise falls back to
+ * "Conversation (first 5 digits of ID)" for local conversations.
+ */
+function getDisplayTitle(conversation: Conversation): string {
+  if (conversation.title) {
+    return conversation.title;
+  }
+  const shortId = conversation.id.slice(0, 5);
+  return `Conversation (${shortId})`;
+}
+
+/**
+ * Generates a preview of the initial user prompt.
+ * Returns the first 100 characters with ellipsis if truncated.
+ */
+function getPromptPreview(firstMessage?: string): string | null {
+  if (!firstMessage) {
+    return null;
+  }
+  if (firstMessage.length <= 100) {
+    return firstMessage;
+  }
+  return `${firstMessage.slice(0, 100)}…`;
+}
+
+/**
+ * Formats a timestamp as a relative time string (e.g., "2h ago").
+ */
+function formatTimeAgo(timestamp: number): string {
+  const now = Date.now();
+  const diff = now - timestamp;
+
+  const seconds = Math.floor(diff / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  if (minutes > 0) return `${minutes}m ago`;
+  return 'Just now';
+}
+
+// --- Components ---
+
+/**
+ * Renders a single conversation item in the history list.
+ * Displays title (clickable), prompt preview, and metadata.
+ */
+function ConversationItem({
+  conversation,
+  isActive,
+  animationDelay,
+  onSelect,
+}: ConversationItemProps) {
+  const displayTitle = getDisplayTitle(conversation);
+  const promptPreview = getPromptPreview(conversation.firstMessage);
+  const timeAgo = formatTimeAgo(conversation.timestamp);
+
+  return (
+    <button
+      onClick={onSelect}
+      className={`
+        w-full text-left p-4 rounded-lg
+        transition-all duration-200
+        border border-transparent
+        hover:border-brand-500/30 hover:bg-white/5
+        focus:outline-none focus:ring-2 focus:ring-brand-500/50
+        ${isActive ? 'bg-brand-500/10 border-brand-500/30' : 'bg-white/5'}
+        animate-slide-up
+      `}
+      style={{ animationDelay: `${animationDelay}ms` }}
+    >
+      {/* Title Row */}
+      <div className="flex items-start justify-between gap-3 mb-1">
+        <div className="font-medium text-sm line-clamp-2 flex-1 text-[var(--vscode-foreground)]">
+          {displayTitle}
+        </div>
+        {isActive && (
+          <span className="flex-shrink-0 w-2 h-2 rounded-full bg-brand-400 mt-1" />
+        )}
+      </div>
+
+      {/* Prompt Preview */}
+      {promptPreview && (
+        <div className="text-xs opacity-60 line-clamp-2 mb-2">
+          {promptPreview}
+        </div>
+      )}
+
+      {/* Metadata Row */}
+      <div className="flex items-center gap-3 text-xs opacity-50">
+        <span className="flex items-center gap-1">
+          <span className="codicon codicon-clock" />
+          {timeAgo}
+        </span>
+        {conversation.messageCount !== undefined && (
+          <span className="flex items-center gap-1">
+            <span className="codicon codicon-comment" />
+            {conversation.messageCount}
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+/**
+ * Renders the empty state when no conversations exist.
+ */
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center px-8 opacity-60">
+      <span className="codicon codicon-inbox text-4xl mb-4 opacity-40" />
+      <p className="text-sm">No conversation history yet</p>
+      <p className="text-xs mt-2 opacity-70">
+        Start a new conversation to begin
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Main history view component that displays a list of past conversations
+ * in a slide-in side panel.
+ */
 export function HistoryView({
   isOpen,
   onClose,
@@ -67,68 +206,21 @@ export function HistoryView({
         {/* Conversations List */}
         <div className="flex-1 overflow-y-auto px-4 py-4">
           {sortedConversations.length === 0 ? (
-            <div className="flex flex-col items-center justify-center h-full text-center px-8 opacity-60">
-              <span className="codicon codicon-inbox text-4xl mb-4 opacity-40" />
-              <p className="text-sm">No conversation history yet</p>
-              <p className="text-xs mt-2 opacity-70">
-                Start a new conversation to begin
-              </p>
-            </div>
+            <EmptyState />
           ) : (
             <div className="space-y-2">
-              {sortedConversations.map((conversation, index) => {
-                const isActive = conversation.id === currentConversationId;
-                const displayTitle = conversation.title || conversation.firstMessage?.slice(0, 60) || 'Untitled Conversation';
-                const timeAgo = formatTimeAgo(conversation.timestamp);
-
-                return (
-                  <button
-                    key={conversation.id}
-                    onClick={() => {
-                      onSelectConversation(conversation.id);
-                      onClose();
-                    }}
-                    className={`
-                      w-full text-left p-4 rounded-lg
-                      transition-all duration-200
-                      border border-transparent
-                      hover:border-brand-500/30 hover:bg-white/5
-                      focus:outline-none focus:ring-2 focus:ring-brand-500/50
-                      ${isActive ? 'bg-brand-500/10 border-brand-500/30' : 'bg-white/5'}
-                      animate-slide-up
-                    `}
-                    style={{ animationDelay: `${index * 30}ms` }}
-                  >
-                    <div className="flex items-start justify-between gap-3 mb-2">
-                      <div className="font-medium text-sm line-clamp-2 flex-1">
-                        {displayTitle}
-                      </div>
-                      {isActive && (
-                        <span className="flex-shrink-0 w-2 h-2 rounded-full bg-brand-400 mt-1" />
-                      )}
-                    </div>
-
-                    <div className="flex items-center gap-3 text-xs opacity-60">
-                      <span className="flex items-center gap-1">
-                        <span className="codicon codicon-clock" />
-                        {timeAgo}
-                      </span>
-                      {conversation.messageCount !== undefined && (
-                        <span className="flex items-center gap-1">
-                          <span className="codicon codicon-comment" />
-                          {conversation.messageCount}
-                        </span>
-                      )}
-                    </div>
-
-                    {conversation.firstMessage && conversation.firstMessage.length > 60 && (
-                      <div className="mt-2 text-xs opacity-50 line-clamp-2">
-                        {conversation.firstMessage}
-                      </div>
-                    )}
-                  </button>
-                );
-              })}
+              {sortedConversations.map((conversation, index) => (
+                <ConversationItem
+                  key={conversation.id}
+                  conversation={conversation}
+                  isActive={conversation.id === currentConversationId}
+                  animationDelay={index * 30}
+                  onSelect={() => {
+                    onSelectConversation(conversation.id);
+                    onClose();
+                  }}
+                />
+              ))}
             </div>
           )}
         </div>
@@ -142,19 +234,4 @@ export function HistoryView({
       </div>
     </>
   );
-}
-
-function formatTimeAgo(timestamp: number): string {
-  const now = Date.now();
-  const diff = now - timestamp;
-
-  const seconds = Math.floor(diff / 1000);
-  const minutes = Math.floor(seconds / 60);
-  const hours = Math.floor(minutes / 60);
-  const days = Math.floor(hours / 24);
-
-  if (days > 0) return `${days}d ago`;
-  if (hours > 0) return `${hours}h ago`;
-  if (minutes > 0) return `${minutes}m ago`;
-  return 'Just now';
 }


### PR DESCRIPTION
- Display conversation title (from server) or "Conversation (xxxxx)" for local
- Show first 100 chars of initial user prompt below the title
- Extract ConversationItem and EmptyState as separate components
- Add utility functions for title generation and prompt preview
- Improve code organization with JSDoc documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized History View component structure for improved code clarity and maintainability
  * Enhanced active item highlighting to provide visual feedback on current selection
  * Optimized animation timing for sequential rendering of history items

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->