### PR TITLE
oh-tab-bm8: align settings schema and provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,9 +103,9 @@
           "default": "",
           "markdownDescription": "OpenHands agent-server base URL. Leave blank to run in local mode."
         },
-	        "openhands.servers": {
-	          "type": "array",
-	          "default": [],
+        "openhands.servers": {
+          "type": "array",
+          "default": [],
           "items": {
             "type": "object",
             "properties": {
@@ -119,20 +119,20 @@
             "required": [
               "url"
             ]
-	          },
-	          "markdownDescription": "List of saved OpenHands server URLs with optional labels."
-	        },
-	        "openhands.secrets.sessionApiKey": {
-	          "type": "string",
-	          "default": "",
-	          "editPresentation": "singlelineText",
-	          "markdownDescription": "**To set your Session API Key securely:**\n\n[🔑 Configure Session API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json. Used to authenticate to agent-server.)_"
-	        },
-	        "openhands.conversation.maxIterations": {
-	          "type": "number",
-	          "default": 50,
-	          "markdownDescription": "Default max iterations for new conversations (server default is 500)."
-	        },
+          },
+          "markdownDescription": "List of saved OpenHands server URLs with optional labels."
+        },
+        "openhands.secrets.sessionApiKey": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your Session API Key securely:**\n\n[🔑 Configure Session API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json. Used to authenticate to agent-server.)_"
+        },
+        "openhands.conversation.maxIterations": {
+          "type": "number",
+          "default": 50,
+          "markdownDescription": "Default max iterations for new conversations (server default is 500)."
+        },
         "openhands.conversation.storeRoot": {
           "type": "string",
           "default": "",
@@ -160,7 +160,7 @@
             "MEDIUM",
             "HIGH"
           ],
-          "default": "HIGH",
+          "default": "MEDIUM",
           "markdownDescription": "Risk threshold for ConfirmRisky policy. Actions at or above this require confirmation."
         },
         "openhands.confirmation.risky.confirmUnknown": {
@@ -168,50 +168,51 @@
           "default": true,
           "markdownDescription": "Whether actions with UNKNOWN risk require confirmation in risky mode."
         },
-	        "openhands.agent.enableSecurityAnalyzer": {
-	          "type": "boolean",
-	          "default": false,
-	          "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
-	        },
-	        "openhands.agent.debug": {
-	          "type": "boolean",
-	          "default": false,
-	          "markdownDescription": "Enable local-mode debug events (e.g., llm_request/tool_call_raw)."
-	        },
-	        "openhands.llm.model": {
-	          "type": "string",
-	          "default": "claude-sonnet-4-20250514",
-	          "markdownDescription": "Default model name for LLM requests."
-	        },
-	        "openhands.llm.provider": {
-	          "type": "string",
-	          "enum": [
-	            "anthropic",
-	            "openai",
-	            "openrouter",
-	            "litellm_proxy"
-	          ],
-	          "default": "anthropic",
-	          "markdownDescription": "Optional explicit provider override. Leave empty to infer from baseUrl (recommended when using OpenRouter/LiteLLM)."
-	        },
-	        "openhands.llm.baseUrl": {
-	          "type": "string",
-	          "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
-	        },
-	        "openhands.llm.apiVersion": {
-	          "type": "string",
-	          "markdownDescription": "Optional LLM API version (e.g., Azure). Leave empty if not applicable."
-	        },
-	        "openhands.llm.apiKey": {
-	          "type": "string",
-	          "default": "",
-	          "editPresentation": "singlelineText",
-	          "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
-	        },
-	        "openhands.llm.timeout": {
-	          "type": "number",
-	          "markdownDescription": "HTTP timeout in seconds. Leave empty to use default."
-	        },
+        "openhands.agent.enableSecurityAnalyzer": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
+        },
+        "openhands.agent.debug": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable local-mode debug events (e.g., llm_request/tool_call_raw)."
+        },
+        "openhands.llm.model": {
+          "type": "string",
+          "default": "claude-sonnet-4-20250514",
+          "markdownDescription": "Default model name for LLM requests."
+        },
+        "openhands.llm.provider": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "anthropic",
+            "openai",
+            "openrouter",
+            "litellm_proxy"
+          ],
+          "default": "auto",
+          "markdownDescription": "LLM provider selection. Use `auto` to infer from `openhands.llm.baseUrl` when set; otherwise local mode defaults to Anthropic."
+        },
+        "openhands.llm.baseUrl": {
+          "type": "string",
+          "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
+        },
+        "openhands.llm.apiVersion": {
+          "type": "string",
+          "markdownDescription": "Optional LLM API version (e.g., Azure). Leave empty if not applicable."
+        },
+        "openhands.llm.apiKey": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.llm.timeout": {
+          "type": "number",
+          "markdownDescription": "HTTP timeout in seconds. Leave empty to use default."
+        },
         "openhands.llm.temperature": {
           "type": "number",
           "default": 0,
@@ -234,56 +235,56 @@
           "type": "number",
           "markdownDescription": "Max output tokens. Leave empty to use default."
         },
