### PR TITLE
Add tests for token redaction heuristics

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -97,6 +97,15 @@ function redactStringHeuristics(text: string): string {
   t = t.replace(/(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._-]+/gi, '$1***');
   // Standalone Bearer tokens
   t = t.replace(/(Bearer\s+)[A-Za-z0-9._-]+/gi, '$1***');
+  // Common token prefixes that may appear without key labels
+  const tokenPatterns = [
+    /sk-[A-Za-z0-9]{12,}/gi,
+    /ghp_[A-Za-z0-9]{12,}/gi,
+    /pat_[A-Za-z0-9_]{12,}/gi,
+  ];
+  tokenPatterns.forEach((pattern) => {
+    t = t.replace(pattern, '***');
+  });
   // Common key=value or key: value patterns
   const keyPattern = /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret)/gi;
   t = t.replace(new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'), (_m, p1, _p2) => `${p1}: ***`);

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.redaction.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.redaction.test.ts
@@ -69,4 +69,44 @@ describe('Agent redacts sensitive tool-call arguments in llm_tool_call_raw', () 
     // Authorization header value should be masked
     expect(parsed.headers.Authorization).toContain('Bearer ***');
   });
+
+  it('masks nested secrets and token-like strings without requiring key names', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ any: string }, { ok: boolean }> = {
+      name: 'noop',
+      validate: (input) => (input as unknown) as { any: string },
+      execute: async () => ({ ok: true }),
+    };
+
+    const args = {
+      note: 'Encountered sk-abc123SECRETvalue while testing',
+      nested: {
+        description: 'bearer TOKENVALUE and ghp_abcdefghijklmnopqrstu',
+        list: ['pat_token_value_123456', 'safe'],
+      },
+      headers: 'Authorization: Bearer AnotherToken',
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'c1', name: 'noop', arguments: JSON.stringify(args) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/tmp', llmClient: llm, tools: [tool] });
+    await agent.run('go');
+
+    const updates = log
+      .list()
+      .filter((e) => e.kind === 'ConversationStateUpdateEvent' && (e as any).key === 'llm_tool_call_raw');
+
+    expect(updates.length).toBeGreaterThan(0);
+    const parsed = JSON.parse((updates[0] as any).value.arguments as string);
+
+    expect(parsed.note).toBe('Encountered *** while testing');
+    expect(parsed.nested.description).toBe('bearer *** and ***');
+    expect(parsed.nested.list[0]).toBe('***');
+    expect(parsed.nested.list[1]).toBe('safe');
+    expect(parsed.headers).toBe('Authorization: Bearer ***');
+  });
 });


### PR DESCRIPTION
## Summary
- mask common standalone token prefixes when redacting strings
- add coverage for nested secrets and token-like strings in tool call arguments

Fix https://github.com/enyst/OpenHands-Tab/issues/173

## Testing
- npm test
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced secret and token redaction to detect additional patterns without explicit key labels.

* **Tests**
  * Added test coverage for nested secrets and token-like string redaction scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->