### PR TITLE
docs: WebviewView migration plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ npm run build
 
 1. Open the project in VS Code
 2. Press F5 to launch Extension Development Host
-3. Run "OpenHands: Open Tab" command
+3. Run "OpenHands: Open Tab" command (opens the chat webview in the editor)
+   - Sidebar `WebviewView` migration plan: `docs/WEBVIEWVIEW_MIGRATION_PLAN.md`
 
 ### Configuration
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,24 +1,22 @@
-# OpenHands-Tab — @openhands/ui Integration and Typed Models Plan (with Unit Tests)
+# OpenHands-Tab — Webview Implementation Plan (React UI + typed agent-sdk events)
 
-This plan executes selective integration of @openhands/ui and completes the TypeScript model alignment with agent-sdk. We include unit tests at every step and run them as we go.
+This document tracks the implementation of the React webview UI and the extension host ↔ webview message bridge. Phases 1–6 reflect the initial build-out (now completed). New phases at the end track ongoing webview work (notably the `WebviewPanel` → `WebviewView` migration and remaining UX gaps).
 
 Guiding principles:
 - Source of truth: agent-sdk models and wire formats.
 - No Zod; use lightweight type guards.
 - Use React in the VS Code webview.
 - Don’t optimize for bundle size during implementation.
-- Commit each task to the develop branch when unit tests pass.
+- Keep changes small and land them when unit tests pass.
 
-## Phase 0 — Baseline and Branching
-1) Ensure we’re on the develop branch and working from a clean tree
-- Commands:
-  - git fetch --all
-  - git checkout develop
-  - git pull --rebase
-- If a feature branch exists, we may cherry-pick as needed later.
+Related docs:
+- `docs/PRD.md` (requirements + feature status)
+- `docs/WEBVIEWVIEW_MIGRATION_PLAN.md` (sidebar `WebviewView` migration plan)
+- `docs/vscode_local_setup.md` (local dev + webview debugging tips)
 
-2) Read this implementation plan and reference it from PRD
-- File: IMPLEMENTATION_PLAN.md (this file)
+## Phase 0 — Baseline
+- Install deps: `npm ci`
+- Validate: `npm test`, `npm run typecheck`, `npm run build:webview`
 
 ## Phase 1 — Test Infrastructure (Vitest + React Testing Library)
 Goal: Add a fast unit test setup usable for pure TS and React components.
@@ -28,26 +26,19 @@ Status: COMPLETED
 Changes done:
 - Added devDependencies: vitest, @vitest/coverage-v8, @testing-library/react, @testing-library/user-event, @testing-library/jest-dom/vitest, jsdom, esbuild
 - Added scripts to package.json:
-  - "test": "vitest run"
-  - "test:watch": "vitest"
-  - "typecheck": "tsc -p . && tsc -p tsconfig.webview.json"
+  - `test`: `npm test -w @openhands/agent-sdk-ts && vitest run --dir src`
+  - `test:watch`: `vitest`
+  - `typecheck`: `tsc -p . && tsc -p tsconfig.webview.json`
 - Created vitest.config.ts (jsdom environment)
 - Created test/setup.ts importing @testing-library/jest-dom/vitest
 
 Initial tests implemented:
-- src/types/__tests__/agent-sdk.guards.test.ts
-  - Validates isEvent, isMessageEvent, isTextContent for minimal valid/invalid samples.
+- `packages/agent-sdk-ts/src/sdk/__tests__/agent-sdk.guards.test.ts`
+  - Validates core guard behavior (e.g., `isEvent`, `isMessageEvent`) with minimal valid/invalid samples.
 
 Run:
 - npm run test (passing)
 - npm run typecheck (passing)
-
-Commit message used:
-"test: add vitest + initial guard tests
-
-- Configure vitest with jsdom and setup file
-- Add initial type guard tests for agent-sdk
-- Add test/typecheck scripts and dev deps"
 
 ## Phase 2 — Webview React Bootstrap + @openhands/ui
 Goal: Convert the webview to React and adopt base UI components.
@@ -56,23 +47,16 @@ Status: COMPLETED
 
 Changes done:
 - Installed runtime deps: react@^19, react-dom@^19
-- Installed @openhands/ui and imported its styles in the webview App
-- Added esbuild with build:webview script; bundling src/webview-src/webview.tsx to media/webview.js
+- Installed @openhands/ui and imported its styles via `src/webview-src/index.css`
+- Added esbuild with `build:webview`; bundles `src/webview-src/webview.tsx` → `media/webview.js` and CSS → `media/index.css`
 - Updated extension HTML to mount React app at #app
