### PR TITLE
[oh-tab-54x] Make Add Context a true toggle

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -603,114 +603,88 @@ describe('App - Advanced Test Coverage', () => {
   });
 
   describe('Click outside and escape handlers', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
     it('toggles context picker closed on second click', async () => {
       render(<App />);
 
-      await userEvent.click(screen.getByLabelText('Add context'));
+      fireEvent.click(screen.getByLabelText('Add context'));
 
-      postToWindow({ type: 'workspaceFiles', files: ['test.ts'] });
-
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
-      });
+      expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
 
       // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
-      await new Promise(resolve => setTimeout(resolve, 150));
+      act(() => { vi.advanceTimersByTime(150); });
 
       // Click the toggle again -> should close
-      await userEvent.click(screen.getByLabelText('Add context'));
+      fireEvent.click(screen.getByLabelText('Add context'));
 
-      await waitFor(() => {
-        expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
     });
 
     it('closes context picker on click outside', async () => {
       render(<App />);
 
-      await userEvent.click(screen.getByLabelText('Add context'));
+      fireEvent.click(screen.getByLabelText('Add context'));
 
-      postToWindow({ type: 'workspaceFiles', files: ['test.ts'] });
-
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
-      });
+      expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
 
       // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
-      await new Promise(resolve => setTimeout(resolve, 150));
+      act(() => { vi.advanceTimersByTime(150); });
 
       // Click outside (on the main app)
-      await userEvent.click(screen.getByText('OpenHands'));
+      fireEvent.click(screen.getByText('OpenHands'));
 
-      await waitFor(() => {
-        expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
     });
 
     it('closes context picker on Escape key', async () => {
       render(<App />);
 
-      await userEvent.click(screen.getByLabelText('Add context'));
+      fireEvent.click(screen.getByLabelText('Add context'));
 
-      postToWindow({ type: 'workspaceFiles', files: ['test.ts'] });
-
-      await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
-      });
+      expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
 
       // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
-      await new Promise(resolve => setTimeout(resolve, 150));
+      act(() => { vi.advanceTimersByTime(150); });
 
       // Press Escape
-      await userEvent.keyboard('{Escape}');
+      fireEvent.keyDown(document, { key: 'Escape' });
 
-      await waitFor(() => {
-        expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
     });
 
     it('closes skills popover on click outside', async () => {
       render(<App />);
 
-      await userEvent.click(screen.getByLabelText('Skills'));
+      fireEvent.click(screen.getByLabelText('Skills'));
 
-      postToWindow({ type: 'skillsList', skills: [{ label: 'Test', path: '/test.md' }] });
-
-      await waitFor(() => {
-        expect(screen.getByText('Test')).toBeInTheDocument();
-      });
+      expect(screen.getByText('Available Skills')).toBeInTheDocument();
 
       // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
-      await new Promise(resolve => setTimeout(resolve, 150));
+      act(() => { vi.advanceTimersByTime(150); });
 
       // Click outside
-      await userEvent.click(screen.getByText('OpenHands'));
+      fireEvent.click(screen.getByText('OpenHands'));
 
-      await waitFor(() => {
-        expect(screen.queryByText('Test')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByText('Available Skills')).not.toBeInTheDocument();
     });
 
     it('closes skills popover on Escape key', async () => {
       render(<App />);
 
-      await userEvent.click(screen.getByLabelText('Skills'));
+      fireEvent.click(screen.getByLabelText('Skills'));
 
-      postToWindow({ type: 'skillsList', skills: [{ label: 'Test', path: '/test.md' }] });
-
-      await waitFor(() => {
-        expect(screen.getByText('Test')).toBeInTheDocument();
-      });
+      expect(screen.getByText('Available Skills')).toBeInTheDocument();
 
       // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
-      await new Promise(resolve => setTimeout(resolve, 150));
+      act(() => { vi.advanceTimersByTime(150); });
 
       // Press Escape
-      await userEvent.keyboard('{Escape}');
+      fireEvent.keyDown(document, { key: 'Escape' });
 
-      await waitFor(() => {
-        expect(screen.queryByText('Test')).not.toBeInTheDocument();
-      });
+      expect(screen.queryByText('Available Skills')).not.toBeInTheDocument();
     });
   });
 

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -603,6 +603,28 @@ describe('App - Advanced Test Coverage', () => {
   });
 
   describe('Click outside and escape handlers', () => {
+    it('toggles context picker closed on second click', async () => {
+      render(<App />);
+
+      await userEvent.click(screen.getByLabelText('Add context'));
+
+      postToWindow({ type: 'workspaceFiles', files: ['test.ts'] });
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
+      });
+
+      // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
+      await new Promise(resolve => setTimeout(resolve, 150));
+
+      // Click the toggle again -> should close
+      await userEvent.click(screen.getByLabelText('Add context'));
+
+      await waitFor(() => {
+        expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
+      });
+    });
+
     it('closes context picker on click outside', async () => {
       render(<App />);
 

--- a/src/webview-src/components/useCloseOnEscapeAndOutsideClick.ts
+++ b/src/webview-src/components/useCloseOnEscapeAndOutsideClick.ts
@@ -24,13 +24,13 @@ export function useCloseOnEscapeAndOutsideClick(
 
     const timer = window.setTimeout(() => {
       document.addEventListener('keydown', handleEscape);
-      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('click', handleClickOutside);
     }, delay);
 
     return () => {
       window.clearTimeout(timer);
       document.removeEventListener('keydown', handleEscape);
-      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('click', handleClickOutside);
     };
   }, [isOpen, onClose, ref, delay]);
 }


### PR DESCRIPTION
Fixes `oh-tab-54x`: clicking "Add context" twice now closes the context picker.

Root cause: our outside-click handler used `document.mousedown`, which ran before the button’s `onClick`, so the close+toggle sequence could re-open the popover.

Changes:
- Use `click` (not `mousedown`) for outside-click detection in `useCloseOnEscapeAndOutsideClick`.
- Add regression test for double-click toggle.

Tests:
- `npm test`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated outside-click event handling to use click events instead of mousedown, improving the reliability of closing interactions.

* **Tests**
  * Added test coverage for context picker toggle behavior on repeated clicks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->