### PR TITLE
[oh-tab-7wu] Store history in ~/.openhands/conversations-vscode

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -131,7 +131,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Approve/Reject buttons with optional reason
 
 ### Persistence
-- Conversation history in ~/.openhands/conversations (default ON)
+- Conversation history in `~/.openhands/conversations-vscode/` (default ON; override with `OPENHANDS_CONVERSATIONS_DIR`)
 - Server/SDK JSON persisted as-is
 
 ## 8. Non-Functional Requirements

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -131,7 +131,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Approve/Reject buttons with optional reason
 
 ### Persistence
-- Conversation history in `~/.openhands/conversations-vscode/` (default ON; override with `OPENHANDS_CONVERSATIONS_DIR`)
+- Conversation history in `~/.openhands/conversations-vscode/` (default ON; override with VS Code setting `openhands.conversation.storeRoot`)
 - Server/SDK JSON persisted as-is
 
 ## 8. Non-Functional Requirements

--- a/package.json
+++ b/package.json
@@ -98,6 +98,11 @@
           "default": 50,
           "markdownDescription": "Default max iterations for new conversations (server default is 500)."
         },
+        "openhands.conversation.storeRoot": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional directory for local-mode conversation history/events. Leave empty to use `~/.openhands/conversations-vscode/`."
+        },
         "openhands.confirmation.policy": {
           "type": "string",
           "enum": [

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -201,13 +201,14 @@ async function resolveChatView(mockContext: any) {
   expect(provider).toBeTruthy();
 
   const view = createMockWebviewView();
+  const { Conversation } = await import('@openhands/agent-sdk-ts');
+  const beforeCalls = (Conversation as Mock).mock.calls.length;
   provider.resolveWebviewView(view);
 
   // ensureConversationAndConnection() is async and invoked without await
   const deadline = Date.now() + 2000;
   while (Date.now() < deadline) {
-    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
-    if (__getLastConversation()) break;
+    if ((Conversation as Mock).mock.calls.length > beforeCalls) break;
     await new Promise((r) => setTimeout(r, 0));
   }
 
@@ -337,12 +338,12 @@ describe('Command handlers', () => {
     expect(handler).toBeTypeOf('function');
 
     const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-homedir-'));
-    const previousOverride = process.env.OPENHANDS_CONVERSATIONS_DIR;
+    const cfgValues = (vscode as any).__getMockConfigValues?.();
 
     try {
       const conversationId = 'local-test-convo';
       const conversationsRoot = path.join(tmpHome, '.openhands', 'conversations-vscode');
-      process.env.OPENHANDS_CONVERSATIONS_DIR = conversationsRoot;
+      cfgValues?.set('openhands.conversation.storeRoot', conversationsRoot);
       const conversationDir = path.join(conversationsRoot, conversationId);
       await fs.mkdir(conversationDir, { recursive: true });
 
@@ -371,11 +372,7 @@ describe('Command handlers', () => {
         }),
       ]);
     } finally {
-      if (previousOverride === undefined) {
-        delete process.env.OPENHANDS_CONVERSATIONS_DIR;
-      } else {
-        process.env.OPENHANDS_CONVERSATIONS_DIR = previousOverride;
-      }
+      cfgValues?.delete('openhands.conversation.storeRoot');
       await fs.rm(tmpHome, { recursive: true, force: true });
     }
   });

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach, Mock } from 'vitest';
 import * as vscode from 'vscode';
 import { EventEmitter } from 'events';
+import * as fsSync from 'node:fs';
+import * as fs from 'node:fs/promises';
+import * as path from 'path';
+import * as os from 'os';
 
 const defaultMockSettings = {
   serverUrl: 'http://localhost:3000',
@@ -83,11 +87,26 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     return emitter;
   });
 
