### PR TITLE
Attach files UI

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -155,7 +155,6 @@ Goal: Close the remaining “Not Yet Implemented” items and polish the webview
 Status: TODO
 
 Backlog (webview-facing):
-- Attach files UX (the “+” affordance currently isn’t backed by a concrete flow)
 - MCP server selection UI (if/when MCP integration lands)
 - History UX improvements (search implemented in PR #203; pagination TBD)
 - Mid-conversation LLM switching UX (may require conversation boundary semantics)

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -34,6 +34,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Security risk indicators (LOW/MEDIUM/HIGH)
 - Conversation persistence to disk
 - Conversation history view
+- Attach files UI (inline text attachments)
 - Workspace file context (@mentions)
 - Skills support (~/.openhands/skills/)
 - Terminal integration (local mode)
@@ -41,10 +42,9 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Event rendering for all event types
 
 ### Not Yet Implemented
-- **Attach files UI** - "+" button placeholder exists but has no backend
 - **MCP server selection** - placeholder in UI, not functional
 - **Mid-conversation LLM switching** - must start new conversation to change model
-- **Full conversation history backend** - basic list implemented, search/pagination TODO
+- **Full conversation history backend** - list + search implemented, pagination TODO
 
 ## 5. Architecture Overview
 
@@ -216,7 +216,7 @@ src/
 - Title and prompt preview
 
 ### TODO: Future Enhancements
-- **Attach Files** - file upload to agent context
+- **Attach Files (images/binary)** - richer attachment support beyond text
 - **MCP Integration** - MCP server selection
 - **Mid-Conversation Model Switch** - change LLM without new conversation
 - **Advanced History** - search, pagination, export

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -46,6 +46,9 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - **Mid-conversation LLM switching** - must start new conversation to change model
 - **Full conversation history backend** - list + search implemented, pagination TODO
 
+**Deferred (requires human approval)**
+- **MCP integration / MCP server selection** - not a priority; do not work on this without explicit approval from a human maintainer
+
 ## 5. Architecture Overview
 
 ### Extension Host
@@ -217,7 +220,7 @@ src/
 
 ### TODO: Future Enhancements
 - **Attach Files (images/binary)** - richer attachment support beyond text
-- **MCP Integration** - MCP server selection
+- **MCP Integration** - DEFERRED until further notice; requires explicit human approval to work on
 - **Mid-Conversation Model Switch** - change LLM without new conversation
 - **Advanced History** - search, pagination, export
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -42,12 +42,11 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Event rendering for all event types
 
 ### Not Yet Implemented
-- **MCP server selection** - placeholder in UI, not functional
 - **Mid-conversation LLM switching** - must start new conversation to change model
 - **Full conversation history backend** - list + search implemented, pagination TODO
 
 **Deferred (requires human approval)**
-- **MCP integration / MCP server selection** - not a priority; do not work on this without explicit approval from a human maintainer
+- **MCP integration / MCP server selection** - UI placeholders exist but are intentionally deferred; not a priority; do not work on this without explicit approval from a human maintainer
 
 ## 5. Architecture Overview
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -138,8 +138,19 @@ function toAttachmentLabel(uri: vscode.Uri): string {
   try {
     const rel = vscode.workspace.asRelativePath(uri, false);
     if (rel && rel !== uri.fsPath) return rel;
-  } catch {}
+  } catch (err) {
+    console.warn('[OpenHands] Failed to compute relative attachment label', err);
+  }
   return path.basename(uri.fsPath);
+}
+
+function safeParseUri(raw: string): vscode.Uri | undefined {
+  try {
+    return vscode.Uri.parse(raw, true);
+  } catch (err) {
+    console.warn('[OpenHands] Skipping invalid URI', err);
+    return undefined;
+  }
 }
 
 async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promise<string> {
@@ -156,9 +167,8 @@ async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promise<stri
 
     try {
       const bytes = await vscode.workspace.fs.readFile(uri);
-      const buf = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
 
-      if (isProbablyBinary(buf)) {
+      if (isProbablyBinary(bytes)) {
         blocks.push(`\n\n${begin}\n(attachment skipped: binary file)\n${end}`);
         continue;
       }
@@ -170,11 +180,11 @@ async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promise<stri
       }
 
       const maxForThis = Math.min(MAX_ATTACHMENT_BYTES_PER_FILE, remaining);
-      const truncated = buf.length > maxForThis;
-      const slice = buf.slice(0, maxForThis);
+      const truncated = bytes.length > maxForThis;
+      const slice = bytes.slice(0, maxForThis);
       totalIncluded += slice.length;
 
-      const meta = truncated ? `(truncated: first ${slice.length} bytes of ${buf.length} bytes)\n` : '';
+      const meta = truncated ? `(truncated: first ${slice.length} bytes of ${bytes.length} bytes)\n` : '';
       const text = decoder.decode(slice);
       blocks.push(`\n\n${begin}\n${meta}${text}\n${end}`);
     } catch (err) {
@@ -1104,7 +1114,9 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
               try {
                 const stat = await vscode.workspace.fs.stat(uri);
                 sizeBytes = stat.size;
-              } catch {}
+              } catch (err) {
+                console.warn('[OpenHands] Failed to stat attachment', err);
+              }
               return { uri: uri.toString(), label, sizeBytes };
             })
           );
