### PR TITLE
webview: show LLM model in input row

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,6 +61,7 @@ let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
 let conversationStoreRoot: string | undefined;
+let lastKnownLlmModel: string | null = null;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -581,6 +582,7 @@ export function activate(context: vscode.ExtensionContext) {
   async function ensureConversationAndConnection(options?: { uiJustCreated?: boolean }) {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
+    lastKnownLlmModel = settings.llm.model ?? null;
     const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = workspaceRoot;
 
@@ -633,7 +635,7 @@ export function activate(context: vscode.ExtensionContext) {
       conversation.on('status', (s: string) => {
         outputChannel?.appendLine(`[status] ${s}`);
         if (chatView && chatWebviewReady && chatView.visible) {
-          void chatView.webview.postMessage({ type: 'status', status: s, mode: conversationMode });
+          void chatView.webview.postMessage({ type: 'status', status: s, mode: conversationMode, llmModel: lastKnownLlmModel });
         }
       });
 
@@ -729,6 +731,7 @@ export function activate(context: vscode.ExtensionContext) {
         type: 'status',
         status: conversation?.getStatus() ?? 'offline',
         mode: conversationMode,
+        llmModel: lastKnownLlmModel,
       });
     }
   }
@@ -988,13 +991,16 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
         chatLastConversationId = message.conversationId;
         chatLastSeenSeq = message.lastSeenSeq;
 
+        const initSettings = await settingsMgr.get();
+        lastKnownLlmModel = initSettings.llm.model ?? null;
+
         void host.postMessage({
           type: 'status',
           status: conversation?.getStatus() ?? 'offline',
           mode: conversationMode,
+          llmModel: lastKnownLlmModel,
         });
 
