### PR TITLE
History: add search

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -157,7 +157,7 @@ Status: TODO
 Backlog (webview-facing):
 - Attach files UX (the “+” affordance currently isn’t backed by a concrete flow)
 - MCP server selection UI (if/when MCP integration lands)
-- History UX improvements (search/pagination/empty states, depending on backend shape)
+- History UX improvements (search implemented in PR #203; pagination TBD)
 - Mid-conversation LLM switching UX (may require conversation boundary semantics)
 
 ## Notes

--- a/src/webview-src/__tests__/HistoryView.test.tsx
+++ b/src/webview-src/__tests__/HistoryView.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+import { HistoryView } from '../components/HistoryView';
+
+describe('HistoryView', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it('filters conversations by search query', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 },
+          { id: 'def456', firstMessage: 'Refactor prompt', timestamp: 2000 },
+        ]}
+        currentConversationId="def456"
+        onSelectConversation={onSelectConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    expect(screen.getByText('Fix sidebar issue')).toBeInTheDocument();
+    expect(screen.getByText('Conversation (def45)')).toBeInTheDocument();
+
+    const input = screen.getByLabelText('Search conversation history');
+    fireEvent.change(input, { target: { value: 'fix' } });
+
+    expect(screen.getByText('Fix sidebar issue')).toBeInTheDocument();
+    expect(screen.queryByText('Conversation (def45)')).not.toBeInTheDocument();
+    expect(screen.getByText('1 of 2 conversations')).toBeInTheDocument();
+  });
+
+  it('shows no-results state and clears search', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 },
+          { id: 'def456', firstMessage: 'Refactor prompt', timestamp: 2000 },
+        ]}
+        onSelectConversation={onSelectConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    const input = screen.getByLabelText('Search conversation history');
+    fireEvent.change(input, { target: { value: 'nope' } });
+
+    expect(screen.getByText('No matches')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Clear search'));
+
+    expect(screen.getByText('Fix sidebar issue')).toBeInTheDocument();
+    expect(screen.getByText('Conversation (def45)')).toBeInTheDocument();
+  });
+
+  it('clears search on Escape without closing', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[{ id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 }]}
+        onSelectConversation={onSelectConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    const input = screen.getByLabelText('Search conversation history');
+    fireEvent.change(input, { target: { value: 'fix' } });
+
+    fireEvent.keyDown(input, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+    expect((input as HTMLInputElement).value).toBe('');
+  });
+
+  it('closes on Escape when search is empty', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[{ id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 }]}
+        onSelectConversation={onSelectConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -220,6 +220,8 @@ export function HistoryView({
     });
   }, [sortedConversations, query]);
 
