### PR TITLE
Fix stuck OpenHands terminal log

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -319,6 +319,46 @@ describe('Settings and modes', () => {
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
     expect(conv?.mode).toBe('local');
   });
+
+  it('streams BashEvents into the OpenHands terminal log in local mode', async () => {
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.openTab');
+
+    const writes: string[] = [];
+    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
+      const pty = options?.pty;
+      if (pty?.onDidWrite) {
+        pty.onDidWrite((chunk: string) => writes.push(chunk));
+      }
+      return { show: vi.fn(), dispose: vi.fn() } as any;
+    });
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+    conv?.emit('terminal', {
+      id: 'bash-1',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:00.000Z',
+      command_id: 'tc-1',
+      order: 0,
+      command: 'pwd && ls -la',
+    });
+    conv?.emit('terminal', {
+      id: 'bash-2',
+      type: 'BashOutput',
+      timestamp: '2025-01-01T00:00:01.000Z',
+      command_id: 'tc-1',
+      order: 1,
+      exit_code: 0,
+      stdout: '/test/workspace\n',
+      stderr: null,
+    });
+
+    expect(vscode.window.createTerminal).toHaveBeenCalledWith(expect.objectContaining({ name: 'OpenHands' }));
+    expect(writes.join('')).toContain('$ pwd && ls -la');
+    expect(writes.join('')).toContain('/test/workspace');
+  });
 });
 
 describe('Deactivation', () => {

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -516,8 +516,8 @@ describe('Settings and modes', () => {
     expect(writes.join('')).toContain('$ echo_large_output\r\n');
     expect(writes.join('')).toContain(largeOutput);
 
-});
   });
