### PR TITLE
Cap and normalize tool error payload size in toolCallErrorEvents (fixes #162)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
@@ -19,18 +19,18 @@ describe('toolCallErrorEvents truncation and normalization', () => {
     expect(payload.error).toBe('line1 line2 with spaces line3');
   });
 
-  it('caps long error messages at 4096 chars and appends suffix', () => {
+  it('caps long error messages at exactly 4096 chars and appends suffix', () => {
     const toolCall = makeToolCall('t2', 'echo');
     const longBase = 'A'.repeat(10_000);
     const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, longBase);
 
     const err = agentErrorEvent.error;
-    expect(err.length).toBeLessThanOrEqual(4096);
+    expect(err.length).toBe(4096);
     expect(err.endsWith('(truncated)')).toBe(true);
 
     const payload = JSON.parse((toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text);
     const toolErr: string = payload.error;
-    expect(toolErr.length).toBeLessThanOrEqual(4096);
+    expect(toolErr.length).toBe(4096);
     expect(toolErr.endsWith('(truncated)')).toBe(true);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { createToolCallErrorEvents } from '../toolCallErrorEvents';
+
+const makeToolCall = (id: string, name: string, args = '{}') => ({
+  id,
+  type: 'function' as const,
+  function: { name, arguments: args },
+});
+
+describe('toolCallErrorEvents truncation and normalization', () => {
+  it('normalizes whitespace in error messages', () => {
+    const toolCall = makeToolCall('t1', 'echo');
+    const messy = 'line1\n\n\tline2    with   spaces\nline3';
+    const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, messy);
+
+    expect(agentErrorEvent.error).toBe('line1 line2 with spaces line3');
+
+    const payload = JSON.parse((toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text);
+    expect(payload.error).toBe('line1 line2 with spaces line3');
+  });
+
+  it('caps long error messages at 4096 chars and appends suffix', () => {
+    const toolCall = makeToolCall('t2', 'echo');
+    const longBase = 'A'.repeat(10_000);
+    const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, longBase);
+
+    const err = agentErrorEvent.error;
+    expect(err.length).toBeLessThanOrEqual(4096);
+    expect(err.endsWith('(truncated)')).toBe(true);
+
+    const payload = JSON.parse((toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text);
+    const toolErr: string = payload.error;
+    expect(toolErr.length).toBeLessThanOrEqual(4096);
+    expect(toolErr.endsWith('(truncated)')).toBe(true);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/truncateError.unit.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/truncateError.unit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { truncateError } from '../toolCallErrorEvents';
+
+describe('truncateError', () => {
+  it('returns empty string when max <= 0', () => {
+    expect(truncateError('anything', 0)).toBe('');
+    expect(truncateError('anything', -5)).toBe('');
+  });
+
+  it('does not append suffix when max < suffix length; caps hard at max', () => {
+    const input = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    // suffix length is 12; choose max smaller than suffix length
+    const out = truncateError(input, 5);
+    expect(out).toHaveLength(5);
+    expect(out).toBe('ABCDE');
+  });
+
+  it('appends suffix when there is room (max >= suffix length + 1)', () => {
+    const input = '0123456789'.repeat(1000);
+    const out = truncateError(input, 50);
+    expect(out.endsWith('(truncated)')).toBe(true);
+    expect(out.length).toBe(50);
+  });
+
+  it('normalizes whitespace before truncation', () => {
+    const input = 'a\n\n\t b     c';
+    const out = truncateError(input, 100);
+    expect(out).toBe('a b c');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/truncateError.unit.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/truncateError.unit.test.ts
@@ -7,6 +7,12 @@ describe('truncateError', () => {
     expect(truncateError('anything', -5)).toBe('');
   });
 
+  it('returns default message for empty or whitespace-only input', () => {
+    expect(truncateError('')).toBe('Unknown tool error');
+    expect(truncateError('   ')).toBe('Unknown tool error');
+    expect(truncateError('\n\t')).toBe('Unknown tool error');
+  });
+
   it('does not append suffix when max < suffix length; caps hard at max', () => {
     const input = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     // suffix length is 12; choose max smaller than suffix length

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -2,7 +2,8 @@ import type { AgentErrorEvent, MessageEvent, ToolCall } from '../types';
 
 export const truncateError = (input: string, max: number = 4096): string => {
   const suffix = ' (truncated)';
-  const normalized = (input || 'Unknown tool error').replace(/\s+/g, ' ').trim();
+  const normalizedRaw = (input ?? '').replace(/\s+/g, ' ').trim();
+  const normalized = normalizedRaw.length === 0 ? 'Unknown tool error' : normalizedRaw;
   if (max <= 0) return '';
   if (normalized.length <= max) return normalized;
   const headLen = max - suffix.length;

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -1,10 +1,19 @@
 import type { AgentErrorEvent, MessageEvent, ToolCall } from '../types';
 
+export const truncateError = (input: string, max: number = 4096): string => {
+  const suffix = ' (truncated)';
+  // Normalize whitespace
+  const normalized = (input || 'Unknown tool error').replace(/\s+/g, ' ').trim();
+  if (normalized.length <= max) return normalized;
+  const head = normalized.slice(0, Math.max(0, max - suffix.length));
+  return head + suffix;
+};
+
 export const createToolCallErrorEvents = (
   toolCall: ToolCall,
   error: string,
 ): { agentErrorEvent: AgentErrorEvent; toolMessageEvent: MessageEvent } => {
-  const message = error || 'Unknown tool error';
+  const message = truncateError(error);
   const toolName = toolCall.function.name;
   const toolCallId = toolCall.id;
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -2,11 +2,15 @@ import type { AgentErrorEvent, MessageEvent, ToolCall } from '../types';
 
 export const truncateError = (input: string, max: number = 4096): string => {
   const suffix = ' (truncated)';
-  // Normalize whitespace
   const normalized = (input || 'Unknown tool error').replace(/\s+/g, ' ').trim();
+  if (max <= 0) return '';
   if (normalized.length <= max) return normalized;
-  const head = normalized.slice(0, Math.max(0, max - suffix.length));
-  return head + suffix;
+  const headLen = max - suffix.length;
+  if (headLen <= 0) {
+    // Not enough room for suffix; hard cap to max without suffix
+    return normalized.slice(0, max);
+  }
+  return normalized.slice(0, headLen) + suffix;
 };
 
 export const createToolCallErrorEvents = (


### PR DESCRIPTION
Summary
- Cap and normalize tool error payload size in toolCallErrorEvents
- Introduce truncateError() utility to trim whitespace and cap error strings to 4KB with a " (truncated)" suffix
- Apply truncation to both AgentErrorEvent.error and the tool Message content payload

Changes
- packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
  - Add truncateError() helper (whitespace normalization + 4KB cap)
  - Use helper when building AgentErrorEvent and tool MessageEvent payloads
- packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
  - Unit tests covering whitespace normalization and long error truncation behavior

Motivation
Large tool error traces were being embedded into tool content without limits, bloating logs. This change ensures error payloads are bounded and normalized as requested.

Testing
- Added unit tests in agent-sdk-ts package
- Ran full workspace test suite: all tests pass locally

Notes
- Kept the implementation intentionally simple per request

Closes #162

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d2e58adb33b8443bae63cdec1641c62e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages now normalize whitespace for consistent formatting.
  * Error messages exceeding 4096 characters are automatically truncated with a "(truncated)" indicator to prevent overflow.

* **Tests**
  * Added test coverage for error message normalization and truncation behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->