-	        "openhands.llm.reasoningEffort": {
-	          "type": "string",
-	          "enum": [
-	            "low",
-	            "medium",
-	            "high",
-	            "none"
-	          ],
-	          "default": "none",
-	          "markdownDescription": "Reasoning effort for supported models."
-	        },
-	        "openhands.llm.inputCostPerToken": {
-	          "type": "number",
-	          "markdownDescription": "Optional cost per input token (USD) for usage stats."
-	        },
-	        "openhands.llm.outputCostPerToken": {
-	          "type": "number",
-	          "markdownDescription": "Optional cost per output token (USD) for usage stats."
-	        },
-	        "openhands.llm.usageId": {
-	          "type": "string",
-	          "default": "default-llm",
-	          "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
-	        },
-	        "openhands.secrets.githubToken": {
-	          "type": "string",
-	          "default": "",
-	          "editPresentation": "singlelineText",
-	          "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
-	        },
-	        "openhands.secrets.customSecret1": {
-	          "type": "string",
-	          "default": "",
-	          "editPresentation": "singlelineText",
-	          "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-	        },
-	        "openhands.secrets.customSecret2": {
-	          "type": "string",
-	          "default": "",
-	          "editPresentation": "singlelineText",
-	          "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-	        },
-	        "openhands.secrets.customSecret3": {
-	          "type": "string",
-	          "default": "",
-	          "editPresentation": "singlelineText",
-	          "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-	        }
-	      }
-	    },
+        "openhands.llm.reasoningEffort": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "none"
+          ],
+          "default": "none",
+          "markdownDescription": "Reasoning effort for supported models."
+        },
+        "openhands.llm.inputCostPerToken": {
+          "type": "number",
+          "markdownDescription": "Optional cost per input token (USD) for usage stats."
+        },
+        "openhands.llm.outputCostPerToken": {
+          "type": "number",
+          "markdownDescription": "Optional cost per output token (USD) for usage stats."
+        },
+        "openhands.llm.usageId": {
+          "type": "string",
+          "default": "default-llm",
+          "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
+        },
+        "openhands.secrets.githubToken": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.customSecret1": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.customSecret2": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.customSecret3": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+        }
+      }
+    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "onCommand:openhands.startNewConversation",
     "onCommand:openhands.configure",
     "onCommand:openhands.setApiKey",
+    "onCommand:openhands.setSessionApiKey",
     "onCommand:openhands.setGithubToken",
     "onCommand:openhands.setCustomSecret1",
     "onCommand:openhands.setCustomSecret2",
@@ -50,6 +51,10 @@
       {
         "command": "openhands.setApiKey",
         "title": "OpenHands: Set API Key"
+      },
+      {
+        "command": "openhands.setSessionApiKey",
+        "title": "OpenHands: Set Session API Key"
       },
       {
         "command": "openhands.setGithubToken",
@@ -98,9 +103,9 @@
           "default": "",
           "markdownDescription": "OpenHands agent-server base URL. Leave blank to run in local mode."
         },
