### PR TITLE
Add support for multiple server URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,19 @@
           "default": "",
           "markdownDescription": "OpenHands agent-server base URL. Leave blank to run in local mode."
         },
+        "openhands.servers": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "object",
+            "properties": {
+              "url": { "type": "string" },
+              "label": { "type": "string" }
+            },
+            "required": ["url"]
+          },
+          "markdownDescription": "List of saved OpenHands server URLs with optional labels."
+        },
         "openhands.conversation.maxIterations": {
           "type": "number",
           "default": 50,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -807,7 +807,13 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
           await settingsMgr.update({ serverUrl: url });
         }
 
-        // This will trigger the config change listener which handles reconnection
+        // Notify webview of updated selection so Header/ServerSelector stay in sync
+        const updated = await settingsMgr.get();
+        void panel.webview.postMessage({
+          type: 'serverListUpdated',
+          servers: updated.servers,
+          serverUrl: updated.serverUrl ?? ''
+        });
         break;
       }
       case 'addServer': {
@@ -837,26 +843,33 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
 
         const currentSettings = await settingsMgr.get();
 
+        // Combine updates into one atomic operation
         const newServers = currentSettings.servers.filter(s => s.url !== url);
-        await settingsMgr.update({ servers: newServers });
+        const newServerUrl = currentSettings.serverUrl === url ? '' : currentSettings.serverUrl;
 
-        // If the removed server was active, switch to local
-        if (currentSettings.serverUrl === url) {
-          await settingsMgr.update({ serverUrl: '' });
-        }
+        await settingsMgr.update({
+          servers: newServers,
+          ...(currentSettings.serverUrl === url ? { serverUrl: '' } : {})
+        });
 
         // Send updated list to webview
-        const updatedSettings = await settingsMgr.get();
         void panel.webview.postMessage({
           type: 'serverListUpdated',
           servers: newServers,
-          serverUrl: updatedSettings.serverUrl ?? ''
+          serverUrl: newServerUrl ?? ''
         });
         break;
       }
       case 'switchToLocal': {
         await settingsMgr.update({ serverUrl: '' });
-        // This will trigger the config change listener which handles mode switch
+
+        // Notify webview so it can clear currentServerUrl and reflect local mode immediately
+        const updated = await settingsMgr.get();
+        void panel.webview.postMessage({
+          type: 'serverListUpdated',
+          servers: updated.servers,
+          serverUrl: ''
+        });
         break;
       }
       case 'send':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { SettingsManager } from './settings/SettingsManager';
