### PR TITLE
Follow-up: address PR #200/#201 review comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,5 +186,5 @@ e2e_logs*.zip
 .mcp.json
 *.mcp.json
 .vscode/mcp.json
-opencode.json
-summary.md
+/opencode.json
+/summary.md

--- a/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
+++ b/docs/WEBVIEWVIEW_MIGRATION_PLAN.md
@@ -212,10 +212,10 @@ Manual QA checklist (Extension Development Host):
 ## 4) Suggested Parallel Workstream Breakdown (multi-agent)
 
 If we want to parallelize safely:
-- **Workstream A (Extension API + contributions):** `package.json` views/activation/settings/commands.
-- **Workstream B (Bridge refactor):** refactor `ensurePanelAndConnection` + `onWebviewMessage` toward a view-only bridge.
-- **Workstream C (Backlog + lifecycle):** webviewReady rehydration + hidden/visible message strategy.
-- **Workstream D (Tests + QA):** unit test updates + manual verification notes.
+- **Extension API + contributions:** `package.json` views/activation/settings/commands.
+- **Bridge refactor:** refactor `ensurePanelAndConnection` + `onWebviewMessage` toward a view-only bridge.
+- **Backlog + lifecycle:** webviewReady rehydration + hidden/visible message strategy.
+- **Tests + QA:** unit test updates + manual verification notes.
 
 Try to keep PRs small and sequential:
 1) Phase 1

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,7 +61,9 @@ const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Tr
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
 type BufferedConversationEvent = { seq: number; event: Event };
-const conversationEventBacklog: BufferedConversationEvent[] = [];
+const conversationEventBacklog: Array<BufferedConversationEvent | undefined> = [];
+let conversationEventBacklogStart = 0;
+let conversationEventBacklogSize = 0;
 let conversationEventSeq = 0;
 let activeConversationId: string | undefined;
 // Buffer of test events sent via _sendTestEvent (used as fallback in E2E query)
