### PR TITLE
Fix LLM streaming output to web view UI

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -254,11 +254,30 @@ export function activate(context: vscode.ExtensionContext) {
         outputChannel?.appendLine(`[status] ${s}`);
         void panel?.webview.postMessage({ type: 'status', status: s, mode: conversationMode });
       });
+      let isStreaming = false;
       conversation.on('event', (ev) => {
-        outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
+        const evAny = ev as { kind?: unknown; key?: unknown; value?: unknown };
+
+        // Skip verbose llm_stream logging - only log start/end
+        if (evAny.kind === 'ConversationStateUpdateEvent' && evAny.key === 'llm_stream') {
+          if (!isStreaming) {
+            isStreaming = true;
+            outputChannel?.appendLine('[llm] Streaming started...');
+          }
+          // Don't log each chunk - too verbose
+        } else {
+          // Log all other events
+          outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
+
+          // End streaming when we get a message event
+          if (evAny.kind === 'MessageEvent' && isStreaming) {
+            isStreaming = false;
+            outputChannel?.appendLine('[llm] Streaming complete');
+          }
+        }
+
         // Friendly LLM request summary for debugging
         try {
-          const evAny = ev as { kind?: unknown; key?: unknown; value?: unknown };
           if (evAny.kind === 'ConversationStateUpdateEvent' && evAny.key === 'llm_request') {
             const raw = evAny.value as {
               model?: unknown;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,8 +269,11 @@ export function activate(context: vscode.ExtensionContext) {
           // Log all other events
           outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
 
-          // End streaming when we get a message event from the agent
-          if (evAny.kind === 'MessageEvent' && isStreaming && (ev as { source?: string }).source === 'agent') {
+          // End streaming when we get a message or action event from the agent
+          // (LLM may respond with tool calls only, no text content)
+          const isAgentResponse = (evAny.kind === 'MessageEvent' || evAny.kind === 'ActionEvent')
+            && (ev as { source?: string }).source === 'agent';
+          if (isStreaming && isAgentResponse) {
             isStreaming = false;
             outputChannel?.appendLine('[llm] Streaming complete');
           }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,8 +269,8 @@ export function activate(context: vscode.ExtensionContext) {
           // Log all other events
           outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
 
-          // End streaming when we get a message event
-          if (evAny.kind === 'MessageEvent' && isStreaming) {
+          // End streaming when we get a message event from the agent
+          if (evAny.kind === 'MessageEvent' && isStreaming && (ev as { source?: string }).source === 'agent') {
             isStreaming = false;
             outputChannel?.appendLine('[llm] Streaming complete');
           }

--- a/src/webview-src/__tests__/App.render.test.tsx
+++ b/src/webview-src/__tests__/App.render.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act, waitFor } from '@testing-library/react';
 import React from 'react';
 import { App } from '../components/App';
 
@@ -9,6 +9,8 @@ describe('App render', () => {
   beforeEach(() => {
     // @ts-expect-error mock VS Code API for tests
     window.acquireVsCodeApi = () => mockApi;
+    // @ts-expect-error reset cached api instance
+    delete window.__OH_VSCODE_API__;
     mockApi.postMessage.mockClear();
   });
 
@@ -18,5 +20,105 @@ describe('App render', () => {
     expect(screen.getByPlaceholderText('Ask OpenHands anything...')).toBeInTheDocument();
     expect(screen.getByLabelText('New')).toBeInTheDocument();
     expect(screen.getByLabelText('Add context')).toBeInTheDocument();
+  });
+
+  it('displays streaming content incrementally', async () => {
+    render(<App />);
+
+    // Simulate a user message first
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'MessageEvent',
+              source: 'user',
+              llm_message: {
+                role: 'user',
+                content: [{ type: 'text', text: 'Test user message xyz123' }],
+              },
+            },
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      // Use getAllByText since there may be multiple due to test isolation
+      const elements = screen.getAllByText('Test user message xyz123');
+      expect(elements.length).toBeGreaterThan(0);
+    });
+
+    // Simulate streaming start
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              source: 'agent',
+              key: 'llm_stream',
+              value: 'Streaming chunk alpha',
+            },
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      const streamElements = screen.queryAllByText('Streaming chunk alpha');
+      expect(streamElements.length).toBeGreaterThan(0);
+      expect(screen.queryAllByText('streaming...').length).toBeGreaterThan(0);
+    });
+
+    // Simulate more streaming content
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              source: 'agent',
+              key: 'llm_stream',
+              value: 'Streaming chunk alpha beta',
+            },
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      const streamElements = screen.queryAllByText('Streaming chunk alpha beta');
+      expect(streamElements.length).toBeGreaterThan(0);
+    });
+
+    // Simulate final message (ends streaming)
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'MessageEvent',
+              source: 'agent',
+              llm_message: {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'Final response content gamma' }],
+              },
+            },
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      const finalElements = screen.queryAllByText('Final response content gamma');
+      expect(finalElements.length).toBeGreaterThan(0);
+      // Streaming indicator should be gone after final message
+      expect(screen.queryByText('streaming...')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -592,7 +592,7 @@ export function App() {
   }, [postMessage]);
 
   // Derived state: conversation is empty when no events and no streaming
