### PR TITLE
Recursively redact tool call logging secrets

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -38,6 +38,24 @@ export interface AgentOptions {
 }
 
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
+const SENSITIVE_FIELD_PATTERN = /^(api[-_]?key|token|secret|password|authorization)$/i;
+
+const redactSensitiveFields = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((entry) => redactSensitiveFields(entry));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        SENSITIVE_FIELD_PATTERN.test(key) ? '[REDACTED]' : redactSensitiveFields(entry),
+      ]),
+    );
+  }
+
+  return value;
+};
 
 export class Agent extends EventEmitter {
   private readonly workspace: LocalWorkspace;
@@ -201,12 +219,8 @@ export class Agent extends EventEmitter {
           let safeArgs = rawArgs;
           try {
             const parsed: unknown = JSON.parse(rawArgs);
-            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-              const redacted: Record<string, unknown> = {};
-              const sensitive = /^(api[-_]?key|token|secret|password|authorization)$/i;
-              for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-                redacted[k] = sensitive.test(k) ? '[REDACTED]' : v;
-              }
+            if (parsed && typeof parsed === 'object') {
+              const redacted = redactSensitiveFields(parsed);
               safeArgs = JSON.stringify(redacted);
             }
           } catch {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
 import { isConversationStateUpdateEvent } from '../../types';
@@ -27,7 +27,22 @@ const baseSettings: OpenHandsSettings = {
   secrets: {},
 };
 
-const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-redaction-'));
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-redaction-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  while (workspaceRoots.length > 0) {
+    const root = workspaceRoots.pop();
+    if (root) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
 
 describe('Agent tool call logging redaction', () => {
   it('redacts nested sensitive values when logging tool calls', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
@@ -1,0 +1,86 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import { isConversationStateUpdateEvent } from '../../types';
+import type { OpenHandsSettings } from '../../types/settings';
+import type { ToolDefinition } from '../../types/tools';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-redaction-'));
+
+describe('Agent tool call logging redaction', () => {
+  it('redacts nested sensitive values when logging tool calls', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {
+      name: 'echo',
+      validate: (input) => input,
+      execute: async (args) => ({ echoed: Boolean(args.value) }),
+    };
+
+    const nestedArgs = {
+      config: {
+        apiKey: 'secret-api-key',
+        nested: { token: 'super-secret', keep: 'public' },
+      },
+      servers: [
+        { url: 'https://example.com', password: 'p@ssw0rd' },
+        { url: 'https://other.com', headers: { authorization: 'Bearer token' } },
+      ],
+      safe: 'value',
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Calling tool with secrets' },
+      { type: 'tool_call_delta', id: 'call_sensitive', name: 'echo', arguments: JSON.stringify(nestedArgs) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('mask secrets');
+
+    const toolCallEvent = log
+      .list()
+      .filter(isConversationStateUpdateEvent)
+      .find((event) => event.key === 'llm_tool_call_raw');
+
+    expect(toolCallEvent).toBeDefined();
+    const rawArgs = (toolCallEvent!.value as { arguments?: string }).arguments;
+    expect(typeof rawArgs).toBe('string');
+
+    const loggedArgs = JSON.parse(rawArgs as string);
+    expect(loggedArgs.config.apiKey).toBe('[REDACTED]');
+    expect(loggedArgs.config.nested.token).toBe('[REDACTED]');
+    expect(loggedArgs.config.nested.keep).toBe('public');
+    expect(loggedArgs.servers[0].password).toBe('[REDACTED]');
+    expect(loggedArgs.servers[1].headers.authorization).toBe('[REDACTED]');
+    expect(loggedArgs.safe).toBe('value');
+  });
+});


### PR DESCRIPTION
Fixes #159

## Summary
- apply recursive redaction to tool call argument logging
- add coverage for nested secret masking in agent runtime

## Testing
- npm test -w @openhands/agent-sdk-ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69270e64ebb48320a1e4cf94daae9a33)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced redaction of sensitive fields (API keys, tokens, passwords, authorization) in tool-call logs with improved support for nested data structures and retained truncation of long redacted values.
* **Tests**
  * Added a unit test validating redaction behavior for nested tool-call arguments and ensuring non-sensitive data remains visible.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->