### PR TITLE
Small cleanup: consolidate restore logic, add renderError helper

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -85,6 +85,11 @@ const createDefaultLocalTools = () => [
   new TaskTrackerTool(),
 ];
 
+/** Render an error for logging/display (handles Error objects and unknown values) */
+function renderError(err: unknown): string {
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+}
+
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 function safeStringify(value: unknown): string {
   try {
@@ -304,7 +309,7 @@ export function activate(context: vscode.ExtensionContext) {
         void panel?.webview.postMessage({ type: 'event', event: ev });
       });
       conversation.on('error', (err) => {
-        const rendered = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+        const rendered = renderError(err);
         outputChannel?.appendLine(`[error] ${rendered}`);
         if (err instanceof Error && err.stack) {
           outputChannel?.appendLine(err.stack);
@@ -320,34 +325,22 @@ export function activate(context: vscode.ExtensionContext) {
         }
       });
       conversation.on('terminal', (event: BashEvent) => handleTerminalEvent(event));
-      if (savedId) {
-        try {
-          const maybe = conversation.restoreConversation(savedId);
-          void Promise.resolve(maybe).catch((err: unknown) => {
-            const rendered = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-            outputChannel?.appendLine(`[restoreConversation] ${rendered}`);
-          });
-        } catch (err) {
-          const rendered = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-          outputChannel?.appendLine(`[restoreConversation] ${rendered}`);
-        }
-      }
     } else if (conversation) {
       conversation.setSettings(settings);
-      if (savedId) {
-        try {
-          const maybe = conversation.restoreConversation(savedId);
-          void Promise.resolve(maybe).catch((err: unknown) => {
-            const rendered = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-            outputChannel?.appendLine(`[restoreConversation] ${rendered}`);
-          });
-        } catch (err) {
-          const rendered = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-          outputChannel?.appendLine(`[restoreConversation] ${rendered}`);
-        }
-      }
     } else {
       outputChannel?.appendLine('[warn] Conversation unavailable during settings refresh');
+    }
+
+    // Restore conversation if needed (after either branch)
+    if (savedId && conversation) {
+      try {
+        const maybe = conversation.restoreConversation(savedId);
+        void Promise.resolve(maybe).catch((err: unknown) => {
+          outputChannel?.appendLine(`[restoreConversation] ${renderError(err)}`);
+        });
+      } catch (err) {
+        outputChannel?.appendLine(`[restoreConversation] ${renderError(err)}`);
+      }
     }
 
     void panel?.webview.postMessage({


### PR DESCRIPTION
## Summary

Small, focused improvements to `extension.ts`:

- Add `renderError()` helper for consistent error formatting
- Consolidate duplicate restore conversation logic (was in two branches, now single location)
- Use helper in error event handler and restore catch blocks

**Net change**: -7 lines (868 → 861)

## Testing

- ✅ Build passes
- ✅ 125 unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error message formatting throughout the application to ensure consistent, clear feedback when issues occur.
  * Optimized conversation restoration workflow by consolidating recovery logic and enhancing error handling paths, improving reliability when recovering previously saved conversations and providing better error context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->