### PR TITLE
oh-tab-sjj: prompt for outside-workspace file access

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -119,6 +119,44 @@ describe('Agent loop control', () => {
     fs.rmSync(externalDir, { recursive: true, force: true });
   });
 
+  it('allows creating an external file after approval', async () => {
+    const log = new EventLog();
+    const workspaceRoot = createWorkspaceRoot();
+    const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-external-create-'));
+    const outsidePath = path.join(externalDir, 'new.txt');
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Creating file' },
+      {
+        type: 'tool_call_delta',
+        id: 'call_create',
+        name: 'file_editor',
+        arguments: JSON.stringify({ command: 'create', path: outsidePath, file_text: 'hello' }),
+      },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot,
+      llmClient: llm,
+      tools: [new FileEditorTool()],
+    });
+
+    await agent.run('create a file');
+    const eventsAfterRun = log.list();
+    expect(eventsAfterRun.some(isActionEvent)).toBe(true);
+    expect(eventsAfterRun.some(isPauseEvent)).toBe(true);
+    expect(eventsAfterRun.some(isObservationEvent)).toBe(false);
+
+    await agent.approveAction();
+    expect(fs.existsSync(outsidePath)).toBe(true);
+    expect(fs.readFileSync(outsidePath, 'utf8')).toBe('hello');
+
+    fs.rmSync(externalDir, { recursive: true, force: true });
+  });
+
   it('records agent error when tool arguments are not objects', async () => {
     const log = new EventLog();
     const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -7,6 +7,7 @@ import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
 import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
 import type { ToolDefinition } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
+import { FileEditorTool } from '../../tools';
 
 class MockLLM implements LLMClient {
   constructor(private readonly chunks: LLMStreamChunk[]) {}
@@ -80,6 +81,42 @@ describe('Agent loop control', () => {
     expect(eventsAfterApproval.some(isObservationEvent)).toBe(true);
     const toolMessages = eventsAfterApproval.filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'tool');
     expect(toolMessages.length).toBe(1);
+  });
+
+  it('prompts for confirmation before accessing files outside the workspace', async () => {
+    const log = new EventLog();
+    const workspaceRoot = createWorkspaceRoot();
+    const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-external-'));
+    const outsidePath = path.join(externalDir, 'outside.txt');
+    fs.writeFileSync(outsidePath, 'hello', 'utf8');
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Viewing file' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'file_editor', arguments: JSON.stringify({ command: 'view', path: outsidePath }) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot,
+      llmClient: llm,
+      tools: [new FileEditorTool()],
+    });
+
+    await agent.run('view a file');
+    const eventsAfterRun = log.list();
+    expect(eventsAfterRun.some(isActionEvent)).toBe(true);
+    expect(eventsAfterRun.some(isPauseEvent)).toBe(true);
+    expect(eventsAfterRun.some(isObservationEvent)).toBe(false);
+
+    await agent.approveAction();
+    const eventsAfterApproval = log.list();
+    const obs = eventsAfterApproval.filter(isObservationEvent).find((e) => e.tool_name === 'file_editor' && e.tool_call_id === 'call_1');
+    expect(obs).toBeTruthy();
+    expect(JSON.stringify(obs?.observation ?? {})).toContain('hello');
+
+    fs.rmSync(externalDir, { recursive: true, force: true });
   });
 
   it('records agent error when tool arguments are not objects', async () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -20,6 +20,21 @@ class MockLLM implements LLMClient {
   }
 }
 
+class SequencedLLM implements LLMClient {
+  private idx = 0;
+
+  constructor(private readonly sequences: LLMStreamChunk[][]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    const seq = this.sequences[this.idx] ?? [];
+    this.idx += 1;
+    for (const chunk of seq) {
+      yield chunk;
+    }
+  }
+}
+
 const baseSettings: OpenHandsSettings = {
   llm: { model: 'test-model' },
   agent: {},
@@ -153,6 +168,54 @@ describe('Agent loop control', () => {
     await agent.approveAction();
     expect(fs.existsSync(outsidePath)).toBe(true);
     expect(fs.readFileSync(outsidePath, 'utf8')).toBe('hello');
+
+    fs.rmSync(externalDir, { recursive: true, force: true });
+  });
+
+  it('does not grant directory access when creating an external file', async () => {
+    const log = new EventLog();
+    const externalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-external-create-siblings-'));
+    const outsidePath = path.join(externalDir, 'new.txt');
+    const siblingPath = path.join(externalDir, 'sibling.txt');
+    fs.writeFileSync(siblingPath, 'sibling', 'utf8');
+
+    const llm = new SequencedLLM([
+      [
+        { type: 'text', text: 'Creating file' },
+        {
+          type: 'tool_call_delta',
+          id: 'call_create',
+          name: 'file_editor',
+          arguments: JSON.stringify({ command: 'create', path: outsidePath, file_text: 'hello' }),
+        },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'Viewing sibling' },
+        { type: 'tool_call_delta', id: 'call_view', name: 'file_editor', arguments: JSON.stringify({ command: 'view', path: siblingPath }) },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, conversation: { maxIterations: 2 } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [new FileEditorTool()],
+    });
+
+    await agent.run('create then view');
+    expect(log.list().filter(isPauseEvent).length).toBe(1);
+
+    await agent.approveAction();
+    expect(fs.existsSync(outsidePath)).toBe(true);
+
+    const pauses = log.list().filter(isPauseEvent);
+    expect(pauses.length).toBe(2);
+
+    const siblingObs = log.list().filter(isObservationEvent).find((e) => e.tool_call_id === 'call_view');
+    expect(siblingObs).toBeUndefined();
 
     fs.rmSync(externalDir, { recursive: true, force: true });
   });

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -647,10 +647,6 @@ export class Agent extends EventEmitter {
     const p = toOptionalNonEmptyString(args.path);
     if (!p || !path.isAbsolute(p)) return undefined;
     if (this.workspace.isPathAllowed(p)) return undefined;
-    const command = toOptionalNonEmptyString(args.command);
-    if (command === 'create') {
-      return { paths: [path.dirname(p), p] };
-    }
     return { paths: [p] };
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -647,6 +647,10 @@ export class Agent extends EventEmitter {
     const p = toOptionalNonEmptyString(args.path);
     if (!p || !path.isAbsolute(p)) return undefined;
     if (this.workspace.isPathAllowed(p)) return undefined;
+    const command = toOptionalNonEmptyString(args.command);
+    if (command === 'create') {
+      return { paths: [path.dirname(p), p] };
+    }
     return { paths: [p] };
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import { randomUUID } from 'crypto';
+import path from 'path';
 import { AgentOrchestrator } from './AgentOrchestrator';
 import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
@@ -157,6 +158,7 @@ export class Agent extends EventEmitter {
   private paused = false;
   private cancelled = false;
   private pendingAction?: { toolCall: ToolCall; actionEvent: ActionEvent; args: Record<string, unknown> };
+  private pendingWorkspaceAccess?: { paths: string[] };
   private readonly agentContext?: AgentContext;
   private readonly activatedSkillNames: string[] = [];
   private readonly registry?: import('../llm').LLMRegistry;
@@ -237,6 +239,7 @@ export class Agent extends EventEmitter {
   cancel(): void {
     this.cancelled = true;
     this.pendingAction = undefined;
+    this.pendingWorkspaceAccess = undefined;
     this.state.setStatus('CANCELLED');
   }
 
@@ -244,7 +247,14 @@ export class Agent extends EventEmitter {
     if (!this.pendingAction) return;
     await this.lock.acquire(async () => {
       const pending = this.pendingAction!;
+      const pendingWorkspaceAccess = this.pendingWorkspaceAccess;
       this.pendingAction = undefined;
+      this.pendingWorkspaceAccess = undefined;
+      if (pendingWorkspaceAccess) {
+        for (const p of pendingWorkspaceAccess.paths) {
+          this.workspace.allowPath(p);
+        }
+      }
       this.state.setStatus('RUNNING');
       await this.executeTool(pending.toolCall, pending.actionEvent, pending.args);
       await this.runLoop();
@@ -255,6 +265,7 @@ export class Agent extends EventEmitter {
     if (!this.pendingAction) return;
     const { actionEvent, toolCall } = this.pendingAction;
     this.pendingAction = undefined;
+    this.pendingWorkspaceAccess = undefined;
     this.events.push({
       kind: 'UserRejectObservation',
       source: 'environment',
@@ -369,6 +380,15 @@ export class Agent extends EventEmitter {
 
         const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
         const recordedAction = this.events.push(actionEvent) as ActionEvent;
+
+        const workspaceAccess = this.getRequiredWorkspaceAccess(toolCall.function.name, args ?? {});
+        if (workspaceAccess) {
+          this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };
+          this.pendingWorkspaceAccess = workspaceAccess;
+          this.state.setStatus('WAITING_FOR_CONFIRMATION');
+          this.events.push({ kind: 'PauseEvent', source: 'user' } as Event);
+          return lastAssistantMessage;
+        }
 
         if (this.requiresConfirmation(recordedAction)) {
           this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };
@@ -617,6 +637,17 @@ export class Agent extends EventEmitter {
     if (!risk) return this.confirmation.confirmUnknown ?? true;
     const threshold = this.confirmation.riskyThreshold ?? 'MEDIUM';
     return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(threshold);
+  }
+
+  private getRequiredWorkspaceAccess(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): { paths: string[] } | undefined {
+    if (toolName !== 'file_editor') return undefined;
+    const p = toOptionalNonEmptyString(args.path);
+    if (!p || !path.isAbsolute(p)) return undefined;
+    if (this.workspace.isPathAllowed(p)) return undefined;
+    return { paths: [p] };
   }
 
   private createActionEvent(

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import path from 'path';
 import { z } from 'zod';
 import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
@@ -147,7 +146,6 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         if (exists) {
           throw new Error('create failed: file already exists');
         }
-        await context.workspace.ensureDirectory(path.dirname(resolved));
         await ws.writeFile(args.path, args.file_text ?? '');
         return { command: 'create', path: resolved, prev_exist: false, old_content: null, new_content: args.file_text ?? '' };
       }

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -40,34 +40,65 @@ export interface DirectoryEntry {
   isDirectory: boolean;
 }
 
+type AllowedRootKind = 'dir' | 'file';
+
 export class LocalWorkspace {
   readonly root: string;
+  private readonly allowedRoots = new Map<string, AllowedRootKind>();
 
   constructor(root?: string) {
     const detectedRoot = root ?? LocalWorkspace.getDefaultRoot();
     this.root = fs.realpathSync(detectedRoot);
+    this.allowedRoots.set(this.root, 'dir');
+    for (const extraRoot of LocalWorkspace.getVsCodeWorkspaceRoots()) {
+      try {
+        this.allowedRoots.set(fs.realpathSync(extraRoot), 'dir');
+      } catch {
+        // Ignore invalid workspace roots.
+      }
+    }
   }
 
   static getDefaultRoot(): string {
-    const vscodeRoot = LocalWorkspace.getVsCodeWorkspaceRoot();
-    if (vscodeRoot) {
-      return vscodeRoot;
-    }
+    const vscodeRoots = LocalWorkspace.getVsCodeWorkspaceRoots();
+    if (vscodeRoots.length > 0) return vscodeRoots[0];
     return process.cwd();
   }
 
-  private static getVsCodeWorkspaceRoot(): string | null {
+  private static getVsCodeWorkspaceRoots(): string[] {
     try {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const vscode = require('vscode') as typeof import('vscode');
-      const folder = vscode.workspace?.workspaceFolders?.[0];
-      if (folder?.uri?.scheme === 'file') {
-        return folder.uri.fsPath;
-      }
+      const folders = vscode.workspace?.workspaceFolders ?? [];
+      return folders
+        .map((folder) => (folder.uri?.scheme === 'file' ? folder.uri.fsPath : undefined))
+        .filter((folder): folder is string => typeof folder === 'string' && folder.length > 0);
     } catch {
-      return null;
+      return [];
     }
-    return null;
+  }
+
+  allowPath(targetPath: string): void {
+    const candidate = path.resolve(targetPath);
+    const normalized = fs.existsSync(candidate) ? fs.realpathSync(candidate) : candidate;
+    const kind: AllowedRootKind = (() => {
+      try {
+        const stat = fs.statSync(normalized);
+        return stat.isDirectory() ? 'dir' : 'file';
+      } catch {
+        return 'file';
+      }
+    })();
+    this.allowedRoots.set(normalized, kind);
+  }
+
+  isPathAllowed(targetPath: string): boolean {
+    try {
+      void this.resolvePath(targetPath);
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   resolvePath(targetPath: string): string {
@@ -75,9 +106,15 @@ export class LocalWorkspace {
       ? path.resolve(targetPath)
       : path.resolve(this.root, targetPath);
     const normalized = fs.existsSync(candidate) ? fs.realpathSync(candidate) : candidate;
-    const relative = path.relative(this.root, normalized);
-    if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
-      return normalized;
+    for (const [root, kind] of this.allowedRoots.entries()) {
+      if (kind === 'file') {
+        if (normalized === root) return normalized;
+        continue;
+      }
+      const relative = path.relative(root, normalized);
+      if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+        return normalized;
+      }
     }
     throw new Error(`Path escapes workspace root: ${targetPath}`);
   }

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -78,9 +78,23 @@ export class LocalWorkspace {
     }
   }
 
+  private normalizeExistingOrParent(candidate: string): string {
+    if (fs.existsSync(candidate)) return fs.realpathSync(candidate);
+    try {
+      const parent = path.dirname(candidate);
+      if (fs.existsSync(parent)) {
+        const realParent = fs.realpathSync(parent);
+        return path.join(realParent, path.basename(candidate));
+      }
+    } catch {
+      // Best-effort normalization only.
+    }
+    return candidate;
+  }
+
   allowPath(targetPath: string): void {
     const candidate = path.resolve(targetPath);
-    const normalized = fs.existsSync(candidate) ? fs.realpathSync(candidate) : candidate;
+    const normalized = this.normalizeExistingOrParent(candidate);
     const kind: AllowedRootKind = (() => {
       try {
         const stat = fs.statSync(normalized);
@@ -105,7 +119,7 @@ export class LocalWorkspace {
     const candidate = path.isAbsolute(targetPath)
       ? path.resolve(targetPath)
       : path.resolve(this.root, targetPath);
-    const normalized = fs.existsSync(candidate) ? fs.realpathSync(candidate) : candidate;
+    const normalized = this.normalizeExistingOrParent(candidate);
     for (const [root, kind] of this.allowedRoots.entries()) {
       if (kind === 'file') {
         if (normalized === root) return normalized;

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -30,6 +30,21 @@ describe('LocalWorkspace', () => {
       const { workspace } = await makeWorkspace((dir) => created.push(dir));
       expect(() => workspace.resolvePath('../etc/passwd')).toThrowError();
     });
+
+    it('allows explicitly-approved external paths', async () => {
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-'));
+      created.push(externalDir);
+      const externalFile = path.join(externalDir, 'outside.txt');
+      await fs.promises.writeFile(externalFile, 'hello', 'utf8');
+
+      expect(() => workspace.resolvePath(externalFile)).toThrowError();
+
+      workspace.allowPath(externalFile);
+      const realExternalFile = await fs.promises.realpath(externalFile);
+      expect(workspace.resolvePath(externalFile)).toBe(realExternalFile);
+      expect(() => workspace.resolvePath(path.join(externalFile, 'child'))).toThrowError();
+    });
   });
 
   describe('commands', () => {

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -64,6 +64,27 @@ describe('App - Confirmation Flow', () => {
     expect(scope.getByText(/Reasoning/)).toBeInTheDocument();
   });
 
+  it('renders file access summary and opens the requested path', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+
+    const requestedPath = '/tmp/outside.txt';
+    postToWindow({
+      type: 'event',
+      event: mkAction({
+        tool_name: 'file_editor',
+        action: { command: 'view', path: requestedPath },
+        security_risk: undefined,
+      }),
+    });
+
+    expect(await screen.findByText(/File Access/i)).toBeInTheDocument();
+    expect(screen.getByText('READ')).toBeInTheDocument();
+    const pathButton = screen.getByRole('button', { name: requestedPath });
+    await userEvent.click(pathButton);
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'openWorkspaceFile', path: requestedPath });
+  });
+
   it('hides prompt when no actions are pending', async () => {
     await renderAppAndWaitReady();
     setWaitingForConfirmation();

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -630,6 +630,10 @@ export function App() {
     postMessage({ type: 'openAttachment', uri });
   }, [postMessage]);
 
+  const handleOpenPath = useCallback((p: string) => {
+    postMessage({ type: 'openWorkspaceFile', path: p });
+  }, [postMessage]);
+
   const handleRemoveAttachment = useCallback((uri: string) => {
     setAttachments((prev) => prev.filter((a) => a.uri !== uri));
   }, []);
@@ -768,6 +772,7 @@ export function App() {
           pendingActions={pendingActions}
           onApprove={handleApprove}
           onReject={handleReject}
+          onOpenPath={handleOpenPath}
           isSubmitting={isSubmitting}
         />
       )}

--- a/src/webview-src/components/ConfirmationPrompt.tsx
+++ b/src/webview-src/components/ConfirmationPrompt.tsx
@@ -5,6 +5,7 @@ interface ConfirmationPromptProps {
   pendingActions: ActionEvent[];
   onApprove: () => void;
   onReject: (reason?: string) => void;
+  onOpenPath?: (path: string) => void;
   isSubmitting?: boolean;
 }
 
@@ -12,6 +13,7 @@ export function ConfirmationPrompt({
   pendingActions,
   onApprove,
   onReject,
+  onOpenPath,
   isSubmitting = false,
 }: ConfirmationPromptProps) {
   const [showRejectInput, setShowRejectInput] = useState(false);
@@ -37,6 +39,16 @@ export function ConfirmationPrompt({
   };
 
   if (pendingActions.length === 0) return null;
+
+  const getFileAccessSummary = (action: ActionEvent): { operation: 'read' | 'write'; path: string } | undefined => {
+    if (action.tool_name !== 'file_editor') return undefined;
+    const record = action.action;
+    const command = typeof record?.command === 'string' ? record.command : undefined;
+    const p = typeof record?.path === 'string' ? record.path : undefined;
+    if (!command || !p) return undefined;
+    const operation: 'read' | 'write' = command === 'view' ? 'read' : 'write';
+    return { operation, path: p };
+  };
 
   return (
     <div
@@ -76,6 +88,7 @@ export function ConfirmationPrompt({
             {pendingActions.map((action, index) => {
               const thought = action.thought.map((t) => t.text).join('\n');
               const hasHighRisk = action.security_risk === 'HIGH';
+              const fileAccess = getFileAccessSummary(action);
 
               return (
                 <div
@@ -119,6 +132,35 @@ export function ConfirmationPrompt({
                         Reasoning
                       </div>
                       <div className="italic text-stone-300">{thought}</div>
+                    </div>
+                  )}
+
+                  {/* File access summary */}
+                  {fileAccess && (
+                    <div className="mb-3 text-sm leading-relaxed">
+                      <div className="font-medium text-xs uppercase tracking-wider text-stone-500 mb-1.5">
+                        File Access
+                      </div>
+                      <div className="flex items-start gap-2">
+                        <span
+                          className={`
+                            inline-flex items-center px-2 py-0.5 rounded-md text-[11px] font-medium border
+                            ${fileAccess.operation === 'write'
+                              ? 'bg-amber-500/15 text-amber-300 border-amber-400/30'
+                              : 'bg-teal-500/15 text-teal-300 border-teal-400/30'
+                            }
+                          `}
+                        >
+                          {fileAccess.operation.toUpperCase()}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => onOpenPath?.(fileAccess.path)}
+                          className="text-xs font-mono text-stone-300 break-all underline decoration-stone-500/50 hover:text-stone-200 hover:decoration-stone-400 transition-colors text-left"
+                        >
+                          {fileAccess.path}
+                        </button>
+                      </div>
                     </div>
                   )}
 


### PR DESCRIPTION
- LocalWorkspace: support extra allowed roots + explicit allowPath()
- Agent: pause for confirmation when file_editor targets absolute path outside workspace folders; approve adds allowPath and retries
- Webview: show File Access summary (READ/WRITE + clickable path) in confirmation modal
- Tests: SDK workspace + agent loop; webview confirmation

Checks: npm test, npm run typecheck, npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace access protection: tools requesting files outside the workspace now pause and require user confirmation; approved paths are granted temporary access.
  * Per-file allowance and multi-root workspace support: explicit path approvals can permit individual external files and handle multiple workspace roots.
  * Confirmation dialogs show file access (read/write) and let you click to open the requested file.

* **Tests**
  * Added tests covering access confirmation, approving external files, and the UI confirmation/open-file flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->