+  class FileStore {
+    static listConversations(rootDir?: string): string[] {
+      const dir = rootDir ?? path.join(process.cwd(), '.openhands', 'conversations');
+      if (!fsSync.existsSync(dir)) return [];
+      return fsSync
+        .readdirSync(dir, { withFileTypes: true })
+        .filter((entry) => entry.isDirectory())
+        .map((entry) => entry.name);
+    }
+  }
+
   return {
     Conversation,
     isBashCommand: vi.fn((event: any) => event?.type === 'BashCommand'),
     isBashOutput: vi.fn((event: any) => event?.type === 'BashOutput'),
     isBashExit: vi.fn((event: any) => event?.type === 'BashExit'),
+    FileStore,
+    isEvent: vi.fn((candidate: any) => !!candidate && typeof candidate === 'object' && typeof candidate.kind === 'string'),
+    isMessageEvent: vi.fn((event: any) => event?.kind === 'MessageEvent' && !!event.llm_message && typeof event.llm_message === 'object'),
+    isTextContent: vi.fn((content: any) => content?.type === 'text'),
     __getLastConversation: () => lastConversation,
     TerminalTool: vi.fn(() => new StubTool('terminal')),
     FileEditorTool: vi.fn(() => new StubTool('file_editor')),
@@ -311,6 +330,54 @@ describe('Command handlers', () => {
     expect(conversationInstance.sendUserMessage).toHaveBeenCalledWith('hello');
     expect(conversationInstance.approveAction).toHaveBeenCalled();
     expect(conversationInstance.rejectAction).toHaveBeenCalledWith('nope');
+  });
+
+  it('returns history from the stable conversation store', async () => {
+    const handler = chatView._messageHandler;
+    expect(handler).toBeTypeOf('function');
+
+    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-homedir-'));
+    const previousOverride = process.env.OPENHANDS_CONVERSATIONS_DIR;
+
+    try {
+      const conversationId = 'local-test-convo';
+      const conversationsRoot = path.join(tmpHome, '.openhands', 'conversations-vscode');
+      process.env.OPENHANDS_CONVERSATIONS_DIR = conversationsRoot;
+      const conversationDir = path.join(conversationsRoot, conversationId);
+      await fs.mkdir(conversationDir, { recursive: true });
+
+      const eventsPath = path.join(conversationDir, 'events.jsonl');
+      const messageEvent = {
+        kind: 'MessageEvent',
+        llm_message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'hello from history' }],
+        },
+      };
+      await fs.writeFile(eventsPath, `${JSON.stringify(messageEvent)}\n`, 'utf8');
+
+      (chatView.webview.postMessage as Mock).mockClear();
+      await handler({ type: 'requestHistory' });
+
+      const historyMessage = (chatView.webview.postMessage as Mock).mock.calls
+        .map((call) => call[0])
+        .find((payload) => payload?.type === 'historyList') as any;
+
+      expect(historyMessage).toBeTruthy();
+      expect(historyMessage.conversations).toEqual([
+        expect.objectContaining({
+          id: conversationId,
+          firstMessage: 'hello from history',
+        }),
+      ]);
+    } finally {
+      if (previousOverride === undefined) {
+        delete process.env.OPENHANDS_CONVERSATIONS_DIR;
+      } else {
+        process.env.OPENHANDS_CONVERSATIONS_DIR = previousOverride;
+      }
+      await fs.rm(tmpHome, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,6 +60,7 @@ let chatWebviewReady = false; // Track if chat WebviewView is ready
 let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+let conversationStoreRoot: string | undefined;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -410,12 +411,68 @@ async function listSkillFiles(): Promise<{ label: string; path: string }[]> {
   }
 }
 
-function getConversationStoreRoot(): string {
-  const override = process.env.OPENHANDS_CONVERSATIONS_DIR;
-  if (override && override.trim()) {
-    return path.resolve(override);
+function normalizeNonEmptyString(value: string | undefined | null): string | undefined {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || undefined;
+}
+
+function resolveConfiguredPath(p: string): string {
+  const raw = p.trim();
+  if (raw.startsWith('~/') || raw === '~') {
+    const suffix = raw === '~' ? '' : raw.slice(2);
+    return path.join(os.homedir(), suffix);
   }
-  return path.join(os.homedir(), '.openhands', 'conversations-vscode');
+  if (raw.startsWith('~\\')) {
+    return path.join(os.homedir(), raw.slice(2));
+  }
+  if (path.isAbsolute(raw)) return raw;
+  // Prefer homedir-relative resolution so behavior is stable even with no workspace open.
+  return path.resolve(os.homedir(), raw);
+}
+
+async function ensureWritableDirectory(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  const probe = path.join(dir, `.openhands-write-probe-${process.pid}-${Date.now()}`);
+  await fs.writeFile(probe, 'ok', 'utf8');
+  await fs.unlink(probe);
+}
+
+async function resolveConversationStoreRoot(context: vscode.ExtensionContext): Promise<string> {
+  const cfg = vscode.workspace.getConfiguration();
+  const configured = normalizeNonEmptyString(cfg.get<string>('openhands.conversation.storeRoot'));
+  const envOverride = normalizeNonEmptyString(process.env.OPENHANDS_CONVERSATIONS_DIR);
+
+  const candidates: Array<{ label: string; dir: string }> = [];
+  if (configured) candidates.push({ label: 'setting openhands.conversation.storeRoot', dir: resolveConfiguredPath(configured) });
+  if (envOverride) candidates.push({ label: 'env OPENHANDS_CONVERSATIONS_DIR', dir: resolveConfiguredPath(envOverride) });
+
+  try {
+    candidates.push({ label: 'default ~/.openhands/conversations-vscode', dir: path.join(os.homedir(), '.openhands', 'conversations-vscode') });
+  } catch (err) {
+    outputChannel?.appendLine(`[storage] Failed to compute home dir default: ${renderError(err)}`);
+  }
+
+  const globalStorage = (context as unknown as { globalStorageUri?: vscode.Uri }).globalStorageUri?.fsPath;
+  if (globalStorage) {
+    candidates.push({ label: 'VS Code globalStorageUri', dir: path.join(globalStorage, 'conversations') });
+  }
+
+  candidates.push({ label: 'os.tmpdir()', dir: path.join(os.tmpdir(), 'openhands-conversations-vscode') });
+
+  for (const candidate of candidates) {
+    try {
+      await ensureWritableDirectory(candidate.dir);
+      if (candidate.dir !== candidates[0]?.dir) {
+        outputChannel?.appendLine(`[storage] Using conversation store root: ${candidate.dir} (${candidate.label})`);
+      }
+      return candidate.dir;
+    } catch (err) {
+      outputChannel?.appendLine(`[storage] Cannot use ${candidate.label} (${candidate.dir}): ${renderError(err)}`);
+    }
+  }
+
+  // Last resort: return tmp path even if we couldn't probe it; conversation may still run without persistence.
+  return path.join(os.tmpdir(), 'openhands-conversations-vscode');
 }
 
 export function activate(context: vscode.ExtensionContext) {
@@ -540,16 +597,38 @@ export function activate(context: vscode.ExtensionContext) {
         conversation?.disconnect();
       } catch {}
 
+      const persistenceDir =
+        desiredMode === 'local'
+          ? await resolveConversationStoreRoot(context).catch((err: unknown) => {
+              outputChannel?.appendLine(`[storage] Failed to resolve conversation store root: ${renderError(err)}`);
+              return path.join(os.tmpdir(), 'openhands-conversations-vscode');
+            })
+          : undefined;
+      conversationStoreRoot = persistenceDir;
+
       const conversationOptions = {
         serverUrl: settings.serverUrl ?? undefined,
         settings,
         workspaceRoot,
         conversationId: savedId,
         tools: settings.serverUrl ? undefined : createDefaultLocalTools(),
-        persistenceDir: settings.serverUrl ? undefined : getConversationStoreRoot(),
+        persistenceDir,
       };
 
-      conversation = Conversation(conversationOptions);
+      try {
+        conversation = Conversation(conversationOptions);
+      } catch (err) {
+        outputChannel?.appendLine(`[error] Failed to create Conversation: ${renderError(err)}`);
+        // Keep extension alive even if persistence path is broken; fall back to temp.
+        if (desiredMode === 'local' && persistenceDir) {
+          const fallbackDir = path.join(os.tmpdir(), 'openhands-conversations-vscode');
+          outputChannel?.appendLine(`[storage] Retrying Conversation with fallback dir: ${fallbackDir}`);
+          conversationStoreRoot = fallbackDir;
+          conversation = Conversation({ ...conversationOptions, persistenceDir: fallbackDir });
+        } else {
+          throw err;
+        }
+      }
       conversationMode = desiredMode;
 
       conversation.removeAllListeners();
@@ -816,6 +895,14 @@ export function activate(context: vscode.ExtensionContext) {
         return;
       }
 
+      if (e.affectsConfiguration('openhands.conversation.storeRoot')) {
+        try { conversation?.removeAllListeners(); conversation?.disconnect(); } catch { }
+        conversation = undefined;
+        conversationStoreRoot = undefined;
+        await ensureConversationAndConnection();
+        return;
+      }
+
       if (e.affectsConfiguration('openhands.llm')) {
         try {
           await ensureConversationAndConnection();
@@ -857,6 +944,7 @@ export function deactivate() {
   chatWebviewReady = false;
   chatLastConversationId = undefined;
   chatLastSeenSeq = undefined;
+  conversationStoreRoot = undefined;
   resetConversationEventBacklog(undefined);
   receivedTerminalEvents.length = 0;
 }
@@ -871,7 +959,7 @@ export function deactivate() {
  * - 'command': Executes agent control commands (reconnect, pause, startNewConversation, approveAction, rejectAction)
  * - 'requestWorkspaceFiles': Returns list of workspace files for @ mentions
  * - 'requestSkills': Returns ~/.openhands/skills markdown files
- * - 'requestHistory': Returns ~/.openhands/conversations-vscode conversations
+ * - 'requestHistory': Returns local conversation history (store root configurable)
  * - 'openSkill': Opens the specified skill file in editor
  * - 'renderedEventsResponse': Receives diagnostic info from webview (for E2E tests)
  *
@@ -982,7 +1070,7 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
       }
       case 'requestHistory': {
         try {
-          const convRoot = getConversationStoreRoot();
+          const convRoot = conversationStoreRoot ?? (await resolveConversationStoreRoot(context));
           let ids: string[] = [];
           try {
             ids = FileStore.listConversations(convRoot);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -410,6 +410,14 @@ async function listSkillFiles(): Promise<{ label: string; path: string }[]> {
   }
 }
 
+function getConversationStoreRoot(): string {
+  const override = process.env.OPENHANDS_CONVERSATIONS_DIR;
+  if (override && override.trim()) {
+    return path.resolve(override);
+  }
+  return path.join(os.homedir(), '.openhands', 'conversations-vscode');
+}
+
 export function activate(context: vscode.ExtensionContext) {
   try {
     const channel = vscode.window.createOutputChannel('OpenHands', { log: true });
@@ -538,7 +546,7 @@ export function activate(context: vscode.ExtensionContext) {
         workspaceRoot,
         conversationId: savedId,
         tools: settings.serverUrl ? undefined : createDefaultLocalTools(),
-        persistenceDir: settings.serverUrl ? undefined : '.openhands/conversations',
+        persistenceDir: settings.serverUrl ? undefined : getConversationStoreRoot(),
       };
 
       conversation = Conversation(conversationOptions);
@@ -863,6 +871,7 @@ export function deactivate() {
  * - 'command': Executes agent control commands (reconnect, pause, startNewConversation, approveAction, rejectAction)
  * - 'requestWorkspaceFiles': Returns list of workspace files for @ mentions
  * - 'requestSkills': Returns ~/.openhands/skills markdown files
+ * - 'requestHistory': Returns ~/.openhands/conversations-vscode conversations
  * - 'openSkill': Opens the specified skill file in editor
  * - 'renderedEventsResponse': Receives diagnostic info from webview (for E2E tests)
  *
@@ -973,8 +982,7 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
       }
       case 'requestHistory': {
         try {
-          const root = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? process.cwd();
-          const convRoot = path.join(root, '.openhands', 'conversations');
+          const convRoot = getConversationStoreRoot();
           let ids: string[] = [];
           try {
             ids = FileStore.listConversations(convRoot);

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,14 @@ This folder contains minimal E2E scaffolding using @vscode/test-electron.
 npm run e2e
 ```
 
+## Local Conversation Storage
+
+In local mode, the extension persists conversation history/events to `~/.openhands/conversations-vscode/` by default.
+
+To override the storage directory (useful for CI runners or read-only home dirs), set either:
+- VS Code setting `openhands.conversation.storeRoot`, or
+- Env var `OPENHANDS_CONVERSATIONS_DIR` (often easiest to wire up for test processes).
+
 ## Agent-SDK Events Test
 
 The agentSdkEvents test verifies that all event types from the OpenHands agent-sdk are properly rendered in the webview:


### PR DESCRIPTION
Fixes Beads `oh-tab-7wu`.

- Local-mode conversation persistence now uses a stable directory (`~/.openhands/conversations-vscode/`) instead of workspace-relative `.openhands/conversations`.
- HistoryView (`requestHistory`) lists conversations from the same stable store so it works even when no workspace folder is open.
- Storage dir override is now a VS Code setting: `openhands.conversation.storeRoot` (env `OPENHANDS_CONVERSATIONS_DIR` still supported for automation).
- Added safety net: probe/create store dir with fallbacks + output logging so activation/history doesn’t crash on read-only envs.
- Updated unit test + e2e README + `docs/PRD.md`.

Checks: `npm test`, `npm run lint`, `npm run typecheck`, `npm run e2e`.