-        const initSettings = await settingsMgr.get();
         void host.postMessage({
           type: 'serverListUpdated',
           servers: initSettings.servers,

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -1,11 +1,15 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor, cleanup } from '@testing-library/react';
 import { App } from '../components/App';
 
 const mockApi = { postMessage: vi.fn() };
 
 describe('App toolbar interactions', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     // @ts-expect-error mock VS Code API
     window.acquireVsCodeApi = () => mockApi;
@@ -24,6 +28,18 @@ describe('App toolbar interactions', () => {
     await waitFor(() => {
       expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestSkills' });
     });
+  });
+
+  it('shows the configured LLM model in the input row', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local', llmModel: 'gpt-4.1' }
+      }));
+    });
+
+    expect(await screen.findByLabelText('LLM model')).toHaveTextContent('gpt-4.1');
   });
 
   it('requests workspace files and inserts context mention at cursor', async () => {

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -42,6 +42,18 @@ describe('App toolbar interactions', () => {
     expect(await screen.findByLabelText('LLM model')).toHaveTextContent('gpt-4.1');
   });
 
+  it('shows a default label when no LLM model is configured', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local', llmModel: null }
+      }));
+    });
+
+    expect(await screen.findByLabelText('LLM model')).toHaveTextContent('default');
+  });
+
   it('requests workspace files and inserts context mention at cursor', async () => {
     render(<App />);
     const input = document.getElementById('openhands-chat-input') as HTMLInputElement;

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -112,6 +112,7 @@ export function App() {
   const [status, setStatus] = useState<'online' | 'offline' | 'connecting'>('offline');
   const [mode, setMode] = useState<'local' | 'remote'>('remote');
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
+  const [llmModel, setLlmModel] = useState<string | null | undefined>(undefined);
 
   // Events and conversation state
   const [events, setEvents] = useState<RenderedEvent[]>([]);
@@ -276,6 +277,7 @@ export function App() {
         status?: 'online' | 'offline' | 'connecting';
         serverUrl?: string | null;
         mode?: 'local' | 'remote';
+        llmModel?: string | null;
         event?: unknown;
         seq?: unknown;
         error?: unknown;
@@ -293,6 +295,9 @@ export function App() {
             setStatus(payload.status);
             if (payload.mode === 'local' || payload.mode === 'remote') {
               setMode(payload.mode);
+            }
+            if (typeof payload.llmModel === 'string' || payload.llmModel === null) {
+              setLlmModel(payload.llmModel);
             }
             if (payload.mode === 'local') {
               setStatusBanner({ message: 'Local mode: running without remote server', level: 'info', dismissible: false });
@@ -635,6 +640,9 @@ export function App() {
 
   // Derived state: conversation is empty when no events and no streaming
   const isEmptyConversation = events.length === 0 && streamingContent === null;
+  const llmModelLabel = llmModel === undefined
+    ? undefined
+    : (llmModel || (mode === 'remote' ? 'server default' : 'default'));
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -713,6 +721,8 @@ export function App() {
           onChange={handleInputChange}
           onSubmit={handleSendMessage}
           disabled={status === 'offline'}
+          modelLabel={llmModelLabel}
+          onOpenModelSettings={handleOpenSettings}
           onOpenContext={handleOpenContext}
           contextCount={selectedContextFiles.length}
           onOpenSkills={handleOpenSkills}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -7,6 +7,9 @@ interface InputAreaProps {
   onSubmit: () => void;
   disabled?: boolean;
   placeholder?: string;
+  // LLM model display
+  modelLabel?: string;
+  onOpenModelSettings?: () => void;
   // Context picker
   onOpenContext: () => void;
   contextCount?: number;
@@ -30,6 +33,8 @@ export function InputArea({
   onSubmit,
   disabled = false,
   placeholder = 'Ask OpenHands anything...',
+  modelLabel,
+  onOpenModelSettings,
   onOpenContext,
   contextCount = 0,
   onOpenSkills,
@@ -153,6 +158,32 @@ export function InputArea({
 
         {/* Accessory buttons row */}
         <div className="flex items-center gap-2 mt-3">
+          {modelLabel !== undefined && (
+            <button
+              type="button"
+              onClick={onOpenModelSettings}
+              className={`
+                inline-flex items-center gap-2
+                px-3 py-2 rounded-lg
+                text-xs font-medium
+                transition-all duration-200
+                border
+                focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+                ${onOpenModelSettings
+                  ? 'bg-white/[0.04] text-stone-400 border-white/[0.06] hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]'
+                  : 'bg-white/[0.02] text-stone-600 border-white/[0.03] cursor-not-allowed'
+                }
+              `}
+              aria-label="LLM model"
+              title={onOpenModelSettings ? 'Change model in settings' : `LLM model: ${modelLabel}`}
+              disabled={!onOpenModelSettings}
+            >
+              <span className="codicon codicon-symbol-parameter text-[13px] text-brand-400/70" />
+              <span className="text-stone-500">Model</span>
+              <span className="font-mono text-stone-300 truncate max-w-[14rem]">{modelLabel}</span>
+            </button>
+          )}
+
           <AccessoryButton
             icon="mention"
             label="Add context"

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -158,10 +158,10 @@ export function InputArea({
 
         {/* Accessory buttons row */}
         <div className="flex items-center gap-2 mt-3">
-          {modelLabel !== undefined && (
-            <button
-              type="button"
-              onClick={onOpenModelSettings}
+	          {modelLabel !== undefined && (
+	            <button
+	              type="button"
+	              onClick={onOpenModelSettings}
               className={`
                 inline-flex items-center gap-2
                 px-3 py-2 rounded-lg
@@ -172,12 +172,16 @@ export function InputArea({
                 ${onOpenModelSettings
                   ? 'bg-white/[0.04] text-stone-400 border-white/[0.06] hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]'
                   : 'bg-white/[0.02] text-stone-600 border-white/[0.03] cursor-not-allowed'
-                }
-              `}
-              aria-label="LLM model"
-              title={onOpenModelSettings ? 'Change model in settings' : `LLM model: ${modelLabel}`}
-              disabled={!onOpenModelSettings}
-            >
+	              }
+	            `}
+	              aria-label="LLM model"
+	              title={
+	                onOpenModelSettings
+	                  ? `LLM model: ${modelLabel} (click to change in settings)`
+	                  : `LLM model: ${modelLabel}`
+	              }
+	              disabled={!onOpenModelSettings}
+	            >
               <span className="codicon codicon-symbol-parameter text-[13px] text-brand-400/70" />
               <span className="text-stone-500">Model</span>
               <span className="font-mono text-stone-300 truncate max-w-[14rem]">{modelLabel}</span>


### PR DESCRIPTION
Implements oh-tab-0thz.

- Extension includes `llmModel` in `status` messages so the webview can display the configured model.
- Webview renders a small “Model” pill/button in the input accessory row (click opens settings).
- Adds unit coverage and fixes `App.toolbar.test.tsx` cleanup to avoid DOM accumulation across tests.

Checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run e2e`

Beads: oh-tab-0thz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display the currently active LLM model in the interface so users can see which model is in use.
  * Added a Model button in the input area that allows users to quickly access and configure LLM model settings.
  * Model information is now tracked and synchronized throughout the application to ensure consistency.

* **Tests**
  * Added test coverage for LLM model display in the interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->