+});
 
 
 describe('Deactivation', () => {

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -423,12 +423,14 @@ describe('Settings and modes', () => {
     expect(writes.join('')).toContain('/test/workspace\r\n');
     expect(writes.join('')).toContain('$ command_with_error\r\n');
     expect(writes.join('')).toContain('Error: command not found\r\n');
-    expect(writes.join('')).toContain('$ echo "hello\r\nworld\n"\r\n');
+    expect(writes.join('')).toContain('$ echo "hello\r\nworld\r\n"\r\n');
     expect(writes.join('')).toContain('hello\r\nworld\r\n');
     expect(writes.join('')).toContain('$ echo_large_output\r\n');
     expect(writes.join('')).toContain(largeOutput);
 
 });
+  });
+
 
 describe('Deactivation', () => {
   it('disconnects the conversation and disposes panel/terminal', async () => {

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -310,6 +310,94 @@ describe('Settings and modes', () => {
     );
   });
 
+  it('recreates the terminal after user closes it', async () => {
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.openTab');
+
+    const writes: string[] = [];
+    let terminalInstance: any;
+    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
+      const pty = options?.pty;
+      if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
+      terminalInstance = { show: vi.fn(), dispose: vi.fn() };
+      return terminalInstance;
+    });
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    conv?.emit('terminal', {
+      id: 'bash-1',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:00.000Z',
+      command_id: 'tc-1',
+      order: 0,
+      command: 'first_command',
+    });
+    expect(vscode.window.createTerminal).toHaveBeenCalledTimes(1);
+
+    const closeHandler = (vscode.window.onDidCloseTerminal as Mock).mock.calls[0]?.[0];
+    closeHandler?.(terminalInstance);
+
+    conv?.emit('terminal', {
+      id: 'bash-2',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:01.000Z',
+      command_id: 'tc-2',
+      order: 0,
+      command: 'second_command',
+    });
+
+    expect(vscode.window.createTerminal).toHaveBeenCalledTimes(2);
+    const joined = writes.join('');
+    expect(joined).toContain('$ first_command');
+    expect(joined).toContain('$ second_command');
+  });
+
+  it('handles ANSI sequences and emoji across chunk boundary', async () => {
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.openTab');
+
+    const writes: string[] = [];
+    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
+      const pty = options?.pty;
+      if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
+      return { show: vi.fn(), dispose: vi.fn() } as any;
+    });
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    const coloredOutput = '\x1b[31m' + 'red'.repeat(5500) + '\x1b[0m' + '🚀'.repeat(100);
+
+    conv?.emit('terminal', {
+      id: 'bash-9',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:08.000Z',
+      command_id: 'tc-5',
+      order: 0,
+      command: 'echo_colored_emoji',
+    });
+    conv?.emit('terminal', {
+      id: 'bash-10',
+      type: 'BashOutput',
+      timestamp: '2025-01-01T00:00:09.000Z',
+      command_id: 'tc-5',
+      order: 1,
+      exit_code: 0,
+      stdout: coloredOutput,
+      stderr: null,
+    });
+
+    const joined = writes.join('');
+    expect(joined).toContain('$ echo_colored_emoji\r\n');
+    expect(joined).toContain(coloredOutput);
+    expect(joined).toContain('\x1b[31m');
+    expect(joined).toContain('\x1b[0m');
+  });
+
   it('creates a local-mode conversation when serverUrl is empty', async () => {
     mockSettings.serverUrl = undefined as any;
     extension = await import('../extension');

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -336,6 +336,8 @@ describe('Settings and modes', () => {
     });
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    // Test 1: Basic command and stdout
     conv?.emit('terminal', {
       id: 'bash-1',
       type: 'BashCommand',
@@ -355,10 +357,77 @@ describe('Settings and modes', () => {
       stderr: null,
     });
 
+    // Test 2: Stderr output
+    conv?.emit('terminal', {
+      id: 'bash-3',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:02.000Z',
+      command_id: 'tc-2',
+      order: 0,
+      command: 'command_with_error',
+    });
+    conv?.emit('terminal', {
+      id: 'bash-4',
+      type: 'BashOutput',
+      timestamp: '2025-01-01T00:00:03.000Z',
+      command_id: 'tc-2',
+      order: 1,
+      exit_code: 1,
+      stdout: null,
+      stderr: 'Error: command not found\n',
+    });
+
+    // Test 3: Newline normalization (mixed \n and \r\n)
+    conv?.emit('terminal', {
+      id: 'bash-5',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:04.000Z',
+      command_id: 'tc-3',
+      order: 0,
+      command: 'echo "hello\r\nworld\n"',
+    });
+    conv?.emit('terminal', {
+      id: 'bash-6',
+      type: 'BashOutput',
+      timestamp: '2025-01-01T00:00:05.000Z',
+      command_id: 'tc-3',
+      order: 1,
+      exit_code: 0,
+      stdout: 'hello\r\nworld\n', // Input with mixed newlines
+      stderr: null,
+    });
+
+    // Test 4: Output chunking (very large string)
+    const largeOutput = 'a'.repeat(20_000); // Larger than PTY_WRITE_CHUNK_SIZE (16KB)
+    conv?.emit('terminal', {
+      id: 'bash-7',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:06.000Z',
+      command_id: 'tc-4',
+      order: 0,
+      command: 'echo_large_output',
+    });
+    conv?.emit('terminal', {
+      id: 'bash-8',
+      type: 'BashOutput',
+      timestamp: '2025-01-01T00:00:07.000Z',
+      command_id: 'tc-4',
+      order: 1,
+      exit_code: 0,
+      stdout: largeOutput,
+      stderr: null,
+    });
+
     expect(vscode.window.createTerminal).toHaveBeenCalledWith(expect.objectContaining({ name: 'OpenHands' }));
-    expect(writes.join('')).toContain('$ pwd && ls -la');
-    expect(writes.join('')).toContain('/test/workspace');
-  });
+    expect(writes.join('')).toContain('$ pwd && ls -la\r\n'); // Command output includes a newline
+    expect(writes.join('')).toContain('/test/workspace\r\n');
+    expect(writes.join('')).toContain('$ command_with_error\r\n');
+    expect(writes.join('')).toContain('Error: command not found\r\n');
+    expect(writes.join('')).toContain('$ echo "hello\r\nworld\n"\r\n');
+    expect(writes.join('')).toContain('hello\r\nworld\r\n');
+    expect(writes.join('')).toContain('$ echo_large_output\r\n');
+    expect(writes.join('')).toContain(largeOutput);
+
 });
 
 describe('Deactivation', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,13 +151,12 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
         end -= 1;
       }
 
