### PR TITLE
docs/scripts: local agent-server launcher

### DIFF
--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -109,7 +109,7 @@ Implementation notes:
 - Build outputs in `media/**` are generated (don’t edit by hand)
 - All styling uses Tailwind CSS 4.x (source in `src/webview-src/tailwind.css`; compiled to `src/webview-src/tailwind.gen.css` and bundled to `media/index.css`)
 - Webview uses React 19 with custom components
-- Backend prerequisite: OpenHands Agent Server (V1) from All-Hands-AI/agent-sdk. See README.md for uv quickstart. Default base http://localhost:3000. Configure via Settings button or openhands.serverUrl.
+- Backend prerequisite: OpenHands Agent Server from https://github.com/OpenHands/software-agent-sdk. See `docs/e2e_testing.md` (or `./scripts/start-agent-server.sh`) for local launch. Default base http://localhost:3000. Configure via Settings button or openhands.serverUrl.
 
 - TODO: Consider removing media/*.map from git if source maps are not needed in repo
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -109,7 +109,7 @@ Implementation notes:
 - Build outputs in `media/**` are generated (don’t edit by hand)
 - All styling uses Tailwind CSS 4.x (source in `src/webview-src/tailwind.css`; compiled to `src/webview-src/tailwind.gen.css` and bundled to `media/index.css`)
 - Webview uses React 19 with custom components
-- Backend prerequisite: OpenHands Agent Server from https://github.com/OpenHands/software-agent-sdk. See `docs/e2e_testing.md` (or `./scripts/start-agent-server.sh`) for local launch. Default base http://localhost:3000. Configure via Settings button or openhands.serverUrl.
+- Backend prerequisite: OpenHands Agent Server from [OpenHands/software-agent-sdk](https://github.com/OpenHands/software-agent-sdk). See `docs/e2e_testing.md` (or `./scripts/start-agent-server.sh`) for local launch. Default base <http://localhost:3000>. Configure via Settings button or openhands.serverUrl.
 
 - TODO: Consider removing media/*.map from git if source maps are not needed in repo
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -223,6 +223,6 @@ src/
 - **Advanced History** - export + richer metadata (and server-backed history if needed)
 
 ## 13. References
-- [agent-sdk](https://github.com/All-Hands-AI/agent-sdk) - Python SDK and agent-server
+- [agent-sdk](https://github.com/OpenHands/software-agent-sdk) - Python SDK and agent-server
 - [agent-sdk-architecture.md](agent-sdk-architecture.md) - SDK architecture
 - [settings_prd.md](settings_prd.md) - Settings system details

--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -1691,4 +1691,4 @@ describe('Type Guards', () => {
 - [Package AGENTS.md](../packages/agent-sdk-ts/AGENTS.md)
 - [Repository Guidelines](../AGENTS.md)
 - [PRD](./PRD.md)
-- [OpenHands agent-sdk (Python)](https://github.com/All-Hands-AI/agent-sdk)
+- [OpenHands agent-sdk (Python)](https://github.com/OpenHands/software-agent-sdk)

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -15,7 +15,7 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
 - Node.js 22+
 - VS Code Desktop (Electron build)
 - Optional: Python 3.12+ and agent-server (agent-sdk) running for full integration testing
-- Recommended default server URL: http://localhost:3000
+- Recommended default server URL: <http://localhost:3000>
 
 ## Testing Approaches
 
@@ -24,7 +24,7 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
    - npm install
    - npm run compile
 2) Start agent-server (separate terminal)
-   - Recommended: use a local checkout of https://github.com/OpenHands/software-agent-sdk
+   - Recommended: use a local checkout of [OpenHands/software-agent-sdk](https://github.com/OpenHands/software-agent-sdk)
      - First time: `AGENT_SDK_DIR=~/repos/agent-sdk npm run agent-server:prepare`
      - After: `AGENT_SDK_DIR=~/repos/agent-sdk npm run agent-server`
    - Or clone it:
@@ -35,7 +35,7 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
    - Open this folder in VS Code
    - Press F5 to run “Extension Development Host”
 4) In the Dev Host window
-   - Run “OpenHands: Configure” → ensure server URL is http://localhost:3000
+   - Run “OpenHands: Configure” → ensure server URL is <http://localhost:3000>
    - Run “OpenHands: Open” (reveals the chat sidebar view)
    - Run "OpenHands: Start New Conversation"
    - Type a message and verify assistant/tool events stream in the webview

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -24,8 +24,13 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
    - npm install
    - npm run compile
 2) Start agent-server (separate terminal)
-   - git clone https://github.com/All-Hands-AI/agent-sdk && cd agent-sdk
-   - `uv run python -m openhands.agent_server --host 0.0.0.0 --port 3000`
+   - Recommended: use a local checkout of https://github.com/OpenHands/software-agent-sdk
+     - First time: `AGENT_SDK_DIR=~/repos/agent-sdk npm run agent-server:prepare`
+     - After: `AGENT_SDK_DIR=~/repos/agent-sdk npm run agent-server`
+   - Or clone it:
+     - `git clone https://github.com/OpenHands/software-agent-sdk.git ~/repos/agent-sdk`
+     - `cd ~/repos/agent-sdk && make build`
+     - `uv run python -m openhands.agent_server --host 0.0.0.0 --port 3000`
 3) Launch the extension in VS Code
    - Open this folder in VS Code
    - Press F5 to run “Extension Development Host”

--- a/package.json
+++ b/package.json
@@ -230,6 +230,8 @@
     "lint": "npm run lint -w @openhands/agent-sdk-ts && eslint src tests",
     "lint:fix": "eslint . --fix",
     "build:webview": "node esbuild.webview.mjs",
+    "agent-server": "bash scripts/start-agent-server.sh",
+    "agent-server:prepare": "PREPARE=1 bash scripts/start-agent-server.sh",
     "dev:vscode": "bash scripts/dev-vscode.sh"
   },
   "files": [

--- a/scripts/start-agent-server.sh
+++ b/scripts/start-agent-server.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Start the Python OpenHands agent-server from a local agent-sdk checkout.
+#
+# Usage:
+#   [AGENT_SDK_DIR=~/repos/agent-sdk] [HOST=0.0.0.0] [PORT=3000] [RELOAD=0] [PREPARE=0] ./scripts/start-agent-server.sh
+#
+# Notes:
+# - This script expects a local clone of https://github.com/OpenHands/software-agent-sdk
+# - The extension should be configured with: openhands.serverUrl = http://localhost:$PORT
+
+set -euo pipefail
+
+HOST=${HOST:-0.0.0.0}
+PORT=${PORT:-3000}
+RELOAD=${RELOAD:-0}
+PREPARE=${PREPARE:-0}
+AGENT_SDK_DIR=${AGENT_SDK_DIR:-${OPENHANDS_AGENT_SDK_DIR:-"$HOME/repos/agent-sdk"}}
+
+if [ ! -d "$AGENT_SDK_DIR" ]; then
+  echo "agent-sdk directory not found: $AGENT_SDK_DIR" >&2
+  echo "Set AGENT_SDK_DIR (or OPENHANDS_AGENT_SDK_DIR) to your local agent-sdk checkout." >&2
+  exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "'uv' is required to run agent-server but was not found on PATH." >&2
+  echo "Install uv: https://docs.astral.sh/uv/" >&2
+  exit 1
+fi
+
+if [ ! -f "$AGENT_SDK_DIR/openhands-agent-server/openhands/agent_server/README.md" ]; then
+  echo "Expected agent-server sources not found under: $AGENT_SDK_DIR" >&2
+  echo "This should be a clone of: https://github.com/OpenHands/software-agent-sdk" >&2
+  exit 1
+fi
+
+cd "$AGENT_SDK_DIR"
+
+if [ "$PREPARE" = "1" ]; then
+  echo "Running: make build"
+  make build
+fi
+
+args=(python -m openhands.agent_server --host "$HOST" --port "$PORT")
+if [ "$RELOAD" = "1" ]; then
+  args+=(--reload)
+fi
+
+echo "Starting OpenHands Agent Server..."
+echo "  Repo:  $AGENT_SDK_DIR"
+echo "  URL:   http://localhost:$PORT"
+echo "  Cmd:   uv run ${args[*]}"
+if [ -n "${SESSION_API_KEY:-}" ]; then
+  echo "  Auth:  SESSION_API_KEY is set (extension must support it)"
+fi
+echo ""
+echo "VS Code tip: set openhands.serverUrl to http://localhost:$PORT"
+echo ""
+
+exec uv run "${args[@]}"

--- a/scripts/start-agent-server.sh
+++ b/scripts/start-agent-server.sh
@@ -10,11 +10,40 @@
 
 set -euo pipefail
 
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  cat <<'EOF'
+Start the Python OpenHands agent-server from a local agent-sdk checkout.
+
+Usage:
+  [AGENT_SDK_DIR=~/repos/agent-sdk] [HOST=0.0.0.0] [PORT=3000] [RELOAD=0] [PREPARE=0] ./scripts/start-agent-server.sh
+
+Env:
+  AGENT_SDK_DIR           Path to a local clone of https://github.com/OpenHands/software-agent-sdk
+  OPENHANDS_AGENT_SDK_DIR Alias for AGENT_SDK_DIR
+  HOST                    Bind host (default: 0.0.0.0)
+  PORT                    Bind port (default: 3000)
+  RELOAD                  1 enables --reload (default: 0)
+  PREPARE                 1 runs `make build` before starting (default: 0)
+EOF
+  exit 0
+fi
+
 HOST=${HOST:-0.0.0.0}
 PORT=${PORT:-3000}
 RELOAD=${RELOAD:-0}
 PREPARE=${PREPARE:-0}
-AGENT_SDK_DIR=${AGENT_SDK_DIR:-${OPENHANDS_AGENT_SDK_DIR:-"$HOME/repos/agent-sdk"}}
+
+HOME_DIR="${HOME:-}"
+DEFAULT_AGENT_SDK_DIR=""
+if [ -n "$HOME_DIR" ]; then
+  DEFAULT_AGENT_SDK_DIR="$HOME_DIR/repos/agent-sdk"
+fi
+AGENT_SDK_DIR="${AGENT_SDK_DIR:-${OPENHANDS_AGENT_SDK_DIR:-$DEFAULT_AGENT_SDK_DIR}}"
+
+if [ -z "${AGENT_SDK_DIR:-}" ]; then
+  echo "AGENT_SDK_DIR is required (HOME is unset)." >&2
+  exit 1
+fi
 
 if [ ! -d "$AGENT_SDK_DIR" ]; then
   echo "agent-sdk directory not found: $AGENT_SDK_DIR" >&2
@@ -28,15 +57,13 @@ if ! command -v uv >/dev/null 2>&1; then
   exit 1
 fi
 
-AGENT_SERVER_ENTRYPOINT="$AGENT_SDK_DIR/openhands-agent-server/openhands/agent_server/__main__.py"
-if [ ! -f "$AGENT_SERVER_ENTRYPOINT" ]; then
-  echo "Expected agent-server entrypoint not found: $AGENT_SERVER_ENTRYPOINT" >&2
-  echo "AGENT_SDK_DIR should point at a clone of: https://github.com/OpenHands/software-agent-sdk" >&2
+if [ "$PREPARE" = "1" ] && ! command -v make >/dev/null 2>&1; then
+  echo "'make' is required for PREPARE=1 but was not found on PATH." >&2
   exit 1
 fi
 
-if [ "$PREPARE" = "1" ] && ! command -v make >/dev/null 2>&1; then
-  echo "'make' is required for PREPARE=1 but was not found on PATH." >&2
+if command -v lsof >/dev/null 2>&1 && lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "Port $PORT is already in use. Set PORT=<free-port> and retry." >&2
   exit 1
 fi
 
@@ -47,6 +74,13 @@ if [ "$PREPARE" = "1" ]; then
   make build
 fi
 
+if ! uv run python -c 'import openhands.agent_server' >/dev/null; then
+  echo "Failed to import openhands.agent_server from: $AGENT_SDK_DIR" >&2
+  echo "Confirm AGENT_SDK_DIR points to: https://github.com/OpenHands/software-agent-sdk" >&2
+  echo "If this is a fresh clone, try: PREPARE=1 AGENT_SDK_DIR=... npm run agent-server:prepare" >&2
+  exit 1
+fi
+
 args=(python -m openhands.agent_server --host "$HOST" --port "$PORT")
 if [ "$RELOAD" = "1" ]; then
   args+=(--reload)
@@ -54,6 +88,7 @@ fi
 
 echo "Starting OpenHands Agent Server..."
 echo "  Repo:  $AGENT_SDK_DIR"
+echo "  Bind:  $HOST:$PORT"
 echo "  URL:   http://localhost:$PORT"
 echo "  Cmd:   uv run ${args[*]}"
 if [ -n "${SESSION_API_KEY:-}" ]; then

--- a/scripts/start-agent-server.sh
+++ b/scripts/start-agent-server.sh
@@ -28,9 +28,15 @@ if ! command -v uv >/dev/null 2>&1; then
   exit 1
 fi
 
-if [ ! -f "$AGENT_SDK_DIR/openhands-agent-server/openhands/agent_server/README.md" ]; then
-  echo "Expected agent-server sources not found under: $AGENT_SDK_DIR" >&2
-  echo "This should be a clone of: https://github.com/OpenHands/software-agent-sdk" >&2
+AGENT_SERVER_ENTRYPOINT="$AGENT_SDK_DIR/openhands-agent-server/openhands/agent_server/__main__.py"
+if [ ! -f "$AGENT_SERVER_ENTRYPOINT" ]; then
+  echo "Expected agent-server entrypoint not found: $AGENT_SERVER_ENTRYPOINT" >&2
+  echo "AGENT_SDK_DIR should point at a clone of: https://github.com/OpenHands/software-agent-sdk" >&2
+  exit 1
+fi
+
+if [ "$PREPARE" = "1" ] && ! command -v make >/dev/null 2>&1; then
+  echo "'make' is required for PREPARE=1 but was not found on PATH." >&2
   exit 1
 fi
 

--- a/tests/e2e/AGENT_SERVER_QUICKSTART.md
+++ b/tests/e2e/AGENT_SERVER_QUICKSTART.md
@@ -5,9 +5,11 @@ Goal: run an agent-server compatible with this extension’s POST /api/conversat
 Option A: agent-sdk local (recommended for developers)
 - Prereqs: Python 3.12+, [uv](https://github.com/astral-sh/uv)
 - Steps:
-  1) git clone https://github.com/All-Hands-AI/agent-sdk
-  2) cd agent-sdk
-  3) `uv run python -m openhands.agent_server --host 0.0.0.0 --port 3000`
+  1) `git clone https://github.com/OpenHands/software-agent-sdk.git ~/repos/agent-sdk`
+  2) `cd ~/repos/agent-sdk && make build`
+  3) Start server:
+     - `AGENT_SDK_DIR=~/repos/agent-sdk npm run agent-server`
+     - Or manually: `uv run python -m openhands.agent_server --host 0.0.0.0 --port 3000`
   4) In VS Code (Extension Dev Host), set openhands.serverUrl to <http://localhost:3000>
 
 Option B: remote server


### PR DESCRIPTION
Implements oh-tab-do7.

- Adds `scripts/start-agent-server.sh` (+ `npm run agent-server*`) to start the python agent-server from a local `agent-sdk` checkout.
- Updates docs (`docs/e2e_testing.md`, `tests/e2e/AGENT_SERVER_QUICKSTART.md`) and refreshes agent-sdk repo links.

Beads: oh-tab-do7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent-SDK repository references in setup guides
  * Enhanced agent-server startup workflows with configurable local path options
  * Added npm-based commands for launching the agent-server

* **Chores**
  * Updated backend dependency documentation links

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->