### PR TITLE
oh-tab-pla: Block LocalWorkspace symlink escapes

### DIFF
--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -218,6 +218,18 @@ export class LocalWorkspace {
     }
   }
 
+  private async writeFileSafely(absPath: string, content: string | Buffer): Promise<void> {
+    const constants = fs.constants as Record<string, number>;
+    const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
+    const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
+    const handle = await fs.promises.open(absPath, flags, 0o666);
+    try {
+      await handle.writeFile(content);
+    } finally {
+      await handle.close();
+    }
+  }
+
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
     return readFileAsync(resolved, encoding);
@@ -227,12 +239,36 @@ export class LocalWorkspace {
     const resolved = this.resolvePath(targetPath);
     const parentDir = path.dirname(resolved);
     const root = this.getContainingDirRoot(parentDir);
-    if (root) {
-      await this.ensureSafeDirectory(root, parentDir);
-    } else {
+    if (!root) {
+      const kind = this.allowedRoots.get(resolved);
+      if (kind === 'file') {
+        let stat: fs.Stats;
+        try {
+          stat = await fs.promises.stat(parentDir);
+        } catch {
+          throw new Error(`writeFile failed: parent directory does not exist: ${parentDir}`);
+        }
+        if (!stat.isDirectory()) {
+          throw new Error(`writeFile failed: parent is not a directory: ${parentDir}`);
+        }
+        await this.writeFileSafely(resolved, content);
+        return;
+      }
+
       await mkdir(parentDir, { recursive: true });
+      await writeFileAsync(resolved, content);
+      return;
     }
-    await writeFileAsync(resolved, content);
+
+    await this.ensureSafeDirectory(root, parentDir);
+    const canonicalParent = await fs.promises.realpath(parentDir);
+    const relative = path.relative(root, canonicalParent);
+    if (relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) {
+      throw new Error(`Path escapes workspace root: ${targetPath}`);
+    }
+
+    const safeResolved = path.join(canonicalParent, path.basename(resolved));
+    await this.writeFileSafely(safeResolved, content);
   }
 
   async remove(targetPath: string): Promise<void> {
@@ -253,10 +289,15 @@ export class LocalWorkspace {
   async ensureDirectory(targetPath: string): Promise<string> {
     const resolved = this.resolvePath(targetPath);
     const root = this.getContainingDirRoot(resolved);
-    if (root) {
-      await this.ensureSafeDirectory(root, resolved);
-    } else {
-      await mkdir(resolved, { recursive: true });
+    if (!root) {
+      throw new Error(`Path escapes workspace root: ${targetPath}`);
+    }
+
+    await this.ensureSafeDirectory(root, resolved);
+    const canonical = await fs.promises.realpath(resolved);
+    const relative = path.relative(root, canonical);
+    if (relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) {
+      throw new Error(`Path escapes workspace root: ${targetPath}`);
     }
     return resolved;
   }

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -79,12 +79,20 @@ export class LocalWorkspace {
   }
 
   private normalizeExistingOrParent(candidate: string): string {
-    if (fs.existsSync(candidate)) return fs.realpathSync(candidate);
     try {
-      const parent = path.dirname(candidate);
-      if (fs.existsSync(parent)) {
-        const realParent = fs.realpathSync(parent);
-        return path.join(realParent, path.basename(candidate));
+      if (fs.existsSync(candidate)) return fs.realpathSync(candidate);
+
+      let current = candidate;
+      const suffix: string[] = [];
+      while (true) {
+        const parent = path.dirname(current);
+        if (parent === current) break;
+        suffix.unshift(path.basename(current));
+        current = parent;
+        if (fs.existsSync(current)) {
+          const realBase = fs.realpathSync(current);
+          return path.join(realBase, ...suffix);
+        }
       }
     } catch {
       // Best-effort normalization only.

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -154,6 +154,70 @@ export class LocalWorkspace {
     throw new Error(`Path escapes workspace root: ${targetPath}`);
   }
 
+  private getContainingDirRoot(resolvedPath: string): string | null {
+    let best: string | null = null;
+    for (const [root, kind] of this.allowedRoots.entries()) {
+      if (kind !== 'dir') continue;
+      const relative = path.relative(root, resolvedPath);
+      if (relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))) {
+        if (!best || root.length > best.length) best = root;
+      }
+    }
+    return best;
+  }
+
+  private async ensureSafeDirectory(root: string, dirPath: string): Promise<void> {
+    const relative = path.relative(root, dirPath);
+    if (relative === '' || relative === '.') return;
+    if (relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) {
+      throw new Error(`Path escapes workspace root: ${dirPath}`);
+    }
+
+    const parts = relative.split(path.sep).filter((part) => part.length > 0);
+    let current = root;
+
+    for (const part of parts) {
+      const next = path.join(current, part);
+
+      let stat: fs.Stats;
+      try {
+        stat = await fs.promises.lstat(next);
+      } catch (error) {
+        if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+          try {
+            await mkdir(next);
+          } catch (mkdirError) {
+            if (typeof mkdirError !== 'object' || !mkdirError || !('code' in mkdirError) || (mkdirError as { code?: unknown }).code !== 'EEXIST') {
+              throw mkdirError;
+            }
+          }
+          stat = await fs.promises.lstat(next);
+        } else {
+          throw error;
+        }
+      }
+
+      if (stat.isSymbolicLink()) {
+        const resolved = await fs.promises.realpath(next);
+        const resolvedRel = path.relative(root, resolved);
+        if (
+          resolvedRel.startsWith(`..${path.sep}`)
+          || resolvedRel === '..'
+          || path.isAbsolute(resolvedRel)
+        ) {
+          throw new Error(`Path escapes workspace root: ${dirPath}`);
+        }
+        current = resolved;
+        continue;
+      }
+
+      if (!stat.isDirectory()) {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
+      current = next;
+    }
+  }
+
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
     return readFileAsync(resolved, encoding);
@@ -161,7 +225,13 @@ export class LocalWorkspace {
 
   async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
     const resolved = this.resolvePath(targetPath);
-    await mkdir(path.dirname(resolved), { recursive: true });
+    const parentDir = path.dirname(resolved);
+    const root = this.getContainingDirRoot(parentDir);
+    if (root) {
+      await this.ensureSafeDirectory(root, parentDir);
+    } else {
+      await mkdir(parentDir, { recursive: true });
+    }
     await writeFileAsync(resolved, content);
   }
 
@@ -182,7 +252,12 @@ export class LocalWorkspace {
 
   async ensureDirectory(targetPath: string): Promise<string> {
     const resolved = this.resolvePath(targetPath);
-    await mkdir(resolved, { recursive: true });
+    const root = this.getContainingDirRoot(resolved);
+    if (root) {
+      await this.ensureSafeDirectory(root, resolved);
+    } else {
+      await mkdir(resolved, { recursive: true });
+    }
     return resolved;
   }
 
@@ -200,7 +275,7 @@ export class LocalWorkspace {
       const spawnOptions: SpawnOptions = {
         cwd,
         env,
-        shell: options.shell ?? (os.platform() === 'win32' ? true : '/bin/bash'),
+        shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
       };
       const child = spawn(command, spawnOptions);
 

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -177,6 +177,25 @@ export class LocalWorkspace {
     let current = root;
 
     for (const part of parts) {
+      let currentStat: fs.Stats;
+      try {
+        currentStat = await fs.promises.lstat(current);
+      } catch {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
+
+      if (currentStat.isSymbolicLink()) {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
+      if (!currentStat.isDirectory()) {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
+
+      current = await fs.promises.realpath(current);
+      const currentRel = path.relative(root, current);
+      if (currentRel.startsWith(`..${path.sep}`) || currentRel === '..' || path.isAbsolute(currentRel)) {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
       const next = path.join(current, part);
 
       let stat: fs.Stats;
@@ -214,13 +233,22 @@ export class LocalWorkspace {
       if (!stat.isDirectory()) {
         throw new Error(`Path escapes workspace root: ${dirPath}`);
       }
-      current = next;
+      current = await fs.promises.realpath(next);
+      const nextRel = path.relative(root, current);
+      if (nextRel.startsWith(`..${path.sep}`) || nextRel === '..' || path.isAbsolute(nextRel)) {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
     }
   }
 
-  private async writeFileSafely(absPath: string, content: string | Buffer): Promise<void> {
+  private async writeFileSafely(absPath: string, content: string | Buffer, containingRoot?: string): Promise<void> {
     const constants = fs.constants as Record<string, number>;
-    const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
+    const noFollow =
+      os.platform() === 'win32'
+        ? 0
+        : typeof constants.O_NOFOLLOW === 'number'
+          ? constants.O_NOFOLLOW
+          : 0;
 
     let targetMode: number | undefined;
     try {
@@ -237,9 +265,37 @@ export class LocalWorkspace {
       }
     }
 
+    const requestedDir = path.dirname(absPath);
+    if (containingRoot) {
+      await this.ensureSafeDirectory(containingRoot, requestedDir);
+    }
+
+    let parentStat: fs.Stats;
+    try {
+      parentStat = await fs.promises.lstat(requestedDir);
+    } catch {
+      throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
+    }
+
+    if (parentStat.isSymbolicLink()) {
+      throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
+    }
+    if (!parentStat.isDirectory()) {
+      throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
+    }
+
+    const canonicalDir = await fs.promises.realpath(requestedDir);
+    if (containingRoot) {
+      const rel = path.relative(containingRoot, canonicalDir);
+      if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
+        throw new Error(`Path escapes workspace root: ${absPath}`);
+      }
+    }
+
+    const safeTargetPath = path.join(canonicalDir, path.basename(absPath));
     if (noFollow) {
       const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
-      const handle = await fs.promises.open(absPath, flags, targetMode ?? 0o666);
+      const handle = await fs.promises.open(safeTargetPath, flags, targetMode ?? 0o666);
       try {
         await handle.writeFile(content);
       } finally {
@@ -248,13 +304,13 @@ export class LocalWorkspace {
       return;
     }
 
-    const dir = path.dirname(absPath);
     const base = path.basename(absPath);
+    const targetPath = path.join(canonicalDir, base);
     const tempFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-      const tempPath = path.join(dir, `.${base}.tmp-${suffix}`);
+      const tempPath = path.join(canonicalDir, `.${base}.tmp-${suffix}`);
 
       let handle: fs.promises.FileHandle | undefined;
       try {
@@ -263,7 +319,28 @@ export class LocalWorkspace {
         await handle.close();
         handle = undefined;
 
-        await fs.promises.rename(tempPath, absPath);
+        // Re-check parent just before renaming to avoid late symlink swaps.
+        const parentStatBeforeRename = await fs.promises.lstat(requestedDir);
+        if (parentStatBeforeRename.isSymbolicLink()) {
+          throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
+        }
+
+        const canonicalDirBeforeRename = await fs.promises.realpath(requestedDir);
+        if (containingRoot) {
+          const relBeforeRename = path.relative(containingRoot, canonicalDirBeforeRename);
+          if (
+            relBeforeRename.startsWith(`..${path.sep}`)
+            || relBeforeRename === '..'
+            || path.isAbsolute(relBeforeRename)
+          ) {
+            throw new Error(`Path escapes workspace root: ${absPath}`);
+          }
+        }
+        if (canonicalDirBeforeRename !== canonicalDir) {
+          throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
+        }
+
+        await fs.promises.rename(tempPath, targetPath);
         return;
       } catch (error) {
         if (handle) {
@@ -285,7 +362,7 @@ export class LocalWorkspace {
         throw error;
       }
     }
-    throw new Error(`writeFile failed: unable to create temp file in ${dir}`);
+    throw new Error(`writeFile failed: unable to create temp file in ${canonicalDir}`);
   }
 
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
@@ -326,7 +403,7 @@ export class LocalWorkspace {
     }
 
     const safeResolved = path.join(canonicalParent, path.basename(resolved));
-    await this.writeFileSafely(safeResolved, content);
+    await this.writeFileSafely(safeResolved, content, root);
   }
 
   async remove(targetPath: string): Promise<void> {

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -79,23 +79,19 @@ export class LocalWorkspace {
   }
 
   private normalizeExistingOrParent(candidate: string): string {
-    try {
-      if (fs.existsSync(candidate)) return fs.realpathSync(candidate);
+    if (fs.existsSync(candidate)) return fs.realpathSync(candidate);
 
-      let current = candidate;
-      const suffix: string[] = [];
-      while (true) {
-        const parent = path.dirname(current);
-        if (parent === current) break;
-        suffix.unshift(path.basename(current));
-        current = parent;
-        if (fs.existsSync(current)) {
-          const realBase = fs.realpathSync(current);
-          return path.join(realBase, ...suffix);
-        }
+    let current = candidate;
+    const suffix: string[] = [];
+    while (true) {
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      suffix.unshift(path.basename(current));
+      current = parent;
+      if (fs.existsSync(current)) {
+        const realBase = fs.realpathSync(current);
+        return path.join(realBase, ...suffix);
       }
-    } catch {
-      // Best-effort normalization only.
     }
     return candidate;
   }
@@ -134,7 +130,10 @@ export class LocalWorkspace {
         continue;
       }
       const relative = path.relative(root, normalized);
-      if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))) {
+      if (
+        relative === ''
+        || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+      ) {
         return normalized;
       }
     }
@@ -187,7 +186,7 @@ export class LocalWorkspace {
       const spawnOptions: SpawnOptions = {
         cwd,
         env,
-        shell: options.shell ?? (os.platform() === 'win32' ? undefined : '/bin/bash'),
+        shell: options.shell ?? (os.platform() === 'win32' ? true : '/bin/bash'),
       };
       const child = spawn(command, spawnOptions);
 

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -173,6 +173,17 @@ export class LocalWorkspace {
       throw new Error(`Path escapes workspace root: ${dirPath}`);
     }
 
+    const assertContained = (candidate: string) => {
+      const candidateRel = path.relative(root, candidate);
+      if (
+        candidateRel.startsWith(`..${path.sep}`)
+        || candidateRel === '..'
+        || path.isAbsolute(candidateRel)
+      ) {
+        throw new Error(`Path escapes workspace root: ${dirPath}`);
+      }
+    };
+
     const parts = relative.split(path.sep).filter((part) => part.length > 0);
     let current = root;
 
@@ -184,25 +195,32 @@ export class LocalWorkspace {
         throw new Error(`Path escapes workspace root: ${dirPath}`);
       }
 
-      if (currentStat.isSymbolicLink()) {
+      if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
         throw new Error(`Path escapes workspace root: ${dirPath}`);
       }
-      if (!currentStat.isDirectory()) {
-        throw new Error(`Path escapes workspace root: ${dirPath}`);
-      }
+      assertContained(current);
 
-      current = await fs.promises.realpath(current);
-      const currentRel = path.relative(root, current);
-      if (currentRel.startsWith(`..${path.sep}`) || currentRel === '..' || path.isAbsolute(currentRel)) {
-        throw new Error(`Path escapes workspace root: ${dirPath}`);
-      }
-      const next = path.join(current, part);
+      let next = path.join(current, part);
 
       let stat: fs.Stats;
       try {
         stat = await fs.promises.lstat(next);
       } catch (error) {
         if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+          // Re-check the parent directory immediately before creating the next component.
+          // This closes a TOCTTOU window where the parent can be swapped to a symlink between
+          // validation and mkdir, causing `mkdir(next)` to escape the workspace root.
+          try {
+            currentStat = await fs.promises.lstat(current);
+          } catch {
+            throw new Error(`Path escapes workspace root: ${dirPath}`);
+          }
+          if (currentStat.isSymbolicLink() || !currentStat.isDirectory()) {
+            throw new Error(`Path escapes workspace root: ${dirPath}`);
+          }
+          assertContained(current);
+          next = path.join(current, part);
+
           try {
             await mkdir(next);
           } catch (mkdirError) {
@@ -218,14 +236,18 @@ export class LocalWorkspace {
 
       if (stat.isSymbolicLink()) {
         const resolved = await fs.promises.realpath(next);
-        const resolvedRel = path.relative(root, resolved);
-        if (
-          resolvedRel.startsWith(`..${path.sep}`)
-          || resolvedRel === '..'
-          || path.isAbsolute(resolvedRel)
-        ) {
+        assertContained(resolved);
+
+        let resolvedStat: fs.Stats;
+        try {
+          resolvedStat = await fs.promises.stat(resolved);
+        } catch {
           throw new Error(`Path escapes workspace root: ${dirPath}`);
         }
+        if (!resolvedStat.isDirectory()) {
+          throw new Error(`Path escapes workspace root: ${dirPath}`);
+        }
+
         current = resolved;
         continue;
       }
@@ -233,11 +255,7 @@ export class LocalWorkspace {
       if (!stat.isDirectory()) {
         throw new Error(`Path escapes workspace root: ${dirPath}`);
       }
-      current = await fs.promises.realpath(next);
-      const nextRel = path.relative(root, current);
-      if (nextRel.startsWith(`..${path.sep}`) || nextRel === '..' || path.isAbsolute(nextRel)) {
-        throw new Error(`Path escapes workspace root: ${dirPath}`);
-      }
+      current = next;
     }
   }
 
@@ -420,15 +438,7 @@ export class LocalWorkspace {
       throw new Error(`writeFile failed: path is not contained in an allowlisted workspace root: ${targetPath}`);
     }
 
-    await this.ensureSafeDirectory(root, parentDir);
-    const canonicalParent = await fs.promises.realpath(parentDir);
-    const relative = path.relative(root, canonicalParent);
-    if (relative.startsWith(`..${path.sep}`) || relative === '..' || path.isAbsolute(relative)) {
-      throw new Error(`Path escapes workspace root: ${targetPath}`);
-    }
-
-    const safeResolved = path.join(canonicalParent, path.basename(resolved));
-    await this.writeFileSafely(safeResolved, content, root);
+    await this.writeFileSafely(resolved, content, root);
   }
 
   async remove(targetPath: string): Promise<void> {

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -302,54 +302,54 @@ export class LocalWorkspace {
       throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
     }
 
-    const canonicalDir = await fs.promises.realpath(requestedDir);
-    if (containingRoot) {
-      const rel = path.relative(containingRoot, canonicalDir);
-      if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
-        throw new Error(`Path escapes workspace root: ${absPath}`);
-      }
-    }
+	    const canonicalDir = await fs.promises.realpath(requestedDir);
+	    if (containingRoot) {
+	      const rel = path.relative(containingRoot, canonicalDir);
+	      if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
+	        throw new Error(`Path escapes workspace root: ${absPath}`);
+	      }
+	    }
 
-    const safeTargetPath = path.join(canonicalDir, path.basename(absPath));
-    if (noFollow) {
-      // `O_NOFOLLOW` only protects the final path component; re-validate the parent directory
-      // immediately before opening so a late parent symlink swap can't redirect the write.
-      let parentStatBeforeOpen: fs.Stats;
-      try {
-        parentStatBeforeOpen = await fs.promises.lstat(canonicalDir);
-      } catch {
-        throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
-      }
-      if (parentStatBeforeOpen.isSymbolicLink()) {
-        throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
-      }
-      if (!parentStatBeforeOpen.isDirectory()) {
-        throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
-      }
-      const canonicalDirBeforeOpen = await fs.promises.realpath(canonicalDir);
-      if (canonicalDirBeforeOpen !== canonicalDir) {
-        throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
-      }
-      if (containingRoot) {
-        const relBeforeOpen = path.relative(containingRoot, canonicalDirBeforeOpen);
-        if (relBeforeOpen.startsWith(`..${path.sep}`) || relBeforeOpen === '..' || path.isAbsolute(relBeforeOpen)) {
-          throw new Error(`Path escapes workspace root: ${absPath}`);
-        }
-      }
+	    const base = path.basename(absPath);
+	    if (noFollow) {
+	      // `O_NOFOLLOW` only protects the final path component; re-validate the parent directory
+	      // immediately before opening so a late parent symlink swap can't redirect the write.
+	      let parentStatBeforeOpen: fs.Stats;
+	      try {
+	        parentStatBeforeOpen = await fs.promises.lstat(requestedDir);
+	      } catch {
+	        throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
+	      }
+	      if (parentStatBeforeOpen.isSymbolicLink()) {
+	        throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
+	      }
+	      if (!parentStatBeforeOpen.isDirectory()) {
+	        throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
+	      }
+	      const canonicalDirBeforeOpen = await fs.promises.realpath(requestedDir);
+	      if (containingRoot) {
+	        const relBeforeOpen = path.relative(containingRoot, canonicalDirBeforeOpen);
+	        if (relBeforeOpen.startsWith(`..${path.sep}`) || relBeforeOpen === '..' || path.isAbsolute(relBeforeOpen)) {
+	          throw new Error(`Path escapes workspace root: ${absPath}`);
+	        }
+	      }
+	      if (canonicalDirBeforeOpen !== canonicalDir) {
+	        throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
+	      }
 
-      const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
-      const handle = await fs.promises.open(safeTargetPath, flags, targetMode ?? 0o666);
-      try {
-        await handle.writeFile(content);
-      } finally {
-        await handle.close();
-      }
-      return;
-    }
+	      const safeTargetPath = path.join(canonicalDirBeforeOpen, base);
+	      const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
+	      const handle = await fs.promises.open(safeTargetPath, flags, targetMode ?? 0o666);
+	      try {
+	        await handle.writeFile(content);
+	      } finally {
+	        await handle.close();
+	      }
+	      return;
+	    }
 
-    const base = path.basename(absPath);
-    const targetPath = path.join(canonicalDir, base);
-    const tempFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+	    const targetPath = path.join(canonicalDir, base);
+	    const tempFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -302,54 +302,54 @@ export class LocalWorkspace {
       throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
     }
 
-	    const canonicalDir = await fs.promises.realpath(requestedDir);
-	    if (containingRoot) {
-	      const rel = path.relative(containingRoot, canonicalDir);
-	      if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
-	        throw new Error(`Path escapes workspace root: ${absPath}`);
-	      }
-	    }
+    const canonicalDir = await fs.promises.realpath(requestedDir);
+    if (containingRoot) {
+      const rel = path.relative(containingRoot, canonicalDir);
+      if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
+        throw new Error(`Path escapes workspace root: ${absPath}`);
+      }
+    }
 
-	    const base = path.basename(absPath);
-	    if (noFollow) {
-	      // `O_NOFOLLOW` only protects the final path component; re-validate the parent directory
-	      // immediately before opening so a late parent symlink swap can't redirect the write.
-	      let parentStatBeforeOpen: fs.Stats;
-	      try {
-	        parentStatBeforeOpen = await fs.promises.lstat(requestedDir);
-	      } catch {
-	        throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
-	      }
-	      if (parentStatBeforeOpen.isSymbolicLink()) {
-	        throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
-	      }
-	      if (!parentStatBeforeOpen.isDirectory()) {
-	        throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
-	      }
-	      const canonicalDirBeforeOpen = await fs.promises.realpath(requestedDir);
-	      if (containingRoot) {
-	        const relBeforeOpen = path.relative(containingRoot, canonicalDirBeforeOpen);
-	        if (relBeforeOpen.startsWith(`..${path.sep}`) || relBeforeOpen === '..' || path.isAbsolute(relBeforeOpen)) {
-	          throw new Error(`Path escapes workspace root: ${absPath}`);
-	        }
-	      }
-	      if (canonicalDirBeforeOpen !== canonicalDir) {
-	        throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
-	      }
+    const base = path.basename(absPath);
+    if (noFollow) {
+      // `O_NOFOLLOW` only protects the final path component; re-validate the parent directory
+      // immediately before opening so a late parent symlink swap can't redirect the write.
+      let parentStatBeforeOpen: fs.Stats;
+      try {
+        parentStatBeforeOpen = await fs.promises.lstat(requestedDir);
+      } catch {
+        throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
+      }
+      if (parentStatBeforeOpen.isSymbolicLink()) {
+        throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
+      }
+      if (!parentStatBeforeOpen.isDirectory()) {
+        throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
+      }
+      const canonicalDirBeforeOpen = await fs.promises.realpath(requestedDir);
+      if (containingRoot) {
+        const relBeforeOpen = path.relative(containingRoot, canonicalDirBeforeOpen);
+        if (relBeforeOpen.startsWith(`..${path.sep}`) || relBeforeOpen === '..' || path.isAbsolute(relBeforeOpen)) {
+          throw new Error(`Path escapes workspace root: ${absPath}`);
+        }
+      }
+      if (canonicalDirBeforeOpen !== canonicalDir) {
+        throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
+      }
 
-	      const safeTargetPath = path.join(canonicalDirBeforeOpen, base);
-	      const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
-	      const handle = await fs.promises.open(safeTargetPath, flags, targetMode ?? 0o666);
-	      try {
-	        await handle.writeFile(content);
-	      } finally {
-	        await handle.close();
-	      }
-	      return;
-	    }
+      const safeTargetPath = path.join(canonicalDirBeforeOpen, base);
+      const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
+      const handle = await fs.promises.open(safeTargetPath, flags, targetMode ?? 0o666);
+      try {
+        await handle.writeFile(content);
+      } finally {
+        await handle.close();
+      }
+      return;
+    }
 
-	    const targetPath = path.join(canonicalDir, base);
-	    const tempFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+    const targetPath = path.join(canonicalDir, base);
+    const tempFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
 
     for (let attempt = 0; attempt < 10; attempt++) {
       const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
@@ -495,8 +495,8 @@ export class LocalWorkspace {
       const timeout = options.timeoutMs
         ? setTimeout(() => {
             if (os.platform() === 'win32') {
-              // If we spawned through a shell, best-effort kill the entire process tree.
-              // `child.kill()` may only terminate the shell process, leaving payloads running.
+              // On Windows, best-effort kill the entire process tree.
+              // `child.kill()` may only terminate the parent process, leaving payloads running.
               try {
                 spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
                   stdio: 'ignore',

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -220,6 +220,19 @@ export class LocalWorkspace {
 
   private async writeFileSafely(absPath: string, content: string | Buffer): Promise<void> {
     const constants = fs.constants as Record<string, number>;
+    try {
+      const stat = await fs.promises.lstat(absPath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`writeFile failed: refusing to write to symlink path: ${absPath}`);
+      }
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+        // ok: creating the file
+      } else {
+        throw error;
+      }
+    }
+
     const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
     const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
     const handle = await fs.promises.open(absPath, flags, 0o666);
@@ -244,9 +257,12 @@ export class LocalWorkspace {
       if (kind === 'file') {
         let stat: fs.Stats;
         try {
-          stat = await fs.promises.stat(parentDir);
+          stat = await fs.promises.lstat(parentDir);
         } catch {
           throw new Error(`writeFile failed: parent directory does not exist: ${parentDir}`);
+        }
+        if (stat.isSymbolicLink()) {
+          throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${parentDir}`);
         }
         if (!stat.isDirectory()) {
           throw new Error(`writeFile failed: parent is not a directory: ${parentDir}`);

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -23,7 +23,7 @@ export interface CommandOptions {
   cwd?: string;
   env?: EnvVars;
   timeoutMs?: number;
-  shell?: string;
+  shell?: string | boolean;
 }
 
 export interface CommandResult {
@@ -79,21 +79,35 @@ export class LocalWorkspace {
   }
 
   private normalizeExistingOrParent(candidate: string): string {
-    if (fs.existsSync(candidate)) return fs.realpathSync(candidate);
+    const parsed = path.parse(candidate);
+    const root = parsed.root;
+    const parts = candidate
+      .slice(root.length)
+      .split(path.sep)
+      .filter((part) => part.length > 0);
 
-    let current = candidate;
-    const suffix: string[] = [];
-    while (true) {
-      const parent = path.dirname(current);
-      if (parent === current) break;
-      suffix.unshift(path.basename(current));
-      current = parent;
-      if (fs.existsSync(current)) {
-        const realBase = fs.realpathSync(current);
-        return path.join(realBase, ...suffix);
+    let current = root;
+    for (let i = 0; i < parts.length; i++) {
+      const next = path.join(current, parts[i]);
+      let stat: fs.Stats;
+      try {
+        stat = fs.lstatSync(next);
+      } catch (error) {
+        if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+          const remaining = parts.slice(i).join(path.sep);
+          return remaining ? path.join(current, remaining) : current;
+        }
+        throw error;
       }
+
+      if (stat.isSymbolicLink()) {
+        // Treat symlink components as hostile: require them to resolve now.
+        current = fs.realpathSync(next);
+        continue;
+      }
+      current = next;
     }
-    return candidate;
+    return current;
   }
 
   allowPath(targetPath: string): void {
@@ -194,6 +208,19 @@ export class LocalWorkspace {
       let stderr = '';
       const timeout = options.timeoutMs
         ? setTimeout(() => {
+            if (os.platform() === 'win32') {
+              // If we spawned through a shell, best-effort kill the entire process tree.
+              // `child.kill()` may only terminate the shell process, leaving payloads running.
+              try {
+                spawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+                  stdio: 'ignore',
+                  windowsHide: true,
+                });
+              } catch {
+                child.kill('SIGTERM');
+              }
+              return;
+            }
             child.kill('SIGTERM');
           }, options.timeoutMs)
         : null;

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import type { SpawnOptions } from 'child_process';
 import * as fs from 'fs';
-import { readFile as readFileAsync, mkdir, writeFile as writeFileAsync, rm, readdir } from 'node:fs/promises';
+import { readFile as readFileAsync, mkdir, rm, readdir } from 'node:fs/promises';
 import path from 'path';
 import os from 'os';
 
@@ -315,10 +315,7 @@ export class LocalWorkspace {
         await this.writeFileSafely(resolved, content);
         return;
       }
-
-      await mkdir(parentDir, { recursive: true });
-      await writeFileAsync(resolved, content);
-      return;
+      throw new Error(`writeFile failed: path is not contained in an allowlisted workspace root: ${targetPath}`);
     }
 
     await this.ensureSafeDirectory(root, parentDir);

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -220,11 +220,15 @@ export class LocalWorkspace {
 
   private async writeFileSafely(absPath: string, content: string | Buffer): Promise<void> {
     const constants = fs.constants as Record<string, number>;
+    const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
+
+    let targetMode: number | undefined;
     try {
       const stat = await fs.promises.lstat(absPath);
       if (stat.isSymbolicLink()) {
         throw new Error(`writeFile failed: refusing to write to symlink path: ${absPath}`);
       }
+      targetMode = stat.mode;
     } catch (error) {
       if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
         // ok: creating the file
@@ -233,14 +237,55 @@ export class LocalWorkspace {
       }
     }
 
-    const noFollow = typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0;
-    const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
-    const handle = await fs.promises.open(absPath, flags, 0o666);
-    try {
-      await handle.writeFile(content);
-    } finally {
-      await handle.close();
+    if (noFollow) {
+      const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
+      const handle = await fs.promises.open(absPath, flags, targetMode ?? 0o666);
+      try {
+        await handle.writeFile(content);
+      } finally {
+        await handle.close();
+      }
+      return;
     }
+
+    const dir = path.dirname(absPath);
+    const base = path.basename(absPath);
+    const tempFlags = constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL;
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const suffix = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      const tempPath = path.join(dir, `.${base}.tmp-${suffix}`);
+
+      let handle: fs.promises.FileHandle | undefined;
+      try {
+        handle = await fs.promises.open(tempPath, tempFlags, targetMode ?? 0o666);
+        await handle.writeFile(content);
+        await handle.close();
+        handle = undefined;
+
+        await fs.promises.rename(tempPath, absPath);
+        return;
+      } catch (error) {
+        if (handle) {
+          try {
+            await handle.close();
+          } catch {
+            // ignore
+          }
+        }
+        try {
+          await fs.promises.unlink(tempPath);
+        } catch {
+          // ignore
+        }
+
+        if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'EEXIST') {
+          continue;
+        }
+        throw error;
+      }
+    }
+    throw new Error(`writeFile failed: unable to create temp file in ${dir}`);
   }
 
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -294,6 +294,31 @@ export class LocalWorkspace {
 
     const safeTargetPath = path.join(canonicalDir, path.basename(absPath));
     if (noFollow) {
+      // `O_NOFOLLOW` only protects the final path component; re-validate the parent directory
+      // immediately before opening so a late parent symlink swap can't redirect the write.
+      let parentStatBeforeOpen: fs.Stats;
+      try {
+        parentStatBeforeOpen = await fs.promises.lstat(canonicalDir);
+      } catch {
+        throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
+      }
+      if (parentStatBeforeOpen.isSymbolicLink()) {
+        throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
+      }
+      if (!parentStatBeforeOpen.isDirectory()) {
+        throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
+      }
+      const canonicalDirBeforeOpen = await fs.promises.realpath(canonicalDir);
+      if (canonicalDirBeforeOpen !== canonicalDir) {
+        throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
+      }
+      if (containingRoot) {
+        const relBeforeOpen = path.relative(containingRoot, canonicalDirBeforeOpen);
+        if (relBeforeOpen.startsWith(`..${path.sep}`) || relBeforeOpen === '..' || path.isAbsolute(relBeforeOpen)) {
+          throw new Error(`Path escapes workspace root: ${absPath}`);
+        }
+      }
+
       const flags = constants.O_WRONLY | constants.O_CREAT | constants.O_TRUNC | noFollow;
       const handle = await fs.promises.open(safeTargetPath, flags, targetMode ?? 0o666);
       try {

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -141,7 +141,7 @@ describe('LocalWorkspace', () => {
     it('runs commands rooted in the workspace', async () => {
       const { workspace, dir } = await makeWorkspace((value) => created.push(value));
       const command = process.platform === 'win32' ? 'cd' : 'pwd';
-      const result = await workspace.runCommand(command);
+      const result = await workspace.runCommand(command, process.platform === 'win32' ? { shell: true } : undefined);
       expect(result.exitCode).toBe(0);
       const realDir = await fs.promises.realpath(dir);
       const printedDir = result.stdout.trim();

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -150,11 +150,11 @@ describe('LocalWorkspace', () => {
       expect(fs.existsSync(externalDir)).toBe(false);
     });
 
-	    it('rejects file-only allowances when the parent becomes a symlink mid-write', async () => {
-	      if (process.platform === 'win32') return;
+    it('rejects file-only allowances when the parent becomes a symlink mid-write', async () => {
+      if (process.platform === 'win32') return;
 
-	      const { workspace } = await makeWorkspace((dir) => created.push(dir));
-	      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-parent-'));
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-parent-'));
       created.push(externalDir);
       const parentDir = path.join(externalDir, 'allowed-parent');
       await fs.promises.mkdir(parentDir, { recursive: true });
@@ -163,123 +163,126 @@ describe('LocalWorkspace', () => {
       await fs.promises.writeFile(allowedFile, 'original', 'utf8');
       workspace.allowPath(allowedFile);
 
-      const canonicalParentDir = await fs.promises.realpath(parentDir);
+      const resolvedAllowedFile = workspace.resolvePath(allowedFile);
+      const canonicalParentDir = path.dirname(resolvedAllowedFile);
 
-	      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-'));
-	      created.push(redirectDir);
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-'));
+      created.push(redirectDir);
 
-	      let swapped = false;
-	      const swapParent = async () => {
+      let swapped = false;
+      const swapParent = async () => {
         if (swapped) return;
         swapped = true;
         const backupDir = `${canonicalParentDir}-bak`;
         await fs.promises.rename(canonicalParentDir, backupDir);
-	        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
-	      };
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
 
-	      const originalLstat = fs.promises.lstat;
-	      const canonicalAllowedFile = await fs.promises.realpath(allowedFile);
+      const originalRealpath = fs.promises.realpath;
+      let parentRealpathCalls = 0;
+      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+        if (!swapped && targetString === canonicalParentDir) {
+          parentRealpathCalls += 1;
+          if (parentRealpathCalls === 1) {
+            await swapParent();
+          }
+        }
+        return result;
+      });
 
-	      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
-	        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
-	        if (!swapped && targetString === canonicalAllowedFile) {
-	          await swapParent();
-	        }
-	        return originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
-	      });
+      try {
+        await expect(workspace.writeFile(allowedFile, 'hello')).rejects.toThrowError(/symlink|escapes|refusing|parent/i);
+        expect(fs.existsSync(path.join(redirectDir, 'outside.txt'))).toBe(false);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
 
-	      try {
-	        await expect(workspace.writeFile(allowedFile, 'hello')).rejects.toThrowError(/symlink|refusing|parent/i);
-	        expect(fs.existsSync(path.join(redirectDir, 'outside.txt'))).toBe(false);
-	      } finally {
-	        lstatSpy.mockRestore();
-	      }
-	    });
+    it('rejects workspace writes when the parent becomes a symlink mid-write', async () => {
+      if (process.platform === 'win32') return;
 
-	    it('rejects workspace writes when the parent becomes a symlink mid-write', async () => {
-	      if (process.platform === 'win32') return;
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      await workspace.ensureDirectory('parent');
+      const canonicalParentDir = workspace.resolvePath('parent');
 
-	      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
-	      const parentDir = path.join(dir, 'parent');
-	      await fs.promises.mkdir(parentDir, { recursive: true });
-	      const canonicalParentDir = await fs.promises.realpath(parentDir);
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-workspace-'));
+      created.push(redirectDir);
 
-	      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-workspace-'));
-	      created.push(redirectDir);
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
 
-	      let swapped = false;
-	      const swapParent = async () => {
-	        if (swapped) return;
-	        swapped = true;
-	        const backupDir = `${canonicalParentDir}-bak`;
-	        await fs.promises.rename(canonicalParentDir, backupDir);
-	        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
-	      };
+      const originalRealpath = fs.promises.realpath;
+      let parentRealpathCalls = 0;
+      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+        if (!swapped && targetString === canonicalParentDir) {
+          parentRealpathCalls += 1;
+          if (parentRealpathCalls === 4) {
+            await swapParent();
+          }
+        }
+        return result;
+      });
 
-	      const originalRealpath = fs.promises.realpath;
-	      let parentRealpathCalls = 0;
-	      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
-	        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
-	        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
-	        if (!swapped && targetString === canonicalParentDir) {
-	          parentRealpathCalls += 1;
-	          if (parentRealpathCalls === 2) {
-	            await swapParent();
-	          }
-	        }
-	        return result;
-	      });
+      try {
+        await expect(workspace.writeFile('parent/inside.txt', 'hello')).rejects.toThrowError(/symlink|escapes|refusing|parent/i);
+        expect(fs.existsSync(path.join(redirectDir, 'inside.txt'))).toBe(false);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
 
-	      try {
-	        await expect(workspace.writeFile('parent/inside.txt', 'hello')).rejects.toThrowError(/symlink|escapes|refusing/i);
-	        expect(fs.existsSync(path.join(redirectDir, 'inside.txt'))).toBe(false);
-	      } finally {
-	        realpathSpy.mockRestore();
-	      }
-	    });
+    it('rejects directory creation when an ancestor becomes a symlink mid-create', async () => {
+      if (process.platform === 'win32') return;
 
-	    it('rejects directory creation when an ancestor becomes a symlink mid-create', async () => {
-	      if (process.platform === 'win32') return;
+      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+      const parentDir = path.join(dir, 'parent');
+      await fs.promises.mkdir(parentDir, { recursive: true });
+      const canonicalParentDir = await fs.promises.realpath(parentDir);
 
-	      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
-	      const parentDir = path.join(dir, 'parent');
-	      await fs.promises.mkdir(parentDir, { recursive: true });
-	      const canonicalParentDir = await fs.promises.realpath(parentDir);
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-dir-'));
+      created.push(redirectDir);
 
-	      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-dir-'));
-	      created.push(redirectDir);
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
 
-	      let swapped = false;
-	      const swapParent = async () => {
-	        if (swapped) return;
-	        swapped = true;
-	        const backupDir = `${canonicalParentDir}-bak`;
-	        await fs.promises.rename(canonicalParentDir, backupDir);
-	        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
-	      };
+      const originalLstat = fs.promises.lstat;
+      let parentLstatCalls = 0;
+      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        const result = await originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
+        if (!swapped && targetString === canonicalParentDir) {
+          parentLstatCalls += 1;
+          if (parentLstatCalls === 2) {
+            await swapParent();
+          }
+        }
+        return result;
+      });
 
-	      const originalLstat = fs.promises.lstat;
-	      let parentLstatCalls = 0;
-	      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
-	        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
-	        const result = await originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
-	        if (!swapped && targetString === canonicalParentDir) {
-	          parentLstatCalls += 1;
-	          if (parentLstatCalls === 2) {
-	            await swapParent();
-	          }
-	        }
-	        return result;
-	      });
-
-	      try {
-	        await expect(workspace.ensureDirectory('parent/child')).rejects.toThrowError(/symlink|escapes|Path escapes/i);
-	        expect(fs.existsSync(path.join(redirectDir, 'child'))).toBe(false);
-	      } finally {
-	        lstatSpy.mockRestore();
-	      }
-	    });
-	  });
+      try {
+        await expect(workspace.ensureDirectory('parent/child')).rejects.toThrowError(/symlink|escapes|Path escapes/i);
+        expect(fs.existsSync(path.join(redirectDir, 'child'))).toBe(false);
+      } finally {
+        lstatSpy.mockRestore();
+      }
+    });
+  });
 
   describe('commands', () => {
     it('runs commands rooted in the workspace', async () => {

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -33,11 +33,14 @@ describe('LocalWorkspace', () => {
         '../../sensitive.txt',
         '../../../etc/passwd',
         'subdir/../../../sensitive.txt',
-        '..\\sensitive.txt',
         'subdir/../../sensitive.txt',
         './../sensitive.txt',
         'a/../../../sensitive.txt',
       ];
+
+      if (process.platform === 'win32') {
+        vectors.push('..\\sensitive.txt');
+      }
 
       for (const attackPath of vectors) {
         expect(() => workspace.resolvePath(attackPath)).toThrowError(/Path escapes workspace root/);
@@ -60,7 +63,9 @@ describe('LocalWorkspace', () => {
       for (const legitPath of legitimatePaths) {
         const resolved = workspace.resolvePath(legitPath);
         const relative = path.relative(realDir, resolved);
-        expect(relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))).toBe(true);
+        expect(
+          relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative)),
+        ).toBe(true);
       }
 
       expect(workspace.resolvePath('')).toBe(realDir);
@@ -79,6 +84,25 @@ describe('LocalWorkspace', () => {
 
       expect(() => workspace.resolvePath('linked')).toThrowError(/Path escapes workspace root/);
       expect(() => workspace.resolvePath('linked/subdir/file.txt')).toThrowError(/Path escapes workspace root/);
+    });
+
+    it('allows symlinks that remain inside the sandbox', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+      const realDir = await fs.promises.realpath(dir);
+
+      const target = path.join(dir, 'target');
+      await fs.promises.mkdir(target, { recursive: true });
+
+      const symlinkPath = path.join(dir, 'inside');
+      await fs.promises.symlink(target, symlinkPath, 'dir');
+
+      const resolved = workspace.resolvePath('inside/file.txt');
+      const relative = path.relative(realDir, resolved);
+      expect(
+        relative === '' || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative)),
+      ).toBe(true);
     });
 
     it('allows explicitly-approved external paths', async () => {
@@ -100,10 +124,16 @@ describe('LocalWorkspace', () => {
   describe('commands', () => {
     it('runs commands rooted in the workspace', async () => {
       const { workspace, dir } = await makeWorkspace((value) => created.push(value));
-      const result = await workspace.runCommand('pwd');
+      const command = process.platform === 'win32' ? 'cd' : 'pwd';
+      const result = await workspace.runCommand(command);
       expect(result.exitCode).toBe(0);
       const realDir = await fs.promises.realpath(dir);
-      expect(result.stdout.trim()).toBe(realDir);
+      const printedDir = result.stdout.trim();
+      if (process.platform === 'win32') {
+        expect(printedDir.toLowerCase()).toBe(realDir.toLowerCase());
+      } else {
+        expect(printedDir).toBe(realDir);
+      }
     });
   });
 });

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -179,15 +179,11 @@ describe('LocalWorkspace', () => {
       };
 
       const originalRealpath = fs.promises.realpath;
-      let parentRealpathCalls = 0;
       const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
         const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
         const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
         if (!swapped && targetString === canonicalParentDir) {
-          parentRealpathCalls += 1;
-          if (parentRealpathCalls === 1) {
-            await swapParent();
-          }
+          await swapParent();
         }
         return result;
       });
@@ -220,15 +216,11 @@ describe('LocalWorkspace', () => {
       };
 
       const originalRealpath = fs.promises.realpath;
-      let parentRealpathCalls = 0;
       const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
         const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
         const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
         if (!swapped && targetString === canonicalParentDir) {
-          parentRealpathCalls += 1;
-          if (parentRealpathCalls === 4) {
-            await swapParent();
-          }
+          await swapParent();
         }
         return result;
       });
@@ -262,17 +254,20 @@ describe('LocalWorkspace', () => {
       };
 
       const originalLstat = fs.promises.lstat;
-      let parentLstatCalls = 0;
+      const childPath = path.join(canonicalParentDir, 'child');
       const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
         const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
-        const result = await originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
-        if (!swapped && targetString === canonicalParentDir) {
-          parentLstatCalls += 1;
-          if (parentLstatCalls === 2) {
-            await swapParent();
+        if (!swapped && targetString === childPath) {
+          try {
+            return await originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
+          } catch (error) {
+            if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+              await swapParent();
+            }
+            throw error;
           }
         }
-        return result;
+        return originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
       });
 
       try {

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -150,11 +150,11 @@ describe('LocalWorkspace', () => {
       expect(fs.existsSync(externalDir)).toBe(false);
     });
 
-    it('rejects file-only allowances when the parent becomes a symlink mid-write', async () => {
-      if (process.platform === 'win32') return;
+	    it('rejects file-only allowances when the parent becomes a symlink mid-write', async () => {
+	      if (process.platform === 'win32') return;
 
-      const { workspace } = await makeWorkspace((dir) => created.push(dir));
-      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-parent-'));
+	      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+	      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-parent-'));
       created.push(externalDir);
       const parentDir = path.join(externalDir, 'allowed-parent');
       await fs.promises.mkdir(parentDir, { recursive: true });
@@ -165,46 +165,121 @@ describe('LocalWorkspace', () => {
 
       const canonicalParentDir = await fs.promises.realpath(parentDir);
 
-      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-'));
-      created.push(redirectDir);
+	      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-'));
+	      created.push(redirectDir);
 
-      let swapped = false;
-      const swapParent = async () => {
+	      let swapped = false;
+	      const swapParent = async () => {
         if (swapped) return;
         swapped = true;
         const backupDir = `${canonicalParentDir}-bak`;
         await fs.promises.rename(canonicalParentDir, backupDir);
-        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
-      };
+	        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+	      };
 
-      const originalStat = fs.promises.stat;
-      const originalLstat = fs.promises.lstat;
+	      const originalLstat = fs.promises.lstat;
+	      const canonicalAllowedFile = await fs.promises.realpath(allowedFile);
 
-      const statSpy = vi.spyOn(fs.promises, 'stat').mockImplementation(async (targetPath, ...args) => {
-        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
-        if (!swapped && targetString === canonicalParentDir) {
-          await swapParent();
-        }
-        return originalStat.call(fs.promises, targetPath as never, ...(args as never[]));
-      });
+	      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
+	        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+	        if (!swapped && targetString === canonicalAllowedFile) {
+	          await swapParent();
+	        }
+	        return originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
+	      });
 
-      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
-        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
-        if (!swapped && targetString === canonicalParentDir) {
-          await swapParent();
-        }
-        return originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
-      });
+	      try {
+	        await expect(workspace.writeFile(allowedFile, 'hello')).rejects.toThrowError(/symlink|refusing|parent/i);
+	        expect(fs.existsSync(path.join(redirectDir, 'outside.txt'))).toBe(false);
+	      } finally {
+	        lstatSpy.mockRestore();
+	      }
+	    });
 
-      try {
-        await expect(workspace.writeFile(allowedFile, 'hello')).rejects.toThrowError(/symlink|refusing|parent/i);
-        expect(fs.existsSync(path.join(redirectDir, 'outside.txt'))).toBe(false);
-      } finally {
-        statSpy.mockRestore();
-        lstatSpy.mockRestore();
-      }
-    });
-  });
+	    it('rejects workspace writes when the parent becomes a symlink mid-write', async () => {
+	      if (process.platform === 'win32') return;
+
+	      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+	      const parentDir = path.join(dir, 'parent');
+	      await fs.promises.mkdir(parentDir, { recursive: true });
+	      const canonicalParentDir = await fs.promises.realpath(parentDir);
+
+	      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-workspace-'));
+	      created.push(redirectDir);
+
+	      let swapped = false;
+	      const swapParent = async () => {
+	        if (swapped) return;
+	        swapped = true;
+	        const backupDir = `${canonicalParentDir}-bak`;
+	        await fs.promises.rename(canonicalParentDir, backupDir);
+	        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+	      };
+
+	      const originalRealpath = fs.promises.realpath;
+	      let parentRealpathCalls = 0;
+	      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+	        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+	        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+	        if (!swapped && targetString === canonicalParentDir) {
+	          parentRealpathCalls += 1;
+	          if (parentRealpathCalls === 2) {
+	            await swapParent();
+	          }
+	        }
+	        return result;
+	      });
+
+	      try {
+	        await expect(workspace.writeFile('parent/inside.txt', 'hello')).rejects.toThrowError(/symlink|escapes|refusing/i);
+	        expect(fs.existsSync(path.join(redirectDir, 'inside.txt'))).toBe(false);
+	      } finally {
+	        realpathSpy.mockRestore();
+	      }
+	    });
+
+	    it('rejects directory creation when an ancestor becomes a symlink mid-create', async () => {
+	      if (process.platform === 'win32') return;
+
+	      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+	      const parentDir = path.join(dir, 'parent');
+	      await fs.promises.mkdir(parentDir, { recursive: true });
+	      const canonicalParentDir = await fs.promises.realpath(parentDir);
+
+	      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-dir-'));
+	      created.push(redirectDir);
+
+	      let swapped = false;
+	      const swapParent = async () => {
+	        if (swapped) return;
+	        swapped = true;
+	        const backupDir = `${canonicalParentDir}-bak`;
+	        await fs.promises.rename(canonicalParentDir, backupDir);
+	        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+	      };
+
+	      const originalLstat = fs.promises.lstat;
+	      let parentLstatCalls = 0;
+	      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
+	        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+	        const result = await originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
+	        if (!swapped && targetString === canonicalParentDir) {
+	          parentLstatCalls += 1;
+	          if (parentLstatCalls === 2) {
+	            await swapParent();
+	          }
+	        }
+	        return result;
+	      });
+
+	      try {
+	        await expect(workspace.ensureDirectory('parent/child')).rejects.toThrowError(/symlink|escapes|Path escapes/i);
+	        expect(fs.existsSync(path.join(redirectDir, 'child'))).toBe(false);
+	      } finally {
+	        lstatSpy.mockRestore();
+	      }
+	    });
+	  });
 
   describe('commands', () => {
     it('runs commands rooted in the workspace', async () => {

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -185,7 +185,6 @@ describe('LocalWorkspace', () => {
         if (!swapped && targetString === canonicalParentDir) {
           await swapParent();
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return originalStat.call(fs.promises, targetPath as never, ...(args as never[]));
       });
 
@@ -194,7 +193,6 @@ describe('LocalWorkspace', () => {
         if (!swapped && targetString === canonicalParentDir) {
           await swapParent();
         }
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         return originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
       });
 

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -135,6 +135,20 @@ describe('LocalWorkspace', () => {
       expect(workspace.resolvePath(externalFile)).toBe(realExternalFile);
       expect(() => workspace.resolvePath(path.join(externalFile, 'child'))).toThrowError();
     });
+
+    it('does not create parent directories for file-only external allowances', async () => {
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-missing-'));
+      created.push(externalDir);
+      await fs.promises.rm(externalDir, { recursive: true, force: true });
+      expect(fs.existsSync(externalDir)).toBe(false);
+
+      const externalFile = path.join(externalDir, 'outside.txt');
+      workspace.allowPath(externalFile);
+
+      await expect(workspace.writeFile(externalFile, 'hello')).rejects.toThrowError(/parent directory does not exist/i);
+      expect(fs.existsSync(externalDir)).toBe(false);
+    });
   });
 
   describe('commands', () => {

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -26,9 +26,59 @@ describe('LocalWorkspace', () => {
       expect(content).toBe('hello');
     });
 
-    it('blocks traversal outside the sandbox', async () => {
+    it('blocks path traversal attacks', async () => {
       const { workspace } = await makeWorkspace((dir) => created.push(dir));
-      expect(() => workspace.resolvePath('../etc/passwd')).toThrowError();
+      const vectors = [
+        '../sensitive.txt',
+        '../../sensitive.txt',
+        '../../../etc/passwd',
+        'subdir/../../../sensitive.txt',
+        '..\\sensitive.txt',
+        'subdir/../../sensitive.txt',
+        './../sensitive.txt',
+        'a/../../../sensitive.txt',
+      ];
+
+      for (const attackPath of vectors) {
+        expect(() => workspace.resolvePath(attackPath)).toThrowError(/Path escapes workspace root/);
+      }
+    });
+
+    it('allows legitimate paths inside the sandbox', async () => {
+      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+      const realDir = await fs.promises.realpath(dir);
+
+      const legitimatePaths = [
+        'file.txt',
+        'subdir/file.txt',
+        'deep/nested/path/file.txt',
+        'file_with_dots.txt',
+        '.hidden_file',
+        'subdir/.hidden',
+      ];
+
+      for (const legitPath of legitimatePaths) {
+        const resolved = workspace.resolvePath(legitPath);
+        const relative = path.relative(realDir, resolved);
+        expect(relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))).toBe(true);
+      }
+
+      expect(workspace.resolvePath('')).toBe(realDir);
+      expect(workspace.resolvePath('.')).toBe(realDir);
+    });
+
+    it('blocks symlink escapes for nested non-existent paths', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-outside-'));
+      created.push(externalDir);
+
+      const symlinkPath = path.join(dir, 'linked');
+      await fs.promises.symlink(externalDir, symlinkPath, 'dir');
+
+      expect(() => workspace.resolvePath('linked')).toThrowError(/Path escapes workspace root/);
+      expect(() => workspace.resolvePath('linked/subdir/file.txt')).toThrowError(/Path escapes workspace root/);
     });
 
     it('allows explicitly-approved external paths', async () => {

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it, afterEach } from 'vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
 import { LocalWorkspace } from '..';
 
 const makeWorkspace = async (register: (dir: string) => void) => {
@@ -148,6 +148,63 @@ describe('LocalWorkspace', () => {
 
       await expect(workspace.writeFile(externalFile, 'hello')).rejects.toThrowError(/parent directory does not exist/i);
       expect(fs.existsSync(externalDir)).toBe(false);
+    });
+
+    it('rejects file-only allowances when the parent becomes a symlink mid-write', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-external-parent-'));
+      created.push(externalDir);
+      const parentDir = path.join(externalDir, 'allowed-parent');
+      await fs.promises.mkdir(parentDir, { recursive: true });
+
+      const allowedFile = path.join(parentDir, 'outside.txt');
+      await fs.promises.writeFile(allowedFile, 'original', 'utf8');
+      workspace.allowPath(allowedFile);
+
+      const canonicalParentDir = await fs.promises.realpath(parentDir);
+
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-'));
+      created.push(redirectDir);
+
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
+
+      const originalStat = fs.promises.stat;
+      const originalLstat = fs.promises.lstat;
+
+      const statSpy = vi.spyOn(fs.promises, 'stat').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        if (!swapped && targetString === canonicalParentDir) {
+          await swapParent();
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return originalStat.call(fs.promises, targetPath as never, ...(args as never[]));
+      });
+
+      const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        if (!swapped && targetString === canonicalParentDir) {
+          await swapParent();
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        return originalLstat.call(fs.promises, targetPath as never, ...(args as never[]));
+      });
+
+      try {
+        await expect(workspace.writeFile(allowedFile, 'hello')).rejects.toThrowError(/symlink|refusing|parent/i);
+        expect(fs.existsSync(path.join(redirectDir, 'outside.txt'))).toBe(false);
+      } finally {
+        statSpy.mockRestore();
+        lstatSpy.mockRestore();
+      }
     });
   });
 

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -86,6 +86,22 @@ describe('LocalWorkspace', () => {
       expect(() => workspace.resolvePath('linked/subdir/file.txt')).toThrowError(/Path escapes workspace root/);
     });
 
+    it('blocks dangling symlink escapes (even when target does not exist)', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace, dir } = await makeWorkspace((value) => created.push(value));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-dangling-'));
+      created.push(externalDir);
+      await fs.promises.rm(externalDir, { recursive: true, force: true });
+
+      const symlinkPath = path.join(dir, 'dangling');
+      await fs.promises.symlink(externalDir, symlinkPath, 'dir');
+
+      expect(() => workspace.resolvePath('dangling/secret.txt')).toThrowError();
+      await expect(workspace.writeFile('dangling/secret.txt', 'nope')).rejects.toThrowError();
+      expect(fs.existsSync(externalDir)).toBe(false);
+    });
+
     it('allows symlinks that remain inside the sandbox', async () => {
       if (process.platform === 'win32') return;
 


### PR DESCRIPTION
Fixes Beads issue oh-tab-pla.\n\n- Harden LocalWorkspace path normalization to realpath the nearest existing ancestor (blocks symlink escapes for nested non-existent paths).\n- Expand LocalWorkspace security tests to cover traversal vectors + symlink escapes.\n\nTests: npm test -w @openhands/agent-sdk-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened path handling to block workspace escapes, including symlink-aware checks, containment roots, and atomic safe-writes with TOCTTOU mitigations.
  * Hardened directory creation and read/write operations to reject unsafe symlinks and prevent escaping the workspace.
  * Improved Windows command timeout behavior to better terminate process trees.
  * Command shell option now accepts string or boolean.

* **Tests**
  * Expanded cross-platform tests for traversal vectors, symlink scenarios, legitimate internal paths, mid-operation symlink changes, and external allowances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->