### PR TITLE
Update message accent colors to golden/blue theme

### DIFF
--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -293,7 +293,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const { main: textContent, files: contextFiles } = parseContextBlock(rawText);
   const imageContent = message.content.filter((c) => c.type === 'image');
 
-  const accentColor = isUser ? '#10B981' : isAgent ? '#8B5CF6' : '#6B7280';
+  const accentColor = isUser ? '#3B82F6' : isAgent ? '#D97706' : '#6B7280';
   const icon = isUser ? 'account' : isAgent ? 'hubot' : 'info';
 
   const handleOpenFile = (file: string) => {

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -11,6 +11,11 @@ import {
   isTextContent,
 } from '@openhands/agent-sdk-ts';
 
+// Message accent colors
+const USER_ACCENT_COLOR = '#3B82F6';
+const AGENT_ACCENT_COLOR = '#D97706';
+const DEFAULT_ACCENT_COLOR = '#6B7280';
+
 // Minimal VS Code API accessor (mirrors App.tsx logic)
 interface VscodeApi { postMessage: (message: unknown) => void }
 let vscodeApiInstance: VscodeApi | undefined;
@@ -293,7 +298,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const { main: textContent, files: contextFiles } = parseContextBlock(rawText);
   const imageContent = message.content.filter((c) => c.type === 'image');
 
-  const accentColor = isUser ? '#3B82F6' : isAgent ? '#D97706' : '#6B7280';
+  const accentColor = isUser ? USER_ACCENT_COLOR : isAgent ? AGENT_ACCENT_COLOR : DEFAULT_ACCENT_COLOR;
   const icon = isUser ? 'account' : isAgent ? 'hubot' : 'info';
 
   const handleOpenFile = (file: string) => {


### PR DESCRIPTION
- Change Agent message border from purple (#8B5CF6) to amber/golden (#D97706)
- Change User message border from green (#10B981) to blue (#3B82F6)

This frees green for success states while creating a warm/cool color contrast.