### PR TITLE
chore: add SDK coverage dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
+        "node": ">=22.12.0 <23",
         "vscode": "^1.104.0"
       }
     },
@@ -10873,6 +10874,7 @@
         "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^8.44.1",
         "@typescript-eslint/parser": "^8.44.1",
+        "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.36.0",
         "tsup": "^8.3.0",
         "typescript": "^5.9.2",

--- a/packages/agent-sdk-ts/package.json
+++ b/packages/agent-sdk-ts/package.json
@@ -42,6 +42,7 @@
     "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^8.44.1",
     "@typescript-eslint/parser": "^8.44.1",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.36.0",
     "tsup": "^8.3.0",
     "typescript": "^5.9.2",


### PR DESCRIPTION
Adds @vitest/coverage-v8 to @openhands/agent-sdk-ts so vitest coverage works with coverage.provider='v8' (per CodeRabbit feedback).

Tests:
- npm test -w @openhands/agent-sdk-ts
- vitest run --coverage (SDK workspace)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies for testing infrastructure improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->