### PR TITLE
docs: require final pre-merge review scan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,10 @@ Reviews (do not merge without review):
   - **CodeRabbitAI**: only wait if its ETA is <=10 minutes (pending or rate-limited). If it would block longer than that, proceed without it.
     - Re-trigger with `@coderabbitai review` if needed.
 - Always read review threads in "Files changed" (OpenHands + bots leave inline comments).
+- Right before merging, do a final pass on GitHub to avoid missing late feedback:
+  - "Conversation" tab: scan top-level comments (including bots).
+  - "Files changed" tab: scan/resolve inline review threads.
+  - Checks: confirm OpenHands/Gemini/CodeRabbit aren't still pending (or explicitly waived per the policy above).
 - If OpenHands feedback is "truly minor" (e.g., wording/typos/formatting only), you can address it without re-requesting review.
 - Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
 


### PR DESCRIPTION
Updates AGENTS.md PR checklist to require a final pre-merge scan of GitHub top-level + inline comments and confirm reviewer/check status, so late feedback isn’t missed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-merge review process guidance to include final GitHub checks and status verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->