### PR TITLE
webview: improve user message styling

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -44,6 +44,7 @@ describe('Agent-SDK event rendering', () => {
     } as any;
     postToWindow({ type: 'event', event: ev });
     expect(await screen.findByText('User message here')).toBeInTheDocument();
+    expect(screen.queryByText('User')).toBeNull();
   });
 
   it('renders agent error events', async () => {

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -278,7 +278,7 @@ function TerminalObservationSummary({ observation }: { observation: JsonRecord }
  * Event color tokens - CSS custom properties defined in tailwind.css
  * Design Philosophy: "Warm Technical Refinement"
  * - Agent/AI: Warm gold (protagonist, signature OpenHands color)
- * - User: Warm slate (supporting role, understated)
+ * - User: Warm stone (supporting role, understated)
  * - System: Soft lavender (informational)
  * - Action: Teal (operational, cool accent for contrast)
  * - Observation: Soft mint (results/completion)
@@ -739,7 +739,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
 
   const handleOpenFile = (file: string) => openWorkspaceFile(file);
 
-  // Agent messages get slightly more prominent styling
+  // User messages get extra contrast; agent messages stay prominent
   const bgOpacity = isUser ? 0.08 : isAgent ? 0.06 : 0.04;
 
   return (

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -735,11 +735,12 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const roleLabel = message.role === 'assistant'
     ? 'Agent'
     : message.role.charAt(0).toUpperCase() + message.role.slice(1);
+  const showRoleLabel = !isUser;
 
   const handleOpenFile = (file: string) => openWorkspaceFile(file);
 
   // Agent messages get slightly more prominent styling
-  const bgOpacity = isAgent ? 0.06 : 0.04;
+  const bgOpacity = isUser ? 0.08 : isAgent ? 0.06 : 0.04;
 
   return (
     <EventContainer accentColor={accentColor} bgOpacity={bgOpacity} index={index} dataTestId="message-event">
@@ -752,17 +753,21 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
         </div>
 
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-2">
-            <div className={`font-semibold text-sm ${isAgent ? 'text-amber-200' : 'text-stone-300'}`}>{roleLabel}</div>
-            {message.created_at && (
-              <div className="text-xs text-stone-500">
-                {new Date(message.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-              </div>
-            )}
-          </div>
+          {(showRoleLabel || message.created_at) && (
+            <div className="flex items-center gap-2 mb-2">
+              {showRoleLabel && (
+                <div className={`font-semibold text-sm ${isAgent ? 'text-amber-200' : 'text-stone-300'}`}>{roleLabel}</div>
+              )}
+              {message.created_at && (
+                <div className={`text-xs text-stone-500 ${showRoleLabel ? '' : 'ml-auto'}`}>
+                  {new Date(message.created_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </div>
+              )}
+            </div>
+          )}
 
           {textContent && (
-            <div className={`text-sm leading-relaxed whitespace-pre-wrap break-words ${isAgent ? 'text-stone-200' : 'text-stone-300'}`}>
+            <div className={`text-sm leading-relaxed whitespace-pre-wrap break-words ${isAgent || isUser ? 'text-stone-200' : 'text-stone-300'}`}>
               {textContent}
             </div>
           )}

--- a/src/webview-src/tailwind.css
+++ b/src/webview-src/tailwind.css
@@ -12,7 +12,7 @@
   :root {
     /* Agent/AI - signature warm gold (the main voice) */
     --event-agent: #E8A642;
-    /* User - warm slate (understated, supporting) */
+    /* User - warm stone (understated, supporting) */
     --event-user: #A8A29E;
     /* System - soft lavender (informational, ambient) */
     --event-system: #A78BFA;

--- a/src/webview-src/tailwind.css
+++ b/src/webview-src/tailwind.css
@@ -13,7 +13,7 @@
     /* Agent/AI - signature warm gold (the main voice) */
     --event-agent: #E8A642;
     /* User - warm slate (understated, supporting) */
-    --event-user: #94A3B8;
+    --event-user: #A8A29E;
     /* System - soft lavender (informational, ambient) */
     --event-system: #A78BFA;
     /* Actions - teal (operational, cool accent contrast) */


### PR DESCRIPTION
Implements oh-tab-14b.

- Remove the "User" role label from user messages.
- Increase user bubble contrast (slightly stronger background + warmer user accent color).
- Add a small regression test asserting the label is absent.

Checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`

Beads: oh-tab-14b