### PR TITLE
[oh-tab-0gk0] Timeout remote connecting when server unreachable

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -79,6 +79,62 @@ describe('RemoteConversation', () => {
     (globalThis as any).fetch = undefined as any;
   });
 
+  it('times out if the WebSocket never connects', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn(async (url: string) => {
+        expect(url).toContain('/events/search');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      });
+      (globalThis as any).fetch = fetchMock;
+
+      const { RemoteConversation } = await import('../conversation/RemoteConversation');
+      const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+      const statuses: string[] = [];
+      const errors: unknown[] = [];
+      conversation.on('status', (s) => statuses.push(s));
+      conversation.on('error', (e) => errors.push(e));
+
+      await conversation.restoreConversation('abc');
+      expect(conversation.getStatus()).toBe('connecting');
+
+      vi.advanceTimersByTime(10_001);
+
+      expect(conversation.getStatus()).toBe('offline');
+      expect(statuses).toContain('connecting');
+      expect(statuses).toContain('offline');
+      expect(errors.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('sets offline when starting a new conversation fails', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    const statuses: string[] = [];
+    conversation.on('status', (s) => statuses.push(s));
+    conversation.on('error', () => {});
+
+    const id = await conversation.startNewConversation();
+    expect(id).toBeUndefined();
+    expect(conversation.getStatus()).toBe('offline');
+    expect(statuses).toContain('connecting');
+    expect(statuses).toContain('offline');
+  });
+
   it('replays history on restore and skips duplicate event ids', async () => {
     const history: Event[] = [
       {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -33,12 +33,16 @@ export class RemoteConversation extends EventEmitter {
   private status: ConversationStatus = 'offline';
   private readonly seenEventIds = new Set<string>();
   private ws?: WebSocket;
+  private wsHandshakeTimer?: ReturnType<typeof setTimeout>;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private retryCount = 0;
   private readonly retryBaseMs = 1000;
   private readonly retryMaxMs = 15000;
   private readonly workspaceRoot: string;
   private static readonly historyPageLimit = 100;
+  private static readonly wsHandshakeTimeoutMs = 10_000;
+  private static readonly httpTimeoutMs = 15_000;
+  private hasEverConnected = false;
 
   constructor(options: RemoteConversationOptions) {
     super();
@@ -80,6 +84,7 @@ export class RemoteConversation extends EventEmitter {
           this.ws.close();
           this.ws = undefined;
         }
+        this.clearWsHandshakeTimer();
         this.seenEventIds.clear();
         this.setStatus('connecting');
         const base = this.serverUrl.replace(/\/$/, '');
@@ -149,11 +154,11 @@ export class RemoteConversation extends EventEmitter {
         confirmation_policy,
         max_iterations: clampedMaxIterations,
       };
-      const res = await fetch(`${base}/api/conversations`, {
+      const res = await this.fetchWithTimeout(`${base}/api/conversations`, {
         method: 'POST',
         headers,
         body: JSON.stringify(req)
-      });
+      }, RemoteConversation.httpTimeoutMs);
         if (!res.ok) {
           const info = await res.text().catch(() => '');
           const status = res.status;
@@ -183,6 +188,7 @@ export class RemoteConversation extends EventEmitter {
       } else {
         this.emit('error', e instanceof Error ? e : new Error(String(e)));
       }
+      this.setStatus('offline');
       return undefined;
     }
   }
@@ -203,7 +209,7 @@ export class RemoteConversation extends EventEmitter {
     const base = this.serverUrl.replace(/\/$/, '');
     try {
       const headers = this.getAuthHeaders();
-      const res = await fetch(`${base}/api/conversations/${this.conversationId}/pause`, { method: 'POST', headers });
+      const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/pause`, { method: 'POST', headers }, RemoteConversation.httpTimeoutMs);
       if (!res.ok) {
         const info = await res.text().catch(() => '');
         const status = res.status;
@@ -222,7 +228,7 @@ export class RemoteConversation extends EventEmitter {
     const base = this.serverUrl.replace(/\/$/, '');
     try {
       const headers = this.getAuthHeaders();
-      const res = await fetch(`${base}/api/conversations/${this.conversationId}/run`, { method: 'POST', headers });
+      const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/run`, { method: 'POST', headers }, RemoteConversation.httpTimeoutMs);
       if (!res.ok) {
         const info = await res.text().catch(() => '');
         const status = res.status;
@@ -283,9 +289,9 @@ export class RemoteConversation extends EventEmitter {
         const base = this.serverUrl.replace(/\/$/, '');
         const headers = this.getAuthHeaders();
         const httpPayload = { ...messagePayload, run: true };
-        const res = await fetch(`${base}/api/conversations/${this.conversationId}/events`, {
+        const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/events`, {
           method: 'POST', headers, body: JSON.stringify(httpPayload)
-        });
+        }, RemoteConversation.httpTimeoutMs);
         if (!res.ok) {
           const info = await res.text().catch(() => '');
           this.emit('error', new Error(`Failed to send message (HTTP ${res.status})${info ? `: ${info}` : ''}`));
@@ -295,6 +301,7 @@ export class RemoteConversation extends EventEmitter {
   }
 
   disconnect() {
+    this.clearWsHandshakeTimer();
     this.clearReconnect();
     if (this.ws) {
       this.ws.removeAllListeners();
@@ -328,11 +335,31 @@ export class RemoteConversation extends EventEmitter {
 
   private scheduleReconnect() {
     this.clearReconnect();
+    // If we have never successfully connected, don't spin in a retry loop.
+    // In that case, surface the error and let the user manually retry.
+    if (!this.hasEverConnected) return;
     const base = Math.min(this.retryMaxMs, Math.floor(this.retryBaseMs * Math.pow(2, this.retryCount)));
     const jitter = Math.floor(base * 0.2 * Math.random());
     const delay = base + jitter;
     this.retryCount = Math.min(this.retryCount + 1, 10);
     this.reconnectTimer = setTimeout(() => this.connect(), delay);
+  }
+
+  private clearWsHandshakeTimer() {
+    if (this.wsHandshakeTimer) {
+      clearTimeout(this.wsHandshakeTimer);
+      this.wsHandshakeTimer = undefined;
+    }
+  }
+
+  private async fetchWithTimeout(url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await fetch(url, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private connect() {
@@ -347,10 +374,46 @@ export class RemoteConversation extends EventEmitter {
     this.setStatus('connecting');
     const ws = new WebSocket(wsUrl);
     this.ws = ws;
+    this.clearWsHandshakeTimer();
+    this.wsHandshakeTimer = setTimeout(() => {
+      // Ignore if another connection attempt replaced this socket.
+      if (this.ws !== ws) return;
+      if (ws.readyState === WebSocket.OPEN) return;
+      this.emit('error', new Error(`Timed out connecting to agent-server at ${this.serverUrl}. Is the server running?`));
+      this.setStatus('offline');
+      try {
+        (ws as unknown as { terminate?: () => void }).terminate?.();
+      } catch (err) {
+        void err;
+      }
+      try {
+        ws.close();
+      } catch (err) {
+        void err;
+      }
+      this.scheduleReconnect();
+    }, RemoteConversation.wsHandshakeTimeoutMs);
 
-    ws.on('open', () => { this.retryCount = 0; this.setStatus('online'); });
-    ws.on('close', () => { this.setStatus('offline'); this.scheduleReconnect(); });
-    ws.on('error', (err: Error) => { this.emit('error', err); this.setStatus('offline'); this.scheduleReconnect(); });
+    ws.on('open', () => {
+      if (this.ws !== ws) return;
+      this.clearWsHandshakeTimer();
+      this.retryCount = 0;
+      this.hasEverConnected = true;
+      this.setStatus('online');
+    });
+    ws.on('close', () => {
+      if (this.ws !== ws) return;
+      this.clearWsHandshakeTimer();
+      this.setStatus('offline');
+      this.scheduleReconnect();
+    });
+    ws.on('error', (err: Error) => {
+      if (this.ws !== ws) return;
+      this.clearWsHandshakeTimer();
+      this.emit('error', err);
+      this.setStatus('offline');
+      this.scheduleReconnect();
+    });
     ws.on('message', (buf: Buffer) => {
       try {
         const str = buf.toString('utf8');
@@ -381,7 +444,7 @@ export class RemoteConversation extends EventEmitter {
       while (true) {
         const params = new URLSearchParams({ limit: String(RemoteConversation.historyPageLimit) });
         if (pageId) params.set('page_id', pageId);
-        const res = await fetch(`${base}/api/conversations/${this.conversationId}/events/search?${params.toString()}`, { headers });
+        const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/events/search?${params.toString()}`, { headers }, RemoteConversation.httpTimeoutMs);
         if (!res.ok) {
           const info = await res.text().catch(() => '');
           this.emit('error', new Error(`Failed to fetch conversation history (HTTP ${res.status})${info ? `: ${info}` : ''}`));

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -260,11 +260,11 @@ export class RemoteConversation extends EventEmitter {
       const payload: { accept: boolean; reason?: string } = { accept };
       if (!accept && reason !== undefined) payload.reason = reason;
 
-      const res = await fetch(`${base}/api/conversations/${this.conversationId}/events/respond_to_confirmation`, {
+      const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/events/respond_to_confirmation`, {
         method: 'POST',
         headers,
         body: JSON.stringify(payload)
-      });
+      }, RemoteConversation.httpTimeoutMs);
 
       if (!res.ok) {
         const info = await res.text().catch(() => '');


### PR DESCRIPTION
Fixes Beads `oh-tab-0gk0`.

Problem:
- When the configured agent-server is unreachable, `RemoteConversation` can remain in `connecting` indefinitely (WebSocket handshake never resolves; some fetches also have no timeout). This leaves the VS Code UI stuck on “Connecting…”.

Changes:
- Add WebSocket handshake timeout so we always transition to `offline` and emit a clear error.
- Add HTTP request timeouts for remote API calls.
- Ensure `startNewConversation()` sets status back to `offline` on failure.
- Avoid infinite reconnect loops before the first successful connection (manual retry via reconnect).

Tests:
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for remote conversation connections to prevent indefinite hangs.
  * Enhanced offline detection and error signaling when WebSocket fails to connect or conversation startup fails.

* **Tests**
  * Added tests for WebSocket connection timeout scenarios and offline handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->