### PR TITLE
Add debug logging for event emission errors

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -55,6 +55,7 @@ export class Agent extends EventEmitter {
   private readonly activatedSkillNames: string[] = [];
   private readonly registry?: import('../llm').LLMRegistry;
   private readonly conversationStats?: import('./ConversationStats').ConversationStats;
+  private readonly debug: boolean;
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -73,6 +74,7 @@ export class Agent extends EventEmitter {
       confirmUnknown: options.settings?.confirmation?.confirmUnknown ?? true,
     };
     this.agentContext = options.agentContext;
+    this.debug = options.settings?.agent?.debug ?? false;
 
     this.events.on((event) => this.emit('event', event));
   }
@@ -159,7 +161,14 @@ export class Agent extends EventEmitter {
           value: { model: this.options.settings?.llm?.model, tool_count: toolNames.length, tools: toolNames },
         } as Event);
       } catch (error) {
-        void error; // ignore debug emission failures
+        if (this.debug) {
+          console.warn('[Agent] Failed to emit llm_request debug event:', error);
+          this.events.push({
+            kind: 'ConversationErrorEvent',
+            source: 'agent',
+            detail: `Debug event emission failed: ${error instanceof Error ? error.message : String(error)}`,
+          } as Event);
+        }
       }
       let response;
       try {
@@ -225,8 +234,15 @@ export class Agent extends EventEmitter {
               arguments: safeArgs,
             },
           } as Event);
