### PR TITLE
Mid-conversation LLM switching (local mode)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
-  "openhands.llm.model": "gpt-5",
-  "openhands.llm.reasoningEffort": "low"
+  "openhands.llm.reasoningEffort": "low",
+  "openhands.servers": [
+    {
+      "url": "localhost:3000"
+    }
+  ]
 }

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -42,7 +42,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Event rendering for all event types
 
 ### Not Yet Implemented
-- **Mid-conversation LLM switching** - must start new conversation to change model
+- **Mid-conversation LLM switching (remote mode)** - must start a new conversation to change model; local mode applies settings updates live
 
 **Deferred (requires human approval)**
 - **MCP integration / MCP server selection** - UI placeholders exist but are intentionally deferred; not a priority; do not work on this without explicit approval from a human maintainer

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -74,9 +74,7 @@ export class LocalConversation extends EventEmitter {
 
   setSettings(settings: OpenHandsSettings) {
     this.settings = settings;
-    // TODO: Is this a good idea?
-    // Recreate the Agent when settings change
-    this.agent = this.createAgent();
+    this.agent.setSettings(settings);
   }
 
   startNewConversation(): Promise<string | undefined> {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -196,12 +196,13 @@ export class Agent extends EventEmitter {
    * an active run. New settings take effect on the next run.
    */
   setSettings(settings: OpenHandsSettings): void {
-    void this.lock.acquire(async () => {
+    void this.lock.acquire(() => {
       this.options.settings = settings;
       this.updateDerivedSettings(settings);
 
       // Force the next run to rebuild the LLM client from updated settings.
       this.orchestratorPromise = undefined;
+      return Promise.resolve();
     });
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -161,7 +161,7 @@ export class Agent extends EventEmitter {
   private readonly activatedSkillNames: string[] = [];
   private readonly registry?: import('../llm').LLMRegistry;
   private readonly conversationStats?: import('./ConversationStats').ConversationStats;
-  private readonly debug: boolean;
+  private debug: boolean;
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -183,6 +183,19 @@ export class Agent extends EventEmitter {
     this.debug = options.settings?.agent?.debug ?? false;
 
     this.events.on((event) => this.emit('event', event));
+  }
+
+  setSettings(settings: OpenHandsSettings): void {
+    this.options.settings = settings;
+
+    // Refresh derived settings used by the agent runtime.
+    this.confirmation.policy = settings?.confirmation?.policy ?? 'never';
+    this.confirmation.riskyThreshold = settings?.confirmation?.riskyThreshold ?? 'MEDIUM';
+    this.confirmation.confirmUnknown = settings?.confirmation?.confirmUnknown ?? true;
+    this.debug = settings?.agent?.debug ?? false;
+
+    // Force the next run to rebuild the LLM client from updated settings.
+    this.orchestratorPromise = undefined;
   }
 
   get pendingActionId(): string | undefined {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -189,12 +189,20 @@ export class Agent extends EventEmitter {
     this.debug = settings?.agent?.debug ?? false;
   }
 
+  /**
+   * Updates the agent's settings at runtime.
+   *
+   * Changes are applied under the agent lock so settings updates can't race with
+   * an active run. New settings take effect on the next run.
+   */
   setSettings(settings: OpenHandsSettings): void {
-    this.options.settings = settings;
-    this.updateDerivedSettings(settings);
+    void this.lock.acquire(async () => {
+      this.options.settings = settings;
+      this.updateDerivedSettings(settings);
 
-    // Force the next run to rebuild the LLM client from updated settings.
-    this.orchestratorPromise = undefined;
+      // Force the next run to rebuild the LLM client from updated settings.
+      this.orchestratorPromise = undefined;
+    });
   }
 
   get pendingActionId(): string | undefined {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -174,25 +174,24 @@ export class Agent extends EventEmitter {
     this.tools = new Map(providedTools.map((tool) => [tool.name, tool]));
     this.registry = options.registry;
     this.conversationStats = options.conversationStats;
-    this.confirmation = {
-      policy: options.settings?.confirmation?.policy ?? 'never',
-      riskyThreshold: options.settings?.confirmation?.riskyThreshold ?? 'MEDIUM',
-      confirmUnknown: options.settings?.confirmation?.confirmUnknown ?? true,
-    };
+    this.confirmation = { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true };
     this.agentContext = options.agentContext;
-    this.debug = options.settings?.agent?.debug ?? false;
+    this.debug = false;
+    this.updateDerivedSettings(options.settings);
 
     this.events.on((event) => this.emit('event', event));
   }
 
-  setSettings(settings: OpenHandsSettings): void {
-    this.options.settings = settings;
-
-    // Refresh derived settings used by the agent runtime.
+  private updateDerivedSettings(settings: OpenHandsSettings): void {
     this.confirmation.policy = settings?.confirmation?.policy ?? 'never';
     this.confirmation.riskyThreshold = settings?.confirmation?.riskyThreshold ?? 'MEDIUM';
     this.confirmation.confirmUnknown = settings?.confirmation?.confirmUnknown ?? true;
     this.debug = settings?.agent?.debug ?? false;
+  }
+
+  setSettings(settings: OpenHandsSettings): void {
+    this.options.settings = settings;
+    this.updateDerivedSettings(settings);
 
     // Force the next run to rebuild the LLM client from updated settings.
     this.orchestratorPromise = undefined;

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -230,6 +230,35 @@ describe('Chat view behavior', () => {
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
     expect(conv?.restoreConversation).not.toHaveBeenCalled();
   });
+
+  it('refreshes the active conversation when LLM settings change', async () => {
+    const view = await resolveChatView(mockContext);
+    expect(view).toBeTruthy();
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const conv = __getLastConversation();
+    expect(conv).toBeTruthy();
+
+    mockSettings = {
+      ...mockSettings,
+      llm: {
+        ...mockSettings.llm,
+        model: 'gpt-4o-mini',
+      },
+    };
+
+    (vscode as any).__triggerConfigChange({
+      affectsConfiguration: (key: string) => key === 'openhands.llm' || key === 'openhands.llm.model',
+    });
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((conv.setSettings as Mock).mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(conv.setSettings).toHaveBeenCalledWith(mockSettings);
+  });
 });
 
 describe('Command handlers', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -805,6 +805,20 @@ export function activate(context: vscode.ExtensionContext) {
         }
         conversation = undefined;
         await ensureConversationAndConnection();
+        return;
+      }
+
+      if (e.affectsConfiguration('openhands.llm')) {
+        try {
+          await ensureConversationAndConnection();
+          if (conversationMode === 'remote') {
+            outputChannel?.appendLine('[settings] LLM settings updated (remote mode: applies on next conversation)');
+          } else {
+            outputChannel?.appendLine('[settings] LLM settings updated (local mode: applies immediately)');
+          }
+        } catch (err: unknown) {
+          outputChannel?.appendLine(`[settings] Failed to apply LLM settings update: ${renderError(err)}`);
+        }
       }
     })
   );


### PR DESCRIPTION
Implements `oh-tab-8x4`.

Changes:
- Refresh active conversation on `openhands.llm` config changes.
- Local mode: apply updated LLM settings without starting a new conversation.
- Agent SDK: add `Agent.setSettings()` and stop recreating `Agent` on `LocalConversation.setSettings()`.
- Docs: clarify that remote mode still requires new conversation.

Tests:
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

Thread: oh-tab-8x4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM settings now apply immediately in local mode and take effect on a new conversation in remote mode; status messages reflect mode-specific behavior and errors are reported consistently.

* **Tests**
  * Added a test verifying the active conversation refreshes when LLM settings change.

* **Documentation**
  * Clarified wording about mid-conversation LLM switching and when changes take effect.

* **Chores**
  * Workspace settings updated: removed a default model and added a servers configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->