+  const hasAnyQuery = query.length > 0;
+
   if (!isOpen) return null;
 
   return (
@@ -266,7 +268,7 @@ export function HistoryView({
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={(e) => {
-                if (e.key === 'Escape' && query.trim()) {
+                if (e.key === 'Escape' && hasAnyQuery) {
                   e.stopPropagation();
                   setQuery('');
                 }
@@ -275,7 +277,7 @@ export function HistoryView({
               className="w-full pl-9 pr-9 py-2 rounded-lg bg-white/[0.03] border border-white/[0.06] text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0"
               aria-label="Search conversation history"
             />
-            {query.trim() && (
+            {hasAnyQuery && (
               <button
                 type="button"
                 onClick={() => setQuery('')}

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -201,20 +201,23 @@ export function HistoryView({
   if (!isOpen) return null;
 
   const sortedConversations = [...conversations].sort((a, b) => b.timestamp - a.timestamp);
-  const normalizedQuery = query.trim().toLowerCase();
-  const filteredConversations = normalizedQuery
-    ? sortedConversations.filter((conversation) => {
+  const filteredConversations = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return sortedConversations;
+    }
+    return sortedConversations.filter((conversation) => {
       const haystack = [
         conversation.title,
         conversation.firstMessage,
         conversation.id,
       ]
-        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .filter(Boolean)
         .join('\n')
         .toLowerCase();
       return haystack.includes(normalizedQuery);
-    })
-    : sortedConversations;
+    });
+  }, [sortedConversations, query]);
 
   return (
     <>

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useRef, useState, useMemo } from 'react';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
 
 // --- Constants ---

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
 
 // --- Constants ---
@@ -159,6 +159,29 @@ function EmptyState() {
 }
 
 /**
+ * Renders the empty state when no conversations match the search query.
+ */
+function NoResultsState({ query, onClear }: { query: string; onClear: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full text-center px-8">
+      <span className="codicon codicon-search text-4xl mb-4 text-stone-600" />
+      <p className="text-sm text-stone-300">No matches</p>
+      <p className="text-xs mt-2 text-stone-500">
+        Nothing matched <span className="font-mono text-stone-400">{query}</span>
+      </p>
+      <button
+        type="button"
+        onClick={onClear}
+        className="mt-4 inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:text-stone-100 transition-all"
+      >
+        <span className="codicon codicon-clear-all" />
+        Clear search
+      </button>
+    </div>
+  );
+}
+
+/**
  * Main history view component that displays a list of past conversations
  * in a slide-in side panel.
  */
@@ -170,6 +193,7 @@ export function HistoryView({
   onSelectConversation,
 }: HistoryViewProps) {
   const panelRef = useRef<HTMLDivElement>(null);
+  const [query, setQuery] = useState('');
 
   // Close on Escape key or click outside (with delay to avoid immediate close on open)
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: panelRef, delay: 100 });
@@ -177,6 +201,20 @@ export function HistoryView({
   if (!isOpen) return null;
 
   const sortedConversations = [...conversations].sort((a, b) => b.timestamp - a.timestamp);
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredConversations = normalizedQuery
+    ? sortedConversations.filter((conversation) => {
+      const haystack = [
+        conversation.title,
+        conversation.firstMessage,
+        conversation.id,
+      ]
+        .filter((value): value is string => typeof value === 'string' && value.length > 0)
+        .join('\n')
+        .toLowerCase();
+      return haystack.includes(normalizedQuery);
+    })
+    : sortedConversations;
 
   return (
     <>
@@ -214,13 +252,46 @@ export function HistoryView({
           </button>
         </div>
 
+        {/* Search */}
+        <div className="px-6 pt-4">
+          <div className="relative">
+            <span className="codicon codicon-search absolute left-3 top-1/2 -translate-y-1/2 text-stone-500" />
+            <input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape' && query.trim()) {
+                  e.stopPropagation();
+                  setQuery('');
+                }
+              }}
+              placeholder="Search history…"
+              className="w-full pl-9 pr-9 py-2 rounded-lg bg-white/[0.03] border border-white/[0.06] text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0"
+              aria-label="Search conversation history"
+            />
+            {query.trim() && (
+              <button
+                type="button"
+                onClick={() => setQuery('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 h-7 w-7 rounded-md text-stone-400 hover:text-stone-200 hover:bg-white/[0.06] flex items-center justify-center transition-all"
+                aria-label="Clear search"
+                title="Clear search"
+              >
+                <span className="codicon codicon-close" />
+              </button>
+            )}
+          </div>
+        </div>
+
         {/* Conversations List */}
         <div className="flex-1 overflow-y-auto px-4 py-4">
           {sortedConversations.length === 0 ? (
             <EmptyState />
+          ) : filteredConversations.length === 0 ? (
+            <NoResultsState query={query.trim()} onClear={() => setQuery('')} />
           ) : (
             <div className="space-y-2">
-              {sortedConversations.map((conversation, index) => (
+              {filteredConversations.map((conversation, index) => (
                 <ConversationItem
                   key={conversation.id}
                   conversation={conversation}
@@ -239,7 +310,9 @@ export function HistoryView({
         {/* Footer */}
         <div className="px-6 py-4 border-t border-white/[0.06] bg-white/[0.02]">
           <p className="text-xs text-stone-500 text-center">
-            {sortedConversations.length} conversation{sortedConversations.length !== 1 ? 's' : ''}
+            {query.trim()
+              ? `${filteredConversations.length} of ${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`
+              : `${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`}
           </p>
         </div>
       </div>

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -198,9 +198,10 @@ export function HistoryView({
   // Close on Escape key or click outside (with delay to avoid immediate close on open)
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: panelRef, delay: 100 });
 
-  if (!isOpen) return null;
-
-  const sortedConversations = [...conversations].sort((a, b) => b.timestamp - a.timestamp);
+  const sortedConversations = useMemo(
+    () => [...conversations].sort((a, b) => b.timestamp - a.timestamp),
+    [conversations]
+  );
   const filteredConversations = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     if (!normalizedQuery) {
@@ -218,6 +219,8 @@ export function HistoryView({
       return haystack.includes(normalizedQuery);
     });
   }, [sortedConversations, query]);
+
+  if (!isOpen) return null;
 
   return (
     <>


### PR DESCRIPTION
Adds a search box to the History slide-over panel.

- Filters by title, first prompt, and id
- Shows a no-results state + clear search action
- Esc clears the query (when non-empty)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search functionality to History view, enabling users to filter conversations by title, message content, and ID.
  * Displays "no results" message when search yields no matches.
  * Shows search context in footer (e.g., "1 of 5 conversations").
  * Clear search button to reset filters.

* **Tests**
  * Added comprehensive test suite for History view search interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->