### PR TITLE
oh-tab-mjt: PauseEvent source for confirmation waits

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -90,6 +90,9 @@ describe('Agent loop control', () => {
     expect(eventsAfterRun.some(isActionEvent)).toBe(true);
     expect(eventsAfterRun.some(isPauseEvent)).toBe(true);
     expect(eventsAfterRun.some(isObservationEvent)).toBe(false);
+    const pausesAfterRun = eventsAfterRun.filter(isPauseEvent);
+    expect(pausesAfterRun).toHaveLength(1);
+    expect(pausesAfterRun[0]?.source).toBe('agent');
 
     await agent.approveAction();
     const eventsAfterApproval = log.list();
@@ -124,6 +127,9 @@ describe('Agent loop control', () => {
     expect(eventsAfterRun.some(isActionEvent)).toBe(true);
     expect(eventsAfterRun.some(isPauseEvent)).toBe(true);
     expect(eventsAfterRun.some(isObservationEvent)).toBe(false);
+    const pausesAfterRun = eventsAfterRun.filter(isPauseEvent);
+    expect(pausesAfterRun).toHaveLength(1);
+    expect(pausesAfterRun[0]?.source).toBe('agent');
 
     await agent.approveAction();
     const eventsAfterApproval = log.list();
@@ -164,6 +170,9 @@ describe('Agent loop control', () => {
     expect(eventsAfterRun.some(isActionEvent)).toBe(true);
     expect(eventsAfterRun.some(isPauseEvent)).toBe(true);
     expect(eventsAfterRun.some(isObservationEvent)).toBe(false);
+    const pausesAfterRun = eventsAfterRun.filter(isPauseEvent);
+    expect(pausesAfterRun).toHaveLength(1);
+    expect(pausesAfterRun[0]?.source).toBe('agent');
 
     await agent.approveAction();
     expect(fs.existsSync(outsidePath)).toBe(true);
@@ -206,13 +215,16 @@ describe('Agent loop control', () => {
     });
 
     await agent.run('create then view');
-    expect(log.list().filter(isPauseEvent).length).toBe(1);
+    const pausesAfterRun = log.list().filter(isPauseEvent);
+    expect(pausesAfterRun).toHaveLength(1);
+    expect(pausesAfterRun[0]?.source).toBe('agent');
 
     await agent.approveAction();
     expect(fs.existsSync(outsidePath)).toBe(true);
 
     const pauses = log.list().filter(isPauseEvent);
     expect(pauses.length).toBe(2);
+    expect(pauses.every((pause) => pause.source === 'agent')).toBe(true);
 
     const siblingObs = log.list().filter(isObservationEvent).find((e) => e.tool_call_id === 'call_view');
     expect(siblingObs).toBeUndefined();

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -386,14 +386,14 @@ export class Agent extends EventEmitter {
           this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };
           this.pendingWorkspaceAccess = workspaceAccess;
           this.state.setStatus('WAITING_FOR_CONFIRMATION');
-          this.events.push({ kind: 'PauseEvent', source: 'user' } as Event);
+          this.events.push({ kind: 'PauseEvent', source: 'agent' } as Event);
           return lastAssistantMessage;
         }
 
         if (this.requiresConfirmation(recordedAction)) {
           this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };
           this.state.setStatus('WAITING_FOR_CONFIRMATION');
-          this.events.push({ kind: 'PauseEvent', source: 'user' } as Event);
+          this.events.push({ kind: 'PauseEvent', source: 'agent' } as Event);
           return lastAssistantMessage;
         }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -224,8 +224,7 @@ export class Agent extends EventEmitter {
   pause(): void {
     if (this.paused) return;
     this.paused = true;
-    const pause: Event = { kind: 'PauseEvent', source: 'user' } as Event;
-    this.events.push(pause);
+    this.events.push({ kind: 'PauseEvent', source: 'user' });
     this.state.setStatus('PAUSED');
   }
 
@@ -275,6 +274,16 @@ export class Agent extends EventEmitter {
       action_id: actionEvent.id!,
     } as Event);
     this.state.setStatus('IDLE');
+  }
+
+  private pauseForConfirmation(
+    pendingAction: { toolCall: ToolCall; actionEvent: ActionEvent; args: Record<string, unknown> },
+    pendingWorkspaceAccess?: { paths: string[] },
+  ): void {
+    this.pendingAction = pendingAction;
+    this.pendingWorkspaceAccess = pendingWorkspaceAccess;
+    this.state.setStatus('WAITING_FOR_CONFIRMATION');
+    this.events.push({ kind: 'PauseEvent', source: 'agent' });
   }
 
   private async runLoop(): Promise<Message | undefined> {
@@ -377,28 +386,24 @@ export class Agent extends EventEmitter {
           continue;
         }
         const { args, securityRisk } = parsed;
+        const actionArgs = args ?? {};
 
         const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
         const recordedAction = this.events.push(actionEvent) as ActionEvent;
 
-        const workspaceAccess = this.getRequiredWorkspaceAccess(toolCall.function.name, args ?? {});
+        const workspaceAccess = this.getRequiredWorkspaceAccess(toolCall.function.name, actionArgs);
         if (workspaceAccess) {
-          this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };
-          this.pendingWorkspaceAccess = workspaceAccess;
-          this.state.setStatus('WAITING_FOR_CONFIRMATION');
-          this.events.push({ kind: 'PauseEvent', source: 'agent' } as Event);
+          this.pauseForConfirmation({ toolCall, actionEvent: recordedAction, args: actionArgs }, workspaceAccess);
           return lastAssistantMessage;
         }
 
         if (this.requiresConfirmation(recordedAction)) {
-          this.pendingAction = { toolCall, actionEvent: recordedAction, args: args ?? {} };
-          this.state.setStatus('WAITING_FOR_CONFIRMATION');
-          this.events.push({ kind: 'PauseEvent', source: 'agent' } as Event);
+          this.pauseForConfirmation({ toolCall, actionEvent: recordedAction, args: actionArgs });
           return lastAssistantMessage;
         }
 
         try {
-          await this.executeTool(toolCall, recordedAction, args ?? {});
+          await this.executeTool(toolCall, recordedAction, actionArgs);
         } catch {
           toolExecutionFailed = true;
           // Continue processing other tool calls but mark this iteration as failed

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -106,7 +106,7 @@ export interface ConversationErrorEvent extends EventBase {
 // PauseEvent - shown in visualizer
 export interface PauseEvent extends EventBase {
   kind: 'PauseEvent';
-  source: 'user';
+  source: 'agent' | 'user';
 }
 
 // Condensation - shown in visualizer
@@ -164,7 +164,7 @@ export const isEvent = (candidate: unknown): candidate is Event => {
     case 'ConversationErrorEvent':
       return typeof obj.detail === 'string' || typeof obj.code === 'string';
     case 'PauseEvent':
-      return obj.source === 'user';
+      return obj.source === 'user' || obj.source === 'agent';
     case 'Condensation':
       return Array.isArray(obj.forgotten_event_ids);
     case 'ConversationStateUpdateEvent':


### PR DESCRIPTION
Fixes: oh-tab-mjt
Fixes: #168

- Emit `PauseEvent` with `source: 'agent'` when the agent is waiting for confirmation.
- Loosen `PauseEvent` type/guard to accept `'agent' | 'user'`.
- Add assertions in `agent.loop.test.ts` for the confirmation pause source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Pause events now correctly attribute their origin, properly distinguishing between pauses initiated by the agent and those initiated by the user. This enhancement improves overall event stream transparency and accuracy.

* **Tests**
  * Enhanced test validations to comprehensively verify pause event source attribution, ensuring proper event sourcing behavior across all interaction scenarios and sequences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->