+import { SettingsManager, type SavedServer } from './settings/SettingsManager';
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { FileStore } from '@openhands/agent-sdk-ts';
 import {
@@ -17,6 +17,30 @@ import {
   isBashOutput,
 } from '@openhands/agent-sdk-ts';
 import { OpenHandsViewProvider } from './sidebar/OpenHandsViewProvider';
+
+// Discriminated union for webview → extension messages
+type WebviewMessage =
+  | { type: 'webviewReady' }
+  | { type: 'openSettingsPage' }
+  | { type: 'openSettings' }
+  | { type: 'requestWorkspaceFiles' }
+  | { type: 'requestSkills' }
+  | { type: 'openSkill'; path: string }
+  | { type: 'openWorkspaceFile'; path: string }
+  | { type: 'requestHistory' }
+  | { type: 'restoreConversation'; id: string }
+  | { type: 'getConfig' }
+  | { type: 'selectServer'; url: string }
+  | { type: 'addServer'; server: SavedServer }
+  | { type: 'removeServer'; url: string }
+  | { type: 'switchToLocal' }
+  | { type: 'send'; text: string }
+  | { type: 'command'; command: string; reason?: string }
+  | { type: 'renderedEventsResponse'; count: number; eventTypes: string[] }
+  | { type: 'webviewConsole'; level: string; args: unknown[] }
+  | { type: 'webviewError'; message: string; stack?: string }
+  | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
+  | { type: 'webviewWebSocket'; phase: string; url: string; code?: number; reason?: string };
 
 let panel: vscode.WebviewPanel | undefined;
 let conversation: ConversationInstance | undefined;
@@ -642,8 +666,8 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
 
   return async (msg: unknown) => {
     // Type guard for message structure
-    if (!msg || typeof msg !== 'object') return;
-    const message = msg as { type?: string; text?: unknown; command?: unknown; reason?: unknown; path?: unknown; count?: unknown; eventTypes?: unknown; level?: unknown; args?: unknown; message?: unknown; stack?: unknown; phase?: unknown; id?: unknown; method?: unknown; url?: unknown; status?: unknown; ok?: unknown; server?: unknown };
+    if (!msg || typeof msg !== 'object' || !('type' in msg)) return;
+    const message = msg as WebviewMessage;
 
     switch (message.type) {
       case 'webviewReady': {
@@ -682,7 +706,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'openSkill': {
-        const skillPath = typeof message.path === 'string' ? message.path : undefined;
+        const skillPath = message.path;
         if (!skillPath) break;
         try {
           const skillsRoot = path.resolve(os.homedir(), '.openhands', 'skills');
@@ -701,7 +725,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'openWorkspaceFile': {
-        const p = typeof (message as any).path === 'string' ? (message as any).path : undefined;
+        const p = message.path;
         if (!p) break;
         try {
           const isAbs = path.isAbsolute(p);
@@ -771,7 +795,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'restoreConversation': {
-        const id = typeof (message as any).id === 'string' ? (message as any).id : undefined;
+        const id = message.id;
         if (!id) break;
         try {
           const maybe = conversation?.restoreConversation?.(id);
@@ -793,7 +817,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'selectServer': {
-        const url = typeof message.url === 'string' ? message.url : '';
+        const url = message.url;
         const currentSettings = await settingsMgr.get();
 
         // Add to servers list if not already present
@@ -817,7 +841,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'addServer': {
-        const server = message.server as { url: string; label?: string } | undefined;
+        const server = message.server;
         if (!server?.url) break;
 
         const currentSettings = await settingsMgr.get();
@@ -838,7 +862,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'removeServer': {
-        const url = typeof message.url === 'string' ? message.url : '';
+        const url = message.url;
         if (!url) break;
 
         const currentSettings = await settingsMgr.get();
@@ -873,81 +897,60 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'send':
-        if (typeof message.text === 'string') {
-          await conversation?.sendUserMessage(message.text);
-        }
+        await conversation?.sendUserMessage(message.text);
         break;
       case 'command':
-        if (typeof message.command === 'string') {
-          switch (message.command) {
-            case 'reconnect':
-              conversation?.reconnect();
-              break;
-            case 'pause':
-              await conversation?.pause();
-              break;
-            case 'startNewConversation': {
-              await conversation?.startNewConversation();
-              break;
-            }
-            case 'approveAction':
-              await conversation?.approveAction();
-              break;
-            case 'rejectAction':
-              await conversation?.rejectAction(typeof message.reason === 'string' ? message.reason : undefined);
-              break;
-            default:
-              console.warn(`Unknown command received from webview: ${message.command}`);
-              break;
-          }
+        switch (message.command) {
+          case 'reconnect':
+            conversation?.reconnect();
+            break;
+          case 'pause':
+            await conversation?.pause();
+            break;
+          case 'startNewConversation':
+            await conversation?.startNewConversation();
+            break;
+          case 'approveAction':
+            await conversation?.approveAction();
+            break;
+          case 'rejectAction':
+            await conversation?.rejectAction(message.reason);
+            break;
+          default:
+            console.warn(`Unknown command received from webview: ${message.command}`);
+            break;
         }
         break;
       case 'renderedEventsResponse':
-        if (typeof message.count === 'number' && Array.isArray(message.eventTypes)) {
-          // Store the response from webview for testing/diagnostics
-          renderedEventsInfo = { count: message.count, eventTypes: message.eventTypes as string[] };
-        }
+        // Store the response from webview for testing/diagnostics
+        renderedEventsInfo = { count: message.count, eventTypes: message.eventTypes };
         break;
       case 'webviewConsole': {
         if (!devBridgeEnabled) break;
-        const level = (typeof message.level === 'string' ? message.level : 'log') as 'log' | 'warn' | 'error';
-        const args = Array.isArray(message.args) ? message.args : [];
-        outputChannel?.appendLine(`[webview ${level}] ${args.join(' ')}`);
-        fileLog(`[console.${level}] ${args.join(' ')}`);
+        outputChannel?.appendLine(`[webview ${message.level}] ${message.args.join(' ')}`);
+        fileLog(`[console.${message.level}] ${message.args.join(' ')}`);
         break;
       }
       case 'webviewError': {
         if (!devBridgeEnabled) break;
-        const m = typeof message.message === 'string' ? message.message : 'error';
-        const s = typeof message.stack === 'string' ? message.stack : '';
-        outputChannel?.appendLine(`[webview error] ${m}`);
-        if (s) outputChannel?.appendLine(s);
-        fileLog(`[error] ${m}${s ? `\n${s}` : ''}`);
+        outputChannel?.appendLine(`[webview error] ${message.message}`);
+        if (message.stack) outputChannel?.appendLine(message.stack);
+        fileLog(`[error] ${message.message}${message.stack ? `\n${message.stack}` : ''}`);
         break;
       }
       case 'webviewNetwork': {
         if (!devBridgeEnabled) break;
-        const phase = typeof message.phase === 'string' ? message.phase : 'unknown';
-        const id = typeof message.id === 'string' ? message.id : '';
-        const method = typeof message.method === 'string' ? message.method : '';
-        const url = typeof message.url === 'string' ? message.url : '';
-        const status = typeof message.status === 'number' ? message.status : undefined;
-        const ok = typeof message.ok === 'boolean' ? message.ok : undefined;
-        const line = `[webview net] ${phase} id=${id} ${method} ${url}${status !== undefined ? ` status=${status} ok=${ok}` : ''}`;
+        const line = `[webview net] ${message.phase} id=${message.id} ${message.method} ${message.url}${message.status !== undefined ? ` status=${message.status} ok=${message.ok}` : ''}`;
         outputChannel?.appendLine(line);
         fileLog(line);
         break;
       }
       case 'webviewWebSocket': {
         if (!devBridgeEnabled) break;
-        const phase = typeof message.phase === 'string' ? message.phase : 'unknown';
-        const url = typeof message.url === 'string' ? message.url : '';
-        const code = (message as any).code as number | undefined;
-        const reason = typeof (message as any).reason === 'string' ? (message as any).reason : undefined;
-        const parts = [`[webview ws] ${phase}`];
-        if (url) parts.push(`url=${url}`);
-        if (code !== undefined) parts.push(`code=${code}`);
-        if (reason) parts.push(`reason=${reason}`);
+        const parts = [`[webview ws] ${message.phase}`];
+        if (message.url) parts.push(`url=${message.url}`);
+        if (message.code !== undefined) parts.push(`code=${message.code}`);
+        if (message.reason) parts.push(`reason=${message.reason}`);
         outputChannel?.appendLine(parts.join(' '));
         fileLog(parts.join(' '));
         break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -640,10 +640,10 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
   return async (msg: unknown) => {
     // Type guard for message structure
     if (!msg || typeof msg !== 'object') return;
-    const message = msg as { type?: string; text?: unknown; command?: unknown; reason?: unknown; path?: unknown; count?: unknown; eventTypes?: unknown; level?: unknown; args?: unknown; message?: unknown; stack?: unknown; phase?: unknown; id?: unknown; method?: unknown; url?: unknown; status?: unknown; ok?: unknown };
+    const message = msg as { type?: string; text?: unknown; command?: unknown; reason?: unknown; path?: unknown; count?: unknown; eventTypes?: unknown; level?: unknown; args?: unknown; message?: unknown; stack?: unknown; phase?: unknown; id?: unknown; method?: unknown; url?: unknown; status?: unknown; ok?: unknown; server?: unknown };
 
     switch (message.type) {
-      case 'webviewReady':
+      case 'webviewReady': {
         // Webview has mounted and is ready to receive messages
         webviewReady = true;
         // Re-send current status so the webview can enable UI immediately
@@ -652,7 +652,15 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
           status: conversation?.getStatus() ?? 'offline',
           mode: conversationMode,
         });
+        // Send initial server list
+        const initSettings = await new SettingsManager(new VscodeSettingsAdapter(context)).get();
+        void panel.webview.postMessage({
+          type: 'serverListUpdated',
+          servers: initSettings.servers,
+          serverUrl: initSettings.serverUrl ?? ''
+        });
         break;
+      }
       case 'openSettingsPage':
         await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
         break;
@@ -779,6 +787,77 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
       case 'getConfig': {
         const settings = await new SettingsManager(new VscodeSettingsAdapter(context)).get();
         void panel.webview.postMessage({ type: 'config', serverUrl: settings.serverUrl ?? null, mode: conversationMode });
+        break;
+      }
+      case 'selectServer': {
+        const url = typeof message.url === 'string' ? message.url : '';
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+        const currentSettings = await settingsMgr.get();
+
+        // Add to servers list if not already present
+        const serverExists = currentSettings.servers.some(s => s.url === url);
+        if (!serverExists && url) {
+          await settingsMgr.update({
+            servers: [...currentSettings.servers, { url }],
+            serverUrl: url
+          });
+        } else {
+          await settingsMgr.update({ serverUrl: url });
+        }
+
+        // This will trigger the config change listener which handles reconnection
+        break;
+      }
+      case 'addServer': {
+        const server = message.server as { url: string; label?: string } | undefined;
+        if (!server?.url) break;
+
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+        const currentSettings = await settingsMgr.get();
+
+        // Check if server already exists
+        const exists = currentSettings.servers.some(s => s.url === server.url);
+        if (!exists) {
+          const newServers = [...currentSettings.servers, server];
+          await settingsMgr.update({ servers: newServers });
+
+          // Send updated list to webview
+          void panel.webview.postMessage({
+            type: 'serverListUpdated',
+            servers: newServers,
+            serverUrl: currentSettings.serverUrl ?? ''
+          });
+        }
+        break;
+      }
+      case 'removeServer': {
+        const url = typeof message.url === 'string' ? message.url : '';
+        if (!url) break;
+
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+        const currentSettings = await settingsMgr.get();
+
+        const newServers = currentSettings.servers.filter(s => s.url !== url);
+        await settingsMgr.update({ servers: newServers });
+
+        // If the removed server was active, switch to local
+        if (currentSettings.serverUrl === url) {
+          await settingsMgr.update({ serverUrl: '' });
+        }
+
+        // Send updated list to webview
+        const updatedSettings = await settingsMgr.get();
+        void panel.webview.postMessage({
+          type: 'serverListUpdated',
+          servers: newServers,
+          serverUrl: updatedSettings.serverUrl ?? ''
+        });
+        break;
+      }
+      case 'switchToLocal': {
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+        await settingsMgr.update({ serverUrl: '' });
+        // This will trigger the config change listener which handles mode switch
         break;
       }
       case 'send':

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -637,6 +637,9 @@ function getWebviewHtml(context: vscode.ExtensionContext, webview: vscode.Webvie
  * avoiding CORS and CSP limitations.
  */
 function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.WebviewPanel) {
+  // Create SettingsManager once and capture in closure for efficiency
+  const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+
   return async (msg: unknown) => {
     // Type guard for message structure
     if (!msg || typeof msg !== 'object') return;
@@ -653,7 +656,7 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
           mode: conversationMode,
         });
         // Send initial server list
-        const initSettings = await new SettingsManager(new VscodeSettingsAdapter(context)).get();
+        const initSettings = await settingsMgr.get();
         void panel.webview.postMessage({
           type: 'serverListUpdated',
           servers: initSettings.servers,
@@ -785,13 +788,12 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'getConfig': {
-        const settings = await new SettingsManager(new VscodeSettingsAdapter(context)).get();
+        const settings = await settingsMgr.get();
         void panel.webview.postMessage({ type: 'config', serverUrl: settings.serverUrl ?? null, mode: conversationMode });
         break;
       }
       case 'selectServer': {
         const url = typeof message.url === 'string' ? message.url : '';
-        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const currentSettings = await settingsMgr.get();
 
         // Add to servers list if not already present
@@ -812,7 +814,6 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         const server = message.server as { url: string; label?: string } | undefined;
         if (!server?.url) break;
 
-        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const currentSettings = await settingsMgr.get();
 
         // Check if server already exists
@@ -834,7 +835,6 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         const url = typeof message.url === 'string' ? message.url : '';
         if (!url) break;
 
-        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const currentSettings = await settingsMgr.get();
 
         const newServers = currentSettings.servers.filter(s => s.url !== url);
@@ -855,7 +855,6 @@ function onWebviewMessage(context: vscode.ExtensionContext, panel: vscode.Webvie
         break;
       }
       case 'switchToLocal': {
-        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         await settingsMgr.update({ serverUrl: '' });
         // This will trigger the config change listener which handles mode switch
         break;

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,10 +1,16 @@
 import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, ConversationSettings, ConfirmationSettings } from './SettingsAdapter';
 
+export interface SavedServer {
+  url: string;
+  label?: string;
+}
+
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
+  servers: SavedServer[];
   secrets: {
     sessionApiKey?: string;
     llmApiKey?: string;
@@ -15,6 +21,7 @@ export type OpenHandsSettings = ServerSettings & {
 
 const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
+  servers: [],
   llm: { usageId: 'default-llm', model: 'claude-sonnet-4-20250514' },
   agent: { enableSecurityAnalyzer: false },
   conversation: { maxIterations: 50 },
@@ -40,6 +47,7 @@ export class SettingsManager {
     const serverUrl = normalizeServerUrl(
       this.adapter.get<string | null>('openhands.serverUrl', DEFAULTS.serverUrl) ?? DEFAULTS.serverUrl
     );
+    const servers = this.adapter.get<SavedServer[]>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers;
     const llm: LLMSettings = {
       // Only return explicitly configured usageId/model so ConnectionManager can omit them when undefined
       usageId: this.adapter.getExplicit<string>('openhands.llm.usageId'),
@@ -71,7 +79,7 @@ export class SettingsManager {
       awsAccessKeyId: await this.adapter.getSecret('openhands.awsAccessKeyId'),
       awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
     };
-    return { serverUrl, llm, agent, conversation, confirmation, secrets };
+    return { serverUrl, servers, llm, agent, conversation, confirmation, secrets };
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
@@ -79,6 +87,10 @@ export class SettingsManager {
 
     if (partial.serverUrl !== undefined) {
       ops.push(this.adapter.update('openhands.serverUrl', partial.serverUrl ?? '', target));
+    }
+
+    if (partial.servers !== undefined) {
+      ops.push(this.adapter.update('openhands.servers', partial.servers, target));
     }
 
     if (partial.llm) {

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -362,7 +362,7 @@ describe('App - Advanced Test Coverage', () => {
       });
     });
 
-    it('hides connection button in local mode', async () => {
+    it('hides connection status in local mode', async () => {
       render(<App />);
 
       postToWindow({ type: 'status', status: 'offline', mode: 'local' });
@@ -371,9 +371,8 @@ describe('App - Advanced Test Coverage', () => {
         expect(screen.getByText('Local Mode')).toBeInTheDocument();
       });
 
-      // In local mode, status indicator shows disconnected but reconnect button is still shown
-      // (The new design always shows reconnect button when offline, regardless of mode)
-      expect(screen.getByLabelText(/Status:/)).toBeInTheDocument();
+      // In local mode, status indicator is hidden - only the server selector shows "Local Mode"
+      expect(screen.queryByLabelText(/Status:/)).not.toBeInTheDocument();
     });
 
     it('shows connection button in remote mode', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -136,6 +136,10 @@ export function App() {
   // History state
   const [history, setHistory] = useState<Array<{ id: string; title?: string; firstMessage?: string; timestamp: number; messageCount?: number }>>([]);
 
+  // Server selection state
+  const [servers, setServers] = useState<{ url: string; label?: string }[]>([]);
+  const [currentServerUrl, setCurrentServerUrl] = useState<string | undefined>(undefined);
+
   // Refs
   const endRef = useRef<HTMLDivElement | null>(null);
   const lastAgentStatusRef = useRef<string | undefined>(undefined);
@@ -231,6 +235,7 @@ export function App() {
         files?: string[];
         skills?: { label: string; path: string }[];
         conversations?: ConversationsList;
+        servers?: { url: string; label?: string }[];
       };
 
       switch (payload?.type) {
@@ -253,14 +258,25 @@ export function App() {
           break;
         case 'configUpdated':
           if (typeof payload.serverUrl === 'string' || payload.serverUrl === null) {
-            const label = payload.serverUrl && payload.serverUrl.length > 0 ? payload.serverUrl : 'local mode';
+            const url = payload.serverUrl || undefined;
+            setCurrentServerUrl(url);
+            const label = url || 'local mode';
             showStatusMessage('info', `Config updated: ${label}`);
           }
           if (payload.mode === 'local') {
             setMode('local');
+            setCurrentServerUrl(undefined);
             setStatusBanner({ message: 'Local mode: running without remote server', level: 'info' });
           } else if (payload.mode === 'remote') {
             setMode('remote');
+          }
+          break;
+        case 'serverListUpdated':
+          if (Array.isArray(payload.servers)) {
+            setServers(payload.servers);
+          }
+          if (typeof payload.serverUrl === 'string') {
+            setCurrentServerUrl(payload.serverUrl || undefined);
           }
           break;
         case 'event':
@@ -540,6 +556,23 @@ export function App() {
     postMessage({ type: 'restoreConversation', id });
   }, [postMessage]);
 
+  // Server selection handlers
+  const handleSelectServer = useCallback((url: string) => {
+    postMessage({ type: 'selectServer', url });
+  }, [postMessage]);
+
+  const handleAddServer = useCallback((server: { url: string; label?: string }) => {
+    postMessage({ type: 'addServer', server });
+  }, [postMessage]);
+
+  const handleRemoveServer = useCallback((url: string) => {
+    postMessage({ type: 'removeServer', url });
+  }, [postMessage]);
+
+  const handleSwitchToLocal = useCallback(() => {
+    postMessage({ type: 'switchToLocal' });
+  }, [postMessage]);
+
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       {/* Header */}
@@ -547,10 +580,16 @@ export function App() {
         status={status}
         mode={mode}
         conversationId={conversationId}
+        currentServerUrl={currentServerUrl}
+        servers={servers}
         onNewConversation={handleStartNewConversation}
         onOpenHistory={handleOpenHistory}
         onOpenSettings={handleOpenSettings}
         onReconnect={handleReconnect}
+        onSelectServer={handleSelectServer}
+        onAddServer={handleAddServer}
+        onRemoveServer={handleRemoveServer}
+        onSwitchToLocal={handleSwitchToLocal}
       />
 
       {/* Main conversation area */}

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -1,11 +1,20 @@
+import { useState } from 'react';
+import { ServerSelector, type SavedServer } from './ServerSelector';
+
 interface HeaderProps {
   status: 'online' | 'offline' | 'connecting';
   mode: 'local' | 'remote';
   conversationId?: string;
+  currentServerUrl?: string;
+  servers: SavedServer[];
   onNewConversation: () => void;
   onOpenHistory: () => void;
   onOpenSettings: () => void;
   onReconnect: () => void;
+  onSelectServer: (url: string) => void;
+  onAddServer: (server: SavedServer) => void;
+  onRemoveServer: (url: string) => void;
+  onSwitchToLocal: () => void;
 }
 
 function StatusIndicator({ status }: { status: 'online' | 'offline' | 'connecting' }) {
@@ -130,11 +139,32 @@ export function Header({
   status,
   mode,
   conversationId,
+  currentServerUrl,
+  servers,
   onNewConversation,
   onOpenHistory,
   onOpenSettings,
   onReconnect,
+  onSelectServer,
+  onAddServer,
+  onRemoveServer,
+  onSwitchToLocal,
 }: HeaderProps) {
+  const [showServerSelector, setShowServerSelector] = useState(false);
+
+  const getServerDisplayName = () => {
+    if (mode === 'local') return 'Local Mode';
+    if (!currentServerUrl) return 'No Server';
+    const server = servers.find(s => s.url === currentServerUrl);
+    if (server?.label) return server.label;
+    try {
+      const url = new URL(currentServerUrl);
+      return url.hostname + (url.port ? ':' + url.port : '');
+    } catch {
+      return currentServerUrl;
+    }
+  };
+
   return (
     <header className="sticky top-0 z-40 border-b border-white/10 bg-[var(--vscode-editor-background)]/95 backdrop-blur-sm">
       <div className="flex items-center justify-between px-4 py-3 gap-4">
@@ -154,13 +184,41 @@ export function Header({
             </div>
           </div>
 
-          <StatusIndicator status={status} />
+          {/* Server selector button - shows current server/mode */}
+          <div className="relative">
+            <button
+              onClick={() => setShowServerSelector(!showServerSelector)}
+              className={`
+                flex items-center gap-2 px-3 py-1.5 rounded-full
+                text-xs font-medium
+                transition-all duration-200
+                hover:bg-white/10
+                ${mode === 'local'
+                  ? 'bg-blue-500/20 text-blue-300 border border-blue-500/30'
+                  : 'glass-effect'}
+              `}
+              title="Select server"
+            >
+              <span className={`codicon codicon-${mode === 'local' ? 'device-desktop' : 'cloud'}`} />
+              <span className="max-w-24 truncate">{getServerDisplayName()}</span>
+              <span className="codicon codicon-chevron-down text-[10px] opacity-60" />
+            </button>
 
-          {mode === 'local' && (
-            <span className="px-2 py-1 rounded text-xs font-medium bg-blue-500/20 text-blue-300 border border-blue-500/30">
-              Local Mode
-            </span>
-          )}
+            <ServerSelector
+              isOpen={showServerSelector}
+              onClose={() => setShowServerSelector(false)}
+              servers={servers}
+              currentServerUrl={currentServerUrl}
+              mode={mode}
+              onSelectServer={onSelectServer}
+              onAddServer={onAddServer}
+              onRemoveServer={onRemoveServer}
+              onSwitchToLocal={onSwitchToLocal}
+            />
+          </div>
+
+          {/* Status indicator - only show for remote mode */}
+          {mode === 'remote' && <StatusIndicator status={status} />}
         </div>
 
         {/* Right side - Actions */}

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { ServerSelector, type SavedServer } from './ServerSelector';
+import { ServerSelector, getServerDisplayLabel, type SavedServer } from './ServerSelector';
 
 interface HeaderProps {
   status: 'online' | 'offline' | 'connecting';
@@ -152,11 +152,13 @@ export function Header({
 }: HeaderProps) {
   const [showServerSelector, setShowServerSelector] = useState(false);
 
+  // Get display name using shared helper for consistency
   const getServerDisplayName = () => {
     if (mode === 'local') return 'Local Mode';
     if (!currentServerUrl) return 'No Server';
     const server = servers.find(s => s.url === currentServerUrl);
-    if (server?.label) return server.label;
+    if (server) return getServerDisplayLabel(server);
+    // Fallback for URL not in servers list
     try {
       const url = new URL(currentServerUrl);
       return url.hostname + (url.port ? ':' + url.port : '');

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'react';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
 
+// Re-export for convenience - canonical definition is in SettingsManager
 export interface SavedServer {
   url: string;
   label?: string;
@@ -16,6 +17,17 @@ interface ServerSelectorProps {
   onAddServer: (server: SavedServer) => void;
   onRemoveServer: (url: string) => void;
   onSwitchToLocal: () => void;
+}
+
+// Helper to extract display name from server - exported for reuse in Header
+export function getServerDisplayLabel(server: SavedServer): string {
+  if (server.label) return server.label;
+  try {
+    const url = new URL(server.url);
+    return url.hostname + (url.port ? ':' + url.port : '');
+  } catch {
+    return server.url;
+  }
 }
 
 export function ServerSelector({
@@ -57,15 +69,9 @@ export function ServerSelector({
     }
   };
 
-  const getDisplayLabel = (server: SavedServer) => {
-    if (server.label) return server.label;
-    try {
-      const url = new URL(server.url);
-      return url.hostname + (url.port ? ':' + url.port : '');
-    } catch {
-      return server.url;
-    }
-  };
+  // Check if current server is selected (handles both empty string and undefined as "none")
+  const isServerSelected = (serverUrl: string) =>
+    mode === 'remote' && currentServerUrl === serverUrl;
 
   return (
     <div
@@ -113,49 +119,53 @@ export function ServerSelector({
           </div>
         ) : (
           <div className="p-2 space-y-1" role="listbox" aria-label="Servers">
-            {servers.map((server) => (
-              <div
-                key={server.url}
-                className={`
-                  flex items-center gap-2 px-3 py-2 rounded-lg
-                  text-sm
-                  transition-colors duration-150
-                  hover:bg-white/10
-                  ${mode === 'remote' && currentServerUrl === server.url ? 'bg-brand-500/20 text-brand-300' : ''}
-                `}
-              >
-                <button
-                  onClick={() => {
-                    onSelectServer(server.url);
-                    onClose();
-                  }}
-                  className="flex-1 text-left flex items-center gap-2"
-                  role="option"
-                  aria-selected={mode === 'remote' && currentServerUrl === server.url}
+            {servers.map((server) => {
+              const selected = isServerSelected(server.url);
+              const displayLabel = getServerDisplayLabel(server);
+              return (
+                <div
+                  key={server.url}
+                  className={`
+                    flex items-center gap-2 px-3 py-2 rounded-lg
+                    text-sm
+                    transition-colors duration-150
+                    hover:bg-white/10
+                    ${selected ? 'bg-brand-500/20 text-brand-300' : ''}
+                  `}
                 >
-                  <span className="codicon codicon-cloud" />
-                  <div className="flex-1 min-w-0">
-                    <div className="truncate">{getDisplayLabel(server)}</div>
-                    {server.label && (
-                      <div className="text-xs opacity-50 truncate">{server.url}</div>
+                  <button
+                    onClick={() => {
+                      onSelectServer(server.url);
+                      onClose();
+                    }}
+                    className="flex-1 text-left flex items-center gap-2"
+                    role="option"
+                    aria-selected={selected}
+                  >
+                    <span className="codicon codicon-cloud" />
+                    <div className="flex-1 min-w-0">
+                      <div className="truncate">{displayLabel}</div>
+                      {server.label && (
+                        <div className="text-xs opacity-50 truncate">{server.url}</div>
+                      )}
+                    </div>
+                    {selected && (
+                      <span className="codicon codicon-check text-brand-400" />
                     )}
-                  </div>
-                  {mode === 'remote' && currentServerUrl === server.url && (
-                    <span className="codicon codicon-check text-brand-400" />
-                  )}
-                </button>
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onRemoveServer(server.url);
-                  }}
-                  className="p-1 rounded hover:bg-red-500/20 hover:text-red-400 opacity-50 hover:opacity-100 transition-all"
-                  aria-label={`Remove ${getDisplayLabel(server)}`}
-                >
-                  <span className="codicon codicon-trash text-xs" />
-                </button>
-              </div>
-            ))}
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onRemoveServer(server.url);
+                    }}
+                    className="p-1 rounded hover:bg-red-500/20 hover:text-red-400 opacity-50 hover:opacity-100 transition-all"
+                    aria-label={`Remove ${displayLabel}`}
+                  >
+                    <span className="codicon codicon-trash text-xs" />
+                  </button>
+                </div>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -1,0 +1,216 @@
+import { useRef, useState } from 'react';
+import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
+
+export interface SavedServer {
+  url: string;
+  label?: string;
+}
+
+interface ServerSelectorProps {
+  isOpen: boolean;
+  onClose: () => void;
+  servers: SavedServer[];
+  currentServerUrl?: string;
+  mode: 'local' | 'remote';
+  onSelectServer: (url: string) => void;
+  onAddServer: (server: SavedServer) => void;
+  onRemoveServer: (url: string) => void;
+  onSwitchToLocal: () => void;
+}
+
+export function ServerSelector({
+  isOpen,
+  onClose,
+  servers,
+  currentServerUrl,
+  mode,
+  onSelectServer,
+  onAddServer,
+  onRemoveServer,
+  onSwitchToLocal,
+}: ServerSelectorProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [showAddForm, setShowAddForm] = useState(false);
+  const [newUrl, setNewUrl] = useState('');
+  const [newLabel, setNewLabel] = useState('');
+
+  useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: popoverRef, delay: 100 });
+
+  if (!isOpen) return null;
+
+  const handleAddServer = () => {
+    if (newUrl.trim()) {
+      onAddServer({ url: newUrl.trim(), label: newLabel.trim() || undefined });
+      setNewUrl('');
+      setNewLabel('');
+      setShowAddForm(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleAddServer();
+    } else if (e.key === 'Escape') {
+      setShowAddForm(false);
+      setNewUrl('');
+      setNewLabel('');
+    }
+  };
+
+  const getDisplayLabel = (server: SavedServer) => {
+    if (server.label) return server.label;
+    try {
+      const url = new URL(server.url);
+      return url.hostname + (url.port ? ':' + url.port : '');
+    } catch {
+      return server.url;
+    }
+  };
+
+  return (
+    <div
+      ref={popoverRef}
+      className="absolute top-full left-0 mt-2 w-80 max-h-96 bg-[var(--vscode-editor-background)] border border-white/10 rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
+    >
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-white/10">
+        <div className="flex items-center gap-2">
+          <span className="codicon codicon-server text-brand-400" />
+          <h3 className="font-semibold text-sm">Server Selection</h3>
+        </div>
+      </div>
+
+      {/* Server list */}
+      <div className="overflow-y-auto max-h-64">
+        {/* Local mode option */}
+        <div className="p-2 border-b border-white/5">
+          <button
+            onClick={() => {
+              onSwitchToLocal();
+              onClose();
+            }}
+            className={`
+              w-full text-left px-3 py-2 rounded-lg
+              text-sm
+              transition-colors duration-150
+              hover:bg-white/10
+              flex items-center gap-2
+              ${mode === 'local' ? 'bg-brand-500/20 text-brand-300' : ''}
+            `}
+          >
+            <span className="codicon codicon-device-desktop" />
+            <span className="flex-1">Local Mode</span>
+            {mode === 'local' && (
+              <span className="codicon codicon-check text-brand-400" />
+            )}
+          </button>
+        </div>
+
+        {/* Saved servers */}
+        {servers.length === 0 ? (
+          <div className="px-4 py-6 text-center text-sm opacity-60">
+            No saved servers
+          </div>
+        ) : (
+          <div className="p-2 space-y-1" role="listbox" aria-label="Servers">
+            {servers.map((server) => (
+              <div
+                key={server.url}
+                className={`
+                  flex items-center gap-2 px-3 py-2 rounded-lg
+                  text-sm
+                  transition-colors duration-150
+                  hover:bg-white/10
+                  ${mode === 'remote' && currentServerUrl === server.url ? 'bg-brand-500/20 text-brand-300' : ''}
+                `}
+              >
+                <button
+                  onClick={() => {
+                    onSelectServer(server.url);
+                    onClose();
+                  }}
+                  className="flex-1 text-left flex items-center gap-2"
+                  role="option"
+                  aria-selected={mode === 'remote' && currentServerUrl === server.url}
+                >
+                  <span className="codicon codicon-cloud" />
+                  <div className="flex-1 min-w-0">
+                    <div className="truncate">{getDisplayLabel(server)}</div>
+                    {server.label && (
+                      <div className="text-xs opacity-50 truncate">{server.url}</div>
+                    )}
+                  </div>
+                  {mode === 'remote' && currentServerUrl === server.url && (
+                    <span className="codicon codicon-check text-brand-400" />
+                  )}
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemoveServer(server.url);
+                  }}
+                  className="p-1 rounded hover:bg-red-500/20 hover:text-red-400 opacity-50 hover:opacity-100 transition-all"
+                  aria-label={`Remove ${getDisplayLabel(server)}`}
+                >
+                  <span className="codicon codicon-trash text-xs" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add server form */}
+      <div className="border-t border-white/10">
+        {showAddForm ? (
+          <div className="p-3 space-y-2">
+            <input
+              type="text"
+              value={newUrl}
+              onChange={(e) => setNewUrl(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="https://server-url..."
+              autoFocus
+              className="w-full px-3 py-2 text-sm bg-black/20 border border-white/10 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+            />
+            <input
+              type="text"
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="Label (optional)"
+              className="w-full px-3 py-2 text-sm bg-black/20 border border-white/10 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={handleAddServer}
+                disabled={!newUrl.trim()}
+                className="flex-1 px-3 py-1.5 text-sm bg-brand-500/20 text-brand-300 rounded-lg hover:bg-brand-500/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Add
+              </button>
+              <button
+                onClick={() => {
+                  setShowAddForm(false);
+                  setNewUrl('');
+                  setNewLabel('');
+                }}
+                className="px-3 py-1.5 text-sm bg-white/5 rounded-lg hover:bg-white/10 transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : (
+          <button
+            onClick={() => setShowAddForm(true)}
+            className="w-full px-4 py-3 text-sm text-left hover:bg-white/5 transition-colors flex items-center gap-2"
+          >
+            <span className="codicon codicon-add" />
+            <span>Add Server</span>
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -45,18 +45,35 @@ export function ServerSelector({
   const [showAddForm, setShowAddForm] = useState(false);
   const [newUrl, setNewUrl] = useState('');
   const [newLabel, setNewLabel] = useState('');
+  const [urlError, setUrlError] = useState<string | null>(null);
 
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: popoverRef, delay: 100 });
 
   if (!isOpen) return null;
 
   const handleAddServer = () => {
-    if (newUrl.trim()) {
-      onAddServer({ url: newUrl.trim(), label: newLabel.trim() || undefined });
-      setNewUrl('');
-      setNewLabel('');
-      setShowAddForm(false);
+    const trimmedUrl = newUrl.trim();
+    if (!trimmedUrl) return;
+
+    // Validate URL format
+    try {
+      new URL(trimmedUrl);
+    } catch {
+      setUrlError('Invalid URL format');
+      return;
     }
+
+    // Check for duplicates
+    if (servers.some(s => s.url === trimmedUrl)) {
+      setUrlError('Server already exists');
+      return;
+    }
+
+    setUrlError(null);
+    onAddServer({ url: trimmedUrl, label: newLabel.trim() || undefined });
+    setNewUrl('');
+    setNewLabel('');
+    setShowAddForm(false);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -66,7 +83,15 @@ export function ServerSelector({
       setShowAddForm(false);
       setNewUrl('');
       setNewLabel('');
+      setUrlError(null);
     }
+  };
+
+  const handleCancelAdd = () => {
+    setShowAddForm(false);
+    setNewUrl('');
+    setNewLabel('');
+    setUrlError(null);
   };
 
   // Check if current server is selected (handles both empty string and undefined as "none")
@@ -177,12 +202,20 @@ export function ServerSelector({
             <input
               type="text"
               value={newUrl}
-              onChange={(e) => setNewUrl(e.target.value)}
+              onChange={(e) => {
+                setNewUrl(e.target.value);
+                setUrlError(null);
+              }}
               onKeyDown={handleKeyDown}
               placeholder="https://server-url..."
               autoFocus
-              className="w-full px-3 py-2 text-sm bg-black/20 border border-white/10 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+              className={`w-full px-3 py-2 text-sm bg-black/20 border rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500/50 ${
+                urlError ? 'border-red-500/50' : 'border-white/10'
+              }`}
             />
+            {urlError && (
+              <div className="text-xs text-red-400">{urlError}</div>
+            )}
             <input
               type="text"
               value={newLabel}
@@ -200,11 +233,7 @@ export function ServerSelector({
                 Add
               </button>
               <button
-                onClick={() => {
-                  setShowAddForm(false);
-                  setNewUrl('');
-                  setNewLabel('');
-                }}
+                onClick={handleCancelAdd}
                 className="px-3 py-1.5 text-sm bg-white/5 rounded-lg hover:bg-white/10 transition-colors"
               >
                 Cancel


### PR DESCRIPTION
- Add servers array to settings for saving multiple server URLs
- Create ServerSelector popover component (similar to SkillsPopover)
- Add server selector button in Header showing current server/mode
- Support add/remove/select servers with labels
- Fix Local/Connected status - status indicator only shows for remote mode
- Add message protocol for server management (selectServer, addServer, removeServer, switchToLocal)
- Send initial server list to webview on startup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage multiple OpenHands servers: save labeled server entries, add/remove servers, select a remote server or switch to local via a server selector UI; list persists and syncs with the UI.

* **UI Behaviour**
  * Header shows current server/mode; connection status hidden in local mode; server selector integrated into header with live updates.

* **Accessibility & Validation**
  * Server selector supports keyboard, ARIA roles, URL validation and duplicate prevention.

* **Configuration**
  * New setting persists an array of saved servers (url + optional label).

* **Tests**
  * Updated test to expect status hidden in local mode.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->