@@ -1138,7 +1150,8 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
           const attachmentUris = Array.isArray(message.attachments)
             ? message.attachments
               .filter((u): u is string => typeof u === 'string' && u.length > 0)
-              .map((u) => vscode.Uri.parse(u, true))
+              .map((u) => safeParseUri(u))
+              .filter((u): u is vscode.Uri => u !== undefined)
             : [];
 
           const attachmentsText = await buildAttachmentBlocks(attachmentUris);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import { TextDecoder } from 'util';
 import { SettingsManager, type SavedServer } from './settings/SettingsManager';
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { FileStore } from '@openhands/agent-sdk-ts';
@@ -39,7 +40,9 @@ type WebviewMessage =
   | { type: 'addServer'; server: SavedServer }
   | { type: 'removeServer'; url: string }
   | { type: 'switchToLocal' }
-  | { type: 'send'; text: string }
+  | { type: 'selectAttachments' }
+  | { type: 'openAttachment'; uri: string }
+  | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
   | { type: 'command'; command: string; reason?: string }
   | { type: 'renderedEventsResponse'; count: number; eventTypes: string[] }
   | { type: 'webviewConsole'; level: string; args: unknown[] }
@@ -60,6 +63,8 @@ let outputChannel: vscode.OutputChannel | undefined;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
+const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;
+const MAX_ATTACHMENT_TOTAL_BYTES = 500 * 1024;
 type BufferedConversationEvent = { seq: number; event: Event };
 const conversationEventBacklog: Array<BufferedConversationEvent | undefined> = [];
 let conversationEventBacklogStart = 0;
@@ -119,6 +124,66 @@ function* iterConversationEventBacklog(): Iterable<BufferedConversationEvent> {
     const item = conversationEventBacklog[idx];
     if (item) yield item;
   }
