### PR TITLE
Validate tool security risk values

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -38,6 +38,7 @@ export interface AgentOptions {
 }
 
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
+const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 
 export class Agent extends EventEmitter {
   private readonly workspace: LocalWorkspace;
@@ -427,7 +428,7 @@ export class Agent extends EventEmitter {
       const parsed: unknown = JSON.parse(raw);
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
         const { security_risk, ...rest } = parsed as Record<string, unknown>;
-        return { args: rest, securityRisk: security_risk as SecurityRisk | undefined };
+        return { args: rest, securityRisk: this.parseSecurityRisk(security_risk) };
       }
       throw new Error('Tool arguments must be a JSON object.');
     } catch (e) {
@@ -437,15 +438,20 @@ export class Agent extends EventEmitter {
     }
   }
 
+  private parseSecurityRisk(value: unknown): SecurityRisk | undefined {
+    if (typeof value !== 'string') return undefined;
+    const normalized = value.toUpperCase() as SecurityRisk;
+    return SECURITY_RISK_ORDER.includes(normalized) ? normalized : undefined;
+  }
+
   private requiresConfirmation(action: ActionEvent): boolean {
     const policy = this.confirmation.policy ?? 'never';
     if (policy === 'never') return false;
     if (policy === 'always') return true;
     const risk = action.security_risk;
     if (!risk) return this.confirmation.confirmUnknown ?? true;
-    const order: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
     const threshold = this.confirmation.riskyThreshold ?? 'MEDIUM';
-    return order.indexOf(risk) >= order.indexOf(threshold);
+    return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(threshold);
   }
 
   private createActionEvent(

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import { isActionEvent } from '../../types';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-security-risk-'));
+
+describe('Agent security risk handling', () => {
+  it('treats unknown tool-provided security_risk as undefined', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {
+      name: 'echo',
+      validate: (input) => input,
+      execute: async (args) => ({ echoed: Boolean(args.value) }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Calling tool' },
+      {
+        type: 'tool_call_delta',
+        id: 'call_unknown_risk',
+        name: 'echo',
+        arguments: '{"security_risk":"CRITICAL","value":true}',
+      },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, confirmation: { policy: 'risky', confirmUnknown: true } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('unknown risk');
+
+    const events = log.list();
+    const action = events.find(isActionEvent);
+    expect(action?.security_risk).toBeUndefined();
+    expect(agent.state.snapshot.status).toBe('WAITING_FOR_CONFIRMATION');
+    expect(agent.pendingActionId).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #157

## Summary
- validate tool-provided security_risk values and ignore unrecognized entries
- update confirmation threshold comparison to use validated security risk order
- add a unit test covering an unknown security_risk value

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69270e2f76008320b0858e9e65c797d6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of unknown or invalid security risk values to ensure proper confirmation workflow.

* **Refactor**
  * Consolidated security risk level normalization logic for consistency.

* **Tests**
  * Added test coverage for unknown security risk scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->