-  const isEmptyConversation = events.length === 0 && !streamingContent;
+  const isEmptyConversation = events.length === 0 && streamingContent === null;
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -629,7 +629,7 @@ export function App() {
             {events.map((ev, index) => (
               <EventBlock key={ev.id} event={ev.event} index={index} />
             ))}
-            {streamingContent && (
+            {streamingContent !== null && (
               <StreamingMessageBlock content={streamingContent} />
             )}
             <div ref={endRef} />

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -177,9 +177,8 @@ export function App() {
         lastAgentStatusRef.current = e.agent_status;
       }
       // Handle streaming LLM content
-      const evAny = e as { key?: string; value?: unknown };
-      if (evAny.key === 'llm_stream' && typeof evAny.value === 'string') {
-        setStreamingContent(evAny.value);
+      if (e.key === 'llm_stream' && typeof e.value === 'string') {
+        setStreamingContent(e.value);
       }
       return; // Don't render state update events
     }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -190,7 +190,7 @@ export function App() {
         setStreamingContent(null);
       }
     }
-    if (known && isActionEvent(e)) {
+    if (known && isActionEvent(e) && e.source === 'agent') {
       setStreamingContent(null);
     }
 
@@ -591,6 +591,9 @@ export function App() {
     postMessage({ type: 'switchToLocal' });
   }, [postMessage]);
 
+  // Derived state: conversation is empty when no events and no streaming
+  const isEmptyConversation = events.length === 0 && !streamingContent;
+
   return (
     <div className="flex flex-col h-screen overflow-hidden">
       {/* Header */}
@@ -612,7 +615,7 @@ export function App() {
 
       {/* Main conversation area */}
       <div className="flex-1 overflow-y-auto px-4 py-4">
-        {events.length === 0 && !streamingContent ? (
+        {isEmptyConversation ? (
           <div className="flex flex-col items-center justify-center h-full text-center opacity-60">
             <div className="text-6xl mb-4">🙌</div>
             <h2 className="text-xl font-semibold mb-2">Welcome to OpenHands</h2>

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -184,12 +184,16 @@ export function App() {
       return; // Don't render state update events
     }
 
-    // Clear streaming when we get the final message
+    // Clear streaming when we get the final message or action from agent
+    // (LLM may respond with tool calls only, no text content)
     if (known && isMessageEvent(e)) {
       const msgRole = (e as any)?.llm_message?.role;
       if (msgRole === 'assistant') {
         setStreamingContent(null);
       }
+    }
+    if (known && isActionEvent(e)) {
+      setStreamingContent(null);
     }
 
     if (known) {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -186,8 +186,7 @@ export function App() {
     // Clear streaming when we get the final message or action from agent
     // (LLM may respond with tool calls only, no text content)
     if (known && isMessageEvent(e)) {
-      const msgRole = (e as any)?.llm_message?.role;
-      if (msgRole === 'assistant') {
+      if (e.llm_message.role === 'assistant') {
         setStreamingContent(null);
       }
     }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -30,6 +30,7 @@ import {
   ConversationErrorBlock,
   CondensationBlock,
   MessageEventBlock,
+  StreamingMessageBlock,
 } from './EventBlock';
 
 interface VscodeApi {
@@ -108,6 +109,7 @@ export function App() {
   const [events, setEvents] = useState<RenderedEvent[]>([]);
   const [agentStatus, setAgentStatus] = useState<string | undefined>(undefined);
   const [pendingActions, setPendingActions] = useState<ActionEvent[]>([]);
+  const [streamingContent, setStreamingContent] = useState<string | null>(null);
   const eventId = useRef(1);
 
   // Input state
@@ -165,7 +167,7 @@ export function App() {
   const handleEvent = useCallback((e: unknown) => {
     const known = isEvent(e);
 
-    // Track agent status from ConversationStateUpdateEvent
+    // Track agent status and streaming from ConversationStateUpdateEvent
     if (known && isConversationStateUpdateEvent(e)) {
       if (e.agent_status) {
         setAgentStatus(e.agent_status);
@@ -174,7 +176,20 @@ export function App() {
         }
         lastAgentStatusRef.current = e.agent_status;
       }
+      // Handle streaming LLM content
+      const evAny = e as { key?: string; value?: unknown };
+      if (evAny.key === 'llm_stream' && typeof evAny.value === 'string') {
+        setStreamingContent(evAny.value);
+      }
       return; // Don't render state update events
+    }
+
+    // Clear streaming when we get the final message
+    if (known && isMessageEvent(e)) {
+      const msgRole = (e as any)?.llm_message?.role;
+      if (msgRole === 'assistant') {
+        setStreamingContent(null);
+      }
     }
 
     if (known) {
@@ -295,6 +310,7 @@ export function App() {
             setEvents([]);
             setPendingActions([]);
             setAgentStatus(undefined);
+            setStreamingContent(null);
             eventId.current = 1;
             // No toast: UI clears and restored/started messages will render naturally
           }
@@ -328,14 +344,13 @@ export function App() {
     return () => window.removeEventListener('message', handler);
   }, [events, handleEvent, postMessage, showStatusMessage]);
 
-  // Auto-scroll to bottom when events change
+  // Auto-scroll to bottom when events change or streaming updates
   useEffect(() => {
     const el = endRef.current;
     if (el && 'scrollIntoView' in el && typeof el.scrollIntoView === 'function') {
       el.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }
-
-  }, [events.length]);
+  }, [events.length, streamingContent]);
 
   // Selection tracking from InputArea
   const handleSelectionChange = useCallback((start: number, end: number) => {
@@ -419,6 +434,7 @@ export function App() {
     setEvents([]);
     setPendingActions([]);
     setAgentStatus(undefined);
+    setStreamingContent(null);
     eventId.current = 1;
     setInput('');
     setSelectedContextFiles([]);
@@ -594,7 +610,7 @@ export function App() {
 
       {/* Main conversation area */}
       <div className="flex-1 overflow-y-auto px-4 py-4">
-        {events.length === 0 ? (
+        {events.length === 0 && !streamingContent ? (
           <div className="flex flex-col items-center justify-center h-full text-center opacity-60">
             <div className="text-6xl mb-4">🙌</div>
             <h2 className="text-xl font-semibold mb-2">Welcome to OpenHands</h2>
@@ -608,6 +624,9 @@ export function App() {
             {events.map((ev, index) => (
               <EventBlock key={ev.id} event={ev.event} index={index} />
             ))}
+            {streamingContent && (
+              <StreamingMessageBlock content={streamingContent} />
+            )}
             <div ref={endRef} />
           </>
         )}

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -423,3 +423,42 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
     </EventContainer>
   );
 }
+
+// Streaming Message Block - displays incrementally arriving LLM content
+export function StreamingMessageBlock({ content }: { content: string }) {
+  const accentColor = AGENT_ACCENT_COLOR;
+
+  return (
+    <div
+      className="relative rounded-lg p-4 my-3 shadow-event border-l-[3px] transition-all duration-300"
+      style={{
+        borderLeftColor: accentColor,
+        backgroundColor: `${accentColor}06`,
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div
+          className="w-8 h-8 rounded-full flex items-center justify-center mt-0.5 flex-shrink-0"
+          style={{ backgroundColor: `${accentColor}20` }}
+        >
+          <span className="codicon codicon-hubot text-sm" style={{ color: accentColor }} />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2">
+            <div className="font-semibold text-sm">Assistant</div>
+            <div className="flex items-center gap-1">
+              <span className="inline-block w-1.5 h-1.5 rounded-full bg-current animate-pulse" style={{ color: accentColor }} />
+              <span className="text-xs opacity-50">streaming...</span>
+            </div>
+          </div>
+
+          <div className="text-sm leading-relaxed whitespace-pre-wrap break-words">
+            {content}
+            <span className="inline-block w-0.5 h-4 ml-0.5 animate-pulse" style={{ backgroundColor: accentColor }} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- Add StreamingMessageBlock component that displays streaming content with a pulsing cursor indicator
- Handle llm_stream state updates in App.tsx to show content as it arrives
- Clear streaming state when final message arrives
- Auto-scroll when streaming content updates
- Reset streaming state on new conversation

Also reduces Output View logging verbosity:
- Only log "[llm] Streaming started..." at beginning
- Only log "[llm] Streaming complete" at end
- Skip logging every llm_stream event (was too verbose)

Includes test for streaming content display.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming display of AI responses as they arrive incrementally
  * Visual streaming indicator while content is being generated
  * Streaming message block added to the UI and shown alongside events; welcome view hides when streaming begins

* **Bug Fixes / UX**
  * Streaming indicator and state reliably clear when generation completes
  * Auto-scroll updated to account for streaming content
  * Reduced noisy per-chunk logs for smoother UX

* **Tests**
  * Added test coverage for incremental streaming rendering and end-of-stream behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->