+}
+
+function isProbablyBinary(bytes: Uint8Array): boolean {
+  // Heuristic: treat NUL bytes as binary.
+  for (let i = 0; i < bytes.length; i += 1) {
+    if (bytes[i] === 0) return true;
+  }
+  return false;
+}
+
+function toAttachmentLabel(uri: vscode.Uri): string {
+  try {
+    const rel = vscode.workspace.asRelativePath(uri, false);
+    if (rel && rel !== uri.fsPath) return rel;
+  } catch {}
+  return path.basename(uri.fsPath);
+}
+
+async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promise<string> {
+  if (attachmentUris.length === 0) return '';
+
+  const decoder = new TextDecoder('utf-8', { fatal: false });
+  const blocks: string[] = [];
+  let totalIncluded = 0;
+
+  for (const uri of attachmentUris) {
+    const label = toAttachmentLabel(uri);
+    const begin = `----- BEGIN ATTACHMENT: ${label} -----`;
+    const end = `----- END ATTACHMENT: ${label} -----`;
+
+    try {
+      const bytes = await vscode.workspace.fs.readFile(uri);
+      const buf = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+
+      if (isProbablyBinary(buf)) {
+        blocks.push(`\n\n${begin}\n(attachment skipped: binary file)\n${end}`);
+        continue;
+      }
+
+      const remaining = MAX_ATTACHMENT_TOTAL_BYTES - totalIncluded;
+      if (remaining <= 0) {
+        blocks.push(`\n\n${begin}\n(attachment skipped: total attachment size limit reached)\n${end}`);
+        continue;
+      }
+
+      const maxForThis = Math.min(MAX_ATTACHMENT_BYTES_PER_FILE, remaining);
+      const truncated = buf.length > maxForThis;
+      const slice = buf.slice(0, maxForThis);
+      totalIncluded += slice.length;
+
+      const meta = truncated ? `(truncated: first ${slice.length} bytes of ${buf.length} bytes)\n` : '';
+      const text = decoder.decode(slice);
+      blocks.push(`\n\n${begin}\n${meta}${text}\n${end}`);
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      blocks.push(`\n\n${begin}\n(attachment skipped: ${reason})\n${end}`);
+    }
+  }
+
+  return blocks.join('');
 }
 
 function flushConversationEventBacklog(params: {
@@ -1020,8 +1085,73 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
         });
         break;
       }
+      case 'selectAttachments': {
+        try {
+          const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+          const picked = await vscode.window.showOpenDialog({
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: true,
+            defaultUri,
+            openLabel: 'Attach',
+          });
+          if (!picked || picked.length === 0) break;
+
+          const attachments = await Promise.all(
+            picked.map(async (uri) => {
+              const label = toAttachmentLabel(uri);
+              let sizeBytes: number | undefined;
+              try {
+                const stat = await vscode.workspace.fs.stat(uri);
+                sizeBytes = stat.size;
+              } catch {}
+              return { uri: uri.toString(), label, sizeBytes };
+            })
+          );
+          void host.postMessage({ type: 'attachmentsSelected', attachments });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void vscode.window.showErrorMessage(`Failed to select attachments: ${reason}`);
+        }
+        break;
+      }
+      case 'openAttachment': {
+        const raw = message.uri;
+        if (!raw) break;
+        try {
+          const uri = vscode.Uri.parse(raw, true);
+          const document = await vscode.workspace.openTextDocument(uri);
+          await vscode.window.showTextDocument(document, { preview: false });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void vscode.window.showErrorMessage(`Failed to open attachment: ${reason}`);
+        }
+        break;
+      }
       case 'send':
-        await conversation?.sendUserMessage(message.text);
+        if (!conversation) break;
+        {
+          const baseText = message.text;
+          const contextFiles = Array.isArray(message.contextFiles)
+            ? message.contextFiles.filter((f): f is string => typeof f === 'string' && f.length > 0)
+            : [];
+          const attachmentUris = Array.isArray(message.attachments)
+            ? message.attachments
+              .filter((u): u is string => typeof u === 'string' && u.length > 0)
+              .map((u) => vscode.Uri.parse(u, true))
+            : [];
+
+          const attachmentsText = await buildAttachmentBlocks(attachmentUris);
+
+          let finalText = baseText;
+          if (attachmentsText) {
+            finalText += attachmentsText;
+          }
+          if (contextFiles.length > 0) {
+            finalText += `\n\nUser has selected the following files for you to read:\n${contextFiles.join('\n')}`;
+          }
+          await conversation.sendUserMessage(finalText);
+        }
         break;
       case 'command':
         switch (message.command) {

--- a/src/webview-src/__tests__/actions.test.tsx
+++ b/src/webview-src/__tests__/actions.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { App } from '../components/App';
@@ -11,6 +11,10 @@ describe('App actions post messages to extension', () => {
     mockApi.postMessage.mockClear();
     // @ts-expect-error define VS Code API mock on window
     window.acquireVsCodeApi = () => mockApi;
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   it('Settings posts openSettingsPage', async () => {
@@ -31,6 +35,13 @@ describe('App actions post messages to extension', () => {
     expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'startNewConversation' });
   });
 
+  it('Attachments posts selectAttachments', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+    await userEvent.click(screen.getByLabelText('Attachments'));
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'selectAttachments' });
+  });
+
   it('Pressing Enter posts send with typed text and closes context picker', async () => {
     render(<App />);
 
@@ -46,7 +57,7 @@ describe('App actions post messages to extension', () => {
     expect(input).toBeTruthy();
     await userEvent.type(input as HTMLInputElement, 'hello{enter}');
 
-    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'send', text: 'hello' });
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'send', text: 'hello', contextFiles: [], attachments: [] });
     expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
   });
 
