### PR TITLE
[oh-tab-2dc] E2E: UI flows suite

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,6 +45,17 @@ type WebviewMessage =
   | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
   | { type: 'command'; command: string; reason?: string }
   | { type: 'renderedEventsResponse'; count: number; eventTypes: string[] }
+  | {
+    type: 'uiStateResponse';
+    input: string;
+    showContextPicker: boolean;
+    showSkillsPopover: boolean;
+    showHistory: boolean;
+    workspaceFilesCount: number;
+    selectedContextFiles: string[];
+    skillsCount: number;
+    attachmentsCount: number;
+  }
   | { type: 'webviewConsole'; level: string; args: unknown[] }
   | { type: 'webviewError'; message: string; stack?: string }
   | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
@@ -56,6 +67,18 @@ let conversationMode: 'local' | 'remote' = 'remote';
 let terminal: vscode.Terminal | undefined;
 let terminalLogPty: OpenHandsTerminalLogPseudoterminal | undefined;
 let renderedEventsInfo: { count: number; eventTypes: string[] } | undefined;
+let uiStateInfo:
+  | {
+    input: string;
+    showContextPicker: boolean;
+    showSkillsPopover: boolean;
+    showHistory: boolean;
+    workspaceFilesCount: number;
+    selectedContextFiles: string[];
+    skillsCount: number;
+    attachmentsCount: number;
+  }
+  | undefined;
 let chatWebviewReady = false; // Track if chat WebviewView is ready
 let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
@@ -796,7 +819,11 @@ export function activate(context: vscode.ExtensionContext) {
 
     // Clear previous response and request from webview
     renderedEventsInfo = undefined;
-    void chatView.webview.postMessage({ type: 'queryRenderedEvents' });
+    void chatView.show?.(true);
+    const posted = await chatView.webview.postMessage({ type: 'queryRenderedEvents' });
+    if (!posted) {
+      return { count: 0, eventTypes: [] };
+    }
 
     // Wait for response (with timeout)
     const deadline = Date.now() + 5000;
@@ -812,6 +839,69 @@ export function activate(context: vscode.ExtensionContext) {
     const types = filtered.map((e) => e.kind ?? 'unknown');
     return { count: types.length, eventTypes: types };
   });