-      // Avoid cutting off an ANSI escape sequence at the end of the chunk (best-effort)
-      // If the chunk tail contains a ESC (\x1b) without a known terminator, backtrack to that ESC
+      // Avoid cutting off an ANSI CSI sequence (ESC [ ... terminator @-~) at the end of the chunk (best-effort)
       const tail = normalized.slice(start, end);
-      const escIdx = Math.max(tail.lastIndexOf('\u001b['), tail.lastIndexOf('\u001b'));
+      const escIdx = tail.lastIndexOf('\u001b[');
       if (escIdx >= 0) {
-        const afterEsc = tail.slice(escIdx);
-        const hasTerminator = /[A-~a-~]/.test(afterEsc.slice(2)); // CSI typically ends with @-~
+        const afterCsi = tail.slice(escIdx + 2); // after ESC [
+        const hasTerminator = /[@-~]/.test(afterCsi); // CSI typically ends with a byte in @-~
         if (!hasTerminator && escIdx > 0) {
           end = start + escIdx;
         }
@@ -328,8 +327,8 @@ export function activate(context: vscode.ExtensionContext) {
         if (event.stdout) terminalLogPty.write(event.stdout);
         if (event.stderr) terminalLogPty.write(event.stderr);
         // Defensive: if exit_code is provided on output but no BashExit arrives, synthesize a footer once
-        const cid = (event as any).command_id as string | undefined;
-        const code = (event as any).exit_code as number | undefined;
+        const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
+        const code = 'exit_code' in event ? (event as { exit_code?: number }).exit_code : undefined;
         if (cid && typeof code === 'number' && !printedExitFor.has(cid)) {
           terminalLogPty.ensureNewline?.();
           terminalLogPty.writeLine(`[Process exited with code ${code}]`);
@@ -338,7 +337,9 @@ export function activate(context: vscode.ExtensionContext) {
       } else if (isBashExit(event)) {
         terminalLogPty.ensureNewline?.();
         terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
-        if ((event as any).command_id) printedExitFor.add((event as any).command_id);
+        if ('command_id' in event && (event as { command_id?: string }).command_id) {
+          printedExitFor.add((event as { command_id?: string }).command_id as string);
+        }
       }
     } catch (e) {
       console.error('[Terminal] Failed to write terminal event:', e);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,6 +51,7 @@ let panel: vscode.WebviewPanel | undefined;
 let conversation: ConversationInstance | undefined;
 let conversationMode: 'local' | 'remote' = 'remote';
 let terminal: vscode.Terminal | undefined;
+let terminalLogPty: OpenHandsTerminalLogPseudoterminal | undefined;
 let renderedEventsInfo: { count: number; eventTypes: string[] } | undefined;
 let webviewReady = false; // Track if webview is ready to receive messages
 let outputChannel: vscode.OutputChannel | undefined;
@@ -77,6 +78,53 @@ function fileLog(line: string) {
   fs.appendFile(webviewLogFile, `[${ts}] ${line}\n`).catch((err: unknown) => {
     console.warn('[OpenHands] Failed to append to webview log', err);
   });
+}
+
+const normalizeTerminalNewlines = (text: string): string => text.replace(/\r?\n/g, '\r\n');
+
+class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
+  private readonly writeEmitter = new vscode.EventEmitter<string>();
+  private readonly closeEmitter = new vscode.EventEmitter<void>();
+  private closed = false;
+  private showedInputHint = false;
+
+  readonly onDidWrite = this.writeEmitter.event;
+  readonly onDidClose = this.closeEmitter.event;
+
+  open(): void {
+    this.writeLine('[OpenHands] Terminal log (read-only)');
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.closeEmitter.fire();
+    this.writeEmitter.dispose();
+    this.closeEmitter.dispose();
+  }
+
+  handleInput(_data: string): void {
+    if (this.closed || this.showedInputHint) return;
+    this.showedInputHint = true;
+    this.writeLine('');
+    this.writeLine('[OpenHands] This terminal is read-only.');
+    this.writeLine('[OpenHands] Use a normal VS Code terminal for manual commands.');
+    this.writeLine('');
+  }
+
+  write(text: string): void {
+    if (this.closed) return;
+    const normalized = normalizeTerminalNewlines(text);
+    // Avoid very large single writes which can fail or lag the terminal renderer.
+    const chunkSize = 16_000;
+    for (let i = 0; i < normalized.length; i += chunkSize) {
+      this.writeEmitter.fire(normalized.slice(i, i + chunkSize));
+    }
+  }
+
+  writeLine(line: string): void {
+    this.write(`${line}\n`);
+  }
 }
 
 const createDefaultLocalTools = () => [
@@ -191,25 +239,28 @@ export function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    if (!terminal) {
+    if (!terminal || !terminalLogPty) {
       try {
-        terminal = vscode.window.createTerminal({ name: 'OpenHands' });
+        terminalLogPty = new OpenHandsTerminalLogPseudoterminal();
+        terminal = vscode.window.createTerminal({ name: 'OpenHands', pty: terminalLogPty });
         terminal.show(true);
       } catch (e) {
-        console.error('[Terminal] Failed to create terminal:', e);
+        console.error('[Terminal] Failed to create terminal log:', e);
+        terminal = undefined;
+        terminalLogPty = undefined;
         return;
       }
     }
 
     try {
       if (isBashCommand(event)) {
-        terminal.sendText(`$ ${event.command}`, false);
-        terminal.sendText('');
+        terminalLogPty.writeLine('');
+        terminalLogPty.writeLine(`$ ${event.command}`);
       } else if (isBashOutput(event)) {
-        if (event.stdout) terminal.sendText(event.stdout, false);
-        if (event.stderr) terminal.sendText(event.stderr, false);
+        if (event.stdout) terminalLogPty.write(event.stdout);
+        if (event.stderr) terminalLogPty.write(event.stderr);
       } else if (isBashExit(event)) {
-        terminal.sendText(`[Process exited with code ${event.exit_code}]`);
+        terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
       }
     } catch (e) {
       console.error('[Terminal] Failed to write terminal event:', e);
@@ -505,6 +556,7 @@ export function deactivate() {
   panel = undefined;
   conversation = undefined;
   terminal = undefined;
+  terminalLogPty = undefined;
   renderedEventsInfo = undefined;
   webviewReady = false;
   receivedTerminalEvents.length = 0;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,8 @@ const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Tr
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 // Buffer of test events sent via _sendTestEvent (used as fallback in E2E query)
 const sentTestEvents: Event[] = [];
+// Track which command_ids have already printed an exit summary to avoid duplicates
+const printedExitFor = new Set<string>();
 
 // Dev logging/instrumentation toggle and file sink
 let devBridgeEnabled = false;
@@ -83,10 +85,13 @@ function fileLog(line: string) {
 const normalizeTerminalNewlines = (text: string): string => text.replace(/\r?\n/g, '\r\n');
 
 class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
+  private static readonly PTY_WRITE_CHUNK_SIZE = 16_000;
+
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   private readonly closeEmitter = new vscode.EventEmitter<void>();
   private closed = false;
   private showedInputHint = false;
+  private lastEndedWithNewline = true;
 
   readonly onDidWrite = this.writeEmitter.event;
   readonly onDidClose = this.closeEmitter.event;
@@ -103,6 +108,12 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
     this.closeEmitter.dispose();
   }
 
+  isClosed(): boolean { return this.closed; }
+
+  ensureNewline(): void {
+    if (!this.lastEndedWithNewline) this.write('\n');
+  }
+
   handleInput(_data: string): void {
     if (this.closed || this.showedInputHint) return;
     this.showedInputHint = true;
@@ -112,13 +123,48 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
     this.writeLine('');
   }
 
+  private emitChunk(chunk: string): void {
+    if (!chunk) return;
+    this.writeEmitter.fire(chunk);
+    this.lastEndedWithNewline = /\n$/.test(chunk);
+  }
+
   write(text: string): void {
     if (this.closed) return;
     const normalized = normalizeTerminalNewlines(text);
-    // Avoid very large single writes which can fail or lag the terminal renderer.
-    const chunkSize = 16_000;
-    for (let i = 0; i < normalized.length; i += chunkSize) {
-      this.writeEmitter.fire(normalized.slice(i, i + chunkSize));
+
+    const max = OpenHandsTerminalLogPseudoterminal.PTY_WRITE_CHUNK_SIZE;
+    let start = 0;
+    while (start < normalized.length) {
+      let end = Math.min(start + max, normalized.length);
+
+      // Prefer to split on newline boundaries if possible
+      const slice = normalized.slice(start, end);
+      const lastNl = slice.lastIndexOf('\n');
+      if (lastNl > 0 && start + lastNl + 1 < normalized.length) {
+        end = start + lastNl + 1;
+      }
+
+      // Avoid splitting surrogate pairs
+      const prevChar = normalized.charCodeAt(end - 1);
+      if (prevChar >= 0xd800 && prevChar <= 0xdbff && end < normalized.length) {
+        end -= 1;
+      }
+
+      // Avoid cutting off an ANSI escape sequence at the end of the chunk (best-effort)
+      // If the chunk tail contains a ESC (\x1b) without a known terminator, backtrack to that ESC
+      const tail = normalized.slice(start, end);
+      const escIdx = Math.max(tail.lastIndexOf('\u001b['), tail.lastIndexOf('\u001b'));
+      if (escIdx >= 0) {
+        const afterEsc = tail.slice(escIdx);
+        const hasTerminator = /[A-~a-~]/.test(afterEsc.slice(2)); // CSI typically ends with @-~
+        if (!hasTerminator && escIdx > 0) {
+          end = start + escIdx;
+        }
+      }
+
+      this.emitChunk(normalized.slice(start, end));
+      start = end;
     }
   }
 
@@ -138,13 +184,32 @@ function renderError(err: unknown): string {
   return err instanceof Error ? `${err.name}: ${err.message}` : String(err);
 }
 
+function shouldRedactKey(key: string): boolean {
+  const k = key.toLowerCase();
+  return (
+    k.includes('api_key') ||
+    k === 'apikey' ||
+    k === 'authorization' ||
+    k === 'auth' ||
+    k.endsWith('token') ||
+    k.includes('secret') ||
+    k === 'llmapikey' ||
+    k === 'sessionapikey'
+  );
+}
+
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 function safeStringify(value: unknown): string {
   try {
-    const rendered = JSON.stringify(value, (_key, val) => (typeof val === 'bigint' ? val.toString() : val));
-    if (typeof rendered === 'string') {
-      return rendered;
-    }
+    const rendered = JSON.stringify(
+      value,
+      (key, val) => {
+        if (typeof val === 'bigint') return val.toString();
+        if (typeof key === 'string' && shouldRedactKey(key)) return '[REDACTED]';
+        return val;
+      }
+    );
+    if (typeof rendered === 'string') return rendered;
     return '<unserializable: undefined>';
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
@@ -239,7 +304,8 @@ export function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    if (!terminal || !terminalLogPty) {
+    // Recreate terminal if not present or if the PTY has been closed
+    if (!terminal || !terminalLogPty || terminalLogPty.isClosed?.()) {
       try {
         terminalLogPty = new OpenHandsTerminalLogPseudoterminal();
         terminal = vscode.window.createTerminal({ name: 'OpenHands', pty: terminalLogPty });
@@ -254,13 +320,25 @@ export function activate(context: vscode.ExtensionContext) {
 
     try {
       if (isBashCommand(event)) {
-        terminalLogPty.writeLine('');
+        // Add a spacer only if previous output didn't end with a newline
+        terminalLogPty.ensureNewline?.();
         terminalLogPty.writeLine(`$ ${event.command}`);
+        if (event.command_id) printedExitFor.delete(event.command_id);
       } else if (isBashOutput(event)) {
         if (event.stdout) terminalLogPty.write(event.stdout);
         if (event.stderr) terminalLogPty.write(event.stderr);
+        // Defensive: if exit_code is provided on output but no BashExit arrives, synthesize a footer once
+        const cid = (event as any).command_id as string | undefined;
+        const code = (event as any).exit_code as number | undefined;
+        if (cid && typeof code === 'number' && !printedExitFor.has(cid)) {
+          terminalLogPty.ensureNewline?.();
+          terminalLogPty.writeLine(`[Process exited with code ${code}]`);
+          printedExitFor.add(cid);
+        }
       } else if (isBashExit(event)) {
+        terminalLogPty.ensureNewline?.();
         terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
+        if ((event as any).command_id) printedExitFor.add((event as any).command_id);
       }
     } catch (e) {
       console.error('[Terminal] Failed to write terminal event:', e);
@@ -513,6 +591,16 @@ export function activate(context: vscode.ExtensionContext) {
     conversation?.reconnect();
   });
 
+  // Clear terminal references when the user closes the OpenHands terminal
+  context.subscriptions.push(
+    vscode.window.onDidCloseTerminal((t) => {
+      if (t === terminal) {
+        terminal = undefined;
+        terminalLogPty = undefined;
+      }
+    })
+  );
+
   const pause = vscode.commands.registerCommand('openhands.pauseCurrentRun', async () => {
     await ensurePanelAndConnection();
     await conversation?.pause();
@@ -528,6 +616,15 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration(async (e) => {
       if (e.affectsConfiguration('openhands.serverUrl')) {
         try { conversation?.removeAllListeners(); conversation?.disconnect(); } catch { }
+        // If switching away from local mode, dispose any lingering log terminal
+        const cfg = vscode.workspace.getConfiguration();
+        const nextUrl = cfg.get<string>('openhands.serverUrl');
+        const nextMode: 'local' | 'remote' = nextUrl ? 'remote' : 'local';
+        if (conversationMode === 'local' && nextMode === 'remote') {
+          try { terminal?.dispose(); } catch { }
+          terminal = undefined;
+          terminalLogPty = undefined;
+        }
         conversation = undefined;
         await ensurePanelAndConnection();
       }

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -52,6 +52,7 @@ export const window = {
   showInputBox: vi.fn(),
   showQuickPick: vi.fn(),
   createTerminal: vi.fn(),
+  onDidCloseTerminal: vi.fn(() => ({ dispose: vi.fn() })),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
   createTreeView: vi.fn(() => ({
     onDidChangeVisibility: vi.fn(() => ({ dispose: vi.fn() })),


### PR DESCRIPTION
Fixes the integrated `OpenHands` terminal view getting stuck / not updating after the first command.

- Replace `Terminal.sendText()` output replay (which can corrupt the shell/session) with a dedicated `vscode.Pseudoterminal` log.
- Normalize newlines + chunk large writes to avoid renderer issues.
- Add a unit test that emits `BashCommand`/`BashOutput` and asserts the PTY receives the output.

Tested: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for local terminal behavior: recreation after close, ANSI/emoji across chunk boundaries, streaming multiple Bash events, command/error handling, newline normalization, large-output chunking, and terminal-close mocking.

* **Improvements**
  * Route terminal I/O through a read-only terminal layer for more reliable logging and lifecycle handling.
  * Improve output chunking and newline normalization, per-command exit summaries, synthesized process-exit footers, sensitive-value redaction, and cleanup on close/config changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->