### PR TITLE
Fix local-mode LLM defaults and surface missing API key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,43 @@ When editing `packages/agent-sdk-ts`, rebuild before launching extension:
 npm run build -w @openhands/agent-sdk-ts
 ```
 
+## Integrating with Beads (dependency-aware task planning)
+
+Beads provides a lightweight, dependency-aware issue database and a CLI (`bd`) for selecting "ready work," setting priorities, and tracking status. It complements MCP Agent Mail's messaging, audit trail, and file-reservation signals. Project: [steveyegge/beads](https://github.com/steveyegge/beads)
+
+Recommended conventions
+- **Single source of truth**: Use **Beads** for task status/priority/dependencies; use **Agent Mail** for conversation, decisions, and attachments (audit).
+- **Shared identifiers**: Use the Beads issue id (e.g., `oh-tab-123`) as the Mail `thread_id` and prefix message subjects with `[oh-tab-123]`.
+- **Reservations**: When starting a `oh-tab-###` task, call `file_reservation_paths(...)` for the affected paths; include the issue id in the `reason` and release on completion.
+
+Typical flow (agents)
+1) **Pick ready work** (Beads)
+   - `bd ready --json` → choose one item (highest priority, no blockers)
+2) **Reserve edit surface** (Mail)
+   - `file_reservation_paths(project_key, agent_name, ["src/**"], ttl_seconds=3600, exclusive=true, reason="oh-tab-123")`
+3) **Announce start** (Mail)
+   - `send_message(..., thread_id="oh-tab-123", subject="[oh-tab-123] Start: <short title>", ack_required=true)`
+4) **Work and update**
+   - Reply in-thread with progress and attach artifacts/images; keep the discussion in one thread per issue id
+5) **Complete and release**
+   - `bd close oh-tab-123 --reason "Completed"` (Beads is status authority)
+   - `release_file_reservations(project_key, agent_name, paths=["src/**"])`
+   - Final Mail reply: `[oh-tab-123] Completed` with summary and links
+
+Mapping cheat-sheet
+- **Mail `thread_id`** ↔ `oh-tab-###`
+- **Mail subject**: `[oh-tab-###] …`
+- **File reservation `reason`**: `oh-tab-###`
+- **Commit messages (optional)**: include `oh-tab-###` for traceability
+
+Event mirroring (optional automation)
+- On `bd update --status blocked`, send a high-importance Mail message in thread `oh-tab-###` describing the blocker.
+- On Mail "ACK overdue" for a critical decision, add a Beads label (e.g., `needs-ack`) or bump priority to surface it in `bd ready`.
+
+Pitfalls to avoid
+- Don't create or manage tasks in Mail; treat Beads as the single task queue.
+- Always include `oh-tab-###` in message `thread_id` to avoid ID drift across tools.
+
 ## Further Reading
 
 - [docs/PRD.md](docs/PRD.md) - Product requirements

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
@@ -153,4 +153,37 @@ describe('LocalConversation', () => {
     const conversationError = events.find(isConversationErrorEvent);
     expect(conversationError).toBeUndefined();
   });
