### PR TITLE
oh-tab-hgj: Update PR review checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,16 +116,16 @@ Before opening or updating a PR:
 - Ensure GitHub CI checks are green on the PR
 
 Reviews (do not merge without review):
-- Ask an active agent/human in this project for review (via Agent Mail or GitHub).
-- If nobody is available, do **not** merge. Leave the PR open and do other work; re-check Mail later for reviewers.
-- Wait for the two GitHub AI reviewers to finish before merging:
+- Request an OpenHands review by commenting `@openhands /codereview-roasted` on the PR (mandatory).
+- Wait for the GitHub AI reviewers to finish (or be clearly unavailable) before merging:
+  - **Gemini-code-assist**: generally considered “done” once it has posted two top-level comments, but also review its inline comment threads.
   - **CodeRabbitAI**: only wait if its ETA is ≤10 minutes (pending or rate-limited). If it would block longer than that, proceed without it.
     - If pending and ETA ≤10 minutes: wait.
     - If rate limited and cooldown ≤10 minutes: wait (and re-trigger via `@coderabbitai review` if needed).
-    - If it’s silent >10 minutes, or rate-limited >10 minutes: proceed with **Gemini-code-assist** + human/agent approval (via Agent Mail or GitHub) and you may merge once those are done.
-  - **Gemini-code-assist**: generally considered “done” once it has posted two top-level comments, but also review its inline comment threads.
-- Always read review threads in “Files changed” (both bots leave inline comments).
-- Merge only after you have an explicit approval and all review threads are resolved/addressed.
+    - If it’s silent >10 minutes, or rate-limited >10 minutes: proceed with OpenHands + Gemini and do not block on CodeRabbit.
+- Always read review threads in “Files changed” (OpenHands + bots leave inline comments).
+- If OpenHands feedback is “truly minor”, use judgment: you can address it without re-requesting review; if it flags deeper issues, re-request `@openhands /codereview-roasted` after fixes.
+- Merge only when CI is green, review threads are resolved/addressed, and required reviews are complete.
 
 ## SDK Package
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,16 +116,16 @@ Before opening or updating a PR:
 - Ensure GitHub CI checks are green on the PR
 
 Reviews (do not merge without review):
-- Request an OpenHands review by commenting `@openhands /codereview-roasted` on the PR (mandatory).
-- Wait for the GitHub AI reviewers to finish (or be clearly unavailable) before merging:
-  - **Gemini-code-assist**: generally considered “done” once it has posted two top-level comments, but also review its inline comment threads.
-  - **CodeRabbitAI**: only wait if its ETA is ≤10 minutes (pending or rate-limited). If it would block longer than that, proceed without it.
-    - If pending and ETA ≤10 minutes: wait.
-    - If rate limited and cooldown ≤10 minutes: wait (and re-trigger via `@coderabbitai review` if needed).
-    - If it’s silent >10 minutes, or rate-limited >10 minutes: proceed with OpenHands + Gemini and do not block on CodeRabbit.
-- Always read review threads in “Files changed” (OpenHands + bots leave inline comments).
-- If OpenHands feedback is “truly minor”, use judgment: you can address it without re-requesting review; if it flags deeper issues, re-request `@openhands /codereview-roasted` after fixes.
-- Merge only when CI is green, review threads are resolved/addressed, and required reviews are complete.
+- Request an OpenHands review (mandatory): comment `@openhands /codereview-roasted`.
+  - If OpenHands is unresponsive after ~15 minutes, do not block indefinitely: proceed with Gemini + CI green and merge, then follow up if needed.
+  - If OpenHands flags deeper issues, fix and re-request `@openhands /codereview-roasted`.
+- Ensure the GitHub AI reviewers are done (or clearly unavailable):
+  - **Gemini-code-assist**: treat as "done" once it has posted two top-level comments and you've checked/resolved its inline threads. Trigger with `/gemini review` if needed.
+  - **CodeRabbitAI**: only wait if its ETA is <=10 minutes (pending or rate-limited). If it would block longer than that, proceed without it.
+    - Re-trigger with `@coderabbitai review` if needed.
+- Always read review threads in "Files changed" (OpenHands + bots leave inline comments).
+- If OpenHands feedback is "truly minor" (e.g., wording/typos/formatting only), you can address it without re-requesting review.
+- Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
 
 ## SDK Package
 


### PR DESCRIPTION
Fixes: oh-tab-hgj

Updates `AGENTS.md` PR review checklist:
- Require `@openhands /codereview-roasted`
- Treat CodeRabbitAI as optional if it would block >10 minutes
- Keep Gemini-code-assist as required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow: added a mandatory review step and clarified merge criteria (CI passing, resolved review threads, required reviews complete).
  * Revised review rhythm so two review sources can proceed when a third is unavailable; removed previous reliance on that third as a blocking gate.
  * Clarified guidance on reading review threads and handling truly minor reviewer feedback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->