### PR TITLE
oh-tab-3r5: log terminal progress overflow

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -706,6 +706,53 @@ describe('Settings and modes', () => {
     expect(joined).not.toContain('\u001b[K');
   });
 
+  it('warns once and flushes when the progress coalescing buffer overflows', async () => {
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await resolveChatView(mockContext);
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const writes: string[] = [];
+    let ptyInstance: any;
+    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
+      const pty = options?.pty;
+      ptyInstance = pty;
+      if (pty?.onDidWrite) {
+        pty.onDidWrite((chunk: string) => writes.push(chunk));
+      }
+      return { show: vi.fn(), dispose: vi.fn() } as any;
+    });
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    conv?.emit('terminal', {
+      id: 'bash-progress-overflow-1',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:00.000Z',
+      command_id: 'tc-progress-overflow-1',
+      order: 0,
+      command: 'progress_overflow',
+    });
+
+    expect(ptyInstance).toBeTruthy();
+
+    const huge = 'a'.repeat(200_001);
+    ptyInstance.write(huge);
+    ptyInstance.write('\n');
+    ptyInstance.write('b'.repeat(200_001));
+    ptyInstance.write('\n');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Terminal progress renderer overflowed')
+    );
+
+    warn.mockRestore();
+    expect(writes.join('')).toContain('$ progress_overflow\r\n');
+  });
+
   it('coalesces ANSI-colored progress output (including split CSI sequences)', async () => {
     mockSettings.serverUrl = undefined as any;
     extension = await import('../extension');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -359,6 +359,7 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   private readonly renderProgress: boolean;
   private progressCarry = '';
   private progressLine = '';
+  private warnedProgressOverflow = false;
 
   readonly onDidWrite = this.writeEmitter.event;
   readonly onDidClose = this.closeEmitter.event;
@@ -509,6 +510,13 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
 
     const { prefix, carry } = this.splitTrailingIncompleteCsi(combined);
     this.progressCarry = carry;
+    if (this.progressCarry.length > OpenHandsTerminalLogPseudoterminal.MAX_PENDING_LINE_CHARS) {
+      if (!this.warnedProgressOverflow) {
+        this.warnedProgressOverflow = true;
+        console.warn('[OpenHands] Terminal progress renderer overflowed (carry); flushing to avoid memory growth.');
+      }
+      this.progressCarry = '';
+    }
 
     const parts = prefix.split('\n');
     for (let i = 0; i < parts.length; i++) {
@@ -533,6 +541,10 @@ class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
       const overflow = this.sanitizeProgressLine(this.progressLine);
       this.progressLine = '';
       this.progressCarry = '';
+      if (!this.warnedProgressOverflow) {
+        this.warnedProgressOverflow = true;
+        console.warn('[OpenHands] Terminal progress renderer overflowed; flushing to avoid memory growth.');
+      }
       this.writeRaw(`${overflow}\n`);
     }
   }


### PR DESCRIPTION
Adds a one-time warning + flush guard when CR progress coalescing buffers overflow, to avoid memory growth/jank. Includes a regression test exercising overflow behavior.\n\nChecks: npm test, npm run typecheck, npm run lint