-        "openhands.servers": {
-          "type": "array",
-          "default": [],
+	        "openhands.servers": {
+	          "type": "array",
+	          "default": [],
           "items": {
             "type": "object",
             "properties": {
@@ -114,14 +119,20 @@
             "required": [
               "url"
             ]
-          },
-          "markdownDescription": "List of saved OpenHands server URLs with optional labels."
-        },
-        "openhands.conversation.maxIterations": {
-          "type": "number",
-          "default": 50,
-          "markdownDescription": "Default max iterations for new conversations (server default is 500)."
-        },
+	          },
+	          "markdownDescription": "List of saved OpenHands server URLs with optional labels."
+	        },
+	        "openhands.secrets.sessionApiKey": {
+	          "type": "string",
+	          "default": "",
+	          "editPresentation": "singlelineText",
+	          "markdownDescription": "**To set your Session API Key securely:**\n\n[🔑 Configure Session API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json. Used to authenticate to agent-server.)_"
+	        },
+	        "openhands.conversation.maxIterations": {
+	          "type": "number",
+	          "default": 50,
+	          "markdownDescription": "Default max iterations for new conversations (server default is 500)."
+	        },
         "openhands.conversation.storeRoot": {
           "type": "string",
           "default": "",
@@ -157,63 +168,50 @@
           "default": true,
           "markdownDescription": "Whether actions with UNKNOWN risk require confirmation in risky mode."
         },
-        "openhands.agent.enableSecurityAnalyzer": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
-        },
-        "openhands.llm.usageId": {
-          "type": "string",
-          "default": "default-llm",
-          "markdownDescription": "Preferred usage_id for LLM config sent to agent-server. If unset, server defaults apply."
-        },
-        "openhands.llm.model": {
-          "type": "string",
-          "default": "claude-sonnet-4-20250514",
-          "markdownDescription": "Default model name for LLM requests."
-        },
-        "openhands.llm.baseUrl": {
-          "type": "string",
-          "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
-        },
-        "openhands.llm.apiKey": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.githubToken": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.customSecret1": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.customSecret2": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.customSecret3": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.llm.apiVersion": {
-          "type": "string",
-          "markdownDescription": "Optional LLM API version (e.g., Azure). Leave empty if not applicable."
-        },
-        "openhands.llm.timeout": {
-          "type": "number",
-          "markdownDescription": "HTTP timeout in seconds. Leave empty to use default."
-        },
+	        "openhands.agent.enableSecurityAnalyzer": {
+	          "type": "boolean",
+	          "default": false,
+	          "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
+	        },
+	        "openhands.agent.debug": {
+	          "type": "boolean",
+	          "default": false,
+	          "markdownDescription": "Enable local-mode debug events (e.g., llm_request/tool_call_raw)."
+	        },
+	        "openhands.llm.model": {
+	          "type": "string",
+	          "default": "claude-sonnet-4-20250514",
+	          "markdownDescription": "Default model name for LLM requests."
+	        },
+	        "openhands.llm.provider": {
+	          "type": "string",
+	          "enum": [
+	            "anthropic",
+	            "openai",
+	            "openrouter",
+	            "litellm_proxy"
+	          ],
+	          "default": "anthropic",
+	          "markdownDescription": "Optional explicit provider override. Leave empty to infer from baseUrl (recommended when using OpenRouter/LiteLLM)."
+	        },
+	        "openhands.llm.baseUrl": {
+	          "type": "string",
+	          "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
+	        },
+	        "openhands.llm.apiVersion": {
+	          "type": "string",
+	          "markdownDescription": "Optional LLM API version (e.g., Azure). Leave empty if not applicable."
+	        },
+	        "openhands.llm.apiKey": {
+	          "type": "string",
+	          "default": "",
+	          "editPresentation": "singlelineText",
+	          "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
+	        },
+	        "openhands.llm.timeout": {
+	          "type": "number",
+	          "markdownDescription": "HTTP timeout in seconds. Leave empty to use default."
+	        },
         "openhands.llm.temperature": {
           "type": "number",
           "default": 0,
@@ -236,19 +234,56 @@
           "type": "number",
           "markdownDescription": "Max output tokens. Leave empty to use default."
         },
