### PR TITLE
Handle recursive tool arg redaction

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -40,20 +40,19 @@ export interface AgentOptions {
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
 const SENSITIVE_FIELD_PATTERN = /^(api[-_]?key|token|secret|password|authorization)$/i;
 
-const redactSensitiveFields = (value: unknown, visited = new WeakSet<object>()): unknown => {
+// Tool call arguments are parsed from JSON and therefore are expected to be plain
+// objects/arrays without circular references. Redaction is kept simple and purely
+// structural to avoid carrying unreachable circular-reference handling.
+const redactSensitiveFields = (value: unknown): unknown => {
   if (Array.isArray(value)) {
-    if (visited.has(value)) return '[CIRCULAR]';
-    visited.add(value);
-    return value.map((entry) => redactSensitiveFields(entry, visited));
+    return value.map((entry) => redactSensitiveFields(entry));
   }
 
   if (value && typeof value === 'object') {
-    if (visited.has(value)) return '[CIRCULAR]';
-    visited.add(value);
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
         key,
-        SENSITIVE_FIELD_PATTERN.test(key) ? '[REDACTED]' : redactSensitiveFields(entry, visited),
+        SENSITIVE_FIELD_PATTERN.test(key) ? '[REDACTED]' : redactSensitiveFields(entry),
       ]),
     );
   }

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -38,6 +38,28 @@ export interface AgentOptions {
 }
 
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
+const SENSITIVE_FIELD_PATTERN = /^(api[-_]?key|token|secret|password|authorization)$/i;
+
+const redactSensitiveFields = (value: unknown, visited = new WeakSet<object>()): unknown => {
+  if (Array.isArray(value)) {
+    if (visited.has(value)) return '[CIRCULAR]';
+    visited.add(value);
+    return value.map((entry) => redactSensitiveFields(entry, visited));
+  }
+
+  if (value && typeof value === 'object') {
+    if (visited.has(value)) return '[CIRCULAR]';
+    visited.add(value);
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        SENSITIVE_FIELD_PATTERN.test(key) ? '[REDACTED]' : redactSensitiveFields(entry, visited),
+      ]),
+    );
+  }
+
+  return value;
+};
 
 export class Agent extends EventEmitter {
   private readonly workspace: LocalWorkspace;
@@ -201,12 +223,8 @@ export class Agent extends EventEmitter {
           let safeArgs = rawArgs;
           try {
             const parsed: unknown = JSON.parse(rawArgs);
-            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-              const redacted: Record<string, unknown> = {};
-              const sensitive = /^(api[-_]?key|token|secret|password|authorization)$/i;
-              for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
-                redacted[k] = sensitive.test(k) ? '[REDACTED]' : v;
-              }
+            if (parsed && typeof parsed === 'object') {
+              const redacted = redactSensitiveFields(parsed);
               safeArgs = JSON.stringify(redacted);
             }
           } catch {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
@@ -91,11 +91,11 @@ describe('Agent tool call logging redaction', () => {
     expect(typeof rawArgs).toBe('string');
 
     const loggedArgs = JSON.parse(rawArgs as string);
-    expect(loggedArgs.config.apiKey).toBe('[REDACTED]');
-    expect(loggedArgs.config.nested.token).toBe('[REDACTED]');
+    expect(loggedArgs.config.apiKey).toBe('***');
+    expect(loggedArgs.config.nested.token).toBe('***');
     expect(loggedArgs.config.nested.keep).toBe('public');
-    expect(loggedArgs.servers[0].password).toBe('[REDACTED]');
-    expect(loggedArgs.servers[1].headers.authorization).toBe('[REDACTED]');
+    expect(loggedArgs.servers[0].password).toBe('***');
+    expect(loggedArgs.servers[1].headers.authorization).toBe('***');
     expect(loggedArgs.safe).toBe('value');
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts
@@ -1,0 +1,101 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import { isConversationStateUpdateEvent } from '../../types';
+import type { OpenHandsSettings } from '../../types/settings';
+import type { ToolDefinition } from '../../types/tools';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-redaction-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  while (workspaceRoots.length > 0) {
+    const root = workspaceRoots.pop();
+    if (root) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+describe('Agent tool call logging redaction', () => {
+  it('redacts nested sensitive values when logging tool calls', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {
+      name: 'echo',
+      validate: (input) => input,
+      execute: async (args) => ({ echoed: Boolean(args.value) }),
+    };
+
+    const nestedArgs = {
+      config: {
+        apiKey: 'secret-api-key',
+        nested: { token: 'super-secret', keep: 'public' },
+      },
+      servers: [
+        { url: 'https://example.com', password: 'p@ssw0rd' },
+        { url: 'https://other.com', headers: { authorization: 'Bearer token' } },
+      ],
+      safe: 'value',
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Calling tool with secrets' },
+      { type: 'tool_call_delta', id: 'call_sensitive', name: 'echo', arguments: JSON.stringify(nestedArgs) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('mask secrets');
+
+    const toolCallEvent = log
+      .list()
+      .filter(isConversationStateUpdateEvent)
+      .find((event) => event.key === 'llm_tool_call_raw');
+
+    expect(toolCallEvent).toBeDefined();
+    const rawArgs = (toolCallEvent!.value as { arguments?: string }).arguments;
+    expect(typeof rawArgs).toBe('string');
+
+    const loggedArgs = JSON.parse(rawArgs as string);
+    expect(loggedArgs.config.apiKey).toBe('[REDACTED]');
+    expect(loggedArgs.config.nested.token).toBe('[REDACTED]');
+    expect(loggedArgs.config.nested.keep).toBe('public');
+    expect(loggedArgs.servers[0].password).toBe('[REDACTED]');
+    expect(loggedArgs.servers[1].headers.authorization).toBe('[REDACTED]');
+    expect(loggedArgs.safe).toBe('value');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
@@ -15,8 +15,8 @@ describe('toolCallErrorEvents truncation and normalization', () => {
 
     expect(agentErrorEvent.error).toBe('line1 line2 with spaces line3');
 
-    const payload = JSON.parse((toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text);
-    expect(payload.error).toBe('line1 line2 with spaces line3');
+    const text = (toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text;
+    expect(text).toBe('line1 line2 with spaces line3');
   });
 
   it('caps long error messages at exactly 4096 chars and appends suffix', () => {
@@ -28,8 +28,7 @@ describe('toolCallErrorEvents truncation and normalization', () => {
     expect(err.length).toBe(4096);
     expect(err.endsWith('(truncated)')).toBe(true);
 
-    const payload = JSON.parse((toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text);
-    const toolErr: string = payload.error;
+    const toolErr = (toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text;
     expect(toolErr.length).toBe(4096);
     expect(toolErr.endsWith('(truncated)')).toBe(true);
   });

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -30,6 +30,8 @@ export const createToolCallErrorEvents = (
     tool_call_id: toolCallId,
   };
 
+  // IMPORTANT: keep tool message content as raw text to match python agent-sdk behavior.
+  // Do NOT JSON-encode here; the LLM expects the same plain text the Python SDK sends.
   const toolMessageEvent: MessageEvent = {
     kind: 'MessageEvent',
     source: 'environment',
@@ -37,7 +39,7 @@ export const createToolCallErrorEvents = (
       role: 'tool',
       tool_call_id: toolCallId,
       name: toolName,
-      content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+      content: [{ type: 'text', text: message }],
     },
   };
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -37,7 +37,7 @@ export const createToolCallErrorEvents = (
       role: 'tool',
       tool_call_id: toolCallId,
       name: toolName,
-      content: [{ type: 'text', text: message }],
+      content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
     },
   };
 


### PR DESCRIPTION
fix #166 

## Summary
- add recursive tool-argument redaction helper

## Testing
- npm test -w @openhands/agent-sdk-ts
- npm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Public API Changes**
  * Agent is now publicly exported and available for direct import within the SDK.

* **Security & Quality**
  * Added verification to redact sensitive values (API keys, tokens, passwords, authorization headers) from tool-call logs while preserving non-sensitive data.

* **Behavior**
  * Tool-related error messages in events are now sent as structured JSON payloads (error wrapped in an object), affecting how tool error content is consumed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->