### PR TITLE
[oh-tab-0swb] Fix server add when no workspace open

### DIFF
--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -19,7 +19,13 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
   }
 
   async update<T = unknown>(key: string, value: T, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
-    await vscode.workspace.getConfiguration().update(key, value, target === 'workspace' ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global);
+    const hasWorkspace = (vscode.workspace.workspaceFolders?.length ?? 0) > 0;
+    const effectiveTarget =
+      target === 'workspace'
+        ? (hasWorkspace ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global)
+        : vscode.ConfigurationTarget.Global;
+
+    await vscode.workspace.getConfiguration().update(key, value, effectiveTarget);
   }
 
   async getSecret(key: string): Promise<string | undefined> {

--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -19,10 +19,10 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
   }
 
   async update<T = unknown>(key: string, value: T, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
-    const hasWorkspace = (vscode.workspace.workspaceFolders?.length ?? 0) > 0;
+    const hasWorkspace = !!vscode.workspace.workspaceFolders?.length;
     const effectiveTarget =
-      target === 'workspace'
-        ? (hasWorkspace ? vscode.ConfigurationTarget.Workspace : vscode.ConfigurationTarget.Global)
+      target === 'workspace' && hasWorkspace
+        ? vscode.ConfigurationTarget.Workspace
         : vscode.ConfigurationTarget.Global;
 
     await vscode.workspace.getConfiguration().update(key, value, effectiveTarget);

--- a/src/settings/__tests__/VscodeSettingsAdapter.test.ts
+++ b/src/settings/__tests__/VscodeSettingsAdapter.test.ts
@@ -12,6 +12,11 @@ describe('VscodeSettingsAdapter', () => {
     // Reset all mocks before each test
     vi.clearAllMocks();
 
+    Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+      value: [{ uri: { fsPath: '/test/workspace' } }],
+      configurable: true,
+    });
+
     // Create mock objects
     mockConfiguration = {
       get: vi.fn(),
@@ -151,6 +156,25 @@ describe('VscodeSettingsAdapter', () => {
         key,
         value,
         vscode.ConfigurationTarget.Workspace
+      );
+    });
+
+    it('should fall back to global when no workspace is open', async () => {
+      const key = 'test.key';
+      const value = 'test-value';
+      mockConfiguration.update.mockResolvedValue(undefined);
+
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value: [],
+        configurable: true,
+      });
+
+      await adapter.update(key, value, 'workspace');
+
+      expect(mockConfiguration.update).toHaveBeenCalledWith(
+        key,
+        value,
+        vscode.ConfigurationTarget.Global
       );
     });
 


### PR DESCRIPTION
Fixes `oh-tab-0swb`: adding a server should work even in a no-folder VS Code window.

Root cause: we defaulted settings updates to `ConfigurationTarget.Workspace`; when no workspace is open, that target is not writable, so `addServer`/`selectServer` updates could fail and the webview never receives `serverListUpdated`.

Change:
- `VscodeSettingsAdapter.update(..., 'workspace')` now writes to **Global** when there is no workspace.

Tests:
- `npm test`
- `npm run lint`
- `npm run typecheck`
