### PR TITLE
[oh-tab-8yu] Remove env override for conversation storeRoot

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -440,11 +440,9 @@ async function ensureWritableDirectory(dir: string): Promise<void> {
 async function resolveConversationStoreRoot(context: vscode.ExtensionContext): Promise<string> {
   const cfg = vscode.workspace.getConfiguration();
   const configured = normalizeNonEmptyString(cfg.get<string>('openhands.conversation.storeRoot'));
-  const envOverride = normalizeNonEmptyString(process.env.OPENHANDS_CONVERSATIONS_DIR);
 
   const candidates: Array<{ label: string; dir: string }> = [];
   if (configured) candidates.push({ label: 'setting openhands.conversation.storeRoot', dir: resolveConfiguredPath(configured) });
-  if (envOverride) candidates.push({ label: 'env OPENHANDS_CONVERSATIONS_DIR', dir: resolveConfiguredPath(envOverride) });
 
   try {
     candidates.push({ label: 'default ~/.openhands/conversations-vscode', dir: path.join(os.homedir(), '.openhands', 'conversations-vscode') });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,9 +20,7 @@ npm run e2e
 
 In local mode, the extension persists conversation history/events to `~/.openhands/conversations-vscode/` by default.
 
-To override the storage directory (useful for CI runners or read-only home dirs), set either:
-- VS Code setting `openhands.conversation.storeRoot`, or
-- Env var `OPENHANDS_CONVERSATIONS_DIR` (often easiest to wire up for test processes).
+To override the storage directory (useful for CI runners or read-only home dirs), set VS Code setting `openhands.conversation.storeRoot`.
 
 ## Agent-SDK Events Test
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,7 +20,7 @@ npm run e2e
 
 In local mode, the extension persists conversation history/events to `~/.openhands/conversations-vscode/` by default.
 
-To override the storage directory (useful for CI runners or read-only home dirs), set VS Code setting `openhands.conversation.storeRoot`.
+To override the storage directory (useful for CI runners or read-only home dirs), set the VS Code setting `openhands.conversation.storeRoot`.
 
 ## Agent-SDK Events Test
 


### PR DESCRIPTION
Removes `OPENHANDS_CONVERSATIONS_DIR` support for conversation storage location; use VS Code setting `openhands.conversation.storeRoot` (or defaults) only.

Tests:
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed support for overriding conversation storage directory via the OPENHANDS_CONVERSATIONS_DIR environment variable. Use the VS Code setting `openhands.conversation.storeRoot` instead.

* **Documentation**
  * Updated configuration documentation to reflect current conversation storage directory override options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->