### PR TITLE
[oh-tab-dm3] Secrets: GitHub token + custom secret slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "onCommand:openhands.startNewConversation",
     "onCommand:openhands.configure",
     "onCommand:openhands.setApiKey",
+    "onCommand:openhands.setGithubToken",
+    "onCommand:openhands.setCustomSecret1",
+    "onCommand:openhands.setCustomSecret2",
+    "onCommand:openhands.setCustomSecret3",
     "onCommand:openhands.reconnect",
     "onCommand:openhands.pauseCurrentRun",
     "onCommand:openhands.resumeCurrentRun",
@@ -47,6 +51,22 @@
       {
         "command": "openhands.setApiKey",
         "title": "OpenHands: Set API Key"
+      },
+      {
+        "command": "openhands.setGithubToken",
+        "title": "OpenHands: Set GitHub Token"
+      },
+      {
+        "command": "openhands.setCustomSecret1",
+        "title": "OpenHands: Set Custom Secret 1"
+      },
+      {
+        "command": "openhands.setCustomSecret2",
+        "title": "OpenHands: Set Custom Secret 2"
+      },
+      {
+        "command": "openhands.setCustomSecret3",
+        "title": "OpenHands: Set Custom Secret 3"
       },
       {
         "command": "openhands.reconnect",
@@ -152,6 +172,30 @@
           "default": "",
           "editPresentation": "singlelineText",
           "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.githubToken": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.customSecret1": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.customSecret2": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.customSecret3": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
         },
         "openhands.llm.apiVersion": {
           "type": "string",

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -43,5 +43,9 @@ export type OpenHandsSettings = ServerSettings & {
     llmApiKey?: string;
     awsAccessKeyId?: string;
     awsSecretAccessKey?: string;
+    githubToken?: string;
+    customSecret1?: string;
+    customSecret2?: string;
+    customSecret3?: string;
   };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -832,6 +832,7 @@ export function activate(context: vscode.ExtensionContext) {
       prompt: string;
       placeHolder?: string;
       successMessage: string;
+      clearedMessage: string;
       errorPrefix: string;
     }
   ) =>
