### PR TITLE
History: add pagination

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -33,7 +33,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Action confirmation with Approve/Reject UI
 - Security risk indicators (LOW/MEDIUM/HIGH)
 - Conversation persistence to disk
-- Conversation history view
+- Conversation history view (search + pagination)
 - Attach files UI (inline text attachments)
 - Workspace file context (@mentions)
 - Skills support (~/.openhands/skills/)
@@ -43,7 +43,6 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 
 ### Not Yet Implemented
 - **Mid-conversation LLM switching** - must start new conversation to change model
-- **Full conversation history backend** - list + search implemented, pagination TODO
 
 **Deferred (requires human approval)**
 - **MCP integration / MCP server selection** - UI placeholders exist but are intentionally deferred; not a priority; do not work on this without explicit approval from a human maintainer
@@ -221,7 +220,7 @@ src/
 - **Attach Files (images/binary)** - richer attachment support beyond text
 - **MCP Integration** - DEFERRED until further notice; requires explicit human approval to work on
 - **Mid-Conversation Model Switch** - change LLM without new conversation
-- **Advanced History** - search, pagination, export
+- **Advanced History** - export + richer metadata (and server-backed history if needed)
 
 ## 13. References
 - [agent-sdk](https://github.com/All-Hands-AI/agent-sdk) - Python SDK and agent-server

--- a/src/webview-src/__tests__/HistoryView.test.tsx
+++ b/src/webview-src/__tests__/HistoryView.test.tsx
@@ -40,7 +40,7 @@ describe('HistoryView', () => {
 
     expect(screen.getByText('Fix sidebar issue')).toBeInTheDocument();
     expect(screen.queryByText('Conversation (def45)')).not.toBeInTheDocument();
-    expect(screen.getByText('1 of 2 conversations')).toBeInTheDocument();
+    expect(screen.getByText('Showing 1 of 1 match (2 total)')).toBeInTheDocument();
   });
 
   it('shows no-results state and clears search', () => {
@@ -111,5 +111,35 @@ describe('HistoryView', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('paginates conversations with Load more', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+
+    const conversations = Array.from({ length: 31 }, (_, idx) => {
+      const n = idx + 1;
+      return { id: `conv-${n}`, title: `Conversation ${n}`, timestamp: n };
+    });
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={conversations}
+        onSelectConversation={onSelectConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    expect(screen.getByText('Showing 30 of 31 conversations')).toBeInTheDocument();
+    expect(screen.queryByText('Conversation 1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Load more conversations' }));
+
+    expect(screen.getByText('Conversation 1')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Load more conversations' })).not.toBeInTheDocument();
+    expect(screen.getByText('31 conversations')).toBeInTheDocument();
   });
 });

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -4,6 +4,7 @@ import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideCli
 // --- Constants ---
 
 const PROMPT_PREVIEW_MAX_LENGTH = 100;
+const HISTORY_PAGE_SIZE = 30;
 
 // --- Types ---
 
@@ -194,6 +195,7 @@ export function HistoryView({
 }: HistoryViewProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState('');
+  const [visibleCount, setVisibleCount] = useState(HISTORY_PAGE_SIZE);
 
   // Close on Escape key or click outside (with delay to avoid immediate close on open)
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: panelRef, delay: 100 });
@@ -221,6 +223,16 @@ export function HistoryView({
   }, [sortedConversations, query]);
 
   const hasAnyQuery = query.length > 0;
+  const visibleConversations = useMemo(
+    () => filteredConversations.slice(0, visibleCount),
+    [filteredConversations, visibleCount]
+  );
+  const canLoadMore = visibleConversations.length < filteredConversations.length;
+
+  const updateQuery = (next: string) => {
+    setQuery(next);
+    setVisibleCount(HISTORY_PAGE_SIZE);
+  };
 
   if (!isOpen) return null;
 
@@ -266,11 +278,11 @@ export function HistoryView({
             <span className="codicon codicon-search absolute left-3 top-1/2 -translate-y-1/2 text-stone-500" />
             <input
               value={query}
-              onChange={(e) => setQuery(e.target.value)}
+              onChange={(e) => updateQuery(e.target.value)}
               onKeyDown={(e) => {
                 if (e.key === 'Escape' && hasAnyQuery) {
                   e.stopPropagation();
-                  setQuery('');
+                  updateQuery('');
                 }
               }}
               placeholder="Search history…"
@@ -280,7 +292,7 @@ export function HistoryView({
             {hasAnyQuery && (
               <button
                 type="button"
-                onClick={() => setQuery('')}
+                onClick={() => updateQuery('')}
                 className="absolute right-2 top-1/2 -translate-y-1/2 h-7 w-7 rounded-md text-stone-400 hover:text-stone-200 hover:bg-white/[0.06] flex items-center justify-center transition-all"
                 aria-label="Clear search"
                 title="Clear search"
@@ -296,10 +308,10 @@ export function HistoryView({
           {sortedConversations.length === 0 ? (
             <EmptyState />
           ) : filteredConversations.length === 0 ? (
-            <NoResultsState query={query.trim()} onClear={() => setQuery('')} />
+            <NoResultsState query={query.trim()} onClear={() => updateQuery('')} />
           ) : (
             <div className="space-y-2">
-              {filteredConversations.map((conversation, index) => (
+              {visibleConversations.map((conversation, index) => (
                 <ConversationItem
                   key={conversation.id}
                   conversation={conversation}
@@ -311,6 +323,19 @@ export function HistoryView({
                   }}
                 />
               ))}
+
+              {canLoadMore && (
+                <div className="pt-2">
+                  <button
+                    type="button"
+                    onClick={() => setVisibleCount((prev) => prev + HISTORY_PAGE_SIZE)}
+                    className="w-full px-4 py-3 rounded-xl bg-white/[0.03] border border-white/[0.06] text-sm text-stone-300 hover:bg-white/[0.06] hover:text-stone-100 hover:border-white/[0.1] transition-all"
+                    aria-label="Load more conversations"
+                  >
+                    Load more
+                  </button>
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -319,8 +344,10 @@ export function HistoryView({
         <div className="px-6 py-4 border-t border-white/[0.06] bg-white/[0.02]">
           <p className="text-xs text-stone-500 text-center">
             {query.trim()
-              ? `${filteredConversations.length} of ${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`
-              : `${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`}
+              ? `Showing ${visibleConversations.length} of ${filteredConversations.length} match${filteredConversations.length !== 1 ? 'es' : ''} (${sortedConversations.length} total)`
+              : canLoadMore
+                ? `Showing ${visibleConversations.length} of ${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`
+                : `${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`}
           </p>
         </div>
       </div>

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -234,6 +234,23 @@ export function HistoryView({
     setVisibleCount(HISTORY_PAGE_SIZE);
   };
 
+  const footerText = useMemo(() => {
+    const trimmedQuery = query.trim();
+    const totalConversations = sortedConversations.length;
+    const visible = visibleConversations.length;
+
+    if (trimmedQuery) {
+      const matchWord = filteredConversations.length === 1 ? 'match' : 'matches';
+      return `Showing ${visible} of ${filteredConversations.length} ${matchWord} (${totalConversations} total)`;
+    }
+
+    const conversationWord = totalConversations === 1 ? 'conversation' : 'conversations';
+    if (canLoadMore) {
+      return `Showing ${visible} of ${totalConversations} ${conversationWord}`;
+    }
+    return `${totalConversations} ${conversationWord}`;
+  }, [canLoadMore, filteredConversations.length, query, sortedConversations.length, visibleConversations.length]);
+
   if (!isOpen) return null;
 
   return (
@@ -343,11 +360,7 @@ export function HistoryView({
         {/* Footer */}
         <div className="px-6 py-4 border-t border-white/[0.06] bg-white/[0.02]">
           <p className="text-xs text-stone-500 text-center">
-            {query.trim()
-              ? `Showing ${visibleConversations.length} of ${filteredConversations.length} match${filteredConversations.length !== 1 ? 'es' : ''} (${sortedConversations.length} total)`
-              : canLoadMore
-                ? `Showing ${visibleConversations.length} of ${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`
-                : `${sortedConversations.length} conversation${sortedConversations.length !== 1 ? 's' : ''}`}
+            {footerText}
           </p>
         </div>
       </div>


### PR DESCRIPTION
Implements PRD history pagination.

- History panel now shows an initial page of conversations with **Load more**.
- Footer reflects visible/total counts, including search matches.
- PRD updated to reflect history pagination is shipped.

Tests:
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversation history now features pagination with a "Load more" button for easier browsing of large conversation lists.
  * Updated history display to show current progress with messages like "Showing 1 of 31 conversations."

* **Documentation**
  * Updated product documentation to reflect search and pagination capabilities in the conversation history view.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->