-        } catch {
-          // Swallow errors from logging tool call metadata; tool execution will still proceed.
+        } catch (error) {
+          if (this.debug) {
+            console.warn('[Agent] Failed to emit tool_call_raw debug event:', error);
+            this.events.push({
+              kind: 'ConversationErrorEvent',
+              source: 'agent',
+              detail: `Debug event emission failed for tool call: ${error instanceof Error ? error.message : String(error)}`,
+            } as Event);
+          }
         }
 
         const parsed = this.parseToolArgs(toolCall);

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.debug-mode.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.debug-mode.test.ts
@@ -1,0 +1,237 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import type { Event } from '../../types';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-debug-'));
+
+class FailingEventLog extends EventLog {
+  private failOnKeys: Set<string>;
+
+  constructor(failOnKeys: string[] = []) {
+    super();
+    this.failOnKeys = new Set(failOnKeys);
+  }
+
+  override push(event: Event): Event {
+    // Fail when trying to push ConversationStateUpdateEvent with specific keys
+    if (event.kind === 'ConversationStateUpdateEvent' && 'key' in event) {
+      const key = (event as { key?: string }).key;
+      if (key && this.failOnKeys.has(key)) {
+        throw new Error(`Simulated failure for key: ${key}`);
+      }
+    }
+    return super.push(event);
+  }
+}
+
+describe('Agent debug mode', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('llm_request debug event emission', () => {
+    it('silently ignores emission failures when debug is disabled (default)', async () => {
+      const log = new FailingEventLog(['llm_request']);
+      const llm = new MockLLM([{ type: 'text', text: 'Done' }, { type: 'finish' }]);
+
+      const agent = new Agent({
+        settings: baseSettings,
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+      });
+
+      await agent.run('test');
+
+      // Console.warn should not be called
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // No ConversationErrorEvent should be emitted
+      const events = log.list();
+      const errorEvents = events.filter((e) => e.kind === 'ConversationErrorEvent');
+      expect(errorEvents).toHaveLength(0);
+    });
+
+    it('logs warnings and emits error events when debug is enabled', async () => {
+      const log = new FailingEventLog(['llm_request']);
+      const llm = new MockLLM([{ type: 'text', text: 'Done' }, { type: 'finish' }]);
+
+      const agent = new Agent({
+        settings: { ...baseSettings, agent: { debug: true } },
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+      });
+
+      await agent.run('test');
+
+      // Console.warn should be called
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Agent] Failed to emit llm_request debug event:',
+        expect.any(Error),
+      );
+
+      // ConversationErrorEvent should be emitted
+      const events = log.list();
+      const errorEvents = events.filter((e) => e.kind === 'ConversationErrorEvent');
+      expect(errorEvents.length).toBeGreaterThan(0);
+      expect(errorEvents.some((e) => (e as { detail?: string }).detail?.includes('Debug event emission failed'))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('tool_call_raw debug event emission', () => {
+    it('silently ignores emission failures when debug is disabled (default)', async () => {
+      const log = new FailingEventLog(['llm_tool_call_raw']);
+      const tool: ToolDefinition<Record<string, unknown>, { result: string }> = {
+        name: 'test_tool',
+        validate: (input) => input,
+        execute: async () => ({ result: 'success' }),
+      };
+      const llm = new MockLLM([
+        { type: 'text', text: 'Calling tool' },
+        { type: 'tool_call_delta', id: 'call_1', name: 'test_tool', arguments: '{}' },
+        { type: 'finish' },
+      ]);
+
+      const agent = new Agent({
+        settings: baseSettings,
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+        tools: [tool],
+      });
+
+      await agent.run('test');
+
+      // Console.warn should not be called
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+      // No ConversationErrorEvent should be emitted for debug failures
+      const events = log.list();
+      const errorEvents = events.filter(
+        (e) =>
+          e.kind === 'ConversationErrorEvent' &&
+          (e as { detail?: string }).detail?.includes('Debug event emission failed'),
+      );
+      expect(errorEvents).toHaveLength(0);
+    });
+
+    it('logs warnings and emits error events when debug is enabled', async () => {
+      const log = new FailingEventLog(['llm_tool_call_raw']);
+      const tool: ToolDefinition<Record<string, unknown>, { result: string }> = {
+        name: 'test_tool',
+        validate: (input) => input,
+        execute: async () => ({ result: 'success' }),
+      };
+      const llm = new MockLLM([
+        { type: 'text', text: 'Calling tool' },
+        { type: 'tool_call_delta', id: 'call_1', name: 'test_tool', arguments: '{}' },
+        { type: 'finish' },
+      ]);
+
+      const agent = new Agent({
+        settings: { ...baseSettings, agent: { debug: true } },
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+        tools: [tool],
+      });
+
+      await agent.run('test');
+
+      // Console.warn should be called
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[Agent] Failed to emit tool_call_raw debug event:',
+        expect.any(Error),
+      );
+
+      // ConversationErrorEvent should be emitted
+      const events = log.list();
+      const errorEvents = events.filter(
+        (e) =>
+          e.kind === 'ConversationErrorEvent' &&
+          (e as { detail?: string }).detail?.includes('Debug event emission failed for tool call'),
+      );
+      expect(errorEvents.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('normal operation without failures', () => {
+    it('emits debug events successfully when debug is disabled', async () => {
+      const log = new EventLog();
+      const llm = new MockLLM([{ type: 'text', text: 'Done' }, { type: 'finish' }]);
+
+      const agent = new Agent({
+        settings: baseSettings,
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+      });
+
+      await agent.run('test');
+
+      // Should have llm_request event
+      const events = log.list();
+      const stateUpdateEvents = events.filter((e) => e.kind === 'ConversationStateUpdateEvent');
+      const llmRequestEvent = stateUpdateEvents.find((e) => (e as { key?: string }).key === 'llm_request');
+      expect(llmRequestEvent).toBeDefined();
+    });
+
+    it('emits debug events successfully when debug is enabled', async () => {
+      const log = new EventLog();
+      const llm = new MockLLM([{ type: 'text', text: 'Done' }, { type: 'finish' }]);
+
+      const agent = new Agent({
+        settings: { ...baseSettings, agent: { debug: true } },
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+      });
+
+      await agent.run('test');
+
+      // Should have llm_request event
+      const events = log.list();
+      const stateUpdateEvents = events.filter((e) => e.kind === 'ConversationStateUpdateEvent');
+      const llmRequestEvent = stateUpdateEvents.find((e) => (e as { key?: string }).key === 'llm_request');
+      expect(llmRequestEvent).toBeDefined();
+
+      // No error events should be emitted
+      const errorEvents = events.filter((e) => e.kind === 'ConversationErrorEvent');
+      expect(errorEvents).toHaveLength(0);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -20,6 +20,7 @@ export type ServerSettings = {
 
 export type AgentSettings = {
   enableSecurityAnalyzer?: boolean;
+  debug?: boolean;
 };
 
 export type ConversationSettings = {


### PR DESCRIPTION
When debug flag is enabled, log warnings to console and emit error events when debug event emissions fail. This makes it easier to detect and diagnose issues with llm_request and tool_call_raw event logging.

Changes:
- Add debug flag to AgentSettings type
- Store debug flag in Agent constructor
- Update llm_request and tool_call_raw logging blocks to:
  - Log console warnings when debug is enabled
  - Emit ConversationErrorEvent when debug is enabled
  - Remain silent when debug is disabled (default behavior)
- Add comprehensive tests for debug mode toggling

Addresses acceptance criteria:
✓ Log warnings to console when debug flag is enabled ✓ Emit error events when debug flag is enabled
✓ Remain silent when debug flag is disabled (default) ✓ Tests toggling debug mode