+
+  // Query UI state from webview for E2E testing (toolbar + popovers)
+  const queryUiState = vscode.commands.registerCommand('openhands._queryUiState', async () => {
+    if (!chatView) {
+      return {
+        input: '',
+        showContextPicker: false,
+        showSkillsPopover: false,
+        showHistory: false,
+        workspaceFilesCount: 0,
+        selectedContextFiles: [] as string[],
+        skillsCount: 0,
+        attachmentsCount: 0,
+      };
+    }
+
+    uiStateInfo = undefined;
+    void chatView.show?.(true);
+    const posted = await chatView.webview.postMessage({ type: 'queryUiState' });
+    if (!posted) {
+      return {
+        input: '',
+        showContextPicker: false,
+        showSkillsPopover: false,
+        showHistory: false,
+        workspaceFilesCount: 0,
+        selectedContextFiles: [] as string[],
+        skillsCount: 0,
+        attachmentsCount: 0,
+      };
+    }
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (uiStateInfo !== undefined) {
+        return uiStateInfo;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    return {
+      input: '',
+      showContextPicker: false,
+      showSkillsPopover: false,
+      showHistory: false,
+      workspaceFilesCount: 0,
+      selectedContextFiles: [] as string[],
+      skillsCount: 0,
+      attachmentsCount: 0,
+    };
+  });
+
+  // Send a test action to the webview for E2E testing (UI flows without DOM automation)
+  const webviewAction = vscode.commands.registerCommand(
+    'openhands._webviewAction',
+    async (req: { action: string; payload?: unknown } | undefined) => {
+      if (!chatView) return { sent: false };
+      if (!req || typeof req.action !== 'string' || req.action.length === 0) return { sent: false };
+      void chatView.show?.(true);
+      const sent = await chatView.webview.postMessage({ type: 'e2eAction', action: req.action, payload: req.payload });
+      return { sent };
+    }
+  );
 
   const startNew = vscode.commands.registerCommand('openhands.startNewConversation', async () => {
     await ensureConversationAndConnection();
@@ -927,6 +1017,8 @@ export function activate(context: vscode.ExtensionContext) {
     diag,
     sendTestEvent,
     queryRenderedEvents,
+    queryUiState,
+    webviewAction,
     startNew,
     configure,
     setApiKey,
@@ -945,6 +1037,7 @@ export function deactivate() {
   terminal = undefined;
   terminalLogPty = undefined;
   renderedEventsInfo = undefined;
+  uiStateInfo = undefined;
   chatWebviewReady = false;
   chatLastConversationId = undefined;
   chatLastSeenSeq = undefined;
@@ -1214,6 +1307,25 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
       }
       case 'selectAttachments': {
         try {
+          if (process.env.E2E_MOCK_ATTACHMENTS === '1') {
+            const mockUris = [vscode.Uri.joinPath(context.extensionUri, 'README.md')];
+            const attachments = await Promise.all(
+              mockUris.map(async (uri) => {
+                const label = toAttachmentLabel(uri);
+                let sizeBytes: number | undefined;
+                try {
+                  const stat = await vscode.workspace.fs.stat(uri);
+                  sizeBytes = stat.size;
+                } catch (err) {
+                  console.warn('[OpenHands] Failed to stat attachment', err);
+                }
+                return { uri: uri.toString(), label, sizeBytes };
+              })
+            );
+            void host.postMessage({ type: 'attachmentsSelected', attachments });
+            break;
+          }
+
           const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
           const picked = await vscode.window.showOpenDialog({
             canSelectFiles: true,
@@ -1307,6 +1419,18 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
         break;
       case 'renderedEventsResponse':
         renderedEventsInfo = { count: message.count, eventTypes: message.eventTypes };
+        break;
+      case 'uiStateResponse':
+        uiStateInfo = {
+          input: message.input,
+          showContextPicker: message.showContextPicker,
+          showSkillsPopover: message.showSkillsPopover,
+          showHistory: message.showHistory,
+          workspaceFilesCount: message.workspaceFilesCount,
+          selectedContextFiles: message.selectedContextFiles,
+          skillsCount: message.skillsCount,
+          attachmentsCount: message.attachmentsCount,
+        };
         break;
       case 'webviewConsole': {
         if (!devBridgeEnabled) break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,9 +44,10 @@ type WebviewMessage =
   | { type: 'openAttachment'; uri: string }
   | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
   | { type: 'command'; command: string; reason?: string }
-  | { type: 'renderedEventsResponse'; count: number; eventTypes: string[] }
+  | { type: 'renderedEventsResponse'; requestId: string; count: number; eventTypes: string[] }
   | {
     type: 'uiStateResponse';
+    requestId: string;
     input: string;
     showContextPicker: boolean;
     showSkillsPopover: boolean;
@@ -61,24 +62,37 @@ type WebviewMessage =
   | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
   | { type: 'webviewWebSocket'; phase: string; url: string; code?: number; reason?: string };
 
+type RenderedEventsInfo = { count: number; eventTypes: string[] };
+type UiStateSnapshot = {
+  input: string;
+  showContextPicker: boolean;
+  showSkillsPopover: boolean;
+  showHistory: boolean;
+  workspaceFilesCount: number;
+  selectedContextFiles: string[];
+  skillsCount: number;
+  attachmentsCount: number;
+};
+
+const DEFAULT_UI_STATE: UiStateSnapshot = {
+  input: '',
+  showContextPicker: false,
+  showSkillsPopover: false,
+  showHistory: false,
+  workspaceFilesCount: 0,
+  selectedContextFiles: [],
+  skillsCount: 0,
+  attachmentsCount: 0,
+};
+
 let chatView: vscode.WebviewView | undefined;
 let conversation: ConversationInstance | undefined;
 let conversationMode: 'local' | 'remote' = 'remote';
 let terminal: vscode.Terminal | undefined;
 let terminalLogPty: OpenHandsTerminalLogPseudoterminal | undefined;
-let renderedEventsInfo: { count: number; eventTypes: string[] } | undefined;
-let uiStateInfo:
-  | {
-    input: string;
-    showContextPicker: boolean;
-    showSkillsPopover: boolean;
-    showHistory: boolean;
-    workspaceFilesCount: number;
-    selectedContextFiles: string[];
-    skillsCount: number;
-    attachmentsCount: number;
-  }
-  | undefined;
+let nextE2ERequestId = 0;
+const pendingRenderedEventsRequests = new Map<string, (info: RenderedEventsInfo) => void>();
+const pendingUiStateRequests = new Map<string, (info: UiStateSnapshot) => void>();
 let chatWebviewReady = false; // Track if chat WebviewView is ready
 let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
@@ -100,6 +114,35 @@ let activeConversationId: string | undefined;
 const sentTestEvents: Event[] = [];
 // Track which command_ids have already printed an exit summary to avoid duplicates
 const printedExitFor = new Set<string>();
+
+function nextRequestId(prefix: string): string {
+  nextE2ERequestId += 1;
+  return `${prefix}-${Date.now().toString(36)}-${nextE2ERequestId}`;
+}
+
+function createPendingResponse<T>(
+  map: Map<string, (value: T) => void>,
+  requestId: string,
+  timeoutMs: number
+): { promise: Promise<T | undefined>; cancel: () => void } {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<T | undefined>((resolve) => {
+    timer = setTimeout(() => {
+      map.delete(requestId);
+      resolve(undefined);
+    }, timeoutMs);
+    map.set(requestId, (value: T) => {
+      if (timer) clearTimeout(timer);
+      map.delete(requestId);
+      resolve(value);
+    });
+  });
+  const cancel = () => {
+    if (timer) clearTimeout(timer);
+    map.delete(requestId);
+  };
+  return { promise, cancel };
+}
 
 // Dev logging/instrumentation toggle and file sink
 let devBridgeEnabled = false;
@@ -817,22 +860,17 @@ export function activate(context: vscode.ExtensionContext) {
       return { count: 0, eventTypes: [] };
     }
 
-    // Clear previous response and request from webview
-    renderedEventsInfo = undefined;
     void chatView.show?.(true);
-    const posted = await chatView.webview.postMessage({ type: 'queryRenderedEvents' });
+    const requestId = nextRequestId('renderedEvents');
+    const pending = createPendingResponse(pendingRenderedEventsRequests, requestId, 5000);
+    const posted = await chatView.webview.postMessage({ type: 'queryRenderedEvents', requestId });
     if (!posted) {
+      pending.cancel();
       return { count: 0, eventTypes: [] };
     }
 
-    // Wait for response (with timeout)
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      if (renderedEventsInfo !== undefined) {
-        return renderedEventsInfo;
-      }
-      await new Promise((r) => setTimeout(r, 50));
-    }
+    const info = await pending.promise;
+    if (info) return info;
 
     // Fallback: if webview didn't respond (e.g., not yet ready), assume events equal to sentTestEvents
     const filtered = sentTestEvents.filter((e) => e.kind !== 'ConversationStateUpdateEvent');
@@ -843,52 +881,19 @@ export function activate(context: vscode.ExtensionContext) {
   // Query UI state from webview for E2E testing (toolbar + popovers)
   const queryUiState = vscode.commands.registerCommand('openhands._queryUiState', async () => {
     if (!chatView) {
-      return {
-        input: '',
-        showContextPicker: false,
-        showSkillsPopover: false,
-        showHistory: false,
-        workspaceFilesCount: 0,
-        selectedContextFiles: [] as string[],
-        skillsCount: 0,
-        attachmentsCount: 0,
-      };
+      return DEFAULT_UI_STATE;
     }
 
-    uiStateInfo = undefined;
     void chatView.show?.(true);
-    const posted = await chatView.webview.postMessage({ type: 'queryUiState' });
+    const requestId = nextRequestId('uiState');
+    const pending = createPendingResponse(pendingUiStateRequests, requestId, 5000);
+    const posted = await chatView.webview.postMessage({ type: 'queryUiState', requestId });
     if (!posted) {
-      return {
-        input: '',
-        showContextPicker: false,
-        showSkillsPopover: false,
-        showHistory: false,
-        workspaceFilesCount: 0,
-        selectedContextFiles: [] as string[],
-        skillsCount: 0,
-        attachmentsCount: 0,
-      };
+      pending.cancel();
+      return DEFAULT_UI_STATE;
     }
 
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      if (uiStateInfo !== undefined) {
-        return uiStateInfo;
-      }
-      await new Promise((r) => setTimeout(r, 50));
-    }
-
-    return {
-      input: '',
-      showContextPicker: false,
-      showSkillsPopover: false,
-      showHistory: false,
-      workspaceFilesCount: 0,
-      selectedContextFiles: [] as string[],
-      skillsCount: 0,
-      attachmentsCount: 0,
-    };
+    return (await pending.promise) ?? DEFAULT_UI_STATE;
   });
 
   // Send a test action to the webview for E2E testing (UI flows without DOM automation)
@@ -1036,8 +1041,8 @@ export function deactivate() {
   conversation = undefined;
   terminal = undefined;
   terminalLogPty = undefined;
-  renderedEventsInfo = undefined;
-  uiStateInfo = undefined;
+  pendingRenderedEventsRequests.clear();
+  pendingUiStateRequests.clear();
   chatWebviewReady = false;
   chatLastConversationId = undefined;
   chatLastSeenSeq = undefined;
@@ -1307,7 +1312,11 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
       }
       case 'selectAttachments': {
         try {
-          if (process.env.E2E_MOCK_ATTACHMENTS === '1') {
+          const extensionMode = vscode.ExtensionMode;
+          const isTestMode =
+            extensionMode?.Test !== undefined &&
+            context.extensionMode === extensionMode.Test;
+          if (isTestMode && process.env.E2E_MOCK_ATTACHMENTS === '1') {
             const mockUris = [vscode.Uri.joinPath(context.extensionUri, 'README.md')];
             const attachments = await Promise.all(
               mockUris.map(async (uri) => {
@@ -1418,10 +1427,10 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
         }
         break;
       case 'renderedEventsResponse':
-        renderedEventsInfo = { count: message.count, eventTypes: message.eventTypes };
+        pendingRenderedEventsRequests.get(message.requestId)?.({ count: message.count, eventTypes: message.eventTypes });
         break;
       case 'uiStateResponse':
-        uiStateInfo = {
+        pendingUiStateRequests.get(message.requestId)?.({
           input: message.input,
           showContextPicker: message.showContextPicker,
           showSkillsPopover: message.showSkillsPopover,
@@ -1430,7 +1439,7 @@ function createWebviewMessageHandler(context: vscode.ExtensionContext, host: Web
           selectedContextFiles: message.selectedContextFiles,
           skillsCount: message.skillsCount,
           attachmentsCount: message.attachmentsCount,
-        };
+        });
         break;
       case 'webviewConsole': {
         if (!devBridgeEnabled) break;

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -748,12 +748,14 @@ describe('App - Advanced Test Coverage', () => {
       mockApi.postMessage.mockClear();
 
       // Query rendered events
-      postToWindow({ type: 'queryRenderedEvents' });
+      const requestId = 'test-query-rendered-events';
+      postToWindow({ type: 'queryRenderedEvents', requestId });
 
       await waitFor(() => {
         expect(mockApi.postMessage).toHaveBeenCalledWith(
           expect.objectContaining({
             type: 'renderedEventsResponse',
+            requestId,
             count: 2,
             eventTypes: ['MessageEvent', 'MessageEvent']
           })

--- a/src/webview-src/__tests__/event.handlers.test.tsx
+++ b/src/webview-src/__tests__/event.handlers.test.tsx
@@ -91,14 +91,16 @@ describe('App event handling helpers', () => {
     });
 
     await act(async () => {
+      const requestId = 'test-query-rendered-events';
       postToWindow({
         type: 'queryRenderedEvents',
+        requestId,
       });
     });
 
     await waitFor(() => {
       expect(mockApi.postMessage).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'renderedEventsResponse', count: 0 })
+        expect.objectContaining({ type: 'renderedEventsResponse', requestId: 'test-query-rendered-events', count: 0 })
       );
     });
   });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -159,12 +159,36 @@ export function App() {
   const lastAgentStatusRef = useRef<string | undefined>(undefined);
   const streamingStateRef = useRef(initialLlmStreamingState);
   const submissionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const uiStateRef = useRef({
+    input: '',
+    showContextPicker: false,
+    showSkillsPopover: false,
+    showHistory: false,
+    workspaceFilesCount: 0,
+    selectedContextFiles: [] as string[],
+    skillsCount: 0,
+    attachmentsCount: 0,
+  });
 
   // Post message helper
   const postMessage = useCallback((msg: unknown) => {
     const api = getVscodeApi();
     api.postMessage(msg);
   }, []);
+
+  // Keep a snapshot for E2E state queries without re-registering message listeners on every keystroke.
+  useEffect(() => {
+    uiStateRef.current = {
+      input,
+      showContextPicker,
+      showSkillsPopover,
+      showHistory,
+      workspaceFilesCount: workspaceFiles.length,
+      selectedContextFiles: selectedContextFiles.slice(),
+      skillsCount: skills.length,
+      attachmentsCount: attachments.length,
+    };
+  }, [attachments.length, input, selectedContextFiles, showContextPicker, showHistory, showSkillsPopover, skills.length, workspaceFiles.length]);
 
   // Show status message with debouncing
   const showStatusMessage = useCallback((level: 'info' | 'warn' | 'error', message: string) => {
@@ -388,6 +412,47 @@ export function App() {
             setSkills(payload.skills);
           }
           break;
+        case 'queryUiState': {
+          postMessage({ type: 'uiStateResponse', ...uiStateRef.current });
+          break;
+        }
+        case 'e2eAction': {
+          if (typeof (payload as { action?: unknown }).action !== 'string') break;
+          const action = (payload as { action: string }).action;
+          const rawPayload = (payload as { payload?: unknown }).payload;
+
+          switch (action) {
+            case 'openContext':
+              setShowSkillsPopover(false);
+              setShowContextPicker(true);
+              postMessage({ type: 'requestWorkspaceFiles' });
+              break;
+            case 'closeContext':
+              setShowContextPicker(false);
+              setIsMentionActive(false);
+              setContextQuery('');
+              mentionStartRef.current = null;
+              break;
+            case 'toggleContextFile': {
+              const file = (rawPayload as { file?: unknown } | undefined)?.file;
+              if (typeof file !== 'string' || file.length === 0) break;
+              setSelectedContextFiles((prev) => (prev.includes(file) ? prev.filter((f) => f !== file) : [...prev, file]));
+              break;
+            }
+            case 'openSkills':
+              setShowContextPicker(false);
+              setShowSkillsPopover(true);
+              postMessage({ type: 'requestSkills' });
+              break;
+            case 'closeSkills':
+              setShowSkillsPopover(false);
+              break;
+            case 'openAttachments':
+              postMessage({ type: 'selectAttachments' });
+              break;
+          }
+          break;
+        }
         case 'queryRenderedEvents': {
           const eventTypes = events.map(({ event }) => {
             if ('kind' in event && typeof event.kind === 'string') return event.kind;

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -298,6 +298,7 @@ export function App() {
     const handler = (event: MessageEvent) => {
       const payload = event.data as {
         type?: string;
+        requestId?: string;
         status?: 'online' | 'offline' | 'connecting';
         serverUrl?: string | null;
         mode?: 'local' | 'remote';
@@ -413,7 +414,9 @@ export function App() {
           }
           break;
         case 'queryUiState': {
-          postMessage({ type: 'uiStateResponse', ...uiStateRef.current });
+          if (typeof payload.requestId === 'string') {
+            postMessage({ type: 'uiStateResponse', requestId: payload.requestId, ...uiStateRef.current });
+          }
           break;
         }
         case 'e2eAction': {
@@ -461,11 +464,14 @@ export function App() {
             }
             return 'unknown';
           });
-          postMessage({
-            type: 'renderedEventsResponse',
-            count: events.length,
-            eventTypes
-          });
+          if (typeof payload.requestId === 'string') {
+            postMessage({
+              type: 'renderedEventsResponse',
+              requestId: payload.requestId,
+              count: events.length,
+              eventTypes
+            });
+          }
           break;
         }
         case 'historyList': {

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -39,6 +39,11 @@ export async function run(): Promise<void> {
     return runErrorHandlingTest();
   }
 
+  if (testName === 'uiFlows') {
+    const { run: runUiFlowsTest } = await import('./uiFlows');
+    return runUiFlowsTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -1,0 +1,99 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
+}
+
+export async function run(): Promise<void> {
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
+
+  // Context picker: open and toggle a known file
+  const openContextResult: any = await vscode.commands.executeCommand('openhands._webviewAction', { action: 'openContext' });
+  if (!openContextResult?.sent) {
+    throw new Error(`openContext action was not sent: ${JSON.stringify(openContextResult)}`);
+  }
+
+  try {
+    await pollUntil(async () => {
+      const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+      return state?.showContextPicker === true && typeof state.workspaceFilesCount === 'number';
+    }, 15000);
+  } catch (err) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+    console.log('diagnosticsOnFailure', diag);
+    console.log('uiStateOnFailure', state);
+    throw err;
+  }
+
+  await vscode.commands.executeCommand('openhands._webviewAction', {
+    action: 'toggleContextFile',
+    payload: { file: 'README.md' }
+  });
+
+  await pollUntil(async () => {
+    const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+    return Array.isArray(state?.selectedContextFiles) && state.selectedContextFiles.includes('README.md');
+  });
+
+  await vscode.commands.executeCommand('openhands._webviewAction', {
+    action: 'toggleContextFile',
+    payload: { file: 'README.md' }
+  });
+
+  await pollUntil(async () => {
+    const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+    return Array.isArray(state?.selectedContextFiles) && !state.selectedContextFiles.includes('README.md');
+  });
+
+  // Skills: create a temp skill file and ensure Skills popover loads it
+  const skillsDir = path.join(os.homedir(), '.openhands', 'skills');
+  await fs.mkdir(skillsDir, { recursive: true });
+  const skillPath = path.join(skillsDir, `e2e-skill-${Date.now()}.md`);
+  await fs.writeFile(skillPath, '# E2E Skill\n\nHello from e2e.\n', 'utf8');
+
+  try {
+    await vscode.commands.executeCommand('openhands._webviewAction', { action: 'openSkills' });
+
+    await pollUntil(async () => {
+      const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+      return state?.showSkillsPopover === true && typeof state.skillsCount === 'number' && state.skillsCount >= 1;
+    }, 15000);
+
+    await vscode.commands.executeCommand('openhands._webviewAction', { action: 'closeSkills' });
+
+    await pollUntil(async () => {
+      const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+      return state?.showSkillsPopover === false;
+    });
+  } finally {
+    await fs.rm(skillPath, { force: true });
+  }
+
+  // Attachments: click attachments and rely on E2E_MOCK_ATTACHMENTS to avoid file picker
+  await vscode.commands.executeCommand('openhands._webviewAction', { action: 'openAttachments' });
+
+  await pollUntil(async () => {
+    const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
+    return typeof state?.attachmentsCount === 'number' && state.attachmentsCount >= 1;
+  }, 15000);
+
+  console.log('✓ All ui flow tests passed');
+}

--- a/tests/e2e/uiFlows.test.ts
+++ b/tests/e2e/uiFlows.test.ts
@@ -1,0 +1,38 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-ui-flows-${Date.now()}`);
+
+describe('OpenHands-Tab UI Flows E2E', function () {
+  this.timeout(120000);
+
+  it('tests context, skills, and attachments UI flows', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'uiFlows',
+        E2E_MOCK_ATTACHMENTS: '1',
+      }
+    });
+
+    assert.ok(true);
+  });
+});
+


### PR DESCRIPTION
Adds a non-DOM E2E harness to validate key UI flows (context picker, skills popover, attachments) in the WebviewView chat UI.

- Extension: add internal E2E commands `openhands._queryUiState` + `openhands._webviewAction`.
- Webview: respond to `queryUiState` and support `e2eAction` helpers.
- E2E: new `uiFlows` suite; attachments use `E2E_MOCK_ATTACHMENTS=1`.

Tests:
- `npm test`
- `npm run lint`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end UI flow testing infrastructure with UI state querying and interaction validation
  * Introduced new test commands for querying UI state and simulating user actions
  * Enabled mock attachment selection during testing to support comprehensive test scenarios
  * Enhanced test suite for validating UI interactions and state changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->