### PR TITLE
Unify streaming state handling

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import {
   isBashOutput,
 } from '@openhands/agent-sdk-ts';
 import { OpenHandsViewProvider } from './sidebar/OpenHandsViewProvider';
+import { initialLlmStreamingState, reduceLlmStreamingState } from './shared/llmStreaming';
 
 // Discriminated union for webview → extension messages
 type WebviewMessage =
@@ -254,29 +255,24 @@ export function activate(context: vscode.ExtensionContext) {
         outputChannel?.appendLine(`[status] ${s}`);
         void panel?.webview.postMessage({ type: 'status', status: s, mode: conversationMode });
       });
-      let isStreaming = false;
+      let streamingState = initialLlmStreamingState;
       conversation.on('event', (ev) => {
         const evAny = ev as { kind?: unknown; key?: unknown; value?: unknown };
 
-        // Skip verbose llm_stream logging - only log start/end
-        if (evAny.kind === 'ConversationStateUpdateEvent' && evAny.key === 'llm_stream') {
-          if (!isStreaming) {
-            isStreaming = true;
-            outputChannel?.appendLine('[llm] Streaming started...');
-          }
-          // Don't log each chunk - too verbose
-        } else {
-          // Log all other events
-          outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
+        const streamingUpdate = reduceLlmStreamingState(streamingState, ev);
+        streamingState = streamingUpdate.state;
+        const isLlmStreamUpdate = evAny.kind === 'ConversationStateUpdateEvent' && evAny.key === 'llm_stream';
 
-          // End streaming when we get a message or action event from the agent
-          // (LLM may respond with tool calls only, no text content)
-          const isAgentResponse = (evAny.kind === 'MessageEvent' || evAny.kind === 'ActionEvent')
-            && (ev as { source?: string }).source === 'agent';
-          if (isStreaming && isAgentResponse) {
-            isStreaming = false;
-            outputChannel?.appendLine('[llm] Streaming complete');
-          }
+        if (streamingUpdate.started) {
+          outputChannel?.appendLine('[llm] Streaming started...');
+        }
+
+        if (!isLlmStreamUpdate) {
+          outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
+        }
+
+        if (streamingUpdate.completed) {
+          outputChannel?.appendLine('[llm] Streaming complete');
         }
 
         // Friendly LLM request summary for debugging

--- a/src/shared/__tests__/llmStreaming.test.ts
+++ b/src/shared/__tests__/llmStreaming.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ActionEvent,
+  type AgentErrorEvent,
+  type ConversationErrorEvent,
+  type ConversationStateUpdateEvent,
+  type MessageEvent,
+} from '@openhands/agent-sdk-ts';
+
+import { initialLlmStreamingState, reduceLlmStreamingState } from '../llmStreaming';
+
+describe('reduceLlmStreamingState', () => {
+  const streamUpdate: ConversationStateUpdateEvent = {
+    kind: 'ConversationStateUpdateEvent',
+    key: 'llm_stream',
+    value: 'partial',
+  };
+
+  it('starts and completes streaming on assistant message', () => {
+    const start = reduceLlmStreamingState(initialLlmStreamingState, streamUpdate);
+    expect(start.started).toBe(true);
+    expect(start.state.phase).toBe('streaming');
+    expect(start.state.content).toBe('partial');
+
+    const assistantMessage: MessageEvent = {
+      kind: 'MessageEvent',
+      source: 'agent',
+      llm_message: { role: 'assistant', content: [] },
+    };
+    const done = reduceLlmStreamingState(start.state, assistantMessage);
+    expect(done.completed).toBe(true);
+    expect(done.state.phase).toBe('idle');
+    expect(done.state.content).toBeNull();
+  });
+
+  it('completes streaming when the first tool call action arrives', () => {
+    const start = reduceLlmStreamingState(initialLlmStreamingState, streamUpdate);
+    expect(start.state.phase).toBe('streaming');
+
+    const action: ActionEvent = {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'thinking' }],
+      action: {},
+      tool_name: 'terminal',
+      tool_call_id: 'tool-1',
+      tool_call: {
+        id: 'tool-1',
+        type: 'function',
+        function: { name: 'terminal', arguments: '{}' },
+      },
+      llm_response_id: 'resp-1',
+    };
+    const done = reduceLlmStreamingState(start.state, action);
+    expect(done.completed).toBe(true);
+    expect(done.state.phase).toBe('idle');
+    expect(done.state.content).toBeNull();
+  });
+
+  it('clears streaming on agent or conversation errors', () => {
+    const start = reduceLlmStreamingState(initialLlmStreamingState, streamUpdate);
+    expect(start.state.phase).toBe('streaming');
+
+    const agentError: AgentErrorEvent = {
+      kind: 'AgentErrorEvent',
+      source: 'agent',
+      error: 'failed',
+      tool_name: 'terminal',
+      tool_call_id: 'tool-1',
+    };
+    const fromAgentError = reduceLlmStreamingState(start.state, agentError);
+    expect(fromAgentError.completed).toBe(true);
+    expect(fromAgentError.state.phase).toBe('idle');
+
+    const restart = reduceLlmStreamingState(initialLlmStreamingState, streamUpdate);
+    expect(restart.state.phase).toBe('streaming');
+
+    const conversationError: ConversationErrorEvent = {
+      kind: 'ConversationErrorEvent',
+      source: 'agent',
+      code: '500',
+      detail: 'abort',
+    };
+    const fromConversationError = reduceLlmStreamingState(restart.state, conversationError);
+    expect(fromConversationError.completed).toBe(true);
+    expect(fromConversationError.state.phase).toBe('idle');
+  });
+});