@@ -839,10 +840,43 @@ export function activate(context: vscode.ExtensionContext) {
       try {
         const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const existing = await settingsMgr.get();
+        const currentValue = existing.secrets[options.secretKey];
+        const isCurrentlySet = typeof currentValue === 'string' && currentValue.trim().length > 0;
+
+        if (isCurrentlySet) {
+          const action = await vscode.window.showQuickPick(
+            [
+              { label: 'Update', value: 'update', description: 'Enter a new value (stored securely)' },
+              { label: 'Clear', value: 'clear', description: 'Remove the stored value' },
+            ],
+            {
+              title: options.title,
+              placeHolder: 'Choose an action',
+              canPickMany: false,
+            }
+          );
+          if (!action) return;
+
+          if (action.value === 'clear') {
+            const confirmed = await vscode.window.showWarningMessage(
+              `Clear ${options.title}?`,
+              { modal: true },
+              'Clear'
+            );
+            if (confirmed !== 'Clear') return;
+
+            const secretsUpdate = { [options.secretKey]: undefined } as Partial<OpenHandsSettings['secrets']>;
+            await settingsMgr.update({ secrets: secretsUpdate });
+            vscode.window.showInformationMessage(options.clearedMessage);
+
+            const newSettings = await settingsMgr.get();
+            conversation?.setSettings(newSettings);
+            return;
+          }
+        }
 
         const value = await vscode.window.showInputBox({
           title: options.title,
-          value: existing.secrets[options.secretKey],
           password: true,
           prompt: options.prompt,
           placeHolder: options.placeHolder,
@@ -850,7 +884,10 @@ export function activate(context: vscode.ExtensionContext) {
 
         if (value === undefined) return;
 
-        const secretsUpdate = { [options.secretKey]: value || undefined } as Partial<OpenHandsSettings['secrets']>;
+        const trimmed = value.trim();
+        if (!trimmed) return;
+
+        const secretsUpdate = { [options.secretKey]: trimmed } as Partial<OpenHandsSettings['secrets']>;
         await settingsMgr.update({ secrets: secretsUpdate });
         vscode.window.showInformationMessage(options.successMessage);
 
@@ -868,6 +905,7 @@ export function activate(context: vscode.ExtensionContext) {
     prompt: 'Enter your LLM API key. It will be stored securely in VS Code SecretStorage.',
     placeHolder: 'sk-...',
     successMessage: 'LLM API Key saved securely.',
+    clearedMessage: 'LLM API Key cleared.',
     errorPrefix: 'Failed to save API Key',
   });
 
@@ -877,6 +915,7 @@ export function activate(context: vscode.ExtensionContext) {
     prompt: 'Enter your GitHub token. It will be stored securely in VS Code SecretStorage.',
     placeHolder: 'ghp_...',
     successMessage: 'GitHub token saved securely.',
+    clearedMessage: 'GitHub token cleared.',
     errorPrefix: 'Failed to save GitHub token',
   });
 
@@ -885,6 +924,7 @@ export function activate(context: vscode.ExtensionContext) {
     secretKey: 'customSecret1',
     prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
     successMessage: 'Custom secret 1 saved securely.',
+    clearedMessage: 'Custom secret 1 cleared.',
     errorPrefix: 'Failed to save custom secret 1',
   });
 
@@ -893,6 +933,7 @@ export function activate(context: vscode.ExtensionContext) {
     secretKey: 'customSecret2',
     prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
     successMessage: 'Custom secret 2 saved securely.',
+    clearedMessage: 'Custom secret 2 cleared.',
     errorPrefix: 'Failed to save custom secret 2',
   });
 
@@ -901,6 +942,7 @@ export function activate(context: vscode.ExtensionContext) {
     secretKey: 'customSecret3',
     prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
     successMessage: 'Custom secret 3 saved securely.',
+    clearedMessage: 'Custom secret 3 cleared.',
     errorPrefix: 'Failed to save custom secret 3',
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { TextDecoder } from 'util';
-import { SettingsManager, type SavedServer } from './settings/SettingsManager';
+import { SettingsManager, type OpenHandsSettings, type SavedServer } from './settings/SettingsManager';
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { FileStore } from '@openhands/agent-sdk-ts';
 import {
@@ -823,140 +823,85 @@ export function activate(context: vscode.ExtensionContext) {
     await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
   });
 
-  const setApiKey = vscode.commands.registerCommand('openhands.setApiKey', async () => {
-    try {
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-      const existing = await settingsMgr.get();
+  type SecretKey = keyof OpenHandsSettings['secrets'];
+  const registerSecretCommand = (
+    commandId: string,
+    options: {
+      title: string;
+      secretKey: SecretKey;
+      prompt: string;
+      placeHolder?: string;
+      successMessage: string;
+      errorPrefix: string;
+    }
+  ) =>
+    vscode.commands.registerCommand(commandId, async () => {
+      try {
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+        const existing = await settingsMgr.get();
 
-      const llmApiKey = await vscode.window.showInputBox({
-        title: 'LLM API Key',
-        value: existing.secrets.llmApiKey,
-        password: true,
-        prompt: 'Enter your LLM API key. It will be stored securely in VS Code SecretStorage.',
-        placeHolder: 'sk-...'
-      });
+        const value = await vscode.window.showInputBox({
+          title: options.title,
+          value: existing.secrets[options.secretKey],
+          password: true,
+          prompt: options.prompt,
+          placeHolder: options.placeHolder,
+        });
 
-      if (llmApiKey === undefined) {
-        // User cancelled
-        return;
+        if (value === undefined) return;
+
+        const secretsUpdate = { [options.secretKey]: value || undefined } as Partial<OpenHandsSettings['secrets']>;
+        await settingsMgr.update({ secrets: secretsUpdate });
+        vscode.window.showInformationMessage(options.successMessage);
+
+        const newSettings = await settingsMgr.get();
+        conversation?.setSettings(newSettings);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`${options.errorPrefix}: ${message}`);
       }
+    });
 
-      // Secrets are stored in VS Code SecretStorage, not workspace settings
-      await settingsMgr.update({ secrets: { llmApiKey: llmApiKey || undefined } });
-
-      vscode.window.showInformationMessage('LLM API Key saved securely.');
-
-      // Apply to conversation
-      const newSettings = await settingsMgr.get();
-      conversation?.setSettings(newSettings);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to save API Key: ${message}`);
-    }
+  const setApiKey = registerSecretCommand('openhands.setApiKey', {
+    title: 'LLM API Key',
+    secretKey: 'llmApiKey',
+    prompt: 'Enter your LLM API key. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'sk-...',
+    successMessage: 'LLM API Key saved securely.',
+    errorPrefix: 'Failed to save API Key',
   });
 
-  const setGithubToken = vscode.commands.registerCommand('openhands.setGithubToken', async () => {
-    try {
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-      const existing = await settingsMgr.get();
-
-      const githubToken = await vscode.window.showInputBox({
-        title: 'GitHub Token',
-        value: existing.secrets.githubToken,
-        password: true,
-        prompt: 'Enter your GitHub token. It will be stored securely in VS Code SecretStorage.',
-        placeHolder: 'ghp_...'
-      });
-
-      if (githubToken === undefined) {
-        // User cancelled
-        return;
-      }
-
-      await settingsMgr.update({ secrets: { githubToken: githubToken || undefined } });
-      vscode.window.showInformationMessage('GitHub token saved securely.');
-
-      const newSettings = await settingsMgr.get();
-      conversation?.setSettings(newSettings);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to save GitHub token: ${message}`);
-    }
+  const setGithubToken = registerSecretCommand('openhands.setGithubToken', {
+    title: 'GitHub Token',
+    secretKey: 'githubToken',
+    prompt: 'Enter your GitHub token. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'ghp_...',
+    successMessage: 'GitHub token saved securely.',
+    errorPrefix: 'Failed to save GitHub token',
   });
 
-  const setCustomSecret1 = vscode.commands.registerCommand('openhands.setCustomSecret1', async () => {
-    try {
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-      const existing = await settingsMgr.get();
-
-      const value = await vscode.window.showInputBox({
-        title: 'Custom Secret 1',
-        value: existing.secrets.customSecret1,
-        password: true,
-        prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
-      });
-
-      if (value === undefined) return;
-
-      await settingsMgr.update({ secrets: { customSecret1: value || undefined } });
-      vscode.window.showInformationMessage('Custom secret 1 saved securely.');
-
-      const newSettings = await settingsMgr.get();
-      conversation?.setSettings(newSettings);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to save custom secret 1: ${message}`);
-    }
+  const setCustomSecret1 = registerSecretCommand('openhands.setCustomSecret1', {
+    title: 'Custom Secret 1',
+    secretKey: 'customSecret1',
+    prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
+    successMessage: 'Custom secret 1 saved securely.',
+    errorPrefix: 'Failed to save custom secret 1',
   });
 
-  const setCustomSecret2 = vscode.commands.registerCommand('openhands.setCustomSecret2', async () => {
-    try {
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-      const existing = await settingsMgr.get();
-
-      const value = await vscode.window.showInputBox({
-        title: 'Custom Secret 2',
-        value: existing.secrets.customSecret2,
-        password: true,
-        prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
-      });
-
-      if (value === undefined) return;
-
-      await settingsMgr.update({ secrets: { customSecret2: value || undefined } });
-      vscode.window.showInformationMessage('Custom secret 2 saved securely.');
-
-      const newSettings = await settingsMgr.get();
-      conversation?.setSettings(newSettings);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to save custom secret 2: ${message}`);
-    }
+  const setCustomSecret2 = registerSecretCommand('openhands.setCustomSecret2', {
+    title: 'Custom Secret 2',
+    secretKey: 'customSecret2',
+    prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
+    successMessage: 'Custom secret 2 saved securely.',
+    errorPrefix: 'Failed to save custom secret 2',
   });
 
-  const setCustomSecret3 = vscode.commands.registerCommand('openhands.setCustomSecret3', async () => {
-    try {
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-      const existing = await settingsMgr.get();
-
-      const value = await vscode.window.showInputBox({
-        title: 'Custom Secret 3',
-        value: existing.secrets.customSecret3,
-        password: true,
-        prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
-      });
-
-      if (value === undefined) return;
-
-      await settingsMgr.update({ secrets: { customSecret3: value || undefined } });
-      vscode.window.showInformationMessage('Custom secret 3 saved securely.');
-
-      const newSettings = await settingsMgr.get();
-      conversation?.setSettings(newSettings);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`Failed to save custom secret 3: ${message}`);
-    }
+  const setCustomSecret3 = registerSecretCommand('openhands.setCustomSecret3', {
+    title: 'Custom Secret 3',
+    secretKey: 'customSecret3',
+    prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
+    successMessage: 'Custom secret 3 saved securely.',
+    errorPrefix: 'Failed to save custom secret 3',
   });
 
   const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -855,6 +855,110 @@ export function activate(context: vscode.ExtensionContext) {
     }
   });
 
+  const setGithubToken = vscode.commands.registerCommand('openhands.setGithubToken', async () => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      const existing = await settingsMgr.get();
+
+      const githubToken = await vscode.window.showInputBox({
+        title: 'GitHub Token',
+        value: existing.secrets.githubToken,
+        password: true,
+        prompt: 'Enter your GitHub token. It will be stored securely in VS Code SecretStorage.',
+        placeHolder: 'ghp_...'
+      });
+
+      if (githubToken === undefined) {
+        // User cancelled
+        return;
+      }
+
+      await settingsMgr.update({ secrets: { githubToken: githubToken || undefined } });
+      vscode.window.showInformationMessage('GitHub token saved securely.');
+
+      const newSettings = await settingsMgr.get();
+      conversation?.setSettings(newSettings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to save GitHub token: ${message}`);
+    }
+  });
+
+  const setCustomSecret1 = vscode.commands.registerCommand('openhands.setCustomSecret1', async () => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      const existing = await settingsMgr.get();
+
+      const value = await vscode.window.showInputBox({
+        title: 'Custom Secret 1',
+        value: existing.secrets.customSecret1,
+        password: true,
+        prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
+      });
+
+      if (value === undefined) return;
+
+      await settingsMgr.update({ secrets: { customSecret1: value || undefined } });
+      vscode.window.showInformationMessage('Custom secret 1 saved securely.');
+
+      const newSettings = await settingsMgr.get();
+      conversation?.setSettings(newSettings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to save custom secret 1: ${message}`);
+    }
+  });
+
+  const setCustomSecret2 = vscode.commands.registerCommand('openhands.setCustomSecret2', async () => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      const existing = await settingsMgr.get();
+
+      const value = await vscode.window.showInputBox({
+        title: 'Custom Secret 2',
+        value: existing.secrets.customSecret2,
+        password: true,
+        prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
+      });
+
+      if (value === undefined) return;
+
+      await settingsMgr.update({ secrets: { customSecret2: value || undefined } });
+      vscode.window.showInformationMessage('Custom secret 2 saved securely.');
+
+      const newSettings = await settingsMgr.get();
+      conversation?.setSettings(newSettings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to save custom secret 2: ${message}`);
+    }
+  });
+
+  const setCustomSecret3 = vscode.commands.registerCommand('openhands.setCustomSecret3', async () => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      const existing = await settingsMgr.get();
+
+      const value = await vscode.window.showInputBox({
+        title: 'Custom Secret 3',
+        value: existing.secrets.customSecret3,
+        password: true,
+        prompt: 'Enter a secret value. It will be stored securely in VS Code SecretStorage.',
+      });
+
+      if (value === undefined) return;
+
+      await settingsMgr.update({ secrets: { customSecret3: value || undefined } });
+      vscode.window.showInformationMessage('Custom secret 3 saved securely.');
+
+      const newSettings = await settingsMgr.get();
+      conversation?.setSettings(newSettings);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`Failed to save custom secret 3: ${message}`);
+    }
+  });
+
   const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {
     await ensureConversationAndConnection();
     conversation?.reconnect();
@@ -930,6 +1034,10 @@ export function activate(context: vscode.ExtensionContext) {
     startNew,
     configure,
     setApiKey,
+    setGithubToken,
+    setCustomSecret1,
+    setCustomSecret2,
+    setCustomSecret3,
     reconnect,
     pause,
     resume

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -16,6 +16,10 @@ export type OpenHandsSettings = ServerSettings & {
     llmApiKey?: string;
     awsAccessKeyId?: string;
     awsSecretAccessKey?: string;
+    githubToken?: string;
+    customSecret1?: string;
+    customSecret2?: string;
+    customSecret3?: string;
   };
 };
 
@@ -85,6 +89,10 @@ export class SettingsManager {
       llmApiKey: await this.adapter.getSecret('openhands.llmApiKey'),
       awsAccessKeyId: await this.adapter.getSecret('openhands.awsAccessKeyId'),
       awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
+      githubToken: await this.adapter.getSecret('openhands.githubToken'),
+      customSecret1: await this.adapter.getSecret('openhands.customSecret1'),
+      customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
+      customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
     };
     return { serverUrl, servers, llm, agent, conversation, confirmation, secrets };
   }
@@ -150,6 +158,18 @@ export class SettingsManager {
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsSecretAccessKey')) {
         ops.push(this.adapter.storeSecret('openhands.awsSecretAccessKey', partial.secrets.awsSecretAccessKey));
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'githubToken')) {
+        ops.push(this.adapter.storeSecret('openhands.githubToken', partial.secrets.githubToken));
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret1')) {
+        ops.push(this.adapter.storeSecret('openhands.customSecret1', partial.secrets.customSecret1));
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret2')) {
+        ops.push(this.adapter.storeSecret('openhands.customSecret2', partial.secrets.customSecret2));
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret3')) {
+        ops.push(this.adapter.storeSecret('openhands.customSecret3', partial.secrets.customSecret3));
       }
     }
 

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -108,6 +108,55 @@ describe('SettingsManager', () => {
     expect(s.secrets.awsSecretAccessKey).toBeUndefined();
   });
 
+  it('updates GitHub token and custom secrets', async () => {
+    await mgr.update({
+      secrets: {
+        githubToken: 'ghp_example123',
+        customSecret1: 'secret-1',
+        customSecret2: 'secret-2',
+        customSecret3: 'secret-3',
+      }
+    });
+
+    const s = await mgr.get();
+    expect(s.secrets.githubToken).toBe('ghp_example123');
+    expect(s.secrets.customSecret1).toBe('secret-1');
+    expect(s.secrets.customSecret2).toBe('secret-2');
+    expect(s.secrets.customSecret3).toBe('secret-3');
+  });
+
+  it('clears GitHub token and custom secrets when undefined is provided', async () => {
+    await mgr.update({
+      secrets: {
+        githubToken: 'ghp_example123',
+        customSecret1: 'secret-1',
+        customSecret2: 'secret-2',
+        customSecret3: 'secret-3',
+      }
+    });
+
+    let s = await mgr.get();
+    expect(s.secrets.githubToken).toBe('ghp_example123');
+    expect(s.secrets.customSecret1).toBe('secret-1');
+    expect(s.secrets.customSecret2).toBe('secret-2');
+    expect(s.secrets.customSecret3).toBe('secret-3');
+
+    await mgr.update({
+      secrets: {
+        githubToken: undefined,
+        customSecret1: undefined,
+        customSecret2: undefined,
+        customSecret3: undefined,
+      }
+    });
+
+    s = await mgr.get();
+    expect(s.secrets.githubToken).toBeUndefined();
+    expect(s.secrets.customSecret1).toBeUndefined();
+    expect(s.secrets.customSecret2).toBeUndefined();
+    expect(s.secrets.customSecret3).toBeUndefined();
+  });
+
   it('updates all optional LLM fields', async () => {
     await mgr.update({
       llm: {


### PR DESCRIPTION
Adds secure GitHub token + custom secret slots backed by VS Code SecretStorage.

- Settings schema: adds `openhands.secrets.*` placeholders so secrets appear grouped in VS Code settings UI.
- Extension commands: `openhands.setGithubToken` + `openhands.setCustomSecret{1,2,3}` store secrets securely.
- SettingsManager: persists new secrets via SecretStorage and exposes them on `settings.secrets`.

Tests:
- `npm test`
- `npm run lint`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added commands to securely set and store a GitHub token and three custom secrets via the VS Code UI.
  * Added configuration properties to manage the GitHub token and the three custom secrets.

* **Tests**
  * Added tests covering storing and clearing the GitHub token and custom secret values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->