-- Implemented React <App /> (header, messages, footer with Send/Stop)
-- Added basic App render test with RTL; configured vitest to ignore built media/** tests
+- Implemented React `<App />` shell (header, event list, input area)
+- Added basic App render test with RTL; vitest excludes built `media/**`
 
 Run:
 - npm run build:webview (succeeds)
 - npm run test (passing)
 - npm run typecheck (passing)
-
-Commit messages used:
-"feat(webview): bootstrap React shell and esbuild bundle"
-"build(webview): generate media/webview.js via esbuild"
-"feat(ui): add @openhands/ui and React type packages"
-"feat(webview): adopt @openhands/ui styles and factor App component"
-"test(config): exclude built media/ from vitest; fix webview tsconfig for JSX/tests"
 
 ## Phase 3 — Typed Event Rendering
 Goal: Bridge VS Code messages into React state using agent-sdk types/guards and render events.
@@ -80,54 +64,30 @@ Goal: Bridge VS Code messages into React state using agent-sdk types/guards and 
 Status: COMPLETED
 
 Changes done:
-- App uses agent-sdk guards to validate events from VS Code messages
-- Message events render text content with role mapping
-- System/error events rendered to system stream; other events noted as tool
-- Added tests: src/webview-src/__tests__/event.rendering.test.tsx
+- Webview validates incoming `{ type: 'event' }` payloads with agent-sdk type guards
+- Event rendering is componentized by event kind (message/action/observation/system prompt/errors/etc.)
+- Streaming UX uses the `ConversationStateUpdateEvent` deltas (via `reduceLlmStreamingState`) without rendering those events as standalone blocks
+- Added tests:
+  - `src/webview-src/__tests__/event.handlers.test.tsx`
+  - `src/webview-src/__tests__/event.rendering.test.tsx`
 
 Run:
 - npm run test (passing)
 - npm run typecheck (passing)
 - npm run build:webview (succeeds)
 
-Changes:
-- In webview.tsx, add window message bridge useEffect
-- Use the `@openhands/agent-sdk-ts` workspace package guards (isEvent, isMessageEvent, etc.) to parse events
-- MessageEvent: push user/assistant messages into messages state
-- Action/Observation/System/Error events: push a tool-style message with a compact header and body
-
-Tests:
-- src/webview-src/__tests__/EventBridge.test.tsx
-  - Simulate postMessage events (MessageEvent and ActionEvent) and assert rendered output updates
-
-Run:
-- npm run test
-- npm run typecheck
-
-Commit message:
-"feat(webview): typed event bridge and rendering
-
-- Use @openhands/agent-sdk-ts guards to validate events
-- Render message and tool events in React
-- Add unit tests for event handling"
-
-## Phase 4 — Commands and Toasts
-Goal: Wire webview commands (send, stop, reconnect, new chat, settings) and show toasts on status + system/error.
+## Phase 4 — Commands and Status UI
+Goal: Wire webview commands (send, pause/resume, reconnect, new chat, settings, history, skills, context) and show transient status/error UI.
 
 Status: COMPLETED
 
-So far:
-- Added ToastManager and toasterMessages usage
-- Toasts on status transitions and config updates
-- Toasts on system and error events
-- Switched header buttons to @openhands/ui Button and Typography
-- Added non-asserting toast runtime test
-
-Next:
-- Add Reconnect and New Chat buttons in UI, postMessage commands
-- Optional: show success toast on command initiation
-- Quick tests to ensure no runtime errors
-
+Changes done:
+- Webview → extension messages cover:
+  - chat: `send`
+  - control: `command` (`startNewConversation`, `reconnect`, `approveAction`, `rejectAction`; `pause`/`resume` supported for future UI)
+  - UX helpers: workspace file list (context picker), skills list/open, history list/restore, server selection
+- Header actions include New, History, Settings, and Reconnect
+- Status/error UX uses an in-webview `StatusBanner` (auto-dismiss for non-errors)
 
 ## Phase 5 — Compile and Manual Verification
 Goal: Build all artifacts, run type-checks, and do a manual smoke test in VS Code.
@@ -141,10 +101,10 @@ Automated:
 
 Manual verification completed:
 - Extension loads in VS Code (F5) and webview opens
-- Status toasts display when connecting and when online
+- Status UI updates on connect/disconnect (header indicator + transient status banner)
 - Messages send and appear correctly in the UI
-- Stop, Reconnect, New Chat commands work
-- System and error events show toasts and render properly
+- New conversation + reconnect flows work
+- Errors surface via the status banner and render appropriately in the event stream
 
 Implementation notes:
 - media/webview.js and index.css generated via build process
@@ -164,18 +124,35 @@ Implementation:
 - Added scripts/dev-vscode.sh: builds webview, compiles, packages .vsix, installs to code-server, runs at 0.0.0.0:12000
 - Added npm script dev:vscode to invoke the script
 - Manual test steps verified:
-  1) Extension tab opens; Connecting and Connected toasts display
+  1) OpenHands UI opens; Connecting/Connected status is visible in the UI
   2) Send message; user message appears and extension receives it
-  3) Stop, Reconnect, New Chat buttons work; toasts appear and extension receives commands
-  4) System/error events display toasts and render correctly
+  3) New, Reconnect, History, Settings work; status banner updates and extension receives commands
+  4) System/error conditions surface via status banner and render correctly
 
 Completed features:
 - Full event visualization including MessageEvent, ActionEvent, ObservationEvent, SystemPromptEvent, AgentErrorEvent, PauseEvent, Condensation
-- Toast notifications for status changes and errors
+- In-webview status banner for status changes and errors
 - React-based UI with @openhands/ui components
 - Tailwind CSS 4.x styling
 - Type-safe event handling with agent-sdk type guards
 
+## Phase 7 — WebviewPanel → WebviewView (Sidebar) Migration
+Goal: Make the chat UI live in the sidebar as a `WebviewView` (sidebar-only) and remove the editor `WebviewPanel`.
+
+Status: PLANNED (see dedicated plan)
+
+Plan: `docs/WEBVIEWVIEW_MIGRATION_PLAN.md`
+
+## Phase 8 — Remaining Webview UX Gaps (from PRD)
+Goal: Close the remaining “Not Yet Implemented” items and polish the webview UX without regressing local/remote parity.
+
+Status: TODO
+
+Backlog (webview-facing):
+- Attach files UX (the “+” affordance currently isn’t backed by a concrete flow)
+- MCP server selection UI (if/when MCP integration lands)
+- History UX improvements (search/pagination/empty states, depending on backend shape)
+- Mid-conversation LLM switching UX (may require conversation boundary semantics)
 
 ## Notes
 - Fonts/CSP: Keep CSP strict; rely on fallback fonts. Optionally localize fonts later.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,11 +1,11 @@
 # OpenHands-Tab VS Code Extension
 
 ## 1. Goal
-A VS Code extension that provides a tab to interact with OpenHands agents, supporting both local execution (in VS Code) and remote execution (via agent-server). The extension streams events in real time, supports action confirmation, and reflects file changes in the workspace.
+A VS Code extension that provides a sidebar chat view to interact with OpenHands agents, supporting both local execution (in VS Code) and remote execution (via agent-server). The extension streams events in real time, supports action confirmation, and reflects file changes in the workspace.
 
 ## 2. Scope
 - In scope
-  - VS Code extension with a dedicated tab (Webview) for chat and agent interaction
+  - VS Code extension with a dedicated sidebar view (`WebviewView`) for chat and agent interaction
   - Local mode: run agent directly in VS Code using the SDK
   - Remote mode: connect to OpenHands agent-server via WebSocket/HTTP
   - Real-time streaming of agent events (messages, tool runs, logs)
@@ -23,6 +23,8 @@ A VS Code extension that provides a tab to interact with OpenHands agents, suppo
 
 ## 4. Current Implementation Status
 
+Note: the current implementation opens chat in an editor `WebviewPanel` (“OpenHands: Open Tab”). Migration to a sidebar `WebviewView` is planned in `docs/WEBVIEWVIEW_MIGRATION_PLAN.md`.
+
 ### Implemented Features ✓
 - Activity bar icon with quick actions
 - Chat webview with streaming events and message rendering
@@ -33,11 +35,11 @@ A VS Code extension that provides a tab to interact with OpenHands agents, suppo
 - Action confirmation with Approve/Reject UI
 - Security risk indicators (LOW/MEDIUM/HIGH)
 - Conversation persistence to disk
-- Conversation history view with search
+- Conversation history view
 - Workspace file context (@mentions)
 - Skills support (~/.openhands/skills/)
 - Terminal integration (local mode)
-- Toast notifications for status and errors
+- Status banner for status and errors
 - Event rendering for all event types
 
 ### Not Yet Implemented
@@ -99,7 +101,7 @@ A VS Code extension that provides a tab to interact with OpenHands agents, suppo
 ## 7. Functional Requirements
 
 ### Commands
-- **OpenHands: Open Tab** - opens the webview
+- **OpenHands: Open** - opens the chat UI (currently exposed as “OpenHands: Open Tab” until the sidebar migration lands)
 - **OpenHands: Start New Conversation** - starts fresh conversation
 - **OpenHands: Configure** - multi-step configuration wizard
 - **OpenHands: Set API Key** - quick API key setup
@@ -141,10 +143,10 @@ A VS Code extension that provides a tab to interact with OpenHands agents, suppo
 ## 9. UX Overview
 
 ### Activity Bar
-- OpenHands icon opens chat tab
-- Quick actions: Open Tab, Settings
+- OpenHands icon opens the OpenHands view container (chat lives in the sidebar)
+- Quick actions: Open, Settings
 
-### Chat Tab Layout
+### Chat View Layout
 - **Header**: connection status, settings button, history button
 - **Main**: message list with streaming events
 - **Bottom**: input area with context picker (@), skills button

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -26,7 +26,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 Note: the current implementation opens chat in an editor `WebviewPanel` (“OpenHands: Open Tab”). Migration to a sidebar `WebviewView` is planned in `docs/WEBVIEWVIEW_MIGRATION_PLAN.md`.
 
 ### Implemented Features ✓
-- Activity bar icon with quick actions
+- Activity bar icon and sidebar container
 - Chat webview with streaming events and message rendering
 - Local mode: full agent execution via SDK (Conversation API)
 - Remote mode: WebSocket connection to agent-server with auto-reconnect
@@ -144,7 +144,7 @@ Note: the current implementation opens chat in an editor `WebviewPanel` (“Open
 
 ### Activity Bar
 - OpenHands icon opens the OpenHands view container (chat lives in the sidebar)
-- Quick actions: Open, Settings
+- No separate “quick actions” view; actions are available in the chat header and via the command palette
 
 ### Chat View Layout
 - **Header**: connection status, settings button, history button
@@ -206,7 +206,7 @@ src/
 - Terminal integration for command output
 
 ### Activity Bar ✓ Complete
-- Custom icon and quick actions
+- Custom icon and sidebar container
 
 ### Chat Toolbar ✓ Complete
 - New Conversation, Settings, Connection status

--- a/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
+++ b/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
@@ -1,8 +1,17 @@
 # OpenHands Tab — WebviewPanel → WebviewView (Sidebar) Migration Plan
 
-Goal: migrate the chat UI from an editor `WebviewPanel` to a sidebar `WebviewView` (while keeping the option to open in the editor if we want), without regressing local/remote mode, history restore, terminal streaming, or tests.
+Goal: migrate the chat UI from an editor `WebviewPanel` to a sidebar `WebviewView` (sidebar-only), without regressing local/remote mode, history restore, terminal streaming, or tests.
+
+Decision (locked in):
+- The chat UI will live only in the sidebar as a `WebviewView`.
+- The editor `WebviewPanel` implementation will be removed (no user-facing “open in editor” option).
 
 This plan is written for parallel execution by multiple agents (implementation + review + testing).
+
+Related docs:
+- `docs/IMPLEMENTATION_PLAN.md` (webview build-out status + next milestones)
+- `docs/PRD.md` (requirements + feature status)
+- `docs/vscode_local_setup.md` (local dev + webview debugging tips)
 
 ---
 
@@ -22,30 +31,27 @@ The chat runtime (Conversation + event wiring) is currently tightly coupled to `
 - `ensurePanelAndConnection()` creates the panel, creates/refreshes the Conversation, and forwards Conversation events/status/errors to `panel.webview.postMessage(...)`.
 - `onWebviewMessage(context, panel)` assumes a `WebviewPanel` and posts all replies back through `panel.webview.postMessage(...)`.
 
+Today the webview also sends a `webviewReady` handshake (currently from both `src/webview-src/webview.tsx` instrumentation and `src/webview-src/components/App.tsx`). The extension host responds by re-sending `status` and `serverListUpdated`. This is sufficient for a panel, but not enough for a `WebviewView` that can be hidden/disposed while the agent continues running.
+
 ---
 
 ## 1) Desired End-State (UX)
 
-We need to decide what “clicking the OpenHands icon” should do, and where the chat UI should live.
+What “clicking the OpenHands icon” should do is now straightforward: it should reveal the OpenHands view container and the chat `WebviewView`.
 
-Recommended UX (min confusion / no double-open):
-- **Default:** chat UI opens in the **sidebar** as a `WebviewView`.
-- **Optional:** a command allows opening the same UI in the **editor** as a `WebviewPanel` (useful for larger screen / multi-monitor).
-- The sidebar tree view (“quick actions”) can remain (or be removed later), but it should not automatically open a second UI surface.
+End-state UX (no double-open, no editor tab):
+- Chat UI is a single sidebar `WebviewView` (e.g. `openhands.chat`).
+- The sidebar tree view (“quick actions”) can remain (or be removed later), but it must not auto-open any editor UI surface.
 
-### Note: Webview placement constraints (Active vs Beside)
+### Notes: `WebviewView` constraints
 
-- A `WebviewPanel` always lives in the **editor area** (editor groups/columns). `ViewColumn.Active` opens in the currently active editor group; `ViewColumn.Beside` opens in a new group to the side (roughly “split editor and put it next to what you’re doing”).
-- A `WebviewView` always lives in a **contributed view container** (sidebar/panel). There is no `ViewColumn` equivalent; you can show/hide the view, but it will not become an editor tab.
+- A `WebviewView` lives in a contributed view container (sidebar). There is no `ViewColumn` equivalent.
+- The extension should provide one “open” command whose job is to focus/reveal the view (and nothing else).
 
-We can support this with:
-- A setting: `openhands.ui.location = "sidebar" | "editor"` (default `"sidebar"`).
-- Commands:
-  - `OpenHands: Open` (respects setting)
-  - `OpenHands: Open in Sidebar`
-  - `OpenHands: Open in Editor`
+Recommended command surface:
+- `OpenHands: Open` (focuses the sidebar chat view; keep `openhands.openTab` as a legacy command id if desired, but it should no longer open an editor tab)
 
-Decision needed before Phase 3:
+Decision needed (still open, but orthogonal to “sidebar-only chat”):
 - Keep `openhands.quickActions` tree view long-term, or replace it with the webview view?
 
 ---
@@ -54,7 +60,7 @@ Decision needed before Phase 3:
 
 ### “Behavior parity” definition
 
-For this migration, “parity” means: regardless of whether the UI is hosted as a sidebar `WebviewView` or editor `WebviewPanel`, users can still:
+For this migration, “parity” means: after moving the UI into the sidebar `WebviewView`, users can still:
 - send messages and see streaming responses
 - see tool execution events (terminal, file edits, etc.)
 - see and act on pending actions (approvals/rejections)
@@ -62,8 +68,7 @@ For this migration, “parity” means: regardless of whether the UI is hosted a
 - see connection/status/config updates and errors
 
 Non-parity differences we accept (by design):
-- **where** the UI appears (sidebar vs editor)
-- whether we allow both surfaces simultaneously (decision in Open Questions)
+- No editor-hosted chat UI (the chat lives in the sidebar only)
 
 ### Why `WebviewView` is not a drop-in replacement
 
@@ -82,7 +87,7 @@ So we need a robust “rehydration” path:
 
 To avoid duplicating events when the webview is retained (or missing events when it wasn’t), use a simple sequence protocol:
 - In the extension host, assign a monotonic `seq` to each forwarded Conversation event and store the last N in a ring buffer (include the current `conversationId`).
-- Have the webview send `webviewReady` with optional fields:
+- Extend the existing `webviewReady` handshake to optionally include:
   - `conversationId?: string`
   - `lastSeenSeq?: number`
   (Persist these in the webview via `acquireVsCodeApi().setState(...)`.)
@@ -90,6 +95,12 @@ To avoid duplicating events when the webview is retained (or missing events when
   - always send `status` + `serverListUpdated`
   - if `conversationId` mismatches or `lastSeenSeq` is missing/out of range: send `conversationStarted` + the full buffer
   - else: send only buffered events with `seq > lastSeenSeq`
+
+Implementation notes:
+- Treat `webviewReady` as idempotent (it may fire more than once per render lifecycle today).
+- Decide which `ConversationStateUpdateEvent`s to buffer:
+  - buffer `agent_status` updates (needed to rehydrate confirmation/pause UI)
+  - consider dropping `llm_stream` / `llm_tool_call` deltas from the backlog (noisy); users will still see the final `MessageEvent`/tool events when the view is shown again
 
 This is the main “state restore nuance” required to achieve parity with `WebviewPanel` behavior.
 
@@ -121,21 +132,17 @@ Suggested PR boundary:
 
 ---
 
-### Phase 2 — Decouple UI wiring from WebviewPanel (introduce a WebviewHost)
-**Goal:** Make the Conversation <-> UI message bridge work with either a panel or a view.
+### Phase 2 — Refactor the message bridge for `WebviewView` lifecycle
+**Goal:** Make the Conversation <-> UI message bridge robust for a sidebar `WebviewView` (hidden/disposed/re-resolved) and remove hard coupling to `panel.webview`.
 
 Key refactor:
-- Introduce a minimal `WebviewHost` abstraction:
-  - `webview: vscode.Webview`
-  - `show(preserveFocus?: boolean): void` (panel.reveal() vs view.show())
-  - optional: `onDidDispose` handler
-  - optional: `visible` (view has it; panel has `visible`)
+- Replace `panel`-centric wiring with a `WebviewView`-centric host:
+  - store the latest `vscode.WebviewView` reference (or just its `webview`)
+  - centralize `postMessage(...)` behind a single helper that no-ops when the view is absent
 
 Refactor steps:
-- Replace global `panel` with `uiHost?: WebviewHost`.
-- Rename `ensurePanelAndConnection()` → `ensureUiHostAndConnection(target: 'panel' | 'view' | 'auto')`.
-- Replace direct `panel.webview.postMessage(...)` with `postToWebview(...)` helper.
-- Refactor `onWebviewMessage(context, panel)` to accept `(context, host)` or `(context, webview, postFn)`.
+- Introduce `ensureChatViewAndConnection()` (or similar) that ensures the Conversation exists and the sidebar view is ready to receive messages.
+- Update `onWebviewMessage(...)` to take `webview: vscode.Webview` (not a `WebviewPanel`) and reuse it for both panel-less message handling and tests.
 
 Event delivery resilience (required for WebviewView):
 - Add an **event backlog buffer** in the extension host (ring buffer, e.g. last 500–2000 events) with a monotonic `seq` id.
@@ -146,38 +153,32 @@ Event delivery resilience (required for WebviewView):
   - “catch-up” events using the `lastSeenSeq` protocol above
 
 Acceptance criteria:
-- Both the existing editor panel and the new sidebar view can:
-  - send messages
-  - receive event stream
-  - render status/config
+- The sidebar chat view can send messages, receive the event stream, and rehydrate after being hidden/disposed.
 
 Suggested PR boundary:
-- “Refactor message bridge to support WebviewView”.
+- “Refactor message bridge for WebviewView”.
 
 ---
 
-### Phase 3 — Remove “double open” and add the user-facing choice
-**Goal:** Clicking the OpenHands icon no longer opens two surfaces; user controls where chat opens.
+### Phase 3 — Remove editor `WebviewPanel` and stop “double open”
+**Goal:** There is exactly one chat UI surface: the sidebar `WebviewView`.
 
 Tasks:
-- Add setting `openhands.ui.location` with enum:
-  - `"sidebar"` (default)
-  - `"editor"`
-- Commands:
-  - Update `openhands.openTab` to behave like `OpenHands: Open` (respects setting)
-  - Add explicit commands:
-    - `openhands.openInSidebar`
-    - `openhands.openInEditor`
+- Commands / contributions:
+  - Update the user-facing command title to remove “Tab” wording (e.g. `OpenHands: Open`).
+  - Keep the existing `openhands.openTab` command id as an alias if we want backward compatibility, but it should focus the sidebar view.
+- Remove editor tab creation:
+  - Delete `vscode.window.createWebviewPanel(...)` usage and `panel` module state.
+  - Remove any editor-tab-only code paths (including tests that assume a panel exists).
 - Change the current auto-open behavior:
-  - Remove `treeView.onDidChangeVisibility -> openTab`, OR gate it behind a setting (default off).
-  - If the tree view remains, it should be “quick actions only”, not a trigger for opening a second UI.
+  - Remove `treeView.onDidChangeVisibility -> openTab`.
+  - If the tree view remains, it should be “quick actions only”, not a trigger for opening any additional UI surface.
 
 Acceptance criteria:
-- Clicking the activity bar icon opens the container; **only one** chat surface appears by default.
-- The other surface is accessible via explicit command.
+- Clicking the activity bar icon opens the container; the chat UI is in the sidebar view and no editor tab is created.
 
 Suggested PR boundary:
-- “Sidebar chat is default; stop auto-opening editor tab”.
+- “Sidebar chat only; remove editor panel”.
 
 ---
 
@@ -210,7 +211,7 @@ Manual QA checklist (Extension Development Host):
 
 If we want to parallelize safely:
 - **Workstream A (Extension API + contributions):** `package.json` views/activation/settings/commands.
-- **Workstream B (Bridge refactor):** `WebviewHost` abstraction + refactor `ensurePanelAndConnection` + `onWebviewMessage`.
+- **Workstream B (Bridge refactor):** refactor `ensurePanelAndConnection` + `onWebviewMessage` toward a view-only bridge.
 - **Workstream C (Backlog + lifecycle):** webviewReady rehydration + hidden/visible message strategy.
 - **Workstream D (Tests + QA):** unit test updates + manual verification notes.
 
@@ -222,9 +223,7 @@ Try to keep PRs small and sequential:
 
 ---
 
-## 5) Open Questions (capture before coding Phase 3)
+## 5) Open Questions
 
 1) Do we keep the sidebar tree view long-term, or replace it entirely with the webview view?
-2) Do we support “both” simultaneously (sidebar + editor), or is it always one-at-a-time?
-3) What is the default: sidebar or editor?
-4) Should the editor tab be opened “Beside” or in the active group when using the editor mode?
+2) When a user runs `OpenHands: Open`, should it also auto-focus the chat view (vs. just reveal the container)?

--- a/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
+++ b/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
@@ -1,0 +1,230 @@
+# OpenHands Tab — WebviewPanel → WebviewView (Sidebar) Migration Plan
+
+Goal: migrate the chat UI from an editor `WebviewPanel` to a sidebar `WebviewView` (while keeping the option to open in the editor if we want), without regressing local/remote mode, history restore, terminal streaming, or tests.
+
+This plan is written for parallel execution by multiple agents (implementation + review + testing).
+
+---
+
+## 0) Current Behavior (baseline)
+
+Today we have two separate UI surfaces:
+
+1) **Sidebar container + tree view**
+   - `package.json` contributes an activity bar container `openhands` with a tree view `openhands.quickActions`.
+2) **Editor tab webview panel**
+   - `openhands.openTab` creates a `WebviewPanel` (`src/extension.ts`) which hosts the React webview.
+
+The “double open” happens because the extension currently auto-runs `openhands.openTab` whenever the sidebar tree view becomes visible:
+- `src/extension.ts` registers a `TreeView` and `onDidChangeVisibility` calls `openhands.openTab`.
+
+The chat runtime (Conversation + event wiring) is currently tightly coupled to `panel.webview`:
+- `ensurePanelAndConnection()` creates the panel, creates/refreshes the Conversation, and forwards Conversation events/status/errors to `panel.webview.postMessage(...)`.
+- `onWebviewMessage(context, panel)` assumes a `WebviewPanel` and posts all replies back through `panel.webview.postMessage(...)`.
+
+---
+
+## 1) Desired End-State (UX)
+
+We need to decide what “clicking the OpenHands icon” should do, and where the chat UI should live.
+
+Recommended UX (min confusion / no double-open):
+- **Default:** chat UI opens in the **sidebar** as a `WebviewView`.
+- **Optional:** a command allows opening the same UI in the **editor** as a `WebviewPanel` (useful for larger screen / multi-monitor).
+- The sidebar tree view (“quick actions”) can remain (or be removed later), but it should not automatically open a second UI surface.
+
+### Note: Webview placement constraints (Active vs Beside)
+
+- A `WebviewPanel` always lives in the **editor area** (editor groups/columns). `ViewColumn.Active` opens in the currently active editor group; `ViewColumn.Beside` opens in a new group to the side (roughly “split editor and put it next to what you’re doing”).
+- A `WebviewView` always lives in a **contributed view container** (sidebar/panel). There is no `ViewColumn` equivalent; you can show/hide the view, but it will not become an editor tab.
+
+We can support this with:
+- A setting: `openhands.ui.location = "sidebar" | "editor"` (default `"sidebar"`).
+- Commands:
+  - `OpenHands: Open` (respects setting)
+  - `OpenHands: Open in Sidebar`
+  - `OpenHands: Open in Editor`
+
+Decision needed before Phase 3:
+- Keep `openhands.quickActions` tree view long-term, or replace it with the webview view?
+
+---
+
+## 2) Key Lifecycle Differences (and what “parity” means)
+
+### “Behavior parity” definition
+
+For this migration, “parity” means: regardless of whether the UI is hosted as a sidebar `WebviewView` or editor `WebviewPanel`, users can still:
+- send messages and see streaming responses
+- see tool execution events (terminal, file edits, etc.)
+- see and act on pending actions (approvals/rejections)
+- restore/start conversations and use history UI
+- see connection/status/config updates and errors
+
+Non-parity differences we accept (by design):
+- **where** the UI appears (sidebar vs editor)
+- whether we allow both surfaces simultaneously (decision in Open Questions)
+
+### Why `WebviewView` is not a drop-in replacement
+
+Even with `retainContextWhenHidden`, `WebviewView` differs in lifecycle:
+- It is only created/resolved when the view becomes visible (`resolveWebviewView` is lazy).
+- It can be disposed by the user (removing/hiding the view), requiring a fresh resolve later.
+- **You cannot rely on message delivery while it is hidden.** (Messages may be dropped when the view is not visible.)
+
+So we need a robust “rehydration” path:
+- When the view becomes visible or the webview signals `webviewReady`, re-send:
+  - current status (`online/offline/connecting`)
+  - current config (serverUrl/mode/server list)
+  - recent event backlog (or at least enough to catch up)
+
+#### Recommended catch-up protocol (prevents duplication)
+
+To avoid duplicating events when the webview is retained (or missing events when it wasn’t), use a simple sequence protocol:
+- In the extension host, assign a monotonic `seq` to each forwarded Conversation event and store the last N in a ring buffer (include the current `conversationId`).
+- Have the webview send `webviewReady` with optional fields:
+  - `conversationId?: string`
+  - `lastSeenSeq?: number`
+  (Persist these in the webview via `acquireVsCodeApi().setState(...)`.)
+- Extension responds on ready/visibility:
+  - always send `status` + `serverListUpdated`
+  - if `conversationId` mismatches or `lastSeenSeq` is missing/out of range: send `conversationStarted` + the full buffer
+  - else: send only buffered events with `seq > lastSeenSeq`
+
+This is the main “state restore nuance” required to achieve parity with `WebviewPanel` behavior.
+
+---
+
+## 3) Implementation Plan (phased)
+
+### Phase 1 — Add a WebviewView host (no UX change yet)
+**Goal:** Introduce a sidebar webview view and prove it can render the existing UI.
+
+Tasks:
+- `package.json`
+  - Add a new contributed view in the `openhands` container:
+    - `id`: `openhands.chat`
+    - `type`: `webview`
+  - Add activation event: `onView:openhands.chat`
+- Extension host
+  - Register `vscode.window.registerWebviewViewProvider('openhands.chat', provider, { webviewOptions: { retainContextWhenHidden: true } })`
+  - Provider `resolveWebviewView(webviewView, ...)` sets:
+    - `webviewView.webview.options = { enableScripts: true, localResourceRoots: [...] }`
+    - `webviewView.webview.html = getWebviewHtml(...)`
+    - `webviewView.webview.onDidReceiveMessage(...)` wiring
+
+Deliverable:
+- We can manually open the sidebar view and see the React UI, even if actions are not fully wired yet.
+
+Suggested PR boundary:
+- “Add sidebar chat view scaffold” (no behavior changes).
+
+---
+
+### Phase 2 — Decouple UI wiring from WebviewPanel (introduce a WebviewHost)
+**Goal:** Make the Conversation <-> UI message bridge work with either a panel or a view.
+
+Key refactor:
+- Introduce a minimal `WebviewHost` abstraction:
+  - `webview: vscode.Webview`
+  - `show(preserveFocus?: boolean): void` (panel.reveal() vs view.show())
+  - optional: `onDidDispose` handler
+  - optional: `visible` (view has it; panel has `visible`)
+
+Refactor steps:
+- Replace global `panel` with `uiHost?: WebviewHost`.
+- Rename `ensurePanelAndConnection()` → `ensureUiHostAndConnection(target: 'panel' | 'view' | 'auto')`.
+- Replace direct `panel.webview.postMessage(...)` with `postToWebview(...)` helper.
+- Refactor `onWebviewMessage(context, panel)` to accept `(context, host)` or `(context, webview, postFn)`.
+
+Event delivery resilience (required for WebviewView):
+- Add an **event backlog buffer** in the extension host (ring buffer, e.g. last 500–2000 events) with a monotonic `seq` id.
+  - Exclude noisy stream deltas if needed (`ConversationStateUpdateEvent` with `key` `llm_stream` / `llm_tool_call`) to keep it readable and small.
+- On `webviewReady` and on `WebviewView` visibility changes, post:
+  - `status`
+  - `serverListUpdated`
+  - “catch-up” events using the `lastSeenSeq` protocol above
+
+Acceptance criteria:
+- Both the existing editor panel and the new sidebar view can:
+  - send messages
+  - receive event stream
+  - render status/config
+
+Suggested PR boundary:
+- “Refactor message bridge to support WebviewView”.
+
+---
+
+### Phase 3 — Remove “double open” and add the user-facing choice
+**Goal:** Clicking the OpenHands icon no longer opens two surfaces; user controls where chat opens.
+
+Tasks:
+- Add setting `openhands.ui.location` with enum:
+  - `"sidebar"` (default)
+  - `"editor"`
+- Commands:
+  - Update `openhands.openTab` to behave like `OpenHands: Open` (respects setting)
+  - Add explicit commands:
+    - `openhands.openInSidebar`
+    - `openhands.openInEditor`
+- Change the current auto-open behavior:
+  - Remove `treeView.onDidChangeVisibility -> openTab`, OR gate it behind a setting (default off).
+  - If the tree view remains, it should be “quick actions only”, not a trigger for opening a second UI.
+
+Acceptance criteria:
+- Clicking the activity bar icon opens the container; **only one** chat surface appears by default.
+- The other surface is accessible via explicit command.
+
+Suggested PR boundary:
+- “Sidebar chat is default; stop auto-opening editor tab”.
+
+---
+
+### Phase 4 — Tests and QA (must-do)
+**Goal:** prevent regressions and ensure WebviewView behaviors are correct.
+
+Unit tests (Vitest):
+- Extend `src/__tests__/extension.test.ts` to cover:
+  - WebviewView provider registration + resolve path
+  - `webviewReady` triggers initial status/config post
+  - backlog flushing sends events after re-open / re-ready
+  - switching modes (serverUrl empty vs set) does not throw
+
+Manual QA checklist (Extension Development Host):
+- Sidebar chat view opens and renders.
+- Local mode:
+  - send a message
+  - terminal events appear in both webview and terminal log
+- Remote mode:
+  - set `openhands.serverUrl`
+  - reconnect works
+- Hide/collapse sidebar view while agent runs:
+  - when expanded again, UI catches up (status + backlog).
+- Disposing the view (hide via view menu) and re-adding it:
+  - extension should handle re-resolve without stale references.
+
+---
+
+## 4) Suggested Parallel Workstream Breakdown (multi-agent)
+
+If we want to parallelize safely:
+- **Workstream A (Extension API + contributions):** `package.json` views/activation/settings/commands.
+- **Workstream B (Bridge refactor):** `WebviewHost` abstraction + refactor `ensurePanelAndConnection` + `onWebviewMessage`.
+- **Workstream C (Backlog + lifecycle):** webviewReady rehydration + hidden/visible message strategy.
+- **Workstream D (Tests + QA):** unit test updates + manual verification notes.
+
+Try to keep PRs small and sequential:
+1) Phase 1
+2) Phase 2
+3) Phase 3
+4) Phase 4 follow-ups
+
+---
+
+## 5) Open Questions (capture before coding Phase 3)
+
+1) Do we keep the sidebar tree view long-term, or replace it entirely with the webview view?
+2) Do we support “both” simultaneously (sidebar + editor), or is it always one-at-a-time?
+3) What is the default: sidebar or editor?
+4) Should the editor tab be opened “Beside” or in the active group when using the editor mode?

--- a/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
+++ b/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
@@ -5,6 +5,8 @@ Goal: migrate the chat UI from an editor `WebviewPanel` to a sidebar `WebviewVie
 Decision (locked in):
 - The chat UI will live only in the sidebar as a `WebviewView`.
 - The editor `WebviewPanel` implementation will be removed (no user-facing “open in editor” option).
+- Remove the sidebar tree view `openhands.quickActions` (no separate “quick actions” view).
+- Replace `openhands.openTab` with a clean command id (e.g. `openhands.open`) and delete `openhands.openTab` (no legacy alias).
 
 This plan is written for parallel execution by multiple agents (implementation + review + testing).
 
@@ -41,7 +43,7 @@ What “clicking the OpenHands icon” should do is now straightforward: it shou
 
 End-state UX (no double-open, no editor tab):
 - Chat UI is a single sidebar `WebviewView` (e.g. `openhands.chat`).
-- The sidebar tree view (“quick actions”) can remain (or be removed later), but it must not auto-open any editor UI surface.
+- The OpenHands view container contains only the chat view; any “quick actions” should move into the chat header (or live only in the command palette).
 
 ### Notes: `WebviewView` constraints
 
@@ -49,10 +51,8 @@ End-state UX (no double-open, no editor tab):
 - The extension should provide one “open” command whose job is to focus/reveal the view (and nothing else).
 
 Recommended command surface:
-- `OpenHands: Open` (focuses the sidebar chat view; keep `openhands.openTab` as a legacy command id if desired, but it should no longer open an editor tab)
-
-Decision needed (still open, but orthogonal to “sidebar-only chat”):
-- Keep `openhands.quickActions` tree view long-term, or replace it with the webview view?
+- `OpenHands: Open` (command id `openhands.open`) reveals the OpenHands view container and focuses `openhands.chat`.
+- `openhands.openTab` is removed as part of the migration (clean command surface; no alias).
 
 ---
 
@@ -164,15 +164,15 @@ Suggested PR boundary:
 **Goal:** There is exactly one chat UI surface: the sidebar `WebviewView`.
 
 Tasks:
-- Commands / contributions:
-  - Update the user-facing command title to remove “Tab” wording (e.g. `OpenHands: Open`).
-  - Keep the existing `openhands.openTab` command id as an alias if we want backward compatibility, but it should focus the sidebar view.
+- Commands / contributions (cleanliness goal):
+  - Add `openhands.open` (“OpenHands: Open”) to reveal/focus the sidebar chat view.
+  - Delete `openhands.openTab` (breaking change; update docs/tests accordingly).
 - Remove editor tab creation:
   - Delete `vscode.window.createWebviewPanel(...)` usage and `panel` module state.
   - Remove any editor-tab-only code paths (including tests that assume a panel exists).
 - Change the current auto-open behavior:
   - Remove `treeView.onDidChangeVisibility -> openTab`.
-  - If the tree view remains, it should be “quick actions only”, not a trigger for opening any additional UI surface.
+  - Remove the `openhands.quickActions` tree view contribution and its `OpenHandsViewProvider` scaffolding.
 
 Acceptance criteria:
 - Clicking the activity bar icon opens the container; the chat UI is in the sidebar view and no editor tab is created.
@@ -225,5 +225,4 @@ Try to keep PRs small and sequential:
 
 ## 5) Open Questions
 
-1) Do we keep the sidebar tree view long-term, or replace it entirely with the webview view?
-2) When a user runs `OpenHands: Open`, should it also auto-focus the chat view (vs. just reveal the container)?
+1) When a user runs `OpenHands: Open`, should it also auto-focus the chat view (vs. just reveal the container)?

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -31,9 +31,9 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
    - Press F5 to run “Extension Development Host”
 4) In the Dev Host window
    - Run “OpenHands: Configure” → ensure server URL is http://localhost:3000
-   - Run “OpenHands: Open Tab”
+   - Run “OpenHands: Open Tab” (opens the chat webview in the editor)
    - Run "OpenHands: Start New Conversation"
-   - Type a message and verify assistant/tool events stream in the tab
+   - Type a message and verify assistant/tool events stream in the webview
 
 ### Option B: Automated E2E Tests with @vscode/test-electron
 
@@ -70,7 +70,7 @@ import { runTests } from '@vscode/test-electron';
 describe('OpenHands-Tab E2E', function() {
   this.timeout(120000);
 
-  it('opens the tab and renders HTML', async () => {
+  it('opens the chat webview and renders HTML', async () => {
     // VS Code launches with extension loaded
     // Test suite verifies commands, webview, etc.
   });
@@ -91,7 +91,7 @@ describe('OpenHands-Tab E2E', function() {
 - Inject `SESSION_API_KEY` environment variable if required
 
 **Test Stability:**
-- Start with smoke tests (activation + command execution + panel created)
+- Start with smoke tests (activation + command execution + webview panel created)
 - Add network-dependent assertions once the server contract is stable
 - Use timeouts appropriately for async operations
 
@@ -99,7 +99,7 @@ describe('OpenHands-Tab E2E', function() {
 
 Whether testing manually or automated, verify:
 - ✅ VS Code launches with the extension
-- ✅ Command "OpenHands: Open Tab" succeeds and a panel appears
+- ✅ Command "OpenHands: Open Tab" succeeds and the chat webview appears
 - ✅ Command "OpenHands: Start New Conversation" succeeds (HTTP 201)
 - ✅ WebSocket connects (status shows online) and events stream when you send a message
 

--- a/docs/vscode_local_setup.md
+++ b/docs/vscode_local_setup.md
@@ -136,7 +136,7 @@ code \
 ## Configuration for the Agent
 In the Dev Host window, use the commands:
 - OpenHands: Configure — set server URL (leave blank for local mode)
-- OpenHands: Open Tab — opens the main tab
+- OpenHands: Open Tab — opens the chat webview in the editor
 - OpenHands: Start New Conversation — starts a new conversation
 
 ## Logs and Diagnostics

--- a/docs/vscode_remote_setup.md
+++ b/docs/vscode_remote_setup.md
@@ -203,7 +203,7 @@ Once connected to the desktop via noVNC:
 1. You should see VS Code running with Fluxbox window manager
 2. Run command: **"OpenHands: Configure"**
    - Set server URL (default: `http://localhost:3000`)
-3. Run command: **"OpenHands: Open Tab"**
+3. Run command: **"OpenHands: Open Tab"** (opens the chat webview in the editor)
 4. Run command: **"OpenHands: Start New Conversation"**
 5. Type a message and verify the extension works
 


### PR DESCRIPTION
Adds and refines the documentation for the upcoming chat UI migration from an editor `WebviewPanel` to a sidebar `WebviewView`.

Highlights:
- Adds/updates `docs/WEBVIEWVIEW_MIGRATION_PLAN.md` with a phased, multi-agent-friendly migration plan (incl. `WebviewView` lifecycle + rehydration/catch-up strategy).
- Updates `docs/IMPLEMENTATION_PLAN.md` to reflect completed webview build-out and track the migration as the next milestone.
- Refreshes `docs/PRD.md` + setup/testing docs to clearly separate current behavior (`OpenHands: Open Tab` opens an editor webview) from the planned sidebar end-state.

No code changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed migration plan and phased roadmap to move the chat UI to a sidebar WebviewView, with acceptance criteria and rollout phases.
  * Renamed and refocused the implementation plan and PRD to reflect a sidebar chat view and updated UX/commands (status banner, history, open behavior).
  * Clarified Quick Start, E2E, and local/remote setup docs to state the chat webview opens in the editor and updated test guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->