@@ -92,16 +94,31 @@ function fileLog(line: string) {
 function resetConversationEventBacklog(conversationId: string | undefined) {
   activeConversationId = conversationId;
   conversationEventSeq = 0;
+  conversationEventBacklogStart = 0;
+  conversationEventBacklogSize = 0;
   conversationEventBacklog.length = 0;
 }
 
 function bufferConversationEvent(event: Event): number {
   conversationEventSeq += 1;
-  conversationEventBacklog.push({ seq: conversationEventSeq, event });
-  if (conversationEventBacklog.length > MAX_EVENT_BACKLOG) {
-    conversationEventBacklog.shift();
+  const item: BufferedConversationEvent = { seq: conversationEventSeq, event };
+  if (conversationEventBacklogSize < MAX_EVENT_BACKLOG) {
+    const idx = (conversationEventBacklogStart + conversationEventBacklogSize) % MAX_EVENT_BACKLOG;
+    conversationEventBacklog[idx] = item;
+    conversationEventBacklogSize += 1;
+  } else {
+    conversationEventBacklog[conversationEventBacklogStart] = item;
+    conversationEventBacklogStart = (conversationEventBacklogStart + 1) % MAX_EVENT_BACKLOG;
   }
   return conversationEventSeq;
+}
+
+function* iterConversationEventBacklog(): Iterable<BufferedConversationEvent> {
+  for (let i = 0; i < conversationEventBacklogSize; i += 1) {
+    const idx = (conversationEventBacklogStart + i) % MAX_EVENT_BACKLOG;
+    const item = conversationEventBacklog[idx];
+    if (item) yield item;
+  }
 }
 
 function flushConversationEventBacklog(params: {
@@ -114,8 +131,8 @@ function flushConversationEventBacklog(params: {
     return;
   }
 
-  const earliestSeq = conversationEventBacklog[0]?.seq;
-  const latestSeq = conversationEventBacklog[conversationEventBacklog.length - 1]?.seq;
+  const earliestSeq = conversationEventBacklogSize > 0 ? conversationEventSeq - conversationEventBacklogSize + 1 : undefined;
+  const latestSeq = conversationEventBacklogSize > 0 ? conversationEventSeq : undefined;
   const lastSeenSeq = params.clientLastSeenSeq;
 
   const lastSeenIsValid = typeof lastSeenSeq === 'number' && Number.isFinite(lastSeenSeq);
@@ -124,7 +141,7 @@ function flushConversationEventBacklog(params: {
 
   if (needsFullReplay) {
     void params.postMessage({ type: 'conversationStarted', conversationId: currentConversationId });
-    for (const item of conversationEventBacklog) {
+    for (const item of iterConversationEventBacklog()) {
       void params.postMessage({ type: 'event', seq: item.seq, event: item.event });
     }
     return;
@@ -134,7 +151,7 @@ function flushConversationEventBacklog(params: {
     return;
   }
 
-  for (const item of conversationEventBacklog) {
+  for (const item of iterConversationEventBacklog()) {
     if (item.seq > lastSeenSeq) {
       void params.postMessage({ type: 'event', seq: item.seq, event: item.event });
     }
@@ -338,7 +355,9 @@ export function activate(context: vscode.ExtensionContext) {
     onResolved: (view) => {
       chatView = view;
       chatWebviewReady = false;
-      void ensureConversationAndConnection({ uiJustCreated: true });
+      void ensureConversationAndConnection({ uiJustCreated: true }).catch((err: unknown) => {
+        outputChannel?.appendLine(`[error] ensureConversationAndConnection failed: ${renderError(err)}`);
+      });
     },
     onDisposed: () => {
       chatView = undefined;
@@ -555,8 +574,14 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   const open = vscode.commands.registerCommand('openhands.open', async () => {
-    await vscode.commands.executeCommand('workbench.view.extension.openhands');
-    chatView?.show?.(true);
+    try {
+      // VS Code auto-creates a focus command for views: `<viewId>.focus`
+      await vscode.commands.executeCommand('openhands.chat.focus');
+    } catch {
+      // Fallback: open the container and reveal the view if already resolved
+      await vscode.commands.executeCommand('workbench.view.extension.openhands');
+      chatView?.show?.(true);
+    }
     await ensureConversationAndConnection();
   });
 
@@ -573,7 +598,7 @@ export function activate(context: vscode.ExtensionContext) {
       },
       eventBacklog: {
         activeConversationId,
-        size: conversationEventBacklog.length,
+        size: conversationEventBacklogSize,
         latestSeq: conversationEventSeq,
       },
       hasConversation: !!conversation,
@@ -737,6 +762,8 @@ export function deactivate() {
   chatLastSeenSeq = undefined;
   activeConversationId = undefined;
   conversationEventSeq = 0;
+  conversationEventBacklogStart = 0;
+  conversationEventBacklogSize = 0;
   conversationEventBacklog.length = 0;
   receivedTerminalEvents.length = 0;
 }
@@ -976,7 +1003,7 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
 
         await settingsMgr.update({
           servers: newServers,
-          ...(currentSettings.serverUrl === url ? { serverUrl: '' } : {}),
+          serverUrl: newServerUrl,
         });
 
         void host.postMessage({

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -760,11 +760,7 @@ export function deactivate() {
   chatWebviewReady = false;
   chatLastConversationId = undefined;
   chatLastSeenSeq = undefined;
-  activeConversationId = undefined;
-  conversationEventSeq = 0;
-  conversationEventBacklogStart = 0;
-  conversationEventBacklogSize = 0;
-  conversationEventBacklog.length = 0;
+  resetConversationEventBacklog(undefined);
   receivedTerminalEvents.length = 0;
 }
 

--- a/src/sidebar/OpenHandsChatViewProvider.ts
+++ b/src/sidebar/OpenHandsChatViewProvider.ts
@@ -15,11 +15,15 @@ export class OpenHandsChatViewProvider implements vscode.WebviewViewProvider {
     private readonly handlers: OpenHandsChatViewHandlers
   ) {}
 
-  resolveWebviewView(webviewView: vscode.WebviewView): void {
+  private disposeViewDisposables(): void {
     this.viewDisposables.forEach((d) => {
-      d.dispose();
+      try { d.dispose(); } catch { }
     });
     this.viewDisposables = [];
+  }
+
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    this.disposeViewDisposables();
 
     webviewView.webview.options = {
       enableScripts: true,
@@ -30,7 +34,12 @@ export class OpenHandsChatViewProvider implements vscode.WebviewViewProvider {
 
     const messageHandler = this.handlers.createMessageHandler(webviewView);
     this.viewDisposables.push(webviewView.webview.onDidReceiveMessage(messageHandler));
-    this.viewDisposables.push(webviewView.onDidDispose(() => this.handlers.onDisposed()));
+    this.viewDisposables.push(
+      webviewView.onDidDispose(() => {
+        this.disposeViewDisposables();
+        this.handlers.onDisposed();
+      })
+    );
 
     this.handlers.onResolved(webviewView);
   }

--- a/src/sidebar/OpenHandsChatViewProvider.ts
+++ b/src/sidebar/OpenHandsChatViewProvider.ts
@@ -17,7 +17,9 @@ export class OpenHandsChatViewProvider implements vscode.WebviewViewProvider {
 
   private disposeViewDisposables(): void {
     this.viewDisposables.forEach((d) => {
-      try { d.dispose(); } catch { }
+      try { d.dispose(); } catch (err) {
+        console.warn('[OpenHands] Failed to dispose a view disposable:', err);
+      }
     });
     this.viewDisposables = [];
   }


### PR DESCRIPTION
This follow-up addresses unresolved review threads left on merged PRs #200 and #201.

- `src/extension.ts`
  - Catch/log errors from the fire-and-forget `ensureConversationAndConnection()` call in the webview `onResolved` handler (prevents unhandled rejections).
  - Use the auto-created view focus command `openhands.chat.focus` for reliable `OpenHands: Open` behavior (with fallback).
  - Simplify `removeServer` update logic.
  - Replace backlog `.shift()` with a constant-time ring buffer.

- `src/sidebar/OpenHandsChatViewProvider.ts`
  - Dispose `viewDisposables` immediately on view dispose.

- `.gitignore`
  - Scope `opencode.json` and `summary.md` ignores to repo root.

- `docs/WEBVIEWVIEW_MIGRATION_PLAN.md`
  - Minor bullet phrasing cleanup.

Local verification:
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening the chat view with fallback behavior
  * Enhanced error handling during initialization
  * Better resource cleanup and disposal to prevent memory leaks

* **Chores**
  * Updated documentation for workstream structure
  * Updated git ignore patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->