### PR TITLE
[oh-tab-0l31] Prefetch skills list for Skills badge

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -18,6 +18,14 @@ describe('App toolbar interactions', () => {
     expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'openSettingsPage' });
   });
 
+  it('requests skills on mount to populate badge', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestSkills' });
+    });
+  });
+
   it('requests workspace files and inserts context mention at cursor', async () => {
     render(<App />);
     const input = document.getElementById('openhands-chat-input') as HTMLInputElement;

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -238,13 +238,17 @@ export function App() {
   // Signal webview is ready on mount
   useEffect(() => {
     const vscodeApi = getVscodeApi();
+    let didRequestSkills = false;
     const sendReady = () => {
       const state = vscodeApi.getState?.<WebviewPersistedState>() ?? {};
       const payload: { type: 'webviewReady'; conversationId?: string; lastSeenSeq?: number } = { type: 'webviewReady' };
       if (typeof state.conversationId === 'string') payload.conversationId = state.conversationId;
       if (typeof state.lastSeenSeq === 'number') payload.lastSeenSeq = state.lastSeenSeq;
       vscodeApi.postMessage(payload);
-      vscodeApi.postMessage({ type: 'requestSkills' });
+      if (!didRequestSkills) {
+        didRequestSkills = true;
+        vscodeApi.postMessage({ type: 'requestSkills' });
+      }
     };
 
     sendReady();

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -244,6 +244,7 @@ export function App() {
       if (typeof state.conversationId === 'string') payload.conversationId = state.conversationId;
       if (typeof state.lastSeenSeq === 'number') payload.lastSeenSeq = state.lastSeenSeq;
       vscodeApi.postMessage(payload);
+      vscodeApi.postMessage({ type: 'requestSkills' });
     };
 
     sendReady();


### PR DESCRIPTION
Fixes Beads oh-tab-0l31.

- Webview now requests skills list on mount/visibility (alongside webviewReady), so the Skills badge count populates without requiring the first click.
- Added a unit test for the new behavior.

Checks: npm test, npm run lint, npm run typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills data is now automatically requested when the app initializes, ensuring data is available on startup.

* **Tests**
  * Added test coverage to validate that skills are requested during app initialization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->