--- a/src/shared/llmStreaming.ts
+++ b/src/shared/llmStreaming.ts
@@ -1,4 +1,5 @@
 import {
+  type Event,
   isActionEvent,
   isAgentErrorEvent,
   isConversationErrorEvent,
@@ -42,7 +43,7 @@ export interface LlmStreamingUpdateResult {
  * - A ConversationStateUpdateEvent with `key === 'llm_stream'` but non-string value clears
  *   streaming content and resets the phase to idle.
  */
-export function reduceLlmStreamingState(current: LlmStreamingState, event: unknown): LlmStreamingUpdateResult {
+export function reduceLlmStreamingState(current: LlmStreamingState, event: Event): LlmStreamingUpdateResult {
   let next = current;
   let started = false;
   let completed = false;

--- a/src/shared/llmStreaming.ts
+++ b/src/shared/llmStreaming.ts
@@ -1,0 +1,79 @@
+import {
+  isActionEvent,
+  isAgentErrorEvent,
+  isConversationErrorEvent,
+  isConversationStateUpdateEvent,
+  isMessageEvent,
+} from '@openhands/agent-sdk-ts';
+
+export type LlmStreamingPhase = 'idle' | 'streaming';
+
+export interface LlmStreamingState {
+  phase: LlmStreamingPhase;
+  content: string | null;
+}
+
+export interface LlmStreamingUpdateResult {
+  state: LlmStreamingState;
+  /**
+   * True when the stream transitions from idle → streaming.
+   */
+  started: boolean;
+  /**
+   * True when the stream transitions from streaming → idle because the agent completed, errored, or aborted.
+   */
+  completed: boolean;
+  /**
+   * True when the ConversationStateUpdateEvent provided new content (including clearing content).
+   */
+  contentUpdated: boolean;
+}
+
+/**
+ * Canonical LLM streaming contract for the extension + webview.
+ *
+ * Start condition
+ * - The first ConversationStateUpdateEvent with `key === 'llm_stream'` and a string `value`
+ *   transitions the phase to `streaming` and records the latest content.
+ *
+ * End conditions
+ * - An assistant MessageEvent, agent ActionEvent, AgentErrorEvent, or ConversationErrorEvent
+ *   always ends streaming (clears content) because the LLM response is complete or aborted.
+ * - A ConversationStateUpdateEvent with `key === 'llm_stream'` but non-string value clears
+ *   streaming content and resets the phase to idle.
+ */
+export function reduceLlmStreamingState(current: LlmStreamingState, event: unknown): LlmStreamingUpdateResult {
+  let next = current;
+  let started = false;
+  let completed = false;
+  let contentUpdated = false;
+
+  if (isConversationStateUpdateEvent(event) && event.key === 'llm_stream') {
+    const nextContent = typeof event.value === 'string' ? event.value : null;
+    const shouldStream = typeof event.value === 'string';
+    next = {
+      phase: shouldStream ? 'streaming' : 'idle',
+      content: nextContent,
+    };
+    started = current.phase === 'idle' && next.phase === 'streaming';
+    contentUpdated = true;
+    // If streaming content is explicitly cleared, mark as complete as well
+    completed = current.phase === 'streaming' && next.phase === 'idle';
+    return { state: next, started, completed, contentUpdated };
+  }
+
+  if (
+    current.phase === 'streaming' &&
+    (isAgentErrorEvent(event) ||
+      isConversationErrorEvent(event) ||
+      (isMessageEvent(event) && event.llm_message.role === 'assistant') ||
+      (isActionEvent(event) && event.source === 'agent'))
+  ) {
+    next = { phase: 'idle', content: null };
+    completed = true;
+  }
+
+  return { state: next, started, completed, contentUpdated };
+}
+
+export const initialLlmStreamingState: LlmStreamingState = { phase: 'idle', content: null };

--- a/src/shared/llmStreaming.ts
+++ b/src/shared/llmStreaming.ts
@@ -50,9 +50,8 @@ export function reduceLlmStreamingState(current: LlmStreamingState, event: unkno
 
   if (isConversationStateUpdateEvent(event) && event.key === 'llm_stream') {
     const nextContent = typeof event.value === 'string' ? event.value : null;
-    const shouldStream = typeof event.value === 'string';
     next = {
-      phase: shouldStream ? 'streaming' : 'idle',
+      phase: nextContent !== null ? 'streaming' : 'idle',
       content: nextContent,
     };
     started = current.phase === 'idle' && next.phase === 'streaming';

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -166,17 +166,15 @@ export function App() {
   }, []);
 
   // Handle incoming events
-  const handleEvent = useCallback((e: unknown) => {
+  const handleEvent = useCallback((e: Event) => {
     const streamingUpdate = reduceLlmStreamingState(streamingStateRef.current, e);
     streamingStateRef.current = streamingUpdate.state;
     if (streamingUpdate.started || streamingUpdate.completed || streamingUpdate.contentUpdated) {
       setStreamingContent(streamingUpdate.state.content);
     }
 
-    const known = isEvent(e);
-
     // Track agent status and streaming from ConversationStateUpdateEvent
-    if (known && isConversationStateUpdateEvent(e)) {
+    if (isConversationStateUpdateEvent(e)) {
       if (e.agent_status) {
         setAgentStatus(e.agent_status);
         if (e.agent_status === 'WAITING_FOR_CONFIRMATION' && lastAgentStatusRef.current !== 'WAITING_FOR_CONFIRMATION') {
@@ -187,41 +185,39 @@ export function App() {
       return; // Don't render state update events
     }
 
-    if (known) {
-      // Track pending actions
-      if (isActionEvent(e)) {
-        setPendingActions((prev) => {
-          const exists = prev.some((a) => a.tool_call_id === e.tool_call_id);
-          return exists ? prev : [...prev, e];
-        });
-      }
+    // Track pending actions
+    if (isActionEvent(e)) {
+      setPendingActions((prev) => {
+        const exists = prev.some((a) => a.tool_call_id === e.tool_call_id);
+        return exists ? prev : [...prev, e];
+      });
+    }
 
-      // Clear pending action when we receive its observation
-      if (isObservationEvent(e) || isUserRejectObservation(e)) {
-        setPendingActions((prev) => prev.filter((a) => a.tool_call_id !== e.tool_call_id));
-        if (submissionTimeoutRef.current) {
-          clearTimeout(submissionTimeoutRef.current);
-          submissionTimeoutRef.current = null;
-        }
-        setIsSubmitting(false);
+    // Clear pending action when we receive its observation
+    if (isObservationEvent(e) || isUserRejectObservation(e)) {
+      setPendingActions((prev) => prev.filter((a) => a.tool_call_id !== e.tool_call_id));
+      if (submissionTimeoutRef.current) {
+        clearTimeout(submissionTimeoutRef.current);
+        submissionTimeoutRef.current = null;
       }
+      setIsSubmitting(false);
+    }
 
-      // Show status messages for certain events
-      if (isAgentErrorEvent(e)) {
-        showStatusMessage('error', e.error);
-        if (submissionTimeoutRef.current) {
-          clearTimeout(submissionTimeoutRef.current);
-          submissionTimeoutRef.current = null;
-        }
-        setIsSubmitting(false);
-      } else if (isPauseEvent(e)) {
-        showStatusMessage('warn', 'Conversation paused');
+    // Show status messages for certain events
+    if (isAgentErrorEvent(e)) {
+      showStatusMessage('error', e.error);
+      if (submissionTimeoutRef.current) {
+        clearTimeout(submissionTimeoutRef.current);
+        submissionTimeoutRef.current = null;
       }
+      setIsSubmitting(false);
+    } else if (isPauseEvent(e)) {
+      showStatusMessage('warn', 'Conversation paused');
     }
 
     // Add event to the list for rendering
     if ((e as any)?.kind !== 'ConversationStateUpdateEvent') {
-      setEvents((ev) => [...ev, { id: eventId.current++, event: e as any }]);
+      setEvents((ev) => [...ev, { id: eventId.current++, event: e }]);
     }
   }, [showStatusMessage]);
 
@@ -290,7 +286,9 @@ export function App() {
           }
           break;
         case 'event':
-          handleEvent(payload.event);
+          if (isEvent(payload.event)) {
+            handleEvent(payload.event);
+          }
           break;
         case 'error':
           if (typeof payload.error === 'string') {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -14,6 +14,7 @@ import {
   type Event,
   type ActionEvent,
 } from '@openhands/agent-sdk-ts';
+import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
 
 // Component imports
 import { Header } from './Header';
@@ -145,6 +146,7 @@ export function App() {
   // Refs
   const endRef = useRef<HTMLDivElement | null>(null);
   const lastAgentStatusRef = useRef<string | undefined>(undefined);
+  const streamingStateRef = useRef(initialLlmStreamingState);
   const submissionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Post message helper
@@ -165,6 +167,12 @@ export function App() {
 
   // Handle incoming events
   const handleEvent = useCallback((e: unknown) => {
+    const streamingUpdate = reduceLlmStreamingState(streamingStateRef.current, e);
+    streamingStateRef.current = streamingUpdate.state;
+    if (streamingUpdate.started || streamingUpdate.completed || streamingUpdate.contentUpdated) {
+      setStreamingContent(streamingUpdate.state.content);
+    }
+
     const known = isEvent(e);
 
     // Track agent status and streaming from ConversationStateUpdateEvent
@@ -176,22 +184,7 @@ export function App() {
         }
         lastAgentStatusRef.current = e.agent_status;
       }
-      // Handle streaming LLM content
-      if (e.key === 'llm_stream' && typeof e.value === 'string') {
-        setStreamingContent(e.value);
-      }
       return; // Don't render state update events
-    }
-
-    // Clear streaming when we get the final message or action from agent
-    // (LLM may respond with tool calls only, no text content)
-    if (known && isMessageEvent(e)) {
-      if (e.llm_message.role === 'assistant') {
-        setStreamingContent(null);
-      }
-    }
-    if (known && isActionEvent(e) && e.source === 'agent') {
-      setStreamingContent(null);
     }
 
     if (known) {


### PR DESCRIPTION
## Summary
- add a shared LLM streaming state reducer with a documented contract
- update the extension and webview to derive logging/UI from the shared streaming model
- cover streaming completion, tool-call, and error/abort cases with new tests

## Testing
- npm test
- npx vitest run --dir src --reporter=basic


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924a5893f5c8320be7c85086f3f8b80)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized LLM streaming state with explicit phases (idle/streaming) and content update tracking.
  * UI streaming content and event handling now driven by the unified streaming state, reducing ad-hoc logic.

* **Bug Fixes**
  * More reliable streaming lifecycle handling and clearer logging for streaming start/completion.
  * Robust clearing of streaming state on errors, agent actions, and other terminal events.

* **Tests**
  * Unit tests covering streaming start, content updates, completion, and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->