### PR TITLE
[oh-tab-v55] Webview: tighten attachment marker parsing

### DIFF
--- a/src/webview-src/__tests__/event.attachments.test.tsx
+++ b/src/webview-src/__tests__/event.attachments.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { App } from '../components/App';
+import type { MessageEvent as AgentMessageEvent } from '@openhands/agent-sdk-ts';
+
+afterEach(() => {
+  cleanup();
+});
+
+function postToWindow(payload: unknown) {
+  window.postMessage(payload, '*');
+}
+
+describe('Attachment marker parsing', () => {
+  it('does not treat end-marker substrings inside content as end markers', async () => {
+    render(<App />);
+
+    const text = [
+      'Intro line',
+      '',
+      '----- BEGIN ATTACHMENT: file.txt -----',
+      'line1',
+      'some text ----- END ATTACHMENT: file.txt ----- in middle',
+      'line3',
+      '----- END ATTACHMENT: file.txt -----',
+      '',
+      'Outro line',
+    ].join('\n');
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText(/Intro line/)).toBeInTheDocument();
+    expect(await screen.findByText(/Outro line/)).toBeInTheDocument();
+    expect(screen.queryByText(/BEGIN ATTACHMENT/)).toBeNull();
+
+    const label = await screen.findByText('file.txt');
+    const details = label.closest('details');
+    expect(details).not.toBeNull();
+    if (!details) return;
+
+    fireEvent.click(label);
+    expect(within(details).getByText(/line1/)).toBeInTheDocument();
+    expect(within(details).getByText(/in middle/)).toBeInTheDocument();
+    expect(within(details).getByText(/line3/)).toBeInTheDocument();
+  });
+
+  it('parses multiple attachment blocks', async () => {
+    render(<App />);
+
+    const text = [
+      'Hello',
+      '',
+      '----- BEGIN ATTACHMENT: a.txt -----',
+      'A1',
+      '----- END ATTACHMENT: a.txt -----',
+      '',
+      'Between',
+      '',
+      '----- BEGIN ATTACHMENT: b.txt -----',
+      'B1',
+      '----- END ATTACHMENT: b.txt -----',
+      '',
+      'Bye',
+    ].join('\n');
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText(/Hello/)).toBeInTheDocument();
+    expect(await screen.findByText(/Between/)).toBeInTheDocument();
+    expect(await screen.findByText(/Bye/)).toBeInTheDocument();
+
+    const aLabel = await screen.findByText('a.txt');
+    const aDetails = aLabel.closest('details');
+    expect(aDetails).not.toBeNull();
+    if (!aDetails) return;
+    fireEvent.click(aLabel);
+    expect(within(aDetails).getByText('A1')).toBeInTheDocument();
+
+    const bLabel = await screen.findByText('b.txt');
+    const bDetails = bLabel.closest('details');
+    expect(bDetails).not.toBeNull();
+    if (!bDetails) return;
+    fireEvent.click(bLabel);
+    expect(within(bDetails).getByText('B1')).toBeInTheDocument();
+  });
+});

--- a/src/webview-src/__tests__/event.attachments.test.tsx
+++ b/src/webview-src/__tests__/event.attachments.test.tsx
@@ -54,6 +54,83 @@ describe('Attachment marker parsing', () => {
     expect(within(details).getByText(/line3/)).toBeInTheDocument();
   });
 
