### PR TITLE
Remove misleading 'workspace' arg from setApiKey

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -438,9 +438,8 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       }
 
-      await settingsMgr.update({
-        secrets: { llmApiKey: llmApiKey || undefined }
-      }, 'workspace');
+      // Secrets are stored in VS Code SecretStorage, not workspace settings
+      await settingsMgr.update({ secrets: { llmApiKey: llmApiKey || undefined } });
 
       vscode.window.showInformationMessage('LLM API Key saved securely.');
 


### PR DESCRIPTION
Secrets are stored in VS Code SecretStorage regardless of the target argument, so the `'workspace'` parameter was misleading.

## Changes
- Removed unused `'workspace'` argument from `settingsMgr.update()`
- Added clarifying comment

## Testing
- ✅ Build passes
- ✅ 125 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API key security by migrating from workspace settings storage to a more secure storage mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->