### PR TITLE
oh-tab-cge: Coalesce CR progress in terminal log

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,11 @@
           "default": "",
           "markdownDescription": "Optional directory for local-mode conversation history/events. Leave empty to use `~/.openhands/conversations-vscode/`."
         },
+        "openhands.terminal.renderProgress": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Coalesce carriage-return progress updates in the OpenHands terminal log."
+        },
         "openhands.confirmation.policy": {
           "type": "string",
           "enum": [

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "openhands.terminal.renderProgress": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Coalesce carriage-return progress updates in the OpenHands terminal log."
+          "markdownDescription": "Coalesce carriage-return (\\r) progress updates in the OpenHands terminal log (keeps only the last update per line)."
         },
         "openhands.confirmation.policy": {
           "type": "string",

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -612,6 +612,57 @@ describe('Settings and modes', () => {
     expect(writes.join('')).toContain(largeOutput);
 
   });
+
+  it('coalesces CR-only progress output in the OpenHands terminal log', async () => {
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await resolveChatView(mockContext);
+
+    const writes: string[] = [];
+    let ptyInstance: any;
+    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
+      const pty = options?.pty;
+      ptyInstance = pty;
+      if (pty?.onDidWrite) {
+        pty.onDidWrite((chunk: string) => writes.push(chunk));
+      }
+      return { show: vi.fn(), dispose: vi.fn() } as any;
+    });
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    conv?.emit('terminal', {
+      id: 'bash-progress-1',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:00.000Z',
+      command_id: 'tc-progress-1',
+      order: 0,
+      command: 'progress_output',
+    });
+
+    expect(ptyInstance).toBeTruthy();
+
+    // Simulate progress updates arriving in multiple chunks (including CSI K split across writes).
+    ptyInstance.write('Downloading 1%');
+    ptyInstance.write('\rDownloading 2%');
+    ptyInstance.write('\rDownloading 3%');
+    ptyInstance.write('\n');
+
+    ptyInstance.write('Longer line that should be cleared');
+    ptyInstance.write('\rShort');
+    ptyInstance.write('\u001b');
+    ptyInstance.write('[K\n');
+
+    const joined = writes.join('');
+    expect(joined).toContain('$ progress_output\r\n');
+    expect(joined).toContain('Downloading 3%\r\n');
+    expect(joined).not.toContain('Downloading 1%');
+    expect(joined).not.toContain('Downloading 2%');
+    expect(joined).toContain('Short\r\n');
+    expect(joined).not.toContain('Longer line that should be cleared');
+    expect(joined).not.toContain('\u001b[K');
+  });
 });
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -309,7 +309,7 @@ type TerminalLogPseudoterminalOptions = {
 
 class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   private static readonly PTY_WRITE_CHUNK_SIZE = 16_000;
-  private static readonly MAX_PENDING_LINE_CHARS = 500_000;
+  private static readonly MAX_PENDING_LINE_CHARS = 200_000;
 
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   private readonly closeEmitter = new vscode.EventEmitter<void>();
@@ -334,9 +334,10 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   close(): void {
     if (this.closed) return;
     if (this.progressLine) {
-      this.writeRaw(this.sanitizeProgressLine(this.progressLine));
+      this.writeRaw(`${this.sanitizeProgressLine(this.progressLine)}\n`);
       this.progressLine = '';
     }
+    this.progressCarry = '';
     this.closed = true;
     this.closeEmitter.fire();
     this.writeEmitter.dispose();
@@ -346,11 +347,14 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   isClosed(): boolean { return this.closed; }
 
   ensureNewline(): void {
-    if (this.progressLine) {
-      this.write('\n');
+    if (this.progressLine || this.progressCarry) {
+      const line = this.sanitizeProgressLine(this.progressLine);
+      this.progressLine = '';
+      this.progressCarry = '';
+      this.writeRaw(`${line}\n`);
       return;
     }
-    if (!this.lastEndedWithNewline) this.write('\n');
+    if (!this.lastEndedWithNewline) this.writeRaw('\n');
   }
 
   handleInput(_data: string): void {
@@ -487,7 +491,8 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
     if (this.progressLine.length > OpenHandsTerminalLogPseudoterminal.MAX_PENDING_LINE_CHARS) {
       const overflow = this.sanitizeProgressLine(this.progressLine);
       this.progressLine = '';
-      this.writeRaw(overflow);
+      this.progressCarry = '';
+      this.writeRaw(`${overflow}\n`);
     }
   }
 
@@ -1210,6 +1215,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (e.affectsConfiguration('openhands.terminal.renderProgress')) {
         // Recreate on next terminal event so it picks up updated rendering behavior.
+        try { terminalLogPty?.ensureNewline?.(); } catch { }
         try { terminal?.dispose(); } catch { }
         terminal = undefined;
         terminalLogPty = undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,17 +303,29 @@ function flushConversationEventBacklog(params: {
 
 const normalizeTerminalNewlines = (text: string): string => text.replace(/\r?\n/g, '\r\n');
 
+type TerminalLogPseudoterminalOptions = {
+  renderProgress: boolean;
+};
+
 class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   private static readonly PTY_WRITE_CHUNK_SIZE = 16_000;
+  private static readonly MAX_PENDING_LINE_CHARS = 500_000;
 
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   private readonly closeEmitter = new vscode.EventEmitter<void>();
   private closed = false;
   private showedInputHint = false;
   private lastEndedWithNewline = true;
+  private readonly renderProgress: boolean;
+  private progressCarry = '';
+  private progressLine = '';
 
   readonly onDidWrite = this.writeEmitter.event;
   readonly onDidClose = this.closeEmitter.event;
+
+  constructor(options?: Partial<TerminalLogPseudoterminalOptions>) {
+    this.renderProgress = options?.renderProgress ?? true;
+  }
 
   open(): void {
     this.writeLine('[OpenHands] Terminal log (read-only)');
@@ -321,6 +333,10 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
 
   close(): void {
     if (this.closed) return;
+    if (this.progressLine) {
+      this.writeRaw(this.sanitizeProgressLine(this.progressLine));
+      this.progressLine = '';
+    }
     this.closed = true;
     this.closeEmitter.fire();
     this.writeEmitter.dispose();
@@ -330,6 +346,10 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   isClosed(): boolean { return this.closed; }
 
   ensureNewline(): void {
+    if (this.progressLine) {
+      this.write('\n');
+      return;
+    }
     if (!this.lastEndedWithNewline) this.write('\n');
   }
 
@@ -348,7 +368,7 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
     this.lastEndedWithNewline = /\n$/.test(chunk);
   }
 
-  write(text: string): void {
+  private writeRaw(text: string): void {
     if (this.closed) return;
     const normalized = normalizeTerminalNewlines(text);
 
@@ -384,6 +404,99 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
       this.emitChunk(normalized.slice(start, end));
       start = end;
     }
+  }
+
+  private sanitizeProgressLine(line: string): string {
+    // ANSI erase-to-EOL (CSI K) is used by progress bars to clear leftover text.
+    // In our coalesced rendering (keeping only last update), the erase is redundant
+    // and can be safely removed to keep the log readable.
+    if (!line.includes('\u001b[')) return line;
+
+    const esc = '\u001b';
+    let out = '';
+
+    for (let i = 0; i < line.length; i++) {
+      if (line[i] === esc && line[i + 1] === '[') {
+        let j = i + 2;
+        while (j < line.length) {
+          const code = line.charCodeAt(j);
+          const isDigit = code >= 48 && code <= 57;
+          const isSemicolon = code === 59;
+          if (!isDigit && !isSemicolon) break;
+          j += 1;
+        }
+
+        if (line[j] === 'K') {
+          i = j;
+          continue;
+        }
+      }
+
+      out += line[i];
+    }
+
+    return out;
+  }
+
+  private splitTrailingIncompleteCsi(text: string): { prefix: string; carry: string } {
+    if (!text) return { prefix: '', carry: '' };
+
+    if (text.endsWith('\u001b')) {
+      return { prefix: text.slice(0, -1), carry: '\u001b' };
+    }
+
+    const escIdx = text.lastIndexOf('\u001b[');
+    if (escIdx < 0) return { prefix: text, carry: '' };
+
+    const afterCsi = text.slice(escIdx + 2);
+    const hasTerminator = /[@-~]/.test(afterCsi);
+    if (hasTerminator) return { prefix: text, carry: '' };
+
+    return { prefix: text.slice(0, escIdx), carry: text.slice(escIdx) };
+  }
+
+  private writeWithProgressCoalescing(text: string): void {
+    if (this.closed) return;
+
+    // Normalize CRLF -> LF so we can treat standalone CR as progress-only updates.
+    const combined = (this.progressCarry + text).replace(/\r\n/g, '\n');
+    this.progressCarry = '';
+
+    const { prefix, carry } = this.splitTrailingIncompleteCsi(combined);
+    this.progressCarry = carry;
+
+    const parts = prefix.split('\n');
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const isLast = i === parts.length - 1;
+
+      const lastCr = part.lastIndexOf('\r');
+      if (lastCr >= 0) {
+        this.progressLine = part.slice(lastCr + 1);
+      } else {
+        this.progressLine += part;
+      }
+
+      if (!isLast) {
+        const line = this.sanitizeProgressLine(this.progressLine);
+        this.progressLine = '';
+        this.writeRaw(`${line}\n`);
+      }
+    }
+
+    if (this.progressLine.length > OpenHandsTerminalLogPseudoterminal.MAX_PENDING_LINE_CHARS) {
+      const overflow = this.sanitizeProgressLine(this.progressLine);
+      this.progressLine = '';
+      this.writeRaw(overflow);
+    }
+  }
+
+  write(text: string): void {
+    if (!this.renderProgress) {
+      this.writeRaw(text);
+      return;
+    }
+    this.writeWithProgressCoalescing(text);
   }
 
   writeLine(line: string): void {
@@ -605,7 +718,9 @@ export function activate(context: vscode.ExtensionContext) {
     // Recreate terminal if not present or if the PTY has been closed
     if (!terminal || !terminalLogPty || terminalLogPty.isClosed?.()) {
       try {
-        terminalLogPty = new OpenHandsTerminalLogPseudoterminal();
+        const renderProgress =
+          vscode.workspace.getConfiguration().get<boolean>('openhands.terminal.renderProgress') ?? true;
+        terminalLogPty = new OpenHandsTerminalLogPseudoterminal({ renderProgress });
         terminal = vscode.window.createTerminal({ name: 'OpenHands', pty: terminalLogPty });
         terminal.show(true);
       } catch (e) {
@@ -1090,6 +1205,14 @@ export function activate(context: vscode.ExtensionContext) {
         conversation = undefined;
         conversationStoreRoot = undefined;
         await ensureConversationAndConnection();
+        return;
+      }
+
+      if (e.affectsConfiguration('openhands.terminal.renderProgress')) {
+        // Recreate on next terminal event so it picks up updated rendering behavior.
+        try { terminal?.dispose(); } catch { }
+        terminal = undefined;
+        terminalLogPty = undefined;
         return;
       }
 


### PR DESCRIPTION
Implements CR-only progress coalescing in the OpenHands terminal log (read-only PTY).

- Adds `openhands.terminal.renderProgress` (default: true)
- Coalesces standalone carriage-return updates; strips ANSI erase-to-EOL (CSI K)
- Adds unit test coverage for chunked progress + split CSI sequence

Checks:
- `npm test`
- `npm run lint`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added `openhands.terminal.renderProgress` VS Code extension configuration option to enhance terminal output rendering. This new setting intelligently consolidates sequential progress updates displayed in the terminal log, resulting in improved readability and a cleaner display. Enabled by default, but can be disabled through VS Code settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->