### PR TITLE
docs(PRD): fix Extension Structure provider

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -168,7 +168,7 @@ src/
 │   ├── SettingsManager.ts       # Settings access layer
 │   └── VscodeSettingsAdapter.ts # VS Code implementation
 ├── sidebar/
-│   └── OpenHandsViewProvider.ts # Activity bar tree view
+│   └── OpenHandsChatViewProvider.ts # Chat sidebar WebviewView provider
 └── webview-src/
     ├── webview.tsx              # Entry point
     └── components/


### PR DESCRIPTION
Fixes a missed follow-up from merged PR #200.

- Update `docs/PRD.md` Extension Structure to reference `src/sidebar/OpenHandsChatViewProvider.ts` (tree view provider was removed).

Checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`

Beads: oh-tab-bm0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component naming conventions for improved clarity and consistency in the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->