### PR TITLE
Emit ActionEvent only after successful tool arg parse

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -110,8 +110,7 @@ describe('Agent loop control', () => {
     expect((agentErrors[0] as { tool_call_id?: string }).tool_call_id).toBe('call_invalid');
 
     const actions = events.filter(isActionEvent);
-    expect(actions).toHaveLength(1);
-    expect((actions[0] as { tool_call_id?: string }).tool_call_id).toBe('call_invalid');
+    expect(actions).toHaveLength(0);
 
     expect(events.some(isObservationEvent)).toBe(false);
   });
@@ -144,8 +143,7 @@ describe('Agent loop control', () => {
     expect((agentErrors[0] as { tool_call_id?: string }).tool_call_id).toBe('call_primitive');
 
     const actions = events.filter(isActionEvent);
-    expect(actions).toHaveLength(1);
-    expect((actions[0] as { tool_call_id?: string }).tool_call_id).toBe('call_primitive');
+    expect(actions).toHaveLength(0);
 
     expect(events.some(isObservationEvent)).toBe(false);
   });

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -230,16 +230,14 @@ export class Agent extends EventEmitter {
         }
 
         const parsed = this.parseToolArgs(toolCall);
-        const args = parsed?.args ?? null;
-        const securityRisk = parsed?.securityRisk;
-
-        const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
-        const recordedAction = this.events.push(actionEvent) as ActionEvent;
-
         if (!parsed) {
           toolExecutionFailed = true;
           continue;
         }
+        const { args, securityRisk } = parsed;
+
+        const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
+        const recordedAction = this.events.push(actionEvent) as ActionEvent;
 
         if (this.requiresConfirmation(recordedAction)) {
           this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };


### PR DESCRIPTION
Summary
- Move ActionEvent emission to occur only after tool arg parsing succeeds
- Prevents misleading ActionEvents for tool calls that will never execute
- Update tests to assert zero ActionEvents on parse failure

Motivation
Issue #163 reported that ActionEvent is pushed before verifying parse success, resulting in actions that never execute. This leads to confusing UI state and incorrect pending action handling.

What changed
- packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
  - Parse tool args first; if parsing fails, emit AgentErrorEvent + tool message, but do not emit ActionEvent
  - Only create and push ActionEvent after parse success
- packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
  - Adjust expectations for invalid argument scenarios to assert no ActionEvent is emitted

Testing
- Ran npm test in the workspace; all suites pass:
  - @openhands/agent-sdk-ts: 16 files, 132 tests passed
  - Extension/webview: 17 files, 141 tests passed (4 skipped)

Backward compatibility
- Event shapes unchanged
- Behavior is more accurate: ActionEvent now represents actions that can actually proceed (subject to validation/confirmation)

Fixes
- Fixes #163

Notes
- No changes required in webview/extension code; they already rely on ObservationEvent/UserReject or AgentErrorEvent for clearing pending actions.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1ec5b98a52ca4e329c4d7def338c72a8)