@@ -76,7 +87,7 @@ describe('App actions post messages to extension', () => {
     expect(input).toBeTruthy();
     await userEvent.type(input as HTMLInputElement, 'ping{enter}');
 
-    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'send', text: 'ping' });
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'send', text: 'ping', contextFiles: [], attachments: [] });
     expect(screen.queryByRole('listbox', { name: 'Skills' })).not.toBeInTheDocument();
   });
 });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -118,6 +118,9 @@ export function App() {
   const [input, setInput] = useState('');
   const selectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
 
+  // Attachments state
+  const [attachments, setAttachments] = useState<Array<{ uri: string; label: string; sizeBytes?: number }>>([]);
+
   // UI state
   const [statusBanner, setStatusBanner] = useState<{ message: string; level: 'info' | 'warn' | 'error' } | null>(
     { message: 'Initializing…', level: 'info' }
@@ -270,6 +273,7 @@ export function App() {
         skills?: { label: string; path: string }[];
         conversations?: ConversationsList;
         servers?: { url: string; label?: string }[];
+        attachments?: Array<{ uri: string; label: string; sizeBytes?: number }>;
       };
 
       switch (payload?.type) {
@@ -311,6 +315,21 @@ export function App() {
           }
           if (typeof payload.serverUrl === 'string') {
             setCurrentServerUrl(payload.serverUrl || undefined);
+          }
+          break;
+        case 'attachmentsSelected':
+          if (Array.isArray(payload.attachments)) {
+            setAttachments((prev) => {
+              const existing = new Set(prev.map((a) => a.uri));
+              const next = [...prev];
+              for (const a of payload.attachments ?? []) {
+                if (!a || typeof a.uri !== 'string' || typeof a.label !== 'string') continue;
+                if (existing.has(a.uri)) continue;
+                next.push(a);
+                existing.add(a.uri);
+              }
+              return next;
+            });
           }
           break;
         case 'event':
@@ -439,6 +458,7 @@ export function App() {
     eventId.current = 1;
     setInput('');
     setSelectedContextFiles([]);
+    setAttachments([]);
     postMessage({ type: 'command', command: 'startNewConversation' });
   }, [postMessage]);
 
@@ -456,24 +476,23 @@ export function App() {
   }, [postMessage]);
 
   const handleSendMessage = useCallback(() => {
-    const baseText = input.trim();
-    if (!baseText) return;
-
-    const files = selectedContextFiles.slice();
-    let finalText = baseText;
-    if (files.length > 0) {
-      const lines = files;
-      finalText += `\n\nUser has selected the following files for you to read:\n${lines.join('\n')}`;
-    }
+    const text = input.trim();
+    if (!text) return;
 
     setInput('');
     setShowContextPicker(false);
     setShowSkillsPopover(false);
     setContextQuery('');
     setSelectedContextFiles([]);
+    setAttachments([]);
     selectionRef.current = { start: 0, end: 0 };
-    postMessage({ type: 'send', text: finalText });
-  }, [input, postMessage, selectedContextFiles]);
+    postMessage({
+      type: 'send',
+      text,
+      contextFiles: selectedContextFiles.slice(),
+      attachments: attachments.map((a) => a.uri),
+    });
+  }, [attachments, input, postMessage, selectedContextFiles]);
 
   const handleApprove = useCallback(() => {
     if (isSubmitting) return;
@@ -514,6 +533,19 @@ export function App() {
       return willBeOpen;
     });
   }, [postMessage]);