-        "openhands.llm.reasoningEffort": {
-          "type": "string",
-          "enum": [
-            "low",
-            "medium",
-            "high",
-            "none"
-          ],
-          "default": "none",
-          "markdownDescription": "Reasoning effort for supported models."
-        }
-      }
-    },
+	        "openhands.llm.reasoningEffort": {
+	          "type": "string",
+	          "enum": [
+	            "low",
+	            "medium",
+	            "high",
+	            "none"
+	          ],
+	          "default": "none",
+	          "markdownDescription": "Reasoning effort for supported models."
+	        },
+	        "openhands.llm.inputCostPerToken": {
+	          "type": "number",
+	          "markdownDescription": "Optional cost per input token (USD) for usage stats."
+	        },
+	        "openhands.llm.outputCostPerToken": {
+	          "type": "number",
+	          "markdownDescription": "Optional cost per output token (USD) for usage stats."
+	        },
+	        "openhands.llm.usageId": {
+	          "type": "string",
+	          "default": "default-llm",
+	          "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
+	        },
+	        "openhands.secrets.githubToken": {
+	          "type": "string",
+	          "default": "",
+	          "editPresentation": "singlelineText",
+	          "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
+	        },
+	        "openhands.secrets.customSecret1": {
+	          "type": "string",
+	          "default": "",
+	          "editPresentation": "singlelineText",
+	          "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+	        },
+	        "openhands.secrets.customSecret2": {
+	          "type": "string",
+	          "default": "",
+	          "editPresentation": "singlelineText",
+	          "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+	        },
+	        "openhands.secrets.customSecret3": {
+	          "type": "string",
+	          "default": "",
+	          "editPresentation": "singlelineText",
+	          "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+	        }
+	      }
+	    },
     "viewsContainers": {
       "activitybar": [
         {

--- a/packages/agent-sdk-ts/src/sdk/llm/provider.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/provider.ts
@@ -8,8 +8,8 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<LLMProvider, string> = {
 };
 
 export const detectProviderFromBaseUrl = (baseUrl?: string | null): LLMProvider => {
+  if (baseUrl?.includes('anthropic.com')) return 'anthropic';
   if (baseUrl?.includes('openrouter.ai')) return 'openrouter';
   if (baseUrl?.includes('litellm')) return 'litellm_proxy';
   return 'openai';
 };
-

--- a/packages/agent-sdk-ts/src/sdk/llm/provider.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/provider.ts
@@ -8,8 +8,9 @@ export const DEFAULT_PROVIDER_BASE_URLS: Record<LLMProvider, string> = {
 };
 
 export const detectProviderFromBaseUrl = (baseUrl?: string | null): LLMProvider => {
-  if (baseUrl?.includes('anthropic.com')) return 'anthropic';
-  if (baseUrl?.includes('openrouter.ai')) return 'openrouter';
-  if (baseUrl?.includes('litellm')) return 'litellm_proxy';
+  const normalized = (baseUrl ?? '').toLowerCase();
+  if (normalized.includes('anthropic.com')) return 'anthropic';
+  if (normalized.includes('openrouter.ai')) return 'openrouter';
+  if (normalized.includes('litellm')) return 'litellm_proxy';
   return 'openai';
 };

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -471,6 +471,7 @@ export class Agent extends EventEmitter {
     }
     const s = this.options.settings;
     const config = {
+      provider: s.llm.provider ?? undefined,
       model: s.llm.model ?? '',
       usageId: s.llm.usageId ?? undefined,
       baseUrl: s.llm.baseUrl ?? undefined,
@@ -506,7 +507,8 @@ export class Agent extends EventEmitter {
     const code = this.classifyConversationError(message);
     const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
     const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
-    const provider = detectProviderFromBaseUrl(configuredBaseUrl);
+    const configuredProvider = this.options.settings?.llm?.provider ?? undefined;
+    const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
     const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
     const configuredApiKey = toOptionalNonEmptyString(this.options.settings?.secrets?.llmApiKey);
     const hasInlineApiKey =

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -1,5 +1,8 @@
+import type { LLMProvider } from '../llm/types';
+
 export type LLMSettings = {
   usageId?: string | null;
+  provider?: LLMProvider | null;
   model?: string | null;
   baseUrl?: string | null;
   apiVersion?: string | null;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,6 +99,7 @@ let chatLastSeenSeq: number | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
 let conversationStoreRoot: string | undefined;
 let lastKnownLlmModel: string | null = null;
+let verboseEventLogging = false;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -568,11 +569,38 @@ function shouldRedactKey(key: string): boolean {
     k === 'apikey' ||
     k === 'authorization' ||
     k === 'auth' ||
+    k.includes('accesskey') ||
     k.endsWith('token') ||
     k.includes('secret') ||
     k === 'llmapikey' ||
     k === 'sessionapikey'
   );
+}
+
+const REDACTED = '[REDACTED]';
+
+function redactStringHeuristics(text: string): string {
+  let t = text;
+
+  // Authorization / Bearer patterns
+  t = t.replace(/(Authorization\s*:\s*Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+  t = t.replace(/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+
+  // Common token prefixes
+  t = t.replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gi, REDACTED);
+  t = t.replace(/\bgh[pousr]_[A-Za-z0-9]{12,}\b/gi, REDACTED);
+  t = t.replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gi, REDACTED);
+
+  // AWS access key ids (AKIA..., ASIA...)
+  t = t.replace(/\b(AKIA|ASIA)[0-9A-Z]{16}\b/g, REDACTED);
+
+  // Common key=value or key: value patterns
+  const keyPattern =
+    /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret|aws[_-]?access[_-]?key[_-]?id|aws[_-]?secret[_-]?access[_-]?key)/gi;
+  t = t.replace(new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'), (_m, key) => `${key}: ${REDACTED}`);
+  t = t.replace(new RegExp(`([?&])(${keyPattern.source})=([^&\\s]+)`, 'gi'), (_m, sep, key) => `${sep}${key}=${REDACTED}`);
+
+  return t;
 }
 
 /* eslint-disable @typescript-eslint/no-unsafe-return */
@@ -582,7 +610,8 @@ function safeStringify(value: unknown): string {
       value,
       (key, val) => {
         if (typeof val === 'bigint') return val.toString();
-        if (typeof key === 'string' && shouldRedactKey(key)) return '[REDACTED]';
+        if (typeof key === 'string' && shouldRedactKey(key)) return REDACTED;
+        if (typeof val === 'string') return redactStringHeuristics(val);
         return val;
       }
     );
@@ -810,6 +839,10 @@ export function activate(context: vscode.ExtensionContext) {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
     lastKnownLlmModel = settings.llm.model ?? null;
+
+    const cfg = vscode.workspace.getConfiguration();
+    verboseEventLogging = Boolean(settings.agent?.debug) || Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
+
     const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = workspaceRoot;
 
@@ -878,7 +911,12 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         if (!isLlmStreamUpdate) {
-          outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
+          const isErrorLike = ev.kind === 'ConversationErrorEvent' || ev.kind === 'AgentErrorEvent';
+          if (verboseEventLogging || isErrorLike) {
+            outputChannel?.appendLine(`[event] ${safeStringify(ev)}`);
+          } else {
+            outputChannel?.appendLine(`[event] ${ev.kind}`);
+          }
         }
 
         if (streamingUpdate.completed) {
@@ -1265,11 +1303,18 @@ export function activate(context: vscode.ExtensionContext) {
 
       if (e.affectsConfiguration('openhands.terminal.renderProgress')) {
         // Recreate on next terminal event so it picks up updated rendering behavior.
-        try { terminalLogPty?.ensureNewline?.(); } catch { }
-        try { terminal?.dispose(); } catch { }
+        try { terminalLogPty?.ensureNewline?.(); } catch {}
+        try { terminal?.dispose(); } catch {}
         terminal = undefined;
         terminalLogPty = undefined;
         return;
+      }
+
+      if (e.affectsConfiguration('openhands.agent.debug') || e.affectsConfiguration('openhands.devBridge.enabled')) {
+        const cfg = vscode.workspace.getConfiguration();
+        const debug = cfg.get<boolean>('openhands.agent.debug') ?? false;
+        const devBridgeEnabled = cfg.get<boolean>('openhands.devBridge.enabled') ?? false;
+        verboseEventLogging = debug || devBridgeEnabled;
       }
 
       if (e.affectsConfiguration('openhands.llm')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1165,6 +1165,15 @@ export function activate(context: vscode.ExtensionContext) {
     errorPrefix: 'Failed to save API Key',
   });
 
+  const setSessionApiKey = registerSecretCommand('openhands.setSessionApiKey', {
+    title: 'Session API Key',
+    secretKey: 'sessionApiKey',
+    prompt: 'Enter your Session API key. It will be stored securely in VS Code SecretStorage.',
+    successMessage: 'Session API Key saved securely.',
+    clearedMessage: 'Session API Key cleared.',
+    errorPrefix: 'Failed to save Session API Key',
+  });
+
   const setGithubToken = registerSecretCommand('openhands.setGithubToken', {
     title: 'GitHub Token',
     secretKey: 'githubToken',
@@ -1288,6 +1297,7 @@ export function activate(context: vscode.ExtensionContext) {
     startNew,
     configure,
     setApiKey,
+    setSessionApiKey,
     setGithubToken,
     setCustomSecret1,
     setCustomSecret2,

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -26,8 +26,8 @@ export type OpenHandsSettings = ServerSettings & {
 const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
   servers: [],
-  llm: { usageId: 'default-llm', model: 'claude-sonnet-4-20250514' },
-  agent: { enableSecurityAnalyzer: false },
+  llm: { usageId: 'default-llm', provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
+  agent: { enableSecurityAnalyzer: false, debug: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'HIGH', confirmUnknown: true },
   secrets: {}
@@ -44,6 +44,20 @@ const sanitizePositiveInteger = (value: number | null | undefined): number | und
   return int > 0 ? int : undefined;
 };
 
+const normalizeLlmProvider = (value: unknown): LLMSettings['provider'] | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return undefined;
+  switch (trimmed) {
+    case 'openai':
+    case 'openrouter':
+    case 'litellm_proxy':
+    case 'anthropic':
+      return trimmed;
+    default:
+      return undefined;
+  }
+};
+
 export class SettingsManager {
   constructor(private adapter: SettingsAdapter) {}
 
@@ -53,6 +67,14 @@ export class SettingsManager {
     );
     const isRemote = !!serverUrl;
     const servers = this.adapter.get<SavedServer[]>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers;
+    const explicitBaseUrl = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.baseUrl'));
+    const explicitProvider = normalizeLlmProvider(this.adapter.getExplicit<string>('openhands.llm.provider'));
+    const provider = isRemote ? explicitProvider : explicitProvider ?? (explicitBaseUrl ? undefined : DEFAULTS.llm.provider);
+    const usageId = normalizeNonEmptyString(
+      isRemote
+        ? this.adapter.getExplicit<string>('openhands.llm.usageId')
+        : (this.adapter.get<string | null>('openhands.llm.usageId', DEFAULTS.llm.usageId) ?? DEFAULTS.llm.usageId)
+    );
     const model = normalizeNonEmptyString(
       isRemote
         ? this.adapter.getExplicit<string>('openhands.llm.model')
@@ -61,9 +83,14 @@ export class SettingsManager {
     const llm: LLMSettings = {
       // In remote mode, omit usageId/model unless explicitly configured.
       // In local mode, we must provide a model so the local Agent can create an LLM client.
-      usageId: normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.usageId')),
+      usageId,
+      provider,
       model,
-      baseUrl: this.adapter.get<string | null>('openhands.llm.baseUrl', DEFAULTS.llm.baseUrl) ?? DEFAULTS.llm.baseUrl,
+      baseUrl: normalizeNonEmptyString(
+        isRemote
+          ? this.adapter.getExplicit<string>('openhands.llm.baseUrl')
+          : (this.adapter.get<string | null>('openhands.llm.baseUrl', DEFAULTS.llm.baseUrl) ?? DEFAULTS.llm.baseUrl)
+      ),
       apiVersion: this.adapter.get<string | null>('openhands.llm.apiVersion', DEFAULTS.llm.apiVersion) ?? DEFAULTS.llm.apiVersion,
       timeout: this.adapter.get<number | null>('openhands.llm.timeout', DEFAULTS.llm.timeout) ?? DEFAULTS.llm.timeout,
       temperature: this.adapter.get<number | null>('openhands.llm.temperature', DEFAULTS.llm.temperature) ?? DEFAULTS.llm.temperature,
@@ -72,9 +99,12 @@ export class SettingsManager {
       maxInputTokens: sanitizePositiveInteger(this.adapter.get<number | null>('openhands.llm.maxInputTokens', null) ?? undefined),
       maxOutputTokens: sanitizePositiveInteger(this.adapter.get<number | null>('openhands.llm.maxOutputTokens', null) ?? undefined),
       reasoningEffort: this.adapter.get<'low' | 'medium' | 'high' | 'none' | null>('openhands.llm.reasoningEffort', DEFAULTS.llm.reasoningEffort) ?? DEFAULTS.llm.reasoningEffort,
+      inputCostPerToken: this.adapter.get<number | null>('openhands.llm.inputCostPerToken', DEFAULTS.llm.inputCostPerToken) ?? DEFAULTS.llm.inputCostPerToken,
+      outputCostPerToken: this.adapter.get<number | null>('openhands.llm.outputCostPerToken', DEFAULTS.llm.outputCostPerToken) ?? DEFAULTS.llm.outputCostPerToken,
     };
     const agent: AgentSettings = {
       enableSecurityAnalyzer: this.adapter.get<boolean>('openhands.agent.enableSecurityAnalyzer', DEFAULTS.agent.enableSecurityAnalyzer) ?? DEFAULTS.agent.enableSecurityAnalyzer,
+      debug: this.adapter.get<boolean>('openhands.agent.debug', DEFAULTS.agent.debug) ?? DEFAULTS.agent.debug,
     };
     const conversation: ConversationSettings = {
       maxIterations: this.adapter.get<number>('openhands.conversation.maxIterations', DEFAULTS.conversation.maxIterations) ?? DEFAULTS.conversation.maxIterations,
@@ -110,6 +140,7 @@ export class SettingsManager {
 
     if (partial.llm) {
       if (partial.llm.usageId !== undefined) ops.push(this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target));
+      if (partial.llm.provider !== undefined) ops.push(this.adapter.update('openhands.llm.provider', partial.llm.provider, target));
       if (partial.llm.model !== undefined) ops.push(this.adapter.update('openhands.llm.model', partial.llm.model, target));
       if (partial.llm.baseUrl !== undefined) ops.push(this.adapter.update('openhands.llm.baseUrl', partial.llm.baseUrl, target));
       if (partial.llm.apiVersion !== undefined) ops.push(this.adapter.update('openhands.llm.apiVersion', partial.llm.apiVersion, target));
@@ -120,11 +151,16 @@ export class SettingsManager {
       if (partial.llm.maxInputTokens !== undefined) ops.push(this.adapter.update('openhands.llm.maxInputTokens', partial.llm.maxInputTokens, target));
       if (partial.llm.maxOutputTokens !== undefined) ops.push(this.adapter.update('openhands.llm.maxOutputTokens', partial.llm.maxOutputTokens, target));
       if (partial.llm.reasoningEffort !== undefined) ops.push(this.adapter.update('openhands.llm.reasoningEffort', partial.llm.reasoningEffort, target));
+      if (partial.llm.inputCostPerToken !== undefined) ops.push(this.adapter.update('openhands.llm.inputCostPerToken', partial.llm.inputCostPerToken, target));
+      if (partial.llm.outputCostPerToken !== undefined) ops.push(this.adapter.update('openhands.llm.outputCostPerToken', partial.llm.outputCostPerToken, target));
     }
 
     if (partial.agent) {
       if (partial.agent.enableSecurityAnalyzer !== undefined) {
         ops.push(this.adapter.update('openhands.agent.enableSecurityAnalyzer', partial.agent.enableSecurityAnalyzer, target));
+      }
+      if (partial.agent.debug !== undefined) {
+        ops.push(this.adapter.update('openhands.agent.debug', partial.agent.debug, target));
       }
     }
 

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -29,7 +29,7 @@ const DEFAULTS: OpenHandsSettings = {
   llm: { usageId: 'default-llm', provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
   agent: { enableSecurityAnalyzer: false, debug: false },
   conversation: { maxIterations: 50 },
-  confirmation: { policy: 'never', riskyThreshold: 'HIGH', confirmUnknown: true },
+  confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
   secrets: {}
 };
 
@@ -47,6 +47,7 @@ const sanitizePositiveInteger = (value: number | null | undefined): number | und
 const normalizeLlmProvider = (value: unknown): LLMSettings['provider'] | undefined => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   if (!trimmed) return undefined;
+  if (trimmed === 'auto') return undefined;
   switch (trimmed) {
     case 'openai':
     case 'openrouter':

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -250,7 +250,7 @@ describe('SettingsManager', () => {
     expect(s.agent.debug).toBe(false);
     expect(s.conversation.maxIterations).toBe(50);
     expect(s.confirmation.policy).toBe('never');
-    expect(s.confirmation.riskyThreshold).toBe('HIGH');
+    expect(s.confirmation.riskyThreshold).toBe('MEDIUM');
     expect(s.confirmation.confirmUnknown).toBe(true);
   });
 

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -26,10 +26,12 @@ describe('SettingsManager', () => {
   it('returns defaults when unset', async () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBeUndefined();
-    expect(s.llm.usageId).toBeUndefined();
+    expect(s.llm.usageId).toBe('default-llm');
+    expect(s.llm.provider).toBe('anthropic');
     // Local mode requires a default model for the local Agent to run.
     expect(s.llm.model).toBe('claude-sonnet-4-20250514');
     expect(s.agent.enableSecurityAnalyzer).toBe(false);
+    expect(s.agent.debug).toBe(false);
   });
 
   it('omits model by default in remote mode', async () => {
@@ -42,8 +44,15 @@ describe('SettingsManager', () => {
   it('updates and persists config and secrets', async () => {
     await mgr.update({
       serverUrl: 'http://example:1234',
-      llm: { usageId: 'my-usage', model: 'foo', baseUrl: 'https://api.example.com' },
-      agent: { enableSecurityAnalyzer: true },
+      llm: {
+        usageId: 'my-usage',
+        provider: 'openrouter',
+        model: 'foo',
+        baseUrl: 'https://api.example.com',
+        inputCostPerToken: 0.000001,
+        outputCostPerToken: 0.000002,
+      },
+      agent: { enableSecurityAnalyzer: true, debug: true },
       conversation: { maxIterations: 42 },
       confirmation: { policy: 'risky', riskyThreshold: 'MEDIUM', confirmUnknown: false },
       secrets: { sessionApiKey: 'sess', llmApiKey: 'key' }
@@ -51,9 +60,13 @@ describe('SettingsManager', () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
     expect(s.llm.usageId).toBe('my-usage');
+    expect(s.llm.provider).toBe('openrouter');
     expect(s.llm.model).toBe('foo');
     expect(s.llm.baseUrl).toBe('https://api.example.com');
+    expect(s.llm.inputCostPerToken).toBe(0.000001);
+    expect(s.llm.outputCostPerToken).toBe(0.000002);
     expect(s.agent.enableSecurityAnalyzer).toBe(true);
+    expect(s.agent.debug).toBe(true);
     expect(s.conversation.maxIterations).toBe(42);
     expect(s.confirmation.policy).toBe('risky');
     expect(s.confirmation.riskyThreshold).toBe('MEDIUM');
@@ -167,7 +180,9 @@ describe('SettingsManager', () => {
         topK: 50,
         maxInputTokens: 4096,
         maxOutputTokens: 2048,
-        reasoningEffort: 'high'
+        reasoningEffort: 'high',
+        inputCostPerToken: 0.000001,
+        outputCostPerToken: 0.000002,
       }
     });
 
@@ -180,6 +195,8 @@ describe('SettingsManager', () => {
     expect(s.llm.maxInputTokens).toBe(4096);
     expect(s.llm.maxOutputTokens).toBe(2048);
     expect(s.llm.reasoningEffort).toBe('high');
+    expect(s.llm.inputCostPerToken).toBe(0.000001);
+    expect(s.llm.outputCostPerToken).toBe(0.000002);
   });
 
   it('handles sanitizePositiveInteger with invalid inputs', async () => {
@@ -215,6 +232,7 @@ describe('SettingsManager', () => {
     const nullKeys = new Set([
       'openhands.serverUrl',
       'openhands.agent.enableSecurityAnalyzer',
+      'openhands.agent.debug',
       'openhands.conversation.maxIterations',
       'openhands.confirmation.policy',
       'openhands.confirmation.risky.threshold',
@@ -229,6 +247,7 @@ describe('SettingsManager', () => {
 
     expect(s.serverUrl).toBeUndefined();
     expect(s.agent.enableSecurityAnalyzer).toBe(false);
+    expect(s.agent.debug).toBe(false);
     expect(s.conversation.maxIterations).toBe(50);
     expect(s.confirmation.policy).toBe('never');
     expect(s.confirmation.riskyThreshold).toBe('HIGH');


### PR DESCRIPTION
Updates VS Code settings to better match SDK + python agent-server expectations:\n\n- Adds Session API Key command + settings UI entry (stored in SecretStorage)\n- Adds LLM provider + cost-per-token settings, and agent debug toggle\n- SDK: threads llm.provider through settings -> LLMFactory; detectProviderFromBaseUrl recognizes anthropic\n\nChecks: npm test, npm run build -w @openhands/agent-sdk-ts, npm run typecheck, npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session API Key command and secure storage for session credentials.
  * Expanded LLM settings: provider selection, base URL, API version, API key, timeout, usage ID, and reasoning effort.
  * Cost tracking: input/output cost-per-token fields.
  * Agent debug mode and enhanced secret entries for GitHub/custom tokens.

* **Tests**
  * Updated tests to cover new LLM fields, cost tracking, usage ID defaults, and agent debug behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->