+  it('accepts markers with more than five dashes', async () => {
+    render(<App />);
+
+    const text = [
+      'Dash test',
+      '',
+      '---------- BEGIN ATTACHMENT: dash.txt ----------',
+      'payload',
+      '---------- END ATTACHMENT: dash.txt ----------',
+      '',
+      'Done',
+    ].join('\n');
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText(/Dash test/)).toBeInTheDocument();
+    expect(await screen.findByText(/Done/)).toBeInTheDocument();
+    expect(screen.queryByText(/BEGIN ATTACHMENT/)).toBeNull();
+
+    const label = await screen.findByText('dash.txt');
+    const details = label.closest('details');
+    expect(details).not.toBeNull();
+    if (!details) return;
+
+    fireEvent.click(label);
+    expect(within(details).getByText(/payload/)).toBeInTheDocument();
+  });
+
+  it('keeps scanning after an unmatched BEGIN marker', async () => {
+    render(<App />);
+
+    const text = [
+      'Intro',
+      '',
+      '----- BEGIN ATTACHMENT: missing.txt -----',
+      'this never closes',
+      '',
+      '----- BEGIN ATTACHMENT: ok.txt -----',
+      'OK',
+      '----- END ATTACHMENT: ok.txt -----',
+      '',
+      'Outro',
+    ].join('\n');
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText(/Intro/)).toBeInTheDocument();
+    expect(await screen.findByText(/Outro/)).toBeInTheDocument();
+    expect(screen.queryByText('missing.txt')).toBeNull();
+
+    const label = await screen.findByText('ok.txt');
+    const details = label.closest('details');
+    expect(details).not.toBeNull();
+    if (!details) return;
+
+    fireEvent.click(label);
+    expect(within(details).getByText('OK')).toBeInTheDocument();
+  });
+
   it('parses multiple attachment blocks', async () => {
     render(<App />);
 

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -687,44 +687,53 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   }
   const { main: withoutContext, files: contextFiles } = parseContextBlock(rawText);
 
-  const ATTACHMENT_BEGIN = '----- BEGIN ATTACHMENT:';
-  const ATTACHMENT_END = '----- END ATTACHMENT:';
-  const stripTrailingDashes = (value: string) => value.replace(/\s*-{5,}\s*$/, '').trim();
+  const ATTACHMENT_BEGIN_LINE_RE = /^----- BEGIN ATTACHMENT:\s*(.*?)\s*-----\s*$/;
+  const ATTACHMENT_END_LINE_RE = /^----- END ATTACHMENT:\s*(.*?)\s*-----\s*$/;
 
   function parseAttachmentBlocks(text: string): { main: string; attachments: Array<{ label: string; content: string }> } {
     const attachments: Array<{ label: string; content: string }> = [];
-    const parts: string[] = [];
-    let cursor = 0;
+    const mainLines: string[] = [];
+    const lines = text.split(/\r?\n/);
 
-    while (true) {
-      const beginIdx = text.indexOf(ATTACHMENT_BEGIN, cursor);
-      if (beginIdx === -1) break;
-      parts.push(text.slice(cursor, beginIdx));
+    let i = 0;
+    while (i < lines.length) {
+      const beginLine = lines[i];
+      const beginMatch = beginLine.match(ATTACHMENT_BEGIN_LINE_RE);
+      if (!beginMatch) {
+        mainLines.push(beginLine);
+        i += 1;
+        continue;
+      }
 
-      const beginLineEnd = text.indexOf('\n', beginIdx);
-      if (beginLineEnd === -1) {
-        cursor = beginIdx;
+      const label = (beginMatch[1] ?? '').trim() || 'Attachment';
+      const contentLines: string[] = [];
+      i += 1;
+
+      let foundEnd = false;
+      while (i < lines.length) {
+        const endMatch = lines[i].match(ATTACHMENT_END_LINE_RE);
+        if (endMatch) {
+          const endLabel = (endMatch[1] ?? '').trim() || 'Attachment';
+          if (endLabel === label) {
+            foundEnd = true;
+            i += 1; // Consume end marker line
+            break;
+          }
+        }
+        contentLines.push(lines[i]);
+        i += 1;
+      }
+
+      if (!foundEnd) {
+        // Incomplete block: treat everything from the begin marker onward as normal message text.
+        mainLines.push(beginLine, ...contentLines, ...lines.slice(i));
         break;
       }
-      const beginLine = text.slice(beginIdx, beginLineEnd).trim();
-      let label = stripTrailingDashes(beginLine.slice(ATTACHMENT_BEGIN.length).trim());
-      if (!label) label = 'Attachment';
 
-      const endToken = `${ATTACHMENT_END} ${label}`;
-      const endIdx = text.indexOf(endToken, beginLineEnd);
-      if (endIdx === -1) {
-        cursor = beginIdx;
-        break;
-      }
-      const endLineEnd = text.indexOf('\n', endIdx);
-      const content = text.slice(beginLineEnd + 1, endIdx).trimEnd();
-
-      attachments.push({ label, content });
-      cursor = endLineEnd === -1 ? text.length : endLineEnd + 1;
+      attachments.push({ label, content: contentLines.join('\n').trimEnd() });
     }
 
-    parts.push(text.slice(cursor));
-    return { main: parts.join('').trim(), attachments };
+    return { main: mainLines.join('\n').trim(), attachments };
   }
 
   const { main: textContent, attachments } = parseAttachmentBlocks(withoutContext);

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -687,8 +687,10 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   }
   const { main: withoutContext, files: contextFiles } = parseContextBlock(rawText);
 
-  const ATTACHMENT_BEGIN_LINE_RE = /^----- BEGIN ATTACHMENT:\s*(.*?)\s*-----\s*$/;
-  const ATTACHMENT_END_LINE_RE = /^----- END ATTACHMENT:\s*(.*?)\s*-----\s*$/;
+  const ATTACHMENT_BEGIN_LINE_RE = /^-{5,}\s*BEGIN ATTACHMENT:\s*(.*?)\s*-{5,}\s*$/;
+  const ATTACHMENT_END_LINE_RE = /^-{5,}\s*END ATTACHMENT:\s*(.*?)\s*-{5,}\s*$/;
+
+  const normalizeAttachmentLabel = (value: string) => value.trim().replace(/\s+/g, ' ');
 
   function parseAttachmentBlocks(text: string): { main: string; attachments: Array<{ label: string; content: string }> } {
     const attachments: Array<{ label: string; content: string }> = [];
@@ -705,35 +707,31 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
         continue;
       }
 
-      const label = (beginMatch[1] ?? '').trim() || 'Attachment';
-      const contentLines: string[] = [];
-      i += 1;
+      const label = normalizeAttachmentLabel(beginMatch[1] ?? '') || 'Attachment';
 
-      let foundEnd = false;
-      while (i < lines.length) {
-        const endMatch = lines[i].match(ATTACHMENT_END_LINE_RE);
-        if (endMatch) {
-          const endLabel = (endMatch[1] ?? '').trim() || 'Attachment';
-          if (endLabel === label) {
-            foundEnd = true;
-            i += 1; // Consume end marker line
-            break;
-          }
+      let endIndex = -1;
+      for (let j = i + 1; j < lines.length; j += 1) {
+        const endMatch = lines[j].match(ATTACHMENT_END_LINE_RE);
+        if (!endMatch) continue;
+        const endLabel = normalizeAttachmentLabel(endMatch[1] ?? '') || 'Attachment';
+        if (endLabel === label) {
+          endIndex = j;
+          break;
         }
-        contentLines.push(lines[i]);
+      }
+
+      if (endIndex === -1) {
+        // No matching end marker: treat the begin marker line as normal text and continue scanning.
+        mainLines.push(beginLine);
         i += 1;
+        continue;
       }
 
-      if (!foundEnd) {
-        // Incomplete block: treat everything from the begin marker onward as normal message text.
-        mainLines.push(beginLine, ...contentLines, ...lines.slice(i));
-        break;
-      }
-
-      attachments.push({ label, content: contentLines.join('\n').trimEnd() });
+      attachments.push({ label, content: lines.slice(i + 1, endIndex).join('\n').trimEnd() });
+      i = endIndex + 1;
     }
 
-    return { main: mainLines.join('\n').trim(), attachments };
+    return { main: mainLines.join('\n').trimEnd(), attachments };
   }
 
   const { main: textContent, attachments } = parseAttachmentBlocks(withoutContext);


### PR DESCRIPTION
Fixes `oh-tab-v55` (GH#91): tighten attachment end-marker parsing to avoid false positives.

Changes
- `parseAttachmentBlocks` now parses markers line-by-line and only accepts exact `BEGIN/END` marker lines
- Adds unit tests covering:
  - end-marker substring inside attachment content (should not terminate early)
  - multiple attachments in one message

Validation
- `npm test`
- `npm run lint`

Beads: `oh-tab-v55`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for attachment marker parsing, including varied marker formats and multiple attachment blocks.

* **Bug Fixes**
  * Enhanced attachment parsing to be more resilient to formatting variations and improved handling of multiple attachment blocks in messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->