+
+  // Attachments handlers
+  const handleOpenAttachments = useCallback(() => {
+    postMessage({ type: 'selectAttachments' });
+  }, [postMessage]);
+
+  const handleOpenAttachment = useCallback((uri: string) => {
+    postMessage({ type: 'openAttachment', uri });
+  }, [postMessage]);
+
+  const handleRemoveAttachment = useCallback((uri: string) => {
+    setAttachments((prev) => prev.filter((a) => a.uri !== uri));
+  }, []);
 
   const handleToggleContextFile = useCallback((file: string) => {
     if (isMentionActive && mentionStartRef.current !== null) {
@@ -661,6 +693,10 @@ export function App() {
           contextCount={selectedContextFiles.length}
           onOpenSkills={handleOpenSkills}
           skillsCount={skills.length}
+          onOpenAttachments={handleOpenAttachments}
+          attachments={attachments}
+          onOpenAttachment={handleOpenAttachment}
+          onRemoveAttachment={handleRemoveAttachment}
           onSelectionChange={handleSelectionChange}
         />
 

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -685,7 +685,48 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
     const files = after.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
     return { main: before, files };
   }
-  const { main: textContent, files: contextFiles } = parseContextBlock(rawText);
+  const { main: withoutContext, files: contextFiles } = parseContextBlock(rawText);
+
+  const ATTACHMENT_BEGIN = '----- BEGIN ATTACHMENT:';
+  const ATTACHMENT_END = '----- END ATTACHMENT:';
+  const stripTrailingDashes = (value: string) => value.replace(/\s*-{5,}\s*$/, '').trim();
+
+  function parseAttachmentBlocks(text: string): { main: string; attachments: Array<{ label: string; content: string }> } {
+    const attachments: Array<{ label: string; content: string }> = [];
+    const parts: string[] = [];
+    let cursor = 0;
+
+    while (true) {
+      const beginIdx = text.indexOf(ATTACHMENT_BEGIN, cursor);
+      if (beginIdx === -1) break;
+      parts.push(text.slice(cursor, beginIdx));
+
+      const beginLineEnd = text.indexOf('\n', beginIdx);
+      if (beginLineEnd === -1) {
+        cursor = beginIdx;
+        break;
+      }
+      const beginLine = text.slice(beginIdx, beginLineEnd).trim();
+      let label = stripTrailingDashes(beginLine.slice(ATTACHMENT_BEGIN.length).trim());
+      if (!label) label = 'Attachment';
+
+      const endIdx = text.indexOf(ATTACHMENT_END, beginLineEnd);
+      if (endIdx === -1) {
+        cursor = beginIdx;
+        break;
+      }
+      const endLineEnd = text.indexOf('\n', endIdx);
+      const content = text.slice(beginLineEnd + 1, endIdx).trimEnd();
+
+      attachments.push({ label, content });
+      cursor = endLineEnd === -1 ? text.length : endLineEnd + 1;
+    }
+
+    parts.push(text.slice(cursor));
+    return { main: parts.join('').trim(), attachments };
+  }
+
+  const { main: textContent, attachments } = parseAttachmentBlocks(withoutContext);
   const imageContent = message.content.filter((c) => c.type === 'image');
 
   const accentColor = isUser ? USER_ACCENT_COLOR : isAgent ? AGENT_ACCENT_COLOR : DEFAULT_ACCENT_COLOR;
@@ -722,6 +763,28 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
           {textContent && (
             <div className={`text-sm leading-relaxed whitespace-pre-wrap break-words ${isAgent ? 'text-stone-200' : 'text-stone-300'}`}>
               {textContent}
+            </div>
+          )}
+
+          {attachments.length > 0 && (
+            <div className="mt-3 pt-3 border-t border-white/[0.06]">
+              <div className="mb-2 text-xs text-stone-500 flex items-center gap-2">
+                <span className="codicon codicon-file text-brand-400/60" />
+                <span>Attachments</span>
+              </div>
+              <div className="space-y-2">
+                {attachments.map((a, idx) => (
+                  <details key={`${a.label}-${idx}`} className="bg-white/[0.03] border border-white/[0.06] rounded-lg px-3 py-2">
+                    <summary className="cursor-pointer text-xs text-stone-400 hover:text-stone-300 font-mono flex items-center gap-2 transition-colors">
+                      <span className="codicon codicon-file text-brand-400/60" />
+                      <span className="truncate">{a.label}</span>
+                    </summary>
+                    <pre className="mt-2 font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 leading-relaxed text-stone-400 text-xs overflow-auto whitespace-pre-wrap break-words">
+                      {a.content}
+                    </pre>
+                  </details>
+                ))}
+              </div>
             </div>
           )}
 

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -710,7 +710,8 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
       let label = stripTrailingDashes(beginLine.slice(ATTACHMENT_BEGIN.length).trim());
       if (!label) label = 'Attachment';
 
-      const endIdx = text.indexOf(ATTACHMENT_END, beginLineEnd);
+      const endToken = `${ATTACHMENT_END} ${label}`;
+      const endIdx = text.indexOf(endToken, beginLineEnd);
       if (endIdx === -1) {
         cursor = beginIdx;
         break;

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -13,8 +13,11 @@ interface InputAreaProps {
   // Skills
   onOpenSkills: () => void;
   skillsCount?: number;
-  // Attachments (placeholder for future)
+  // Attachments
   onOpenAttachments?: () => void;
+  attachments?: Array<{ uri: string; label: string }>;
+  onOpenAttachment?: (uri: string) => void;
+  onRemoveAttachment?: (uri: string) => void;
   // MCP (placeholder for future)
   onOpenMCP?: () => void;
   // Selection tracking (for mention-style context)
@@ -32,6 +35,9 @@ export function InputArea({
   onOpenSkills,
   skillsCount = 0,
   onOpenAttachments,
+  attachments = [],
+  onOpenAttachment,
+  onRemoveAttachment,
   onOpenMCP,
   onSelectionChange,
 }: InputAreaProps) {
@@ -166,7 +172,7 @@ export function InputArea({
               icon="file"
               label="Attachments"
               onClick={onOpenAttachments}
-              comingSoon
+              badge={attachments.length > 0 ? attachments.length : undefined}
             />
           )}
 
@@ -186,6 +192,40 @@ export function InputArea({
             <span className="font-mono text-stone-400">Enter</span> to send, <span className="font-mono text-stone-400">Shift+Enter</span> for new line
           </div>
         </div>
+
+        {attachments.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-3">
+            {attachments.map((a) => (
+              <div
+                key={a.uri}
+                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-white/[0.04] border border-white/[0.06] text-xs text-stone-400"
+              >
+                <button
+                  type="button"
+                  onClick={() => onOpenAttachment?.(a.uri)}
+                  className="inline-flex items-center gap-2 min-w-0 hover:text-stone-300 transition-colors"
+                  aria-label={`Open attachment ${a.label}`}
+                  title={a.label}
+                >
+                  <span className="codicon codicon-file text-brand-400/60" />
+                  <span className="truncate">{a.label}</span>
+                </button>
+
+                {onRemoveAttachment && (
+                  <button
+                    type="button"
+                    onClick={() => onRemoveAttachment(a.uri)}
+                    className="text-stone-500 hover:text-stone-300 transition-colors"
+                    aria-label={`Remove attachment ${a.label}`}
+                    title="Remove"
+                  >
+                    <span className="codicon codicon-close" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
Implements the PRD “Attach files UI”.

- Webview: enables **Attachments** button, shows attached file chips, and sends attachments + context files as structured payload.
- Extension: file picker + open attachment; on send, inlines attachment contents (bounded size, binary-skip) using BEGIN/END markers, then appends the existing context-files header.
- Rendering: `MessageEvent` hides attachment payload behind collapsed `<details>`.
- Docs: updates PRD + implementation plan to reflect shipping attachments.

Tests:
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File attachment support: Users can now attach files to messages with inline display, labels, and size information.
  * Enhanced attachment management: Ability to open and remove attachments from conversations.
  * Improved conversation history: Search and pagination support now implemented.

* **Documentation**
  * Updated implementation plan and product roadmap reflecting completed and upcoming attachment features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->