### PR TITLE
Improve ConversationErrorEvent debugging context

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,19 @@
       "preLaunchTask": "npm: compile"
     },
     {
+      "type": "extensionHost",
+      "request": "launch",
+      "name": "Run OH-Tab (normal profile)",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "npm: compile"
+    },
+    {
       "name": "OH-Tab-Tests",
       "type": "extensionHost",
       "request": "launch",

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -1,10 +1,11 @@
 import { LLMCredentialProvider } from './credentials';
 import { AnthropicClient } from './anthropic';
 import { OpenAICompatibleClient } from './openai-compatible';
-import type { ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
+import type { ChatCompletionRequest, LLMClient, LLMConfiguration } from './types';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMRegistry, TrackedLLMClient } from './registry';
 import { Metrics } from './metrics';
+import { detectProviderFromBaseUrl } from './provider';
 
 export interface LLMFactoryOptions {
   secrets?: SecretRegistry;
@@ -40,7 +41,7 @@ export class LLMFactory {
       throw new Error('Missing API key for LLM provider');
     }
 
-    const provider = this.config.provider ?? this.detectProviderFromBaseUrl();
+    const provider = this.config.provider ?? detectProviderFromBaseUrl(this.config.baseUrl);
     const base = provider === 'anthropic' ? new AnthropicClient(this.config, apiKey) : new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
 
     if (this.config.usageId) {
@@ -55,12 +56,6 @@ export class LLMFactory {
 
   requestFromDefaults(messages: ChatCompletionRequest['messages'], systemPrompt: string): ChatCompletionRequest {
     return { systemPrompt, messages };
-  }
-
-  private detectProviderFromBaseUrl(): LLMProvider {
-    if (this.config.baseUrl?.includes('openrouter.ai')) return 'openrouter';
-    if (this.config.baseUrl?.includes('litellm')) return 'litellm_proxy';
-    return 'openai';
   }
 
   private getDefaultApiKeyName(): string {

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -3,5 +3,6 @@ export * from './credentials';
 export * from './openai-compatible';
 export * from './anthropic';
 export * from './factory';
+export * from './provider';
 export * from './metrics';
 export * from './registry';

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -1,5 +1,6 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions, type ToolCallAccumulator } from './types';
+import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 
 const decoder = new TextDecoder();
 
@@ -80,9 +81,9 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
 });
 
 const defaultBaseUrls: Record<string, string> = {
-  openai: 'https://api.openai.com/v1',
-  openrouter: 'https://openrouter.ai/api/v1',
-  litellm_proxy: 'http://localhost:4000',
+  openai: DEFAULT_PROVIDER_BASE_URLS.openai,
+  openrouter: DEFAULT_PROVIDER_BASE_URLS.openrouter,
+  litellm_proxy: DEFAULT_PROVIDER_BASE_URLS.litellm_proxy,
 };
 
 const parseSseLines = async function* (response: Response): AsyncGenerator<string> {

--- a/packages/agent-sdk-ts/src/sdk/llm/provider.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/provider.ts
@@ -1,0 +1,15 @@
+import type { LLMProvider } from './types';
+
+export const DEFAULT_PROVIDER_BASE_URLS: Record<LLMProvider, string> = {
+  openai: 'https://api.openai.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+  litellm_proxy: 'http://localhost:4000',
+  anthropic: 'https://api.anthropic.com/v1',
+};
+
+export const detectProviderFromBaseUrl = (baseUrl?: string | null): LLMProvider => {
+  if (baseUrl?.includes('openrouter.ai')) return 'openrouter';
+  if (baseUrl?.includes('litellm')) return 'litellm_proxy';
+  return 'openai';
+};
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -40,6 +40,12 @@ export interface AgentOptions {
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
 const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 
+const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
+  openai: 'https://api.openai.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+  litellm_proxy: 'http://localhost:4000',
+};
+
 // Simple utility to cap logged/tool result sizes
 const TRUNCATE_LIMIT = 2000;
 const ELLIPSIS = '…(truncated)';
@@ -57,6 +63,27 @@ function deepTruncate(value: unknown): unknown {
     return out;
   }
   return value;
+}
+
+function toOptionalNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function stringifyErrorWithCause(error: unknown, maxDepth = 4): string {
+  if (error instanceof Error) {
+    const base = error.message || error.name || 'Error';
+    const anyErr = error as Error & { cause?: unknown };
+    if (!anyErr.cause || maxDepth <= 0) return base;
+    return `${base}; caused by: ${stringifyErrorWithCause(anyErr.cause, maxDepth - 1)}`;
+  }
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
 }
 
 
@@ -234,13 +261,7 @@ export class Agent extends EventEmitter {
     try {
       orchestrator = await this.getOrchestrator();
     } catch (error) {
-      // Orchestrator creation can fail before the main loop begins (e.g., missing LLM API key).
-      // Surface this as an event instead of throwing so hosts can render/report it.
-      this.events.push({
-        kind: 'ConversationErrorEvent',
-        source: 'agent',
-        detail: error instanceof Error ? error.message : String(error),
-      } as Event);
+      this.events.push(this.toConversationErrorEvent(error));
       this.state.setStatus('IDLE');
       // Allow a future retry after settings/secrets are updated.
       this.orchestratorPromise = undefined;
@@ -274,11 +295,7 @@ export class Agent extends EventEmitter {
       try {
         response = await orchestrator.runChat(request);
       } catch (error) {
-        this.events.push({
-          kind: 'ConversationErrorEvent',
-          source: 'agent',
-          detail: error instanceof Error ? error.message : String(error),
-        } as Event);
+        this.events.push(this.toConversationErrorEvent(error));
         this.state.setStatus('IDLE');
         break;
       }
@@ -467,6 +484,42 @@ export class Agent extends EventEmitter {
       },
     });
     return factory.createClient();
+  }
+
+  private toConversationErrorEvent(error: unknown): Event {
+    const message = stringifyErrorWithCause(error);
+    const code = this.classifyConversationError(message);
+    const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
+    const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
+    const detectedProvider =
+      configuredBaseUrl?.includes('openrouter.ai')
+        ? 'openrouter'
+        : configuredBaseUrl?.includes('litellm')
+          ? 'litellm_proxy'
+          : 'openai';
+    const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[detectedProvider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
+    const hasInlineApiKey = Boolean(this.options.settings?.secrets?.llmApiKey);
+    const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
+    const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
+
+    const contextParts = [
+      `mode=${mode}`,
+      `llm.model=${model ?? '(unset)'}`,
+      `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
+      `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
+      `llm.apiKey=${hasInlineApiKey ? 'set' : 'unset'}`,
+    ];
+    if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
+
+    const detail = `${message} (${contextParts.join(', ')})`;
+    return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail } as Event;
+  }
+
+  private classifyConversationError(message: string): string | undefined {
+    if (message.includes('Missing API key for LLM provider')) return 'missing_llm_api_key';
+    if (message.includes('LLM model is not configured')) return 'llm_model_not_configured';
+    if (message.startsWith('LLM request failed')) return 'llm_request_failed';
+    return undefined;
   }
 
   private ensureSystemPrompt() {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -487,7 +487,10 @@ export class Agent extends EventEmitter {
     const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
     const provider = detectProviderFromBaseUrl(configuredBaseUrl);
     const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
-    const hasInlineApiKey = Boolean(this.options.settings?.secrets?.llmApiKey);
+    const configuredApiKey = toOptionalNonEmptyString(this.options.settings?.secrets?.llmApiKey);
+    const hasInlineApiKey =
+      typeof configuredApiKey === 'string' && !/^[A-Z0-9_]+$/.test(configuredApiKey);
+    const apiKeyStatus = configuredApiKey ? (hasInlineApiKey ? 'inline' : 'reference') : 'unset';
     const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
     const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
 
@@ -497,7 +500,7 @@ export class Agent extends EventEmitter {
       `llm.provider=${provider}`,
       `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
       `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
-      `llm.apiKey=${hasInlineApiKey ? 'set' : 'unset'}`,
+      `llm.apiKey=${apiKeyStatus}`,
     ];
     if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -5,7 +5,7 @@ import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
 import type { LLMClient, LLMToolDefinition } from '../llm';
-import { LLMFactory } from '../llm';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMFactory } from '../llm';
 import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
 import { isMessageEvent, isSystemPromptEvent, isTextContent, type SecurityRisk } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
@@ -39,12 +39,6 @@ export interface AgentOptions {
 
 const SYSTEM_PROMPT = 'You are OpenHands, an autonomous AI agent running inside VS Code.';
 const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
-
-const DEFAULT_PROVIDER_BASE_URLS: Record<string, string> = {
-  openai: 'https://api.openai.com/v1',
-  openrouter: 'https://openrouter.ai/api/v1',
-  litellm_proxy: 'http://localhost:4000',
-};
 
 // Simple utility to cap logged/tool result sizes
 const TRUNCATE_LIMIT = 2000;
@@ -491,13 +485,8 @@ export class Agent extends EventEmitter {
     const code = this.classifyConversationError(message);
     const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
     const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
-    const detectedProvider =
-      configuredBaseUrl?.includes('openrouter.ai')
-        ? 'openrouter'
-        : configuredBaseUrl?.includes('litellm')
-          ? 'litellm_proxy'
-          : 'openai';
-    const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[detectedProvider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
+    const provider = detectProviderFromBaseUrl(configuredBaseUrl);
+    const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
     const hasInlineApiKey = Boolean(this.options.settings?.secrets?.llmApiKey);
     const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
     const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
@@ -505,6 +494,7 @@ export class Agent extends EventEmitter {
     const contextParts = [
       `mode=${mode}`,
       `llm.model=${model ?? '(unset)'}`,
+      `llm.provider=${provider}`,
       `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
       `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
       `llm.apiKey=${hasInlineApiKey ? 'set' : 'unset'}`,

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -72,6 +72,8 @@ describe('Agent-SDK event rendering', () => {
     postToWindow({ type: 'event', event: ev });
     expect(await screen.findByText(/Conversation Error/)).toBeInTheDocument();
     expect(await screen.findByText(/LLMBadRequestError/)).toBeInTheDocument();
+    const details = await screen.findByText(/Details/);
+    fireEvent.click(details);
     expect(await screen.findByText(/Unsupported value/)).toBeInTheDocument();
   });
 

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -565,7 +565,14 @@ export function ConversationErrorBlock({ event, index }: { event: ConversationEr
         <div className="text-xs font-mono mb-2 opacity-70">Code: {event.code}</div>
       )}
       {event.detail && (
-        <div className="text-sm bg-black/20 rounded p-3 font-mono whitespace-pre-wrap break-words">{event.detail}</div>
+        <details className="text-xs opacity-80">
+          <summary className="cursor-pointer hover:opacity-100 font-medium">
+            Details
+          </summary>
+          <div className="mt-2 text-sm bg-black/20 rounded p-3 font-mono whitespace-pre-wrap break-words">
+            {event.detail}
+          </div>
+        </details>
       )}
     </EventContainer>
   );

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -565,7 +565,7 @@ export function ConversationErrorBlock({ event, index }: { event: ConversationEr
         <div className="text-xs font-mono mb-2 opacity-70">Code: {event.code}</div>
       )}
       {event.detail && (
-        <div className="text-sm bg-black/20 rounded p-3">{event.detail}</div>
+        <div className="text-sm bg-black/20 rounded p-3 font-mono whitespace-pre-wrap break-words">{event.detail}</div>
       )}
     </EventContainer>
   );


### PR DESCRIPTION
This follow-up improves the local-mode failure experience by surfacing more actionable context when the agent fails to start or the LLM call fails.

- Add `Run OH-Tab (normal profile)` debug launch config (no `--user-data-dir`) so VS Code SecretStorage keys from the normal profile are available.
- Enrich `ConversationErrorEvent` emitted by the local agent with `llm.model`, configured/effective `llm.baseUrl`, and whether an inline API key is set.
- Render conversation error details in monospace with pre-wrapped formatting for readability.

Tested: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a VS Code launch configuration for running the extension in a normal profile.
  * Exposed provider utilities so provider detection and default base URLs are available publicly.

* **Improvements**
  * Enhanced error reporting with richer context and machine-readable classification codes.
  * Centralized LLM provider base URLs into configurable defaults.
  * Error details UI now collapsible with monospace, preserved-whitespace rendering.

* **Tests**
  * Updated UI tests to verify collapsible error details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->