+
+  it('emits ConversationErrorEvent when no LLM API key is available', async () => {
+    const envKeys = [
+      'OPENAI_API_KEY',
+      'OPENROUTER_API_KEY',
+      'LITELLM_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'LLM_API_KEY',
+    ];
+    const previous = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+    for (const key of envKeys) delete process.env[key];
+
+    try {
+      const conversation = new LocalConversation({ settings: baseSettings, tools: createDefaultTools() });
+      const events: Event[] = [];
+      conversation.on('event', (e: Event) => events.push(e));
+
+      await conversation.sendUserMessage('hi');
+
+      const error = events.find(isConversationErrorEvent);
+      expect(error).toBeDefined();
+      expect(error?.detail).toContain('Missing API key for LLM provider');
+    } finally {
+      for (const key of envKeys) {
+        const value = previous[key];
+        if (value === undefined) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -230,7 +230,22 @@ export class Agent extends EventEmitter {
     }
 
     const maxIterations = this.clampMaxIterations();
-    const orchestrator = await this.getOrchestrator();
+    let orchestrator: AgentOrchestrator;
+    try {
+      orchestrator = await this.getOrchestrator();
+    } catch (error) {
+      // Orchestrator creation can fail before the main loop begins (e.g., missing LLM API key).
+      // Surface this as an event instead of throwing so hosts can render/report it.
+      this.events.push({
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        detail: error instanceof Error ? error.message : String(error),
+      } as Event);
+      this.state.setStatus('IDLE');
+      // Allow a future retry after settings/secrets are updated.
+      this.orchestratorPromise = undefined;
+      return undefined;
+    }
     let lastAssistantMessage: Message | undefined;
 
     while (!this.paused && !this.pendingAction && !this.cancelled && this.state.snapshot.iteration < maxIterations) {

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -29,7 +29,7 @@ const DEFAULTS: OpenHandsSettings = {
   secrets: {}
 };
 
-const normalizeServerUrl = (value: string | null | undefined): string | undefined => {
+const normalizeNonEmptyString = (value: string | null | undefined): string | undefined => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   return trimmed || undefined;
 };
@@ -44,14 +44,21 @@ export class SettingsManager {
   constructor(private adapter: SettingsAdapter) {}
 
   async get(): Promise<OpenHandsSettings> {
-    const serverUrl = normalizeServerUrl(
+    const serverUrl = normalizeNonEmptyString(
       this.adapter.get<string | null>('openhands.serverUrl', DEFAULTS.serverUrl) ?? DEFAULTS.serverUrl
     );
+    const isRemote = !!serverUrl;
     const servers = this.adapter.get<SavedServer[]>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers;
+    const model = normalizeNonEmptyString(
+      isRemote
+        ? this.adapter.getExplicit<string>('openhands.llm.model')
+        : (this.adapter.get<string | null>('openhands.llm.model', DEFAULTS.llm.model) ?? DEFAULTS.llm.model)
+    );
     const llm: LLMSettings = {
-      // Only return explicitly configured usageId/model so ConnectionManager can omit them when undefined
-      usageId: this.adapter.getExplicit<string>('openhands.llm.usageId'),
-      model: this.adapter.getExplicit<string>('openhands.llm.model'),
+      // In remote mode, omit usageId/model unless explicitly configured.
+      // In local mode, we must provide a model so the local Agent can create an LLM client.
+      usageId: normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.usageId')),
+      model,
       baseUrl: this.adapter.get<string | null>('openhands.llm.baseUrl', DEFAULTS.llm.baseUrl) ?? DEFAULTS.llm.baseUrl,
       apiVersion: this.adapter.get<string | null>('openhands.llm.apiVersion', DEFAULTS.llm.apiVersion) ?? DEFAULTS.llm.apiVersion,
       timeout: this.adapter.get<number | null>('openhands.llm.timeout', DEFAULTS.llm.timeout) ?? DEFAULTS.llm.timeout,

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -27,7 +27,16 @@ describe('SettingsManager', () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBeUndefined();
     expect(s.llm.usageId).toBeUndefined();
+    // Local mode requires a default model for the local Agent to run.
+    expect(s.llm.model).toBe('claude-sonnet-4-20250514');
     expect(s.agent.enableSecurityAnalyzer).toBe(false);
+  });
+
+  it('omits model by default in remote mode', async () => {
+    await mgr.update({ serverUrl: 'http://example:1234' });
+    const s = await mgr.get();
+    expect(s.serverUrl).toBe('http://example:1234');
+    expect(s.llm.model).toBeUndefined();
   });
 
   it('updates and persists config and secrets', async () => {


### PR DESCRIPTION
### What
- Local mode now provides a default `llm.model` when unset, avoiding `LLM model is not configured` errors.
- Local mode now surfaces missing LLM API key failures as a `ConversationErrorEvent` instead of throwing, so the webview can render an actionable error (and the extension host doesn’t just log an unhandled error).
- Added/updated tests for both behaviors.
- Added Beads + Agent Mail workflow guidance to `AGENTS.md`.

### Why
In the Extension Development Host, sending a message could appear to do nothing: the user message was recorded, but the local conversation failed before any LLM call if `llm.model` or the API key was missing. These changes make local-mode behavior predictable and user-visible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for Beads integration, covering dependency-aware task planning conventions and best practices.

* **Bug Fixes**
  * Improved error handling for missing LLM API keys—errors now surface as events rather than causing failures.

* **Tests**
  * Expanded test coverage for API key validation and model selection behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->