### PR TITLE
oh-tab-d0b: CI job for agent-server e2e

### DIFF
--- a/.github/workflows/e2e-agent-server.yml
+++ b/.github/workflows/e2e-agent-server.yml
@@ -1,0 +1,72 @@
+name: E2E (Agent-Server)
+
+on:
+  pull_request:
+    branches: [ develop ]
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  agent-server-e2e:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout (oh-tab)
+        uses: actions/checkout@v4
+
+      - name: Checkout (agent-sdk)
+        uses: actions/checkout@v4
+        with:
+          repository: OpenHands/software-agent-sdk
+          path: agent-sdk
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          check-latest: true
+
+      - name: Use Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Prepare agent-sdk environment
+        working-directory: agent-sdk
+        run: uv sync --frozen
+
+      - name: Update apt cache
+        run: sudo apt-get update -y
+
+      - name: Install base VS Code desktop dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get -o Acquire::Retries=3 update -y
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+            libgtk-3-0 libnss3 libnspr4 libasound2 libxss1 libxkbfile1 libsecret-1-0 \
+            libx11-6 libx11-xcb1 libxshmfence1 libgbm1 libglib2.0-0 xauth xvfb ca-certificates || \
+          (sudo apt-get update -y && sudo apt-get install -y --no-install-recommends \
+            libgtk-3-0 libnss3 libnspr4 libasound2 libxss1 libxkbfile1 libsecret-1-0 \
+            libx11-6 libx11-xcb1 libxshmfence1 libgbm1 libglib2.0-0 xauth xvfb ca-certificates)
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Run agent-server E2E tests (headless)
+        run: xvfb-run -a --server-args="-screen 0 1920x1080x24" npm run e2e:agent-server
+        env:
+          AGENT_SDK_DIR: ${{ github.workspace }}/agent-sdk
+          E2E_AGENT_SERVER: '1'
+          ELECTRON_DISABLE_SANDBOX: '1'
+          ELECTRON_ENABLE_LOGGING: '1'
+          ELECTRON_IS_DEV: '1'
+          QTWEBENGINE_DISABLE_SANDBOX: '1'
+

--- a/.github/workflows/e2e-agent-server.yml
+++ b/.github/workflows/e2e-agent-server.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   agent-server-e2e:
     runs-on: ubuntu-22.04
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: Checkout (oh-tab)
         uses: actions/checkout@v4
@@ -38,12 +38,30 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Cache uv
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/uv
+            agent-sdk/.venv
+          key: uv-${{ runner.os }}-${{ hashFiles('agent-sdk/uv.lock') }}
+
       - name: Prepare agent-sdk environment
         working-directory: agent-sdk
         run: uv sync --frozen
 
-      - name: Update apt cache
-        run: sudo apt-get update -y
+      - name: Get VS Code version for caching
+        id: vscode-version
+        run: |
+          echo "version=stable-$(date +%Y-W%V)" >> $GITHUB_OUTPUT
+
+      - name: Cache VS Code download
+        uses: actions/cache@v4
+        with:
+          path: ~/.vscode-test
+          key: vscode-${{ steps.vscode-version.outputs.version }}-${{ runner.os }}
+          restore-keys: |
+            vscode-stable-
 
       - name: Install base VS Code desktop dependencies
         env:
@@ -57,6 +75,14 @@ jobs:
             libgtk-3-0 libnss3 libnspr4 libasound2 libxss1 libxkbfile1 libsecret-1-0 \
             libx11-6 libx11-xcb1 libxshmfence1 libgbm1 libglib2.0-0 xauth xvfb ca-certificates)
 
+      - name: Install additional optional GUI deps (best-effort)
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            libxrender1 libgdk-pixbuf2.0-0 libpango1.0-0 libxinerama1 libxcursor1 libxkbcommon-x11-0 \
+            libwayland-client0 libwayland-cursor0 libcairo2 || true
+
       - name: Install dependencies
         run: npm ci || npm install
 
@@ -69,4 +95,3 @@ jobs:
           ELECTRON_ENABLE_LOGGING: '1'
           ELECTRON_IS_DEV: '1'
           QTWEBENGINE_DISABLE_SANDBOX: '1'
-

--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
     "vscode:prepublish": "npm run build",
     "package": "node scripts/run-vsce-package.js",
     "e2e": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/**/*.test.js",
+    "e2e:agent-server": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/agentServerRemote.test.js",
     "test": "npm test -w @openhands/agent-sdk-ts && vitest run --dir src",
     "test:watch": "vitest",
     "typecheck": "tsc -p . && tsc -p tsconfig.webview.json",


### PR DESCRIPTION
Implements `oh-tab-d0b`.

Adds a dedicated GitHub Actions workflow to run the live python agent-server E2E suite.

Notes:
- Depends on #236 (adds the `e2e:agent-server` script + remote agent-server E2E).
