### PR TITLE
oh-tab-o6t: remote agent-server E2E smoke

### DIFF
--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -76,14 +76,14 @@ export class SettingsManager {
         ? this.adapter.getExplicit<string>('openhands.llm.usageId')
         : (this.adapter.get<string | null>('openhands.llm.usageId', DEFAULTS.llm.usageId) ?? DEFAULTS.llm.usageId)
     );
-    const model = normalizeNonEmptyString(
-      isRemote
-        ? this.adapter.getExplicit<string>('openhands.llm.model')
-        : (this.adapter.get<string | null>('openhands.llm.model', DEFAULTS.llm.model) ?? DEFAULTS.llm.model)
+    const explicitModel = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.model'));
+    // Always provide a model name, even in remote mode: the python agent-server requires it in StartConversationRequest.
+    const model = explicitModel ?? normalizeNonEmptyString(
+      this.adapter.get<string | null>('openhands.llm.model', DEFAULTS.llm.model) ?? DEFAULTS.llm.model
     );
     const llm: LLMSettings = {
-      // In remote mode, omit usageId/model unless explicitly configured.
-      // In local mode, we must provide a model so the local Agent can create an LLM client.
+      // In remote mode, omit usageId unless explicitly configured.
+      // Always provide a model so LocalConversation and RemoteConversation can start reliably.
       usageId,
       provider,
       model,

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -34,11 +34,11 @@ describe('SettingsManager', () => {
     expect(s.agent.debug).toBe(false);
   });
 
-  it('omits model by default in remote mode', async () => {
+  it('includes a default model in remote mode', async () => {
     await mgr.update({ serverUrl: 'http://example:1234' });
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
-    expect(s.llm.model).toBeUndefined();
+    expect(s.llm.model).toBe('claude-sonnet-4-20250514');
   });
 
   it('updates and persists config and secrets', async () => {

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -35,10 +35,11 @@ describe('SettingsManager', () => {
   });
 
   it('includes a default model in remote mode', async () => {
+    const defaults = await mgr.get();
     await mgr.update({ serverUrl: 'http://example:1234' });
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
-    expect(s.llm.model).toBe('claude-sonnet-4-20250514');
+    expect(s.llm.model).toBe(defaults.llm.model);
   });
 
   it('updates and persists config and secrets', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -453,6 +453,14 @@ export function App() {
             case 'openAttachments':
               postMessage({ type: 'selectAttachments' });
               break;
+            case 'sendMessage': {
+              const text = (rawPayload as { text?: unknown } | undefined)?.text;
+              if (typeof text !== 'string') break;
+              const normalized = text.trim();
+              if (!normalized) break;
+              postMessage({ type: 'send', text: normalized, contextFiles: [], attachments: [] });
+              break;
+            }
           }
           break;
         }

--- a/tests/e2e/AGENT_SERVER_QUICKSTART.md
+++ b/tests/e2e/AGENT_SERVER_QUICKSTART.md
@@ -6,20 +6,20 @@ Option A: agent-sdk local (recommended for developers)
 - Prereqs: Python 3.12+, [uv](https://github.com/astral-sh/uv)
 - Steps:
   1) `git clone https://github.com/OpenHands/software-agent-sdk.git ~/repos/agent-sdk`
-  2) `cd ~/repos/agent-sdk && make build`
-  3) Start server:
-     - `AGENT_SDK_DIR=~/repos/agent-sdk npm run agent-server`
-     - Or manually: `uv run python -m openhands.agent_server --host 0.0.0.0 --port 3000`
+  2) `cd ~/repos/agent-sdk && make build` (optional; `uv run` will usually work without it)
+  3) Start server from this repo:
+     - `AGENT_SDK_DIR=~/repos/agent-sdk PORT=3000 ./scripts/start-agent-server.sh`
+     - Or manually (from `~/repos/agent-sdk`): `uv run python -m openhands.agent_server --host 127.0.0.1 --port 3000`
   4) In VS Code (Extension Dev Host), set openhands.serverUrl to <http://localhost:3000>
 
 Option B: remote server
 - If you have a remote agent-server URL, set openhands.serverUrl accordingly.
-- If it requires a session API key, set SESSION_API_KEY in the VS Code launch env or shell.
+- If it requires a session API key, set it via `OpenHands: Set Session API Key`.
 
 Session API Key (optional)
-- HTTP: the extension adds X-Session-API-Key when SESSION_API_KEY is present
-- WebSocket: the extension appends ?session_api_key=... to the WS URL
+- HTTP: the extension adds `X-Session-API-Key` when `openhands.secrets.sessionApiKey` is set
+- WebSocket: the extension appends `?session_api_key=...` to the WS URL when `openhands.secrets.sessionApiKey` is set
 
 Notes
 - The extension sends a Start Conversation payload containing LLM and tool configuration for PoC. Ensure your server accepts that.
-- For CI smoke in this repo, we do NOT start a server; tests run with E2E_WITH_SERVER=0.
+- Live agent-server E2E tests are gated behind `E2E_AGENT_SERVER=1` and will skip otherwise.

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,7 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **serverSelection.test.ts**: Tests server selection and local/remote mode switching
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels
 - **errorHandling.test.ts**: Tests error events and error state handling
+- **agentServerRemote.test.ts**: (Optional) Starts a local python agent-server and tests remote mode end-to-end (gated by `E2E_AGENT_SERVER=1`)
 
 ### Suite Files (suite/*.ts)
 These run inside VS Code and execute the actual tests:
@@ -36,6 +37,17 @@ These run inside VS Code and execute the actual tests:
 
 ```bash
 npm run e2e
+```
+
+### Remote agent-server E2E (optional)
+
+Requires:
+- `uv` installed
+- a local agent-sdk checkout (default `~/repos/agent-sdk`)
+
+Run:
+```bash
+E2E_AGENT_SERVER=1 npm run e2e
 ```
 
 ## Local Conversation Storage

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -1,0 +1,158 @@
+import * as assert from 'assert';
+import { spawn, spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import { runTests } from '@vscode/test-electron';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+function getDefaultAgentSdkDir(): string {
+  return path.join(os.homedir(), 'repos', 'agent-sdk');
+}
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close(() => reject(new Error('Failed to allocate free port')));
+        return;
+      }
+      const { port } = addr;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+async function waitForHealth(url: string, timeoutMs: number = 30000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url, { method: 'GET' });
+      if (res.ok) return;
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Timed out waiting for agent-server health at ${url}: ${String(lastError)}`);
+}
+
+function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
+  return new Promise((resolve) => {
+    const pid = proc.pid;
+    if (!pid) return resolve();
+
+    const killSignal = 'SIGTERM' as const;
+    try {
+      if (process.platform !== 'win32') {
+        process.kill(-pid, killSignal);
+      } else {
+        proc.kill(killSignal);
+      }
+    } catch {
+      // ignore
+    }
+
+    const timeout = setTimeout(() => {
+      try {
+        if (process.platform !== 'win32') process.kill(-pid, 'SIGKILL');
+        else proc.kill('SIGKILL');
+      } catch {
+        // ignore
+      }
+      resolve();
+    }, 5000);
+
+    proc.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+describe('OpenHands-Tab Remote Agent-Server E2E', function () {
+  this.timeout(180000);
+
+  it('connects to a live python agent-server and streams events', async function () {
+    if (process.env.E2E_AGENT_SERVER !== '1') {
+      this.skip();
+    }
+
+    const agentSdkDir = process.env.AGENT_SDK_DIR || process.env.OPENHANDS_AGENT_SDK_DIR || getDefaultAgentSdkDir();
+    if (!agentSdkDir) {
+      this.skip();
+    }
+    if (!fs.existsSync(agentSdkDir)) {
+      this.skip();
+    }
+    const uvCheck = spawnSync('uv', ['--version'], { stdio: 'ignore' });
+    if (uvCheck.error || uvCheck.status !== 0) {
+      this.skip();
+    }
+
+    const port = await getFreePort();
+    const serverUrl = `http://127.0.0.1:${port}`;
+
+    const output: string[] = [];
+    const child = spawn(
+      'uv',
+      ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
+      {
+        cwd: agentSdkDir,
+        env: { ...process.env, PYTHONUNBUFFERED: '1', SESSION_API_KEY: '' },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: process.platform !== 'win32',
+      }
+    );
+
+    const append = (buf: Buffer) => {
+      output.push(buf.toString('utf8'));
+      // Keep a small tail for failure debugging
+      if (output.join('').length > 20000) {
+        output.splice(0, Math.max(0, output.length - 20));
+      }
+    };
+    child.stdout?.on('data', append);
+    child.stderr?.on('data', append);
+
+    try {
+      await waitForHealth(`${serverUrl}/health`, 45000);
+
+      const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+      const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+      const extensionTestsPath = path.resolve(__dirname, './suite');
+      const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-server-${Date.now()}`);
+
+      await runTests({
+        vscodeExecutablePath,
+        extensionDevelopmentPath,
+        extensionTestsPath,
+        launchArgs: [
+          '--no-sandbox',
+          '--user-data-dir', userDataDir,
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--disable-software-rasterizer',
+          extensionDevelopmentPath
+        ],
+        extensionTestsEnv: {
+          TEST_NAME: 'agentServerRemote',
+          AGENT_SERVER_URL: serverUrl,
+        }
+      });
+
+      assert.ok(true);
+    } catch (err) {
+      console.error('agent-server output (tail):\n', output.join(''));
+      throw err;
+    } finally {
+      await killProcessTree(child);
+    }
+  });
+});

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -105,7 +105,15 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
       {
         cwd: agentSdkDir,
-        env: { ...process.env, PYTHONUNBUFFERED: '1', SESSION_API_KEY: '' },
+        env: {
+          ...process.env,
+          PYTHONUNBUFFERED: '1',
+          SESSION_API_KEY: '',
+          // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
+          OH_ENABLE_VSCODE: '0',
+          OH_ENABLE_VNC: '0',
+          OH_PRELOAD_TOOLS: '0',
+        },
         stdio: ['ignore', 'pipe', 'pipe'],
         detached: process.platform !== 'win32',
       }

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -51,6 +51,9 @@ export async function run(): Promise<void> {
 
   const before: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   const beforeCount = typeof before?.count === 'number' ? before.count : 0;
+  const beforeMessageCount = Array.isArray(before?.eventTypes)
+    ? before.eventTypes.filter((t: unknown) => t === 'MessageEvent').length
+    : 0;
 
   const send: any = await vscode.commands.executeCommand('openhands._webviewAction', {
     action: 'sendMessage',
@@ -64,8 +67,8 @@ export async function run(): Promise<void> {
     const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const count = typeof rendered?.count === 'number' ? rendered.count : 0;
     const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
-    const interesting = types.includes('MessageEvent') || types.includes('ConversationErrorEvent') || types.includes('AgentErrorEvent');
-    return count > beforeCount && interesting;
+    const messageCount = types.filter((t: unknown) => t === 'MessageEvent').length;
+    return count > beforeCount && messageCount > beforeMessageCount;
   }, 60000);
 
   const after: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
@@ -73,4 +76,3 @@ export async function run(): Promise<void> {
 
   console.log('✓ Remote agent-server E2E test passed');
 }
-

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,0 +1,76 @@
+import * as vscode from 'vscode';
+
+async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
+}
+
+export async function run(): Promise<void> {
+  const serverUrl = process.env.AGENT_SERVER_URL;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) {
+    throw new Error('Missing required env var: AGENT_SERVER_URL');
+  }
+
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+  }, 15000);
+
+  await vscode.workspace.getConfiguration().update(
+    'openhands.serverUrl',
+    serverUrl,
+    vscode.ConfigurationTarget.Global
+  );
+  await vscode.workspace.getConfiguration().update(
+    'openhands.conversation.maxIterations',
+    1,
+    vscode.ConfigurationTarget.Global
+  );
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
+  }, 45000);
+
+  const before: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  const beforeCount = typeof before?.count === 'number' ? before.count : 0;
+
+  const send: any = await vscode.commands.executeCommand('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text: 'Hello from E2E (agent-server remote smoke).' }
+  });
+  if (!send?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+  }
+
+  await pollUntil(async () => {
+    const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = typeof rendered?.count === 'number' ? rendered.count : 0;
+    const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
+    const interesting = types.includes('MessageEvent') || types.includes('ConversationErrorEvent') || types.includes('AgentErrorEvent');
+    return count > beforeCount && interesting;
+  }, 60000);
+
+  const after: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(`Remote rendered events: count=${after?.count} types=${Array.isArray(after?.eventTypes) ? after.eventTypes.slice(-10).join(', ') : ''}`);
+
+  console.log('✓ Remote agent-server E2E test passed');
+}
+

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -44,6 +44,11 @@ export async function run(): Promise<void> {
     return runUiFlowsTest();
   }
 
+  if (testName === 'agentServerRemote') {
+    const { run: runAgentServerRemoteTest } = await import('./agentServerRemote');
+    return runAgentServerRemoteTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness


### PR DESCRIPTION
Implements `oh-tab-o6t` and `oh-tab-2zr`.

- Adds opt-in E2E that starts the local python agent-server and verifies remote-mode conversation start + streamed events.
- Adds a small webview E2E action (`sendMessage`) to exercise the real message pipeline (webview → extension → RemoteConversation).
- Fixes remote-mode settings to always supply an LLM `model` (required by current python agent-server).

How to run locally:
- `E2E_AGENT_SERVER=1 npm run e2e`
  - Uses `AGENT_SDK_DIR` / `OPENHANDS_AGENT_SDK_DIR` (defaults to `~/repos/agent-sdk`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Programmatic message sending via e2eAction
  * Optional remote agent-server end-to-end testing flow

* **Bug Fixes**
  * Ensure a default model is provided in remote mode to prevent undefined model values

* **Tests**
  * Added orchestration and smoke tests for remote agent-server scenarios

* **Documentation**
  * Updated agent-server setup/start instructions and session API key guidance; optional tests gated behind a feature flag

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->