### PR TITLE
Add e2e tests for OpenHands extension

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -776,10 +776,13 @@ export function activate(context: vscode.ExtensionContext) {
   // Test command to send mock events to webview for E2E testing
   const sendTestEvent = vscode.commands.registerCommand('openhands._sendTestEvent', (event: Event) => {
     sentTestEvents.push(event);
+    const seq = bufferConversationEvent(event);
     if (chatView) {
-      void chatView.webview.postMessage({ type: 'event', event });
+      const payload: { type: 'event'; event: Event; seq?: number } = { type: 'event', event };
+      if (typeof seq === 'number') payload.seq = seq;
+      void chatView.webview.postMessage(payload);
     }
-    return { sent: true };
+    return { sent: true, buffered: true, seq };
   });
 
   // Query rendered events from webview for E2E testing

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,14 +1,36 @@
 # E2E Tests
 
-This folder contains minimal E2E scaffolding using @vscode/test-electron.
+This folder contains E2E test scaffolding using @vscode/test-electron.
 
 ## Test Files
 
-- **open.test.ts**: orchestrates a VS Code instance and runs the suite entry.
-- **diagnostics.test.ts**: tests the diagnostics command.
-- **agentSdkEvents.test.ts**: tests agent-sdk event rendering in the webview.
-- **suite/index.ts**: called by the VS Code runner; triggers extension commands.
-- **suite/agentSdkEvents.ts**: exercises all agent-sdk event types (SystemPromptEvent, ActionEvent, ObservationEvent, MessageEvent, etc.)
+### Entry Point Tests (*.test.ts)
+Each test file orchestrates a VS Code instance and runs a specific test suite:
+
+- **open.test.ts**: Basic smoke test - opens the chat view and executes commands
+- **diagnostics.test.ts**: Tests the diagnostics command structure
+- **agentSdkEvents.test.ts**: Tests agent-sdk event rendering in the webview
+- **settings.test.ts**: Tests settings and configuration commands
+- **history.test.ts**: Tests conversation history and restore functionality
+- **messaging.test.ts**: Tests message events and rendering
+- **serverSelection.test.ts**: Tests server selection and local/remote mode switching
+- **confirmation.test.ts**: Tests action confirmation workflow with security levels
+- **errorHandling.test.ts**: Tests error events and error state handling
+
+### Suite Files (suite/*.ts)
+These run inside VS Code and execute the actual tests:
+
+- **suite/index.ts**: Routes to the appropriate test based on TEST_NAME env var
+- **suite/agentSdkEvents.ts**: Exercises all agent-sdk event types
+- **suite/settings.ts**: Tests extension commands and diagnostics structure
+- **suite/history.ts**: Tests conversation state and event backlog
+- **suite/messaging.ts**: Tests message event rendering and multi-part content
+- **suite/serverSelection.ts**: Tests mode switching and diagnostics state
+- **suite/confirmation.ts**: Tests actions with different security risk levels
+- **suite/errorHandling.ts**: Tests error events and recovery
+
+### Helper Files
+- **testHelpers.ts**: Utility functions including VS Code download with retry
 
 ## Run locally
 
@@ -16,9 +38,10 @@ This folder contains minimal E2E scaffolding using @vscode/test-electron.
 npm run e2e
 ```
 
-## Agent-SDK Events Test
+## Test Coverage
 
-The agentSdkEvents test verifies that all event types from the OpenHands agent-sdk are properly rendered in the webview:
+### Agent-SDK Events Test
+Verifies that all event types from the OpenHands agent-sdk are properly rendered:
 
 - SystemPromptEvent
 - ActionEvent (with/without execution, different security risk levels)
@@ -30,15 +53,71 @@ The agentSdkEvents test verifies that all event types from the OpenHands agent-s
 - Condensation
 - ConversationStateUpdateEvent (filtered out, not rendered)
 
-The test:
-1. Uses `openhands._sendTestEvent` to inject 14 mock events into the webview
-2. Uses `openhands._queryRenderedEvents` to query the webview's actual rendered state
-3. Verifies that exactly 13 events were rendered (14 sent minus 1 ConversationStateUpdateEvent which is filtered)
-4. Verifies the event types match the expected sequence
+### Settings Test
+Verifies extension commands and configuration:
 
-This ensures the webview actually receives, processes, and renders the events correctly.
+- Diagnostics command structure
+- Configure command execution
+- Reconnect command
+- Start new conversation command
+- Pause and resume commands
+
+### History Test
+Verifies conversation management:
+
+- Conversation ID tracking
+- Event backlog management
+- Test event injection and querying
+- Conversation reset behavior
+
+### Messaging Test
+Verifies message handling and rendering:
+
+- User messages with different content types
+- Assistant messages with reasoning
+- Action events with observations
+- Multi-part content messages
+- System prompt events
+
+### Server Selection Test
+Verifies mode switching and server configuration:
+
+- Local vs remote mode detection
+- Status reporting
+- Terminal state tracking
+- Mode persistence across operations
+
+### Confirmation Test
+Verifies action confirmation workflow:
+
+- Actions with LOW/MEDIUM/HIGH security risks
+- Actions with UNKNOWN risk (missing field)
+- User rejection handling
+- ConversationStateUpdateEvent filtering
+- Unexecuted actions (null action)
+
+### Error Handling Test
+Verifies error event handling:
+
+- AgentErrorEvent rendering
+- ConversationErrorEvent rendering
+- Multiple sequential errors
+- Failed observations (non-zero exit codes)
+- Recovery via new conversation
+- Condensation events
+
+## Internal Commands Used
+
+The tests use these internal extension commands:
+
+- `openhands._diagnostics`: Returns extension state for verification
+- `openhands._sendTestEvent`: Injects mock events into the webview
+- `openhands._queryRenderedEvents`: Queries webview rendered state
 
 ## Notes
 
-- These are smoke tests. They don't yet verify webview DOM. For deeper checks, expose a diagnostics command in the extension or use a headless desktop with UI automation.
-- The e2e tests require network access to download VS Code. They may fail in network-restricted environments.
+- Tests use `@vscode/test-electron` to launch real VS Code instances
+- Each test runs in isolated user data directories
+- Tests require network access to download VS Code (cached after first run)
+- The tests verify actual webview rendering through the query mechanism
+- For deeper DOM verification, use headless desktop with UI automation

--- a/tests/e2e/confirmation.test.ts
+++ b/tests/e2e/confirmation.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-confirmation-${Date.now()}`);
+
+// E2E test for action confirmation workflow
+describe('OpenHands-Tab Confirmation E2E', function () {
+  this.timeout(120000);
+
+  it('tests action confirmation rendering with different security levels', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'confirmation'
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/errorHandling.test.ts
+++ b/tests/e2e/errorHandling.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-errors-${Date.now()}`);
+
+// E2E test for error handling and error event rendering
+describe('OpenHands-Tab Error Handling E2E', function () {
+  this.timeout(120000);
+
+  it('tests error events and error state handling', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'errorHandling'
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/history.test.ts
+++ b/tests/e2e/history.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-history-${Date.now()}`);
+
+// E2E test for conversation history functionality
+describe('OpenHands-Tab History E2E', function () {
+  this.timeout(120000);
+
+  it('tests conversation history and restore functionality', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'history'
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/messaging.test.ts
+++ b/tests/e2e/messaging.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-messaging-${Date.now()}`);
+
+// E2E test for message input and event rendering
+describe('OpenHands-Tab Messaging E2E', function () {
+  this.timeout(120000);
+
+  it('tests message events and rendering', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'messaging'
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/serverSelection.test.ts
+++ b/tests/e2e/serverSelection.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-server-${Date.now()}`);
+
+// E2E test for server selection and local/remote mode switching
+describe('OpenHands-Tab Server Selection E2E', function () {
+  this.timeout(120000);
+
+  it('tests server selection and mode switching', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'serverSelection'
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -1,0 +1,37 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-settings-${Date.now()}`);
+
+// E2E test for settings and configuration functionality
+describe('OpenHands-Tab Settings E2E', function () {
+  this.timeout(120000);
+
+  it('tests settings commands and configuration', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'settings'
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/suite/agentSdkEvents.ts
+++ b/tests/e2e/suite/agentSdkEvents.ts
@@ -160,7 +160,7 @@ export async function run(): Promise<void> {
     // Condensation
     {
       kind: 'Condensation',
-      source: 'agent',
+      source: 'environment',
       forgotten_event_ids: ['event_001', 'event_002', 'event_003'],
       summary: 'Condensed 3 events to save memory'
     },

--- a/tests/e2e/suite/agentSdkEvents.ts
+++ b/tests/e2e/suite/agentSdkEvents.ts
@@ -98,7 +98,7 @@ export async function run(): Promise<void> {
     // UserRejectObservation
     {
       kind: 'UserRejectObservation',
-      source: 'user',
+      source: 'environment',
       rejection_reason: 'This command looks dangerous',
       tool_name: 'terminal',
       tool_call_id: 'call_002',

--- a/tests/e2e/suite/confirmation.ts
+++ b/tests/e2e/suite/confirmation.ts
@@ -158,7 +158,7 @@ export async function run(): Promise<void> {
   // Test 3: Send user rejection observation
   const rejection = {
     kind: 'UserRejectObservation',
-    source: 'user',
+    source: 'environment',
     rejection_reason: 'This command is too dangerous',
     tool_name: 'terminal',
     tool_call_id: 'call_high_risk',

--- a/tests/e2e/suite/confirmation.ts
+++ b/tests/e2e/suite/confirmation.ts
@@ -1,20 +1,34 @@
 import * as vscode from 'vscode';
 
+// Helper to poll until condition is met
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 export async function run(): Promise<void> {
   // Ensure chat view is created
   await vscode.commands.executeCommand('openhands.open');
 
   // Wait until view and webview are ready
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
+  await pollUntil(async () => {
     const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
-    await new Promise((r) => setTimeout(r, 200));
-  }
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
 
   // Start fresh conversation
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 500));
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   // Test 1: Send action events with different security risk levels
   const actionEventsWithRisks = [
@@ -86,10 +100,14 @@ export async function run(): Promise<void> {
 
   for (const event of actionEventsWithRisks) {
     await vscode.commands.executeCommand('openhands._sendTestEvent', event);
-    await new Promise((r) => setTimeout(r, 100));
   }
 
-  await new Promise((r) => setTimeout(r, 500));
+  // Poll until all action events are rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'ActionEvent').length || 0;
+    return count >= 4;
+  });
 
   // Query rendered events
   let result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -124,10 +142,14 @@ export async function run(): Promise<void> {
 
   for (const obs of observations) {
     await vscode.commands.executeCommand('openhands._sendTestEvent', obs);
-    await new Promise((r) => setTimeout(r, 100));
   }
 
-  await new Promise((r) => setTimeout(r, 300));
+  // Poll until observations are rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'ObservationEvent').length || 0;
+    return count >= 2;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After observations - Count: ${result.count}`);
@@ -143,7 +165,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', rejection);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until rejection is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'UserRejectObservation').length || 0;
+    return count >= 1;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After rejection - Count: ${result.count}`);
@@ -161,7 +189,9 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', confirmationStateEvent);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Small delay to ensure event is processed
+  await new Promise((r) => setTimeout(r, 200));
 
   // ConversationStateUpdateEvent should be filtered from rendering
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -190,7 +220,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', unexecutedAction);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until unexecuted action is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'ActionEvent').length || 0;
+    return count >= 5;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After unexecuted action - Count: ${result.count}`);

--- a/tests/e2e/suite/confirmation.ts
+++ b/tests/e2e/suite/confirmation.ts
@@ -11,6 +11,7 @@ async function pollUntil(
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
 export async function run(): Promise<void> {
@@ -106,7 +107,7 @@ export async function run(): Promise<void> {
   await pollUntil(async () => {
     const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const count = r?.eventTypes?.filter((t: string) => t === 'ActionEvent').length || 0;
-    return count >= 4;
+    return count >= actionEventsWithRisks.length;
   });
 
   // Query rendered events
@@ -116,8 +117,8 @@ export async function run(): Promise<void> {
 
   // Verify all action events rendered
   const actionCount = result.eventTypes.filter((t: string) => t === 'ActionEvent').length;
-  if (actionCount !== 4) {
-    throw new Error(`Expected 4 ActionEvents with different risk levels, got ${actionCount}`);
+  if (actionCount !== actionEventsWithRisks.length) {
+    throw new Error(`Expected ${actionEventsWithRisks.length} ActionEvents with different risk levels, got ${actionCount}`);
   }
 
   // Test 2: Send observation events to complete the actions
@@ -148,7 +149,7 @@ export async function run(): Promise<void> {
   await pollUntil(async () => {
     const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const count = r?.eventTypes?.filter((t: string) => t === 'ObservationEvent').length || 0;
-    return count >= 2;
+    return count >= observations.length;
   });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -221,11 +222,13 @@ export async function run(): Promise<void> {
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', unexecutedAction);
 
+  const expectedTotalActions = actionEventsWithRisks.length + 1; // +1 for unexecutedAction
+
   // Poll until unexecuted action is rendered
   await pollUntil(async () => {
     const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const count = r?.eventTypes?.filter((t: string) => t === 'ActionEvent').length || 0;
-    return count >= 5;
+    return count >= expectedTotalActions;
   });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -233,8 +236,8 @@ export async function run(): Promise<void> {
 
   // Total should include all action types
   const totalActions = result.eventTypes.filter((t: string) => t === 'ActionEvent').length;
-  if (totalActions !== 5) {
-    throw new Error(`Expected 5 total ActionEvents, got ${totalActions}`);
+  if (totalActions !== expectedTotalActions) {
+    throw new Error(`Expected ${expectedTotalActions} total ActionEvents, got ${totalActions}`);
   }
 
   console.log('✓ All confirmation tests passed');

--- a/tests/e2e/suite/confirmation.ts
+++ b/tests/e2e/suite/confirmation.ts
@@ -1,0 +1,205 @@
+import * as vscode from 'vscode';
+
+export async function run(): Promise<void> {
+  // Ensure chat view is created
+  await vscode.commands.executeCommand('openhands.open');
+
+  // Wait until view and webview are ready
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  // Start fresh conversation
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Test 1: Send action events with different security risk levels
+  const actionEventsWithRisks = [
+    // LOW risk action
+    {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'Reading a file is safe' }],
+      action: { command: 'cat README.md' },
+      tool_name: 'terminal',
+      tool_call_id: 'call_low_risk',
+      tool_call: {
+        id: 'call_low_risk',
+        type: 'function',
+        function: { name: 'terminal', arguments: '{"command":"cat README.md"}' }
+      },
+      llm_response_id: 'resp_low',
+      security_risk: 'LOW'
+    },
+    // MEDIUM risk action
+    {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'Installing a package' }],
+      action: { command: 'npm install express' },
+      tool_name: 'terminal',
+      tool_call_id: 'call_medium_risk',
+      tool_call: {
+        id: 'call_medium_risk',
+        type: 'function',
+        function: { name: 'terminal', arguments: '{"command":"npm install express"}' }
+      },
+      llm_response_id: 'resp_medium',
+      security_risk: 'MEDIUM'
+    },
+    // HIGH risk action
+    {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'This is a dangerous command' }],
+      action: { command: 'rm -rf /tmp/test' },
+      tool_name: 'terminal',
+      tool_call_id: 'call_high_risk',
+      tool_call: {
+        id: 'call_high_risk',
+        type: 'function',
+        function: { name: 'terminal', arguments: '{"command":"rm -rf /tmp/test"}' }
+      },
+      llm_response_id: 'resp_high',
+      security_risk: 'HIGH'
+    },
+    // UNKNOWN risk action (no security_risk field)
+    {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'Unknown risk command' }],
+      action: { command: 'echo hello' },
+      tool_name: 'terminal',
+      tool_call_id: 'call_unknown_risk',
+      tool_call: {
+        id: 'call_unknown_risk',
+        type: 'function',
+        function: { name: 'terminal', arguments: '{"command":"echo hello"}' }
+      },
+      llm_response_id: 'resp_unknown'
+      // No security_risk field
+    }
+  ];
+
+  for (const event of actionEventsWithRisks) {
+    await vscode.commands.executeCommand('openhands._sendTestEvent', event);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Query rendered events
+  let result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+
+  console.log(`After actions - Count: ${result.count}, Types: ${result.eventTypes.join(', ')}`);
+
+  // Verify all action events rendered
+  const actionCount = result.eventTypes.filter((t: string) => t === 'ActionEvent').length;
+  if (actionCount !== 4) {
+    throw new Error(`Expected 4 ActionEvents with different risk levels, got ${actionCount}`);
+  }
+
+  // Test 2: Send observation events to complete the actions
+  const observations = [
+    {
+      kind: 'ObservationEvent',
+      source: 'environment',
+      observation: { content: 'README content here', exit_code: 0 },
+      tool_name: 'terminal',
+      tool_call_id: 'call_low_risk',
+      action_id: 'action_low'
+    },
+    {
+      kind: 'ObservationEvent',
+      source: 'environment',
+      observation: { content: 'added 50 packages', exit_code: 0 },
+      tool_name: 'terminal',
+      tool_call_id: 'call_medium_risk',
+      action_id: 'action_medium'
+    }
+  ];
+
+  for (const obs of observations) {
+    await vscode.commands.executeCommand('openhands._sendTestEvent', obs);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After observations - Count: ${result.count}`);
+
+  // Test 3: Send user rejection observation
+  const rejection = {
+    kind: 'UserRejectObservation',
+    source: 'user',
+    rejection_reason: 'This command is too dangerous',
+    tool_name: 'terminal',
+    tool_call_id: 'call_high_risk',
+    action_id: 'action_high'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', rejection);
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After rejection - Count: ${result.count}`);
+
+  const rejectCount = result.eventTypes.filter((t: string) => t === 'UserRejectObservation').length;
+  if (rejectCount !== 1) {
+    throw new Error(`Expected 1 UserRejectObservation, got ${rejectCount}`);
+  }
+
+  // Test 4: Send ConversationStateUpdateEvent with confirmation status
+  const confirmationStateEvent = {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', confirmationStateEvent);
+  await new Promise((r) => setTimeout(r, 300));
+
+  // ConversationStateUpdateEvent should be filtered from rendering
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  const stateUpdateCount = result.eventTypes.filter((t: string) => t === 'ConversationStateUpdateEvent').length;
+
+  if (stateUpdateCount > 0) {
+    throw new Error('ConversationStateUpdateEvent should be filtered from rendering');
+  }
+
+  console.log('✓ ConversationStateUpdateEvent correctly filtered');
+
+  // Test 5: Action without execution (action is null)
+  const unexecutedAction = {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'This action was not executed' }],
+    action: null,
+    tool_name: 'file_editor',
+    tool_call_id: 'call_unexecuted',
+    tool_call: {
+      id: 'call_unexecuted',
+      type: 'function',
+      function: { name: 'file_editor', arguments: '{"path":"test.txt"}' }
+    },
+    llm_response_id: 'resp_unexecuted'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', unexecutedAction);
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After unexecuted action - Count: ${result.count}`);
+
+  // Total should include all action types
+  const totalActions = result.eventTypes.filter((t: string) => t === 'ActionEvent').length;
+  if (totalActions !== 5) {
+    throw new Error(`Expected 5 total ActionEvents, got ${totalActions}`);
+  }
+
+  console.log('✓ All confirmation tests passed');
+}

--- a/tests/e2e/suite/errorHandling.ts
+++ b/tests/e2e/suite/errorHandling.ts
@@ -210,6 +210,11 @@ export async function run(): Promise<void> {
   }
 
   console.log(`Diagnostics - eventBacklog size: ${diag.eventBacklog.size}`);
+  const expectedMinBacklogSize = expectedAgentErrors + 1 + 1 + 1 + 1; // +ConversationError +Observation +Pause +Condensation
+  if ((diag.eventBacklog?.size ?? 0) < expectedMinBacklogSize) {
+    throw new Error(`Expected eventBacklog.size >= ${expectedMinBacklogSize}, got ${diag.eventBacklog?.size ?? 0}`);
+  }
+  const backlogBeforeRecovery = diag.eventBacklog?.size ?? 0;
 
   // Test 8: Recovery - start new conversation after errors
   await vscode.commands.executeCommand('openhands.startNewConversation');
@@ -219,6 +224,12 @@ export async function run(): Promise<void> {
     const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
     return d?.chat?.webviewReady;
   });
+
+  const diagAfterRecovery: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const backlogAfterRecovery = diagAfterRecovery?.eventBacklog?.size ?? 0;
+  if (backlogAfterRecovery >= backlogBeforeRecovery) {
+    throw new Error(`Expected eventBacklog.size to reset after recovery (before=${backlogBeforeRecovery}, after=${backlogAfterRecovery})`);
+  }
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After new conversation - Events should be cleared or minimal: ${result.count}`);

--- a/tests/e2e/suite/errorHandling.ts
+++ b/tests/e2e/suite/errorHandling.ts
@@ -1,20 +1,34 @@
 import * as vscode from 'vscode';
 
+// Helper to poll until condition is met
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 export async function run(): Promise<void> {
   // Ensure chat view is created
   await vscode.commands.executeCommand('openhands.open');
 
   // Wait until view and webview are ready
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
+  await pollUntil(async () => {
     const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
-    await new Promise((r) => setTimeout(r, 200));
-  }
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
 
   // Start fresh conversation
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 500));
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   // Test 1: Send AgentErrorEvent
   const agentError = {
@@ -26,7 +40,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', agentError);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until error event is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'AgentErrorEvent').length || 0;
+    return count >= 1;
+  });
 
   let result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After agent error - Count: ${result.count}, Types: ${result.eventTypes.join(', ')}`);
@@ -45,7 +65,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', conversationError);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until conversation error is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'ConversationErrorEvent').length || 0;
+    return count >= 1;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After conversation error - Count: ${result.count}`);
@@ -82,10 +108,14 @@ export async function run(): Promise<void> {
 
   for (const err of multipleErrors) {
     await vscode.commands.executeCommand('openhands._sendTestEvent', err);
-    await new Promise((r) => setTimeout(r, 100));
   }
 
-  await new Promise((r) => setTimeout(r, 300));
+  // Poll until all error events are rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'AgentErrorEvent').length || 0;
+    return count >= 4;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After multiple errors - Count: ${result.count}`);
@@ -109,7 +139,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', failedObservation);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until observation is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'ObservationEvent').length || 0;
+    return count >= 1;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After failed observation - Count: ${result.count}`);
@@ -126,7 +162,9 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', pauseEvent);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Small delay for pause event processing
+  await new Promise((r) => setTimeout(r, 200));
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After pause event - Count: ${result.count}`);
@@ -145,7 +183,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', condensation);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until condensation is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = r?.eventTypes?.filter((t: string) => t === 'Condensation').length || 0;
+    return count >= 1;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After condensation - Count: ${result.count}`);
@@ -166,7 +210,12 @@ export async function run(): Promise<void> {
 
   // Test 8: Recovery - start new conversation after errors
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 500));
+
+  // Poll until webview is ready
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After new conversation - Events should be cleared or minimal: ${result.count}`);

--- a/tests/e2e/suite/errorHandling.ts
+++ b/tests/e2e/suite/errorHandling.ts
@@ -1,0 +1,178 @@
+import * as vscode from 'vscode';
+
+export async function run(): Promise<void> {
+  // Ensure chat view is created
+  await vscode.commands.executeCommand('openhands.open');
+
+  // Wait until view and webview are ready
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  // Start fresh conversation
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Test 1: Send AgentErrorEvent
+  const agentError = {
+    kind: 'AgentErrorEvent',
+    source: 'agent',
+    error: 'Failed to execute tool: API rate limit exceeded',
+    tool_name: 'terminal',
+    tool_call_id: 'call_error_001'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', agentError);
+  await new Promise((r) => setTimeout(r, 300));
+
+  let result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After agent error - Count: ${result.count}, Types: ${result.eventTypes.join(', ')}`);
+
+  let errorCount = result.eventTypes.filter((t: string) => t === 'AgentErrorEvent').length;
+  if (errorCount !== 1) {
+    throw new Error(`Expected 1 AgentErrorEvent, got ${errorCount}`);
+  }
+
+  // Test 2: Send ConversationErrorEvent
+  const conversationError = {
+    kind: 'ConversationErrorEvent',
+    source: 'agent',
+    error: 'Connection lost to server',
+    error_type: 'ConnectionError'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', conversationError);
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After conversation error - Count: ${result.count}`);
+
+  const convErrorCount = result.eventTypes.filter((t: string) => t === 'ConversationErrorEvent').length;
+  if (convErrorCount !== 1) {
+    throw new Error(`Expected 1 ConversationErrorEvent, got ${convErrorCount}`);
+  }
+
+  // Test 3: Send multiple error events in sequence
+  const multipleErrors = [
+    {
+      kind: 'AgentErrorEvent',
+      source: 'agent',
+      error: 'Permission denied: /etc/passwd',
+      tool_name: 'file_editor',
+      tool_call_id: 'call_error_002'
+    },
+    {
+      kind: 'AgentErrorEvent',
+      source: 'agent',
+      error: 'Timeout: operation took too long',
+      tool_name: 'browser',
+      tool_call_id: 'call_error_003'
+    },
+    {
+      kind: 'AgentErrorEvent',
+      source: 'agent',
+      error: 'Invalid JSON response from LLM',
+      tool_name: 'llm',
+      tool_call_id: 'call_error_004'
+    }
+  ];
+
+  for (const err of multipleErrors) {
+    await vscode.commands.executeCommand('openhands._sendTestEvent', err);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After multiple errors - Count: ${result.count}`);
+
+  errorCount = result.eventTypes.filter((t: string) => t === 'AgentErrorEvent').length;
+  if (errorCount !== 4) {
+    throw new Error(`Expected 4 AgentErrorEvents total, got ${errorCount}`);
+  }
+
+  // Test 4: Send observation with non-zero exit code (error state)
+  const failedObservation = {
+    kind: 'ObservationEvent',
+    source: 'environment',
+    observation: {
+      content: 'bash: command not found: nonexistent_command',
+      exit_code: 127
+    },
+    tool_name: 'terminal',
+    tool_call_id: 'call_failed',
+    action_id: 'action_failed'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', failedObservation);
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After failed observation - Count: ${result.count}`);
+
+  const obsCount = result.eventTypes.filter((t: string) => t === 'ObservationEvent').length;
+  if (obsCount !== 1) {
+    throw new Error(`Expected 1 ObservationEvent, got ${obsCount}`);
+  }
+
+  // Test 5: Send PauseEvent (indicates interrupted state)
+  const pauseEvent = {
+    kind: 'PauseEvent',
+    source: 'user'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', pauseEvent);
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After pause event - Count: ${result.count}`);
+
+  // PauseEvent is not rendered but should not cause errors
+  const pauseCount = result.eventTypes.filter((t: string) => t === 'PauseEvent').length;
+  // PauseEvent may or may not render (it shows in status bar)
+  console.log(`PauseEvent count (may be 0 if not rendered): ${pauseCount}`);
+
+  // Test 6: Send Condensation event (memory compaction)
+  const condensation = {
+    kind: 'Condensation',
+    source: 'agent',
+    forgotten_event_ids: ['evt_1', 'evt_2', 'evt_3'],
+    summary: 'Condensed 3 events from earlier conversation'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', condensation);
+  await new Promise((r) => setTimeout(r, 300));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After condensation - Count: ${result.count}`);
+
+  const condensationCount = result.eventTypes.filter((t: string) => t === 'Condensation').length;
+  if (condensationCount !== 1) {
+    throw new Error(`Expected 1 Condensation event, got ${condensationCount}`);
+  }
+
+  // Test 7: Verify diagnostics show proper state
+  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+
+  if (!diag.chat.webviewReady) {
+    throw new Error('Webview should still be ready after error events');
+  }
+
+  console.log(`Diagnostics - eventBacklog size: ${diag.eventBacklog.size}`);
+
+  // Test 8: Recovery - start new conversation after errors
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 500));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After new conversation - Events should be cleared or minimal: ${result.count}`);
+
+  // After new conversation, events should be reset
+  // (either 0 or any restored events from previous persistence)
+
+  console.log('✓ All error handling tests passed');
+}

--- a/tests/e2e/suite/errorHandling.ts
+++ b/tests/e2e/suite/errorHandling.ts
@@ -11,6 +11,7 @@ async function pollUntil(
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
 export async function run(): Promise<void> {
@@ -56,12 +57,12 @@ export async function run(): Promise<void> {
     throw new Error(`Expected 1 AgentErrorEvent, got ${errorCount}`);
   }
 
-  // Test 2: Send ConversationErrorEvent
+  // Test 2: Send ConversationErrorEvent (uses detail/code per agent-sdk-ts types)
   const conversationError = {
     kind: 'ConversationErrorEvent',
-    source: 'agent',
-    error: 'Connection lost to server',
-    error_type: 'ConnectionError'
+    source: 'environment',
+    detail: 'Connection lost to server',
+    code: 'ConnectionError'
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', conversationError);
@@ -110,19 +111,21 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands._sendTestEvent', err);
   }
 
+  const expectedAgentErrors = 1 + multipleErrors.length;
+
   // Poll until all error events are rendered
   await pollUntil(async () => {
     const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const count = r?.eventTypes?.filter((t: string) => t === 'AgentErrorEvent').length || 0;
-    return count >= 4;
+    return count >= expectedAgentErrors;
   });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After multiple errors - Count: ${result.count}`);
 
   errorCount = result.eventTypes.filter((t: string) => t === 'AgentErrorEvent').length;
-  if (errorCount !== 4) {
-    throw new Error(`Expected 4 AgentErrorEvents total, got ${errorCount}`);
+  if (errorCount !== expectedAgentErrors) {
+    throw new Error(`Expected ${expectedAgentErrors} AgentErrorEvents total, got ${errorCount}`);
   }
 
   // Test 4: Send observation with non-zero exit code (error state)
@@ -174,10 +177,10 @@ export async function run(): Promise<void> {
   // PauseEvent may or may not render (it shows in status bar)
   console.log(`PauseEvent count (may be 0 if not rendered): ${pauseCount}`);
 
-  // Test 6: Send Condensation event (memory compaction)
+  // Test 6: Send Condensation event (memory compaction) - source must be 'environment' per type
   const condensation = {
     kind: 'Condensation',
-    source: 'agent',
+    source: 'environment',
     forgotten_event_ids: ['evt_1', 'evt_2', 'evt_3'],
     summary: 'Condensed 3 events from earlier conversation'
   };

--- a/tests/e2e/suite/history.ts
+++ b/tests/e2e/suite/history.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+
+export async function run(): Promise<void> {
+  // Ensure chat view is created
+  await vscode.commands.executeCommand('openhands.open');
+
+  // Wait until view and webview are ready
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  // Test 1: Verify initial state - webview should be ready
+  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  if (!diag?.chat?.webviewReady) {
+    throw new Error('Webview not ready');
+  }
+
+  // Test 2: Start a new conversation and verify conversation ID changes
+  const initialConversationId = diag.conversationId;
+  console.log(`Initial conversation ID: ${initialConversationId || 'none'}`);
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 1000));
+
+  const diagAfterNew: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  console.log(`Conversation ID after new: ${diagAfterNew.conversationId || 'none'}`);
+
+  // Test 3: Send test events to create conversation content
+  const testEvents = [
+    {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Test message for history' }]
+      }
+    },
+    {
+      kind: 'MessageEvent',
+      source: 'agent',
+      llm_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Test response from agent' }]
+      }
+    }
+  ];
+
+  for (const event of testEvents) {
+    await vscode.commands.executeCommand('openhands._sendTestEvent', event);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  // Wait for events to be processed
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Test 4: Query rendered events
+  const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+
+  if (!result) {
+    throw new Error('Query rendered events returned null');
+  }
+
+  if (typeof result.count !== 'number') {
+    throw new Error('Query rendered events missing count');
+  }
+
+  if (!Array.isArray(result.eventTypes)) {
+    throw new Error('Query rendered events missing eventTypes array');
+  }
+
+  console.log(`Rendered events count: ${result.count}`);
+  console.log(`Event types: ${result.eventTypes.join(', ')}`);
+
+  // Verify we have at least the test events
+  if (result.count < 2) {
+    throw new Error(`Expected at least 2 events, got ${result.count}`);
+  }
+
+  // Test 5: Verify event backlog is tracked
+  const diagWithEvents: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  console.log(`Event backlog size: ${diagWithEvents.eventBacklog?.size || 0}`);
+
+  // Test 6: Start another new conversation and verify events are cleared
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 1000));
+
+  const resultAfterNew: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+
+  // After new conversation, the webview should have cleared events (or show just the restored ones)
+  // Since it's a fresh conversation with no persistence, expect fewer events
+  console.log(`Events after new conversation: ${resultAfterNew?.count || 0}`);
+
+  console.log('✓ All history tests passed');
+}

--- a/tests/e2e/suite/history.ts
+++ b/tests/e2e/suite/history.ts
@@ -44,6 +44,9 @@ export async function run(): Promise<void> {
 
   const diagAfterNew: any = await vscode.commands.executeCommand('openhands._diagnostics');
   console.log(`Conversation ID after new: ${diagAfterNew.conversationId || 'none'}`);
+  if (initialConversationId && diagAfterNew.conversationId && diagAfterNew.conversationId === initialConversationId) {
+    throw new Error(`Expected conversationId to change after startNewConversation (still ${diagAfterNew.conversationId})`);
+  }
 
   // Test 3: Send test events to create conversation content
   const testEvents = [
@@ -101,6 +104,10 @@ export async function run(): Promise<void> {
   // Test 5: Verify event backlog is tracked
   const diagWithEvents: any = await vscode.commands.executeCommand('openhands._diagnostics');
   console.log(`Event backlog size: ${diagWithEvents.eventBacklog?.size || 0}`);
+  const backlogWithEvents = diagWithEvents.eventBacklog?.size ?? 0;
+  if (backlogWithEvents < testEvents.length) {
+    throw new Error(`Expected eventBacklog.size >= ${testEvents.length}, got ${backlogWithEvents}`);
+  }
 
   // Test 6: Start another new conversation and verify events are cleared
   await vscode.commands.executeCommand('openhands.startNewConversation');
@@ -110,6 +117,12 @@ export async function run(): Promise<void> {
     const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
     return d?.chat?.webviewReady;
   });
+
+  const diagAfterReset: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const backlogAfterReset = diagAfterReset.eventBacklog?.size ?? 0;
+  if (backlogAfterReset >= backlogWithEvents) {
+    throw new Error(`Expected eventBacklog.size to reset after new conversation (before=${backlogWithEvents}, after=${backlogAfterReset})`);
+  }
 
   const resultAfterNew: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
 

--- a/tests/e2e/suite/history.ts
+++ b/tests/e2e/suite/history.ts
@@ -1,16 +1,27 @@
 import * as vscode from 'vscode';
 
+// Helper to poll until condition is met
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 export async function run(): Promise<void> {
   // Ensure chat view is created
   await vscode.commands.executeCommand('openhands.open');
 
   // Wait until view and webview are ready
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
+  await pollUntil(async () => {
     const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
-    await new Promise((r) => setTimeout(r, 200));
-  }
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
 
   // Test 1: Verify initial state - webview should be ready
   const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
@@ -23,7 +34,12 @@ export async function run(): Promise<void> {
   console.log(`Initial conversation ID: ${initialConversationId || 'none'}`);
 
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 1000));
+
+  // Poll until webview is ready after new conversation
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   const diagAfterNew: any = await vscode.commands.executeCommand('openhands._diagnostics');
   console.log(`Conversation ID after new: ${diagAfterNew.conversationId || 'none'}`);
@@ -50,11 +66,13 @@ export async function run(): Promise<void> {
 
   for (const event of testEvents) {
     await vscode.commands.executeCommand('openhands._sendTestEvent', event);
-    await new Promise((r) => setTimeout(r, 100));
   }
 
-  // Wait for events to be processed
-  await new Promise((r) => setTimeout(r, 500));
+  // Poll until events are rendered
+  await pollUntil(async () => {
+    const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    return result?.count >= 2;
+  });
 
   // Test 4: Query rendered events
   const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -85,7 +103,12 @@ export async function run(): Promise<void> {
 
   // Test 6: Start another new conversation and verify events are cleared
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 1000));
+
+  // Poll until webview is ready
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   const resultAfterNew: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
 

--- a/tests/e2e/suite/history.ts
+++ b/tests/e2e/suite/history.ts
@@ -11,6 +11,7 @@ async function pollUntil(
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
 export async function run(): Promise<void> {
@@ -71,7 +72,7 @@ export async function run(): Promise<void> {
   // Poll until events are rendered
   await pollUntil(async () => {
     const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
-    return result?.count >= 2;
+    return result?.count >= testEvents.length;
   });
 
   // Test 4: Query rendered events
@@ -93,8 +94,8 @@ export async function run(): Promise<void> {
   console.log(`Event types: ${result.eventTypes.join(', ')}`);
 
   // Verify we have at least the test events
-  if (result.count < 2) {
-    throw new Error(`Expected at least 2 events, got ${result.count}`);
+  if (result.count < testEvents.length) {
+    throw new Error(`Expected at least ${testEvents.length} events, got ${result.count}`);
   }
 
   // Test 5: Verify event backlog is tracked

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -9,6 +9,35 @@ export async function run(): Promise<void> {
     return runAgentSdkEventsTest();
   }
 
+  if (testName === 'settings') {
+    const { run: runSettingsTest } = await import('./settings');
+    return runSettingsTest();
+  }
+
+  if (testName === 'history') {
+    const { run: runHistoryTest } = await import('./history');
+    return runHistoryTest();
+  }
+
+  if (testName === 'messaging') {
+    const { run: runMessagingTest } = await import('./messaging');
+    return runMessagingTest();
+  }
+
+  if (testName === 'serverSelection') {
+    const { run: runServerSelectionTest } = await import('./serverSelection');
+    return runServerSelectionTest();
+  }
+
+  if (testName === 'confirmation') {
+    const { run: runConfirmationTest } = await import('./confirmation');
+    return runConfirmationTest();
+  }
+
+  if (testName === 'errorHandling') {
+    const { run: runErrorHandlingTest } = await import('./errorHandling');
+    return runErrorHandlingTest();
+  }
 
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');

--- a/tests/e2e/suite/messaging.ts
+++ b/tests/e2e/suite/messaging.ts
@@ -1,0 +1,168 @@
+import * as vscode from 'vscode';
+
+export async function run(): Promise<void> {
+  // Ensure chat view is created
+  await vscode.commands.executeCommand('openhands.open');
+
+  // Wait until view and webview are ready
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  // Start fresh conversation
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Test 1: Send various message events with different roles
+  const messageEvents = [
+    // User message
+    {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Hello, can you help me with coding?' }]
+      }
+    },
+    // Assistant message with thinking
+    {
+      kind: 'MessageEvent',
+      source: 'agent',
+      llm_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Of course! I\'d be happy to help you with coding. What would you like to work on?' }],
+        reasoning_content: 'The user is asking for coding help, I should be friendly and ask for more details.'
+      }
+    },
+    // User follow-up
+    {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'I need to write a function to sort an array' }]
+      }
+    }
+  ];
+
+  for (const event of messageEvents) {
+    await vscode.commands.executeCommand('openhands._sendTestEvent', event);
+    await new Promise((r) => setTimeout(r, 100));
+  }
+
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Query rendered events
+  let result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+
+  console.log(`After messages - Count: ${result.count}, Types: ${result.eventTypes.join(', ')}`);
+
+  // Verify message events rendered
+  const messageCount = result.eventTypes.filter((t: string) => t === 'MessageEvent').length;
+  if (messageCount !== 3) {
+    throw new Error(`Expected 3 MessageEvents, got ${messageCount}`);
+  }
+
+  // Test 2: Send action event with observation
+  const actionEvent = {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'I will create a sort function' }],
+    action: { command: 'cat sort.js' },
+    tool_name: 'terminal',
+    tool_call_id: 'call_msg_001',
+    tool_call: {
+      id: 'call_msg_001',
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"cat sort.js"}' }
+    },
+    llm_response_id: 'resp_msg_001',
+    security_risk: 'LOW'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', actionEvent);
+  await new Promise((r) => setTimeout(r, 100));
+
+  // Send corresponding observation
+  const observationEvent = {
+    kind: 'ObservationEvent',
+    source: 'environment',
+    observation: {
+      content: 'function sort(arr) {\n  return arr.sort((a, b) => a - b);\n}',
+      exit_code: 0
+    },
+    tool_name: 'terminal',
+    tool_call_id: 'call_msg_001',
+    action_id: 'action_msg_001'
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', observationEvent);
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Query again
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+
+  console.log(`After action/observation - Count: ${result.count}, Types: ${result.eventTypes.join(', ')}`);
+
+  // Verify action and observation rendered
+  const actionCount = result.eventTypes.filter((t: string) => t === 'ActionEvent').length;
+  const obsCount = result.eventTypes.filter((t: string) => t === 'ObservationEvent').length;
+
+  if (actionCount < 1) {
+    throw new Error(`Expected at least 1 ActionEvent, got ${actionCount}`);
+  }
+  if (obsCount < 1) {
+    throw new Error(`Expected at least 1 ObservationEvent, got ${obsCount}`);
+  }
+
+  // Test 3: Send message with multi-part content (text and potential image reference)
+  const multiPartMessage = {
+    kind: 'MessageEvent',
+    source: 'user',
+    llm_message: {
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Here is the code I mentioned:' },
+        { type: 'text', text: '```javascript\nconsole.log("Hello");\n```' }
+      ]
+    }
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', multiPartMessage);
+  await new Promise((r) => setTimeout(r, 500));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After multi-part message - Count: ${result.count}`);
+
+  // Test 4: Send system prompt event
+  const systemPrompt = {
+    kind: 'SystemPromptEvent',
+    source: 'agent',
+    system_prompt: { type: 'text', text: 'You are a helpful coding assistant.' },
+    tools: [
+      { name: 'terminal', description: 'Execute commands' },
+      { name: 'file_editor', description: 'Edit files' }
+    ]
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', systemPrompt);
+  await new Promise((r) => setTimeout(r, 500));
+
+  result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`After system prompt - Count: ${result.count}`);
+
+  const sysPromptCount = result.eventTypes.filter((t: string) => t === 'SystemPromptEvent').length;
+  if (sysPromptCount < 1) {
+    throw new Error(`Expected at least 1 SystemPromptEvent, got ${sysPromptCount}`);
+  }
+
+  // Verify total event count
+  if (result.count < 7) {
+    throw new Error(`Expected at least 7 total events, got ${result.count}`);
+  }
+
+  console.log('✓ All messaging tests passed');
+}

--- a/tests/e2e/suite/messaging.ts
+++ b/tests/e2e/suite/messaging.ts
@@ -1,20 +1,34 @@
 import * as vscode from 'vscode';
 
+// Helper to poll until condition is met
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 export async function run(): Promise<void> {
   // Ensure chat view is created
   await vscode.commands.executeCommand('openhands.open');
 
   // Wait until view and webview are ready
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
+  await pollUntil(async () => {
     const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
-    await new Promise((r) => setTimeout(r, 200));
-  }
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
 
   // Start fresh conversation
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 500));
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   // Test 1: Send various message events with different roles
   const messageEvents = [
@@ -50,10 +64,14 @@ export async function run(): Promise<void> {
 
   for (const event of messageEvents) {
     await vscode.commands.executeCommand('openhands._sendTestEvent', event);
-    await new Promise((r) => setTimeout(r, 100));
   }
 
-  await new Promise((r) => setTimeout(r, 500));
+  // Poll until message events are rendered
+  await pollUntil(async () => {
+    const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const msgCount = result?.eventTypes?.filter((t: string) => t === 'MessageEvent').length || 0;
+    return msgCount >= 3;
+  });
 
   // Query rendered events
   let result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -84,7 +102,6 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', actionEvent);
-  await new Promise((r) => setTimeout(r, 100));
 
   // Send corresponding observation
   const observationEvent = {
@@ -100,7 +117,14 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', observationEvent);
-  await new Promise((r) => setTimeout(r, 500));
+
+  // Poll until action and observation are rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const actionCount = r?.eventTypes?.filter((t: string) => t === 'ActionEvent').length || 0;
+    const obsCount = r?.eventTypes?.filter((t: string) => t === 'ObservationEvent').length || 0;
+    return actionCount >= 1 && obsCount >= 1;
+  });
 
   // Query again
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -132,7 +156,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', multiPartMessage);
-  await new Promise((r) => setTimeout(r, 500));
+
+  // Poll until multi-part message is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const msgCount = r?.eventTypes?.filter((t: string) => t === 'MessageEvent').length || 0;
+    return msgCount >= 4;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After multi-part message - Count: ${result.count}`);
@@ -149,7 +179,13 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', systemPrompt);
-  await new Promise((r) => setTimeout(r, 500));
+
+  // Poll until system prompt is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const sysCount = r?.eventTypes?.filter((t: string) => t === 'SystemPromptEvent').length || 0;
+    return sysCount >= 1;
+  });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   console.log(`After system prompt - Count: ${result.count}`);

--- a/tests/e2e/suite/messaging.ts
+++ b/tests/e2e/suite/messaging.ts
@@ -11,6 +11,7 @@ async function pollUntil(
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
 export async function run(): Promise<void> {
@@ -70,7 +71,7 @@ export async function run(): Promise<void> {
   await pollUntil(async () => {
     const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const msgCount = result?.eventTypes?.filter((t: string) => t === 'MessageEvent').length || 0;
-    return msgCount >= 3;
+    return msgCount >= messageEvents.length;
   });
 
   // Query rendered events
@@ -80,8 +81,8 @@ export async function run(): Promise<void> {
 
   // Verify message events rendered
   const messageCount = result.eventTypes.filter((t: string) => t === 'MessageEvent').length;
-  if (messageCount !== 3) {
-    throw new Error(`Expected 3 MessageEvents, got ${messageCount}`);
+  if (messageCount !== messageEvents.length) {
+    throw new Error(`Expected ${messageEvents.length} MessageEvents, got ${messageCount}`);
   }
 
   // Test 2: Send action event with observation
@@ -157,11 +158,13 @@ export async function run(): Promise<void> {
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', multiPartMessage);
 
+  const expectedMessagesAfterMultiPart = messageEvents.length + 1;
+
   // Poll until multi-part message is rendered
   await pollUntil(async () => {
     const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const msgCount = r?.eventTypes?.filter((t: string) => t === 'MessageEvent').length || 0;
-    return msgCount >= 4;
+    return msgCount >= expectedMessagesAfterMultiPart;
   });
 
   result = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -195,9 +198,10 @@ export async function run(): Promise<void> {
     throw new Error(`Expected at least 1 SystemPromptEvent, got ${sysPromptCount}`);
   }
 
-  // Verify total event count
-  if (result.count < 7) {
-    throw new Error(`Expected at least 7 total events, got ${result.count}`);
+  // Verify total event count: messages + action + observation + multipart + system prompt
+  const expectedTotalEvents = messageEvents.length + 1 + 1 + 1 + 1;
+  if (result.count < expectedTotalEvents) {
+    throw new Error(`Expected at least ${expectedTotalEvents} total events, got ${result.count}`);
   }
 
   console.log('✓ All messaging tests passed');

--- a/tests/e2e/suite/serverSelection.ts
+++ b/tests/e2e/suite/serverSelection.ts
@@ -1,0 +1,114 @@
+import * as vscode from 'vscode';
+
+export async function run(): Promise<void> {
+  // Ensure chat view is created
+  await vscode.commands.executeCommand('openhands.open');
+
+  // Wait until view and webview are ready
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  // Test 1: Check initial mode (should be local when no serverUrl configured)
+  let diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+
+  if (!diag) {
+    throw new Error('Diagnostics returned null');
+  }
+
+  console.log(`Initial mode: ${diag.mode}`);
+  console.log(`Initial serverUrl: ${diag.serverUrl || 'empty'}`);
+
+  // In a fresh install, serverUrl should be empty
+  if (diag.serverUrl && diag.serverUrl.length > 0) {
+    console.log('Server URL is configured, testing remote mode...');
+    if (diag.mode !== 'remote') {
+      throw new Error(`Expected remote mode when serverUrl is set, got ${diag.mode}`);
+    }
+  } else {
+    console.log('Server URL is empty, testing local mode...');
+    if (diag.mode !== 'local') {
+      throw new Error(`Expected local mode when serverUrl is empty, got ${diag.mode}`);
+    }
+  }
+
+  // Test 2: Verify status is present
+  const validStatuses = ['online', 'offline', 'connecting'];
+  console.log(`Status: ${diag.status}`);
+  // Status might be undefined initially in local mode
+
+  // Test 3: Verify conversation state structure
+  if (typeof diag.hasConversation !== 'boolean') {
+    throw new Error('Missing hasConversation boolean');
+  }
+
+  console.log(`Has conversation: ${diag.hasConversation}`);
+
+  // Test 4: Verify terminal state (only relevant in local mode)
+  if (typeof diag.terminal !== 'object') {
+    throw new Error('Missing terminal object in diagnostics');
+  }
+
+  console.log(`Has terminal: ${diag.terminal.hasTerminal}`);
+  console.log(`Terminal events received: ${diag.terminal.received}`);
+
+  // Test 5: Test reconnect command behavior
+  await vscode.commands.executeCommand('openhands.reconnect');
+  await new Promise((r) => setTimeout(r, 500));
+
+  diag = await vscode.commands.executeCommand('openhands._diagnostics');
+  console.log(`Mode after reconnect: ${diag.mode}`);
+
+  // Test 6: Verify webview maintains readiness after reconnect
+  if (!diag.chat.webviewReady) {
+    throw new Error('Webview lost readiness after reconnect');
+  }
+
+  // Test 7: Start new conversation and verify mode persists
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await new Promise((r) => setTimeout(r, 500));
+
+  diag = await vscode.commands.executeCommand('openhands._diagnostics');
+  console.log(`Mode after new conversation: ${diag.mode}`);
+
+  // Mode should persist across conversation changes
+  // (it's determined by serverUrl config, not conversation state)
+
+  // Test 8: Verify event backlog is reset with new conversation
+  console.log(`Event backlog after new conversation: ${diag.eventBacklog?.size || 0}`);
+  // New conversation should have empty or minimal event backlog
+
+  // Test 9: Send a test event and verify mode handling
+  const testEvent = {
+    kind: 'MessageEvent',
+    source: 'user',
+    llm_message: {
+      role: 'user',
+      content: [{ type: 'text', text: 'Test message' }]
+    }
+  };
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', testEvent);
+  await new Promise((r) => setTimeout(r, 300));
+
+  diag = await vscode.commands.executeCommand('openhands._diagnostics');
+
+  // Verify backlog increased
+  if (diag.eventBacklog.size < 1) {
+    console.log('Warning: Event backlog did not increase after test event');
+  }
+
+  // Test 10: Query rendered events should work regardless of mode
+  const result: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+
+  if (!result || typeof result.count !== 'number') {
+    throw new Error('Query rendered events failed');
+  }
+
+  console.log(`Rendered events: ${result.count}`);
+
+  console.log('✓ All server selection tests passed');
+}

--- a/tests/e2e/suite/serverSelection.ts
+++ b/tests/e2e/suite/serverSelection.ts
@@ -1,16 +1,27 @@
 import * as vscode from 'vscode';
 
+// Helper to poll until condition is met
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
 export async function run(): Promise<void> {
   // Ensure chat view is created
   await vscode.commands.executeCommand('openhands.open');
 
   // Wait until view and webview are ready
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
+  await pollUntil(async () => {
     const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
-    await new Promise((r) => setTimeout(r, 200));
-  }
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
 
   // Test 1: Check initial mode (should be local when no serverUrl configured)
   let diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
@@ -36,7 +47,6 @@ export async function run(): Promise<void> {
   }
 
   // Test 2: Verify status is present
-  const validStatuses = ['online', 'offline', 'connecting'];
   console.log(`Status: ${diag.status}`);
   // Status might be undefined initially in local mode
 
@@ -57,7 +67,12 @@ export async function run(): Promise<void> {
 
   // Test 5: Test reconnect command behavior
   await vscode.commands.executeCommand('openhands.reconnect');
-  await new Promise((r) => setTimeout(r, 500));
+
+  // Poll until webview is ready after reconnect
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   diag = await vscode.commands.executeCommand('openhands._diagnostics');
   console.log(`Mode after reconnect: ${diag.mode}`);
@@ -69,7 +84,12 @@ export async function run(): Promise<void> {
 
   // Test 7: Start new conversation and verify mode persists
   await vscode.commands.executeCommand('openhands.startNewConversation');
-  await new Promise((r) => setTimeout(r, 500));
+
+  // Poll until webview is ready after new conversation
+  await pollUntil(async () => {
+    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return d?.chat?.webviewReady;
+  });
 
   diag = await vscode.commands.executeCommand('openhands._diagnostics');
   console.log(`Mode after new conversation: ${diag.mode}`);
@@ -92,7 +112,12 @@ export async function run(): Promise<void> {
   };
 
   await vscode.commands.executeCommand('openhands._sendTestEvent', testEvent);
-  await new Promise((r) => setTimeout(r, 300));
+
+  // Poll until event is rendered
+  await pollUntil(async () => {
+    const r: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    return r?.count >= 1;
+  });
 
   diag = await vscode.commands.executeCommand('openhands._diagnostics');
 

--- a/tests/e2e/suite/serverSelection.ts
+++ b/tests/e2e/suite/serverSelection.ts
@@ -11,6 +11,7 @@ async function pollUntil(
     if (await condition()) return;
     await new Promise((r) => setTimeout(r, intervalMs));
   }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
 export async function run(): Promise<void> {
@@ -123,7 +124,7 @@ export async function run(): Promise<void> {
 
   // Verify backlog increased
   if (diag.eventBacklog.size < 1) {
-    console.log('Warning: Event backlog did not increase after test event');
+    throw new Error('Event backlog should have increased after sending a test event');
   }
 
   // Test 10: Query rendered events should work regardless of mode

--- a/tests/e2e/suite/settings.ts
+++ b/tests/e2e/suite/settings.ts
@@ -1,0 +1,97 @@
+import * as vscode from 'vscode';
+
+export async function run(): Promise<void> {
+  // Ensure chat view is created
+  await vscode.commands.executeCommand('openhands.open');
+
+  // Wait until view and webview are ready
+  const deadline = Date.now() + 15000;
+  while (Date.now() < deadline) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+
+  // Test 1: Verify diagnostics command returns expected structure
+  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+
+  if (!diag) {
+    throw new Error('Diagnostics command returned null/undefined');
+  }
+
+  // Verify chat state
+  if (typeof diag.chat !== 'object') {
+    throw new Error('Diagnostics missing chat object');
+  }
+  if (typeof diag.chat.hasView !== 'boolean') {
+    throw new Error('Diagnostics missing chat.hasView');
+  }
+  if (typeof diag.chat.webviewReady !== 'boolean') {
+    throw new Error('Diagnostics missing chat.webviewReady');
+  }
+
+  // Verify event backlog state
+  if (typeof diag.eventBacklog !== 'object') {
+    throw new Error('Diagnostics missing eventBacklog object');
+  }
+  if (typeof diag.eventBacklog.size !== 'number') {
+    throw new Error('Diagnostics missing eventBacklog.size');
+  }
+
+  // Verify mode is present
+  if (diag.mode !== 'local' && diag.mode !== 'remote') {
+    throw new Error(`Unexpected mode: ${diag.mode}`);
+  }
+
+  // Test 2: Verify configure command can be executed (opens settings)
+  try {
+    await vscode.commands.executeCommand('openhands.configure');
+    console.log('✓ Configure command executed successfully');
+  } catch (err) {
+    throw new Error(`Configure command failed: ${err}`);
+  }
+
+  // Test 3: Verify reconnect command works
+  try {
+    await vscode.commands.executeCommand('openhands.reconnect');
+    console.log('✓ Reconnect command executed successfully');
+  } catch (err) {
+    throw new Error(`Reconnect command failed: ${err}`);
+  }
+
+  // Test 4: Verify startNewConversation command works
+  try {
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+    console.log('✓ Start new conversation command executed successfully');
+  } catch (err) {
+    throw new Error(`Start new conversation command failed: ${err}`);
+  }
+
+  // Wait a bit for conversation to reset
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Verify diagnostics after new conversation
+  const diagAfter: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  if (!diagAfter?.chat?.webviewReady) {
+    throw new Error('Webview not ready after new conversation');
+  }
+
+  // Test 5: Verify pause and resume commands exist and can be called
+  try {
+    await vscode.commands.executeCommand('openhands.pauseCurrentRun');
+    console.log('✓ Pause command executed successfully');
+  } catch (err) {
+    // Pause may fail if no agent is running, but command should exist
+    console.log('✓ Pause command exists (may have failed due to no active run)');
+  }
+
+  try {
+    await vscode.commands.executeCommand('openhands.resumeCurrentRun');
+    console.log('✓ Resume command executed successfully');
+  } catch (err) {
+    // Resume may fail if agent is not paused
+    console.log('✓ Resume command exists (may have failed due to no paused run)');
+  }
+
+  console.log('✓ All settings tests passed');
+}

--- a/tests/e2e/suite/settings.ts
+++ b/tests/e2e/suite/settings.ts
@@ -67,11 +67,14 @@ export async function run(): Promise<void> {
     throw new Error(`Start new conversation command failed: ${err}`);
   }
 
-  // Wait a bit for conversation to reset
-  await new Promise((r) => setTimeout(r, 500));
-
-  // Verify diagnostics after new conversation
-  const diagAfter: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  // Poll until webview is ready after new conversation
+  const afterDeadline = Date.now() + 10000;
+  let diagAfter: any;
+  while (Date.now() < afterDeadline) {
+    diagAfter = await vscode.commands.executeCommand('openhands._diagnostics');
+    if (diagAfter?.chat?.webviewReady) break;
+    await new Promise((r) => setTimeout(r, 200));
+  }
   if (!diagAfter?.chat?.webviewReady) {
     throw new Error('Webview not ready after new conversation');
   }


### PR DESCRIPTION
Add 6 new e2e test suites covering:
- Settings/configuration commands and diagnostics
- Conversation history and event backlog
- Message events and rendering
- Server selection and local/remote mode switching
- Action confirmation workflow with security levels
- Error handling and recovery

Each test uses the existing @vscode/test-electron infrastructure and routes through the suite index based on TEST_NAME env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suites for confirmation, error handling, history restore, messaging, server selection/mode, and settings to broaden automated UI validation.

* **Documentation**
  * Reworked e2e test README into a structured, categorized guide with sections for entry-point tests, suites, helpers, execution notes, and an Agent-SDK events overview.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->