### PR TITLE
[oh-tab-981] Reserve status row space

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -300,6 +300,22 @@ describe('App - Advanced Test Coverage', () => {
       });
     });
 
+    it('keeps the status row mounted when auto-dismiss hides the banner', async () => {
+      vi.useFakeTimers();
+      render(<App />);
+
+      expect(screen.getByTestId('status-row')).toBeInTheDocument();
+      expect(screen.getByText(/Initializing/)).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+
+      expect(screen.queryByText(/Initializing/)).not.toBeInTheDocument();
+
+      expect(screen.getByTestId('status-row')).toBeInTheDocument();
+    });
+
     it('shows local mode banner when mode is local', async () => {
       render(<App />);
 
@@ -308,6 +324,18 @@ describe('App - Advanced Test Coverage', () => {
       await waitFor(() => {
         expect(screen.getByText(/Local mode: running without remote server/)).toBeInTheDocument();
       });
+    });
+
+    it('does not show a dismiss button for the local mode banner', async () => {
+      render(<App />);
+
+      postToWindow({ type: 'status', status: 'offline', mode: 'local' });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Local mode: running without remote server/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: 'Dismiss' })).not.toBeInTheDocument();
     });
 
     it('updates banner on conversation start', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -52,6 +52,12 @@ type ConversationsList = Array<{
   messageCount?: number;
 }>;
 
+type StatusBannerState = {
+  message: string;
+  level: 'info' | 'warn' | 'error';
+  dismissible?: boolean;
+};
+
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.
  */
@@ -122,7 +128,7 @@ export function App() {
   const [attachments, setAttachments] = useState<Array<{ uri: string; label: string; sizeBytes?: number }>>([]);
 
   // UI state
-  const [statusBanner, setStatusBanner] = useState<{ message: string; level: 'info' | 'warn' | 'error' } | null>(
+  const [statusBanner, setStatusBanner] = useState<StatusBannerState | null>(
     { message: 'Initializing…', level: 'info' }
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -289,7 +295,7 @@ export function App() {
               setMode(payload.mode);
             }
             if (payload.mode === 'local') {
-              setStatusBanner({ message: 'Local mode: running without remote server', level: 'info' });
+              setStatusBanner({ message: 'Local mode: running without remote server', level: 'info', dismissible: false });
             } else if (payload.status === 'connecting') {
               setStatusBanner({ message: 'Connecting to server…', level: 'info' });
             } else if (payload.status === 'online') {
@@ -309,7 +315,7 @@ export function App() {
           if (payload.mode === 'local') {
             setMode('local');
             setCurrentServerUrl(undefined);
-            setStatusBanner({ message: 'Local mode: running without remote server', level: 'info' });
+            setStatusBanner({ message: 'Local mode: running without remote server', level: 'info', dismissible: false });
           } else if (payload.mode === 'remote') {
             setMode('remote');
           }
@@ -689,6 +695,19 @@ export function App() {
 
       {/* Input area */}
       <div className="relative">
+        {/* Status banner (space reserved to prevent layout jumps) */}
+        <div className="px-4 pb-2 min-h-[56px] flex items-end" data-testid="status-row">
+          {statusBanner && (
+            <StatusBanner
+              message={statusBanner.message}
+              level={statusBanner.level}
+              dismissible={statusBanner.dismissible}
+              onDismiss={() => setStatusBanner(null)}
+              autoDismiss={statusBanner.level !== 'error'}
+            />
+          )}
+        </div>
+
         <InputArea
           value={input}
           onChange={handleInputChange}
@@ -723,18 +742,6 @@ export function App() {
           skills={skills}
           onOpenSkill={handleOpenSkill}
         />
-
-        {/* Status banner */}
-        {statusBanner && (
-          <div className="px-4 pb-4">
-            <StatusBanner
-              message={statusBanner.message}
-              level={statusBanner.level}
-              onDismiss={() => setStatusBanner(null)}
-              autoDismiss={statusBanner.level !== 'error'}
-            />
-          </div>
-        )}
       </div>
 
       {/* History view (slide-over panel) */}

--- a/src/webview-src/components/StatusBanner.tsx
+++ b/src/webview-src/components/StatusBanner.tsx
@@ -4,6 +4,7 @@ interface StatusBannerProps {
   message: string;
   level: 'info' | 'warn' | 'error';
   onDismiss: () => void;
+  dismissible?: boolean;
   autoDismiss?: boolean;
   autoDismissDelay?: number;
 }
@@ -12,6 +13,7 @@ export function StatusBanner({
   message,
   level,
   onDismiss,
+  dismissible = true,
   autoDismiss = true,
   autoDismissDelay = 5000,
 }: StatusBannerProps) {
@@ -64,14 +66,21 @@ export function StatusBanner({
         className={`codicon codicon-${config.icon} flex-shrink-0`}
         style={{ color: config.iconColor }}
       />
-      <div className="flex-1 text-sm">{message}</div>
-      <button
-        onClick={onDismiss}
-        className="flex-shrink-0 w-6 h-6 rounded-md hover:bg-white/[0.08] flex items-center justify-center transition-colors text-stone-400 hover:text-stone-300"
-        aria-label="Dismiss"
+      <div
+        className={`flex-1 text-sm ${level === 'error' ? 'break-words' : 'truncate'}`}
+        title={message}
       >
-        <span className="codicon codicon-close text-xs" />
-      </button>
+        {message}
+      </div>
+      {dismissible && (
+        <button
+          onClick={onDismiss}
+          className="flex-shrink-0 w-6 h-6 rounded-md hover:bg-white/[0.08] flex items-center justify-center transition-colors text-stone-400 hover:text-stone-300"
+          aria-label="Dismiss"
+        >
+          <span className="codicon codicon-close text-xs" />
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Fixes layout jump when transient status messages (e.g., local mode banner) appear/disappear by reserving a persistent status row.

Changes:
- Always render a bottom status row (reserved height) so the webview doesn't shift when the banner auto-dismisses.
- Hide the close (x) on the local-mode banner; it auto-dismisses.
- Truncate non-error banner text to keep row height stable.
- Add unit coverage for status row persistence + local-mode dismiss button.

Verification:
- 
> openhands-tab@0.0.4 test
> npm test -w @openhands/agent-sdk-ts && vitest run --dir src


> @openhands/agent-sdk-ts@0.1.0 test
> vitest run


 RUN  v2.1.9 /Users/enyst/repos/oh-tab/packages/agent-sdk-ts

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers keyword skills
Skill 'react-skill' triggered by keyword 'react'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers multiple skills
Skill 'react-skill' triggered by keyword 'react'
Skill 'typescript-skill' triggered by keyword 'typescript'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > appends custom user message suffix to triggered skills
Skill 'test-skill' triggered by keyword 'test'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles multiple text content blocks
Skill 'test-skill' triggered by keyword 'keyword'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles task triggers
Skill 'refactor' triggered by keyword '/refactor'

 ✓ src/sdk/context/__tests__/agent-context.test.ts (26 tests) 9ms
 ✓ src/sdk/context/skills/__tests__/skill.test.ts (37 tests) 23ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-errors.test.ts (4 tests) 9ms
 ✓ src/sdk/__tests__/persistence.test.ts (11 tests) 13ms
 ✓ src/sdk/runtime/__tests__/Agent.debug-mode.test.ts (6 tests) 13ms
 ✓ src/sdk/conversation/LocalConversation.test.ts (6 tests) 41ms
 ✓ src/sdk/__tests__/remoteConversation.test.ts (3 tests) 21ms
 ✓ src/tools/__tests__/new-tools.test.ts (12 tests) 114ms
 ✓ src/sdk/__tests__/agent.loop.test.ts (4 tests) 20ms
 ✓ src/sdk/runtime/__tests__/Agent.redaction.test.ts (2 tests) 4ms
 ✓ src/sdk/__tests__/conversation-stats.test.ts (3 tests) 2ms
 ✓ src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts (3 tests) 4ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts (1 test) 4ms
 ✓ src/sdk/__tests__/agent-sdk.guards.test.ts (5 tests) 2ms
 ✓ src/sdk/__tests__/registry.test.ts (3 tests) 3ms
 ✓ src/sdk/__tests__/metrics.test.ts (4 tests) 2ms
 ✓ src/sdk/runtime/__tests__/Agent.security-risk.test.ts (1 test) 3ms
 ✓ src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts (2 tests) 1ms
 ✓ src/workspace/__tests__/local.workspace.test.ts (3 tests) 17ms
 ✓ src/tools/__tests__/tools.test.ts (6 tests) 227ms
 ✓ src/sdk/runtime/__tests__/truncateError.unit.test.ts (5 tests) 2ms
 ✓ src/sdk/__tests__/runtime.test.ts (3 tests) 2ms
 ✓ src/sdk/__tests__/llm.orchestrator.test.ts (5 tests | 1 skipped) 1015ms
   ✓ OpenAICompatibleClient streaming > propagates failure after retries 757ms

 Test Files  23 passed (23)
      Tests  154 passed | 1 skipped (155)
   Start at  06:36:25
   Duration  1.67s (transform 427ms, setup 0ms, collect 1.55s, tests 1.55s, environment 2ms, prepare 1.11s)


 RUN  v2.1.9 /Users/enyst/repos/oh-tab

 ✓ src/settings/__tests__/VscodeSettingsAdapter.test.ts (17 tests) 8ms
 ✓ src/settings/__tests__/SettingsManager.test.ts (11 tests) 4ms
 ✓ src/__tests__/extension.test.ts (15 tests) 129ms
 ✓ src/webview-src/__tests__/event.handlers.test.tsx (4 tests) 208ms
 ✓ src/shared/__tests__/llmStreaming.test.ts (4 tests) 2ms
 ✓ src/webview-src/__tests__/HistoryView.test.tsx (5 tests) 263ms
 ✓ src/webview-src/__tests__/event.rendering.test.tsx (15 tests) 395ms
 ✓ src/webview-src/__tests__/App.render.test.tsx (2 tests) 110ms
 ✓ src/webview-src/__tests__/App.confirmation.test.tsx (12 tests) 690ms
 ✓ src/webview-src/__tests__/App.advanced.test.tsx (46 tests | 2 skipped) 828ms
 ✓ src/webview-src/__tests__/App.toolbar.test.tsx (6 tests | 2 skipped) 105ms
 ✓ src/webview-src/__tests__/toasts.test.tsx (1 test) 36ms
 ✓ src/webview-src/__tests__/actions.test.tsx (6 tests) 213ms

 Test Files  13 passed (13)
      Tests  140 passed | 4 skipped (144)
   Start at  06:36:26
   Duration  1.95s (transform 503ms, setup 480ms, collect 2.98s, tests 2.99s, environment 3.19s, prepare 620ms)
- 
> openhands-tab@0.0.4 typecheck
> tsc -p . && tsc -p tsconfig.webview.json
- 
> openhands-tab@0.0.4 lint
> npm run lint -w @openhands/agent-sdk-ts && eslint src tests


> @openhands/agent-sdk-ts@0.1.0 lint
> eslint ./src