### PR TITLE
oh-tab-jl4: Sanitize terminal control sequences

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -663,6 +663,52 @@ describe('Settings and modes', () => {
     expect(joined).not.toContain('Longer line that should be cleared');
     expect(joined).not.toContain('\u001b[K');
   });
+
+  it('strips terminal string control sequences (OSC/DCS) from the OpenHands terminal log', async () => {
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await resolveChatView(mockContext);
+
+    const writes: string[] = [];
+    let ptyInstance: any;
+    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
+      const pty = options?.pty;
+      ptyInstance = pty;
+      if (pty?.onDidWrite) {
+        pty.onDidWrite((chunk: string) => writes.push(chunk));
+      }
+      return { show: vi.fn(), dispose: vi.fn() } as any;
+    });
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    conv?.emit('terminal', {
+      id: 'bash-sanitize-1',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:00.000Z',
+      command_id: 'tc-sanitize-1',
+      order: 0,
+      command: 'sanitize_output',
+    });
+
+    expect(ptyInstance).toBeTruthy();
+
+    // OSC with BEL terminator
+    ptyInstance.write('hello\u001b]0;title\u0007world\n');
+    // OSC with ST (ESC \\) terminator
+    ptyInstance.write('a\u001b]8;;https://example.com\u001b\\b\n');
+    // DCS with ST terminator
+    ptyInstance.write('x\u001bPqstuff\u001b\\y\n');
+
+    const joined = writes.join('');
+    expect(joined).toContain('$ sanitize_output\r\n');
+    expect(joined).toContain('helloworld\r\n');
+    expect(joined).toContain('ab\r\n');
+    expect(joined).toContain('xy\r\n');
+    expect(joined).not.toContain('\u001b]');
+    expect(joined).not.toContain('\u001bP');
+  });
 });
 
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,6 +303,46 @@ function flushConversationEventBacklog(params: {
 
 const normalizeTerminalNewlines = (text: string): string => text.replace(/\r?\n/g, '\r\n');
 
+const sanitizeTerminalControlSequences = (text: string): string => {
+  if (!text.includes('\u001b')) return text;
+
+  const esc = '\u001b';
+  const bel = '\u0007';
+
+  let out = '';
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (ch === esc) {
+      const introducer = text[i + 1];
+      const isOsc = introducer === ']';
+      const isStringSequence = isOsc || introducer === 'P' || introducer === '^' || introducer === '_';
+
+      if (isStringSequence) {
+        i += 2; // skip ESC + introducer
+        while (i < text.length) {
+          const c = text[i];
+          if (isOsc && c === bel) {
+            i += 1;
+            break;
+          }
+          if (c === esc && text[i + 1] === '\\') {
+            i += 2;
+            break;
+          }
+          i += 1;
+        }
+        continue;
+      }
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  return out;
+};
+
 type TerminalLogPseudoterminalOptions = {
   renderProgress: boolean;
 };
@@ -374,7 +414,8 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
 
   private writeRaw(text: string): void {
     if (this.closed) return;
-    const normalized = normalizeTerminalNewlines(text);
+    const sanitized = sanitizeTerminalControlSequences(text);
+    const normalized = normalizeTerminalNewlines(sanitized);
 
     const max = OpenHandsTerminalLogPseudoterminal.PTY_WRITE_CHUNK_SIZE;
     let start = 0;


### PR DESCRIPTION
Sanitizes terminal output written to the OpenHands read-only PTY.

- Strip terminal *string* control sequences (OSC and DCS, incl. BEL and ST terminators)
- Prevents terminal title/hyperlink/control payloads from affecting the log view
- Adds unit tests for OSC (BEL/ST) + DCS sanitization

Checks:
- 
> openhands-tab@0.0.4 test
> npm test -w @openhands/agent-sdk-ts && vitest run --dir src


> @openhands/agent-sdk-ts@0.1.0 test
> vitest run


 RUN  v2.1.9 /Users/enyst/repos/oh-tab/packages/agent-sdk-ts

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers keyword skills
Skill 'react-skill' triggered by keyword 'react'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers multiple skills
Skill 'react-skill' triggered by keyword 'react'
Skill 'typescript-skill' triggered by keyword 'typescript'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > appends custom user message suffix to triggered skills
Skill 'test-skill' triggered by keyword 'test'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles multiple text content blocks
Skill 'test-skill' triggered by keyword 'keyword'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles task triggers
Skill 'refactor' triggered by keyword '/refactor'

 ✓ src/sdk/context/__tests__/agent-context.test.ts (26 tests) 8ms
 ✓ src/sdk/context/skills/__tests__/skill.test.ts (37 tests) 23ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-errors.test.ts (4 tests) 7ms
 ✓ src/sdk/runtime/__tests__/Agent.debug-mode.test.ts (6 tests) 8ms
 ✓ src/sdk/conversation/LocalConversation.test.ts (6 tests) 14ms
 ✓ src/sdk/__tests__/persistence.test.ts (11 tests) 12ms
 ✓ src/tools/__tests__/new-tools.test.ts (12 tests) 70ms
 ✓ src/sdk/__tests__/remoteConversation.test.ts (3 tests) 29ms
 ✓ src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts (2 tests) 12ms
 ✓ src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts (3 tests) 5ms
 ✓ src/sdk/__tests__/agent.loop.test.ts (4 tests) 5ms
 ✓ src/sdk/runtime/__tests__/Agent.redaction.test.ts (2 tests) 4ms
 ✓ src/sdk/__tests__/agent-sdk.guards.test.ts (5 tests) 2ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts (1 test) 23ms
 ✓ src/sdk/__tests__/conversation-stats.test.ts (3 tests) 2ms
 ✓ src/sdk/__tests__/registry.test.ts (3 tests) 2ms
 ✓ src/sdk/__tests__/metrics.test.ts (4 tests) 3ms
 ✓ src/sdk/runtime/__tests__/Agent.security-risk.test.ts (1 test) 3ms
 ✓ src/workspace/__tests__/local.workspace.test.ts (3 tests) 16ms
 ✓ src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts (2 tests) 1ms
 ✓ src/sdk/runtime/__tests__/truncateError.unit.test.ts (5 tests) 2ms
 ✓ src/tools/__tests__/tools.test.ts (6 tests) 232ms
 ✓ src/sdk/__tests__/runtime.test.ts (3 tests) 2ms
 ✓ src/sdk/__tests__/llm.orchestrator.test.ts (5 tests | 1 skipped) 1020ms
   ✓ OpenAICompatibleClient streaming > propagates failure after retries 756ms

 Test Files  24 passed (24)
      Tests  156 passed | 1 skipped (157)
   Start at  12:04:56
   Duration  1.58s (transform 415ms, setup 0ms, collect 1.55s, tests 1.51s, environment 2ms, prepare 1.05s)


 RUN  v2.1.9 /Users/enyst/repos/oh-tab

 ✓ src/settings/__tests__/VscodeSettingsAdapter.test.ts (17 tests) 16ms
 ✓ src/settings/__tests__/SettingsManager.test.ts (13 tests) 25ms
 ✓ src/__tests__/extension.test.ts (17 tests) 149ms
 ✓ src/webview-src/__tests__/event.handlers.test.tsx (4 tests) 238ms
 ✓ src/webview-src/__tests__/HistoryView.test.tsx (5 tests) 197ms
 ✓ src/webview-src/__tests__/event.attachments.test.tsx (4 tests) 153ms
 ✓ src/webview-src/__tests__/event.rendering.test.tsx (15 tests) 340ms
 ✓ src/webview-src/__tests__/App.toolbar.test.tsx (8 tests | 2 skipped) 158ms
 ✓ src/webview-src/__tests__/App.confirmation.test.tsx (12 tests) 766ms
 ✓ src/shared/__tests__/llmStreaming.test.ts (4 tests) 3ms
 ✓ src/webview-src/__tests__/App.advanced.test.tsx (46 tests | 2 skipped) 895ms
 ✓ src/webview-src/__tests__/toasts.test.tsx (1 test) 36ms
 ✓ src/webview-src/__tests__/App.render.test.tsx (2 tests) 92ms
 ✓ src/webview-src/__tests__/actions.test.tsx (6 tests) 193ms

 Test Files  14 passed (14)
      Tests  150 passed | 4 skipped (154)
   Start at  12:04:58
   Duration  2.08s (transform 586ms, setup 490ms, collect 3.16s, tests 3.26s, environment 3.49s, prepare 647ms)
- 
> openhands-tab@0.0.4 lint
> npm run lint -w @openhands/agent-sdk-ts && eslint src tests


> @openhands/agent-sdk-ts@0.1.0 lint
> eslint ./src
- 
> openhands-tab@0.0.4 typecheck
> tsc -p . && tsc -p tsconfig.webview.json