### PR TITLE
oh-tab-nbc: Add file_editor undo_edit

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -115,6 +115,8 @@ type UndoEntry = {
   oldContent: string | null;
 };
 
+const MAX_UNDO_ENTRIES_PER_PATH = 10;
+
 export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, FileEditorResult> {
   readonly name = 'file_editor';
   readonly description = TOOL_DESCRIPTION;
@@ -188,7 +190,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         const current = await this.readOptionalFile(resolved);
 
         if (!undo.prevExist) {
-          await ws.remove(resolved);
+          await this.removeCreatedFile(resolved);
           return { command: 'undo_edit', path: resolved, prev_exist: true, old_content: current, new_content: null };
         }
 
@@ -205,6 +207,9 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
   private pushUndo(resolvedPath: string, entry: UndoEntry): void {
     const stack = this.undoHistory.get(resolvedPath) ?? [];
     stack.push(entry);
+    while (stack.length > MAX_UNDO_ENTRIES_PER_PATH) {
+      stack.shift();
+    }
     this.undoHistory.set(resolvedPath, stack);
   }
 
@@ -225,6 +230,19 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       return await fs.readFile(absPath, 'utf8');
     } catch {
       return null;
+    }
+  }
+
+  private async removeCreatedFile(absPath: string): Promise<void> {
+    try {
+      const stat = await fs.lstat(absPath);
+      if (stat.isDirectory()) {
+        throw new Error(`undo_edit failed: refusing to delete directory: ${absPath}`);
+      }
+      await fs.unlink(absPath);
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') return;
+      throw error;
     }
   }
 }

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -207,9 +207,9 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         }
 
         if (!undo.prevExist) {
-          return { command: 'undo_edit', path: resolved, prev_exist: current !== null, old_content: current, new_content: null };
+          return { command: 'undo_edit', path: resolved, prev_exist: undo.prevExist, old_content: current, new_content: null };
         }
-        return { command: 'undo_edit', path: resolved, prev_exist: current !== null, old_content: current, new_content: undo.oldContent };
+        return { command: 'undo_edit', path: resolved, prev_exist: undo.prevExist, old_content: current, new_content: undo.oldContent };
       }
       default: {
         const unreachable: never = args.command;

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -186,16 +186,30 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {
-        const undo = this.popUndo(resolved);
         const current = await this.readOptionalFile(resolved);
+
+        const stack = this.undoHistory.get(resolved);
+        if (!stack || stack.length === 0) {
+          throw new Error('undo_edit failed: no edit history for path');
+        }
+
+        const undo = stack[stack.length - 1];
 
         if (!undo.prevExist) {
           await this.removeCreatedFile(resolved);
-          return { command: 'undo_edit', path: resolved, prev_exist: true, old_content: current, new_content: null };
+        } else {
+          await ws.writeFile(resolved, undo.oldContent ?? '');
         }
 
-        await ws.writeFile(resolved, undo.oldContent ?? '');
-        return { command: 'undo_edit', path: resolved, prev_exist: true, old_content: current, new_content: undo.oldContent };
+        stack.pop();
+        if (stack.length === 0) {
+          this.undoHistory.delete(resolved);
+        }
+
+        if (!undo.prevExist) {
+          return { command: 'undo_edit', path: resolved, prev_exist: current !== null, old_content: current, new_content: null };
+        }
+        return { command: 'undo_edit', path: resolved, prev_exist: current !== null, old_content: current, new_content: undo.oldContent };
       }
       default: {
         const unreachable: never = args.command;
@@ -211,18 +225,6 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       stack.shift();
     }
     this.undoHistory.set(resolvedPath, stack);
-  }
-
-  private popUndo(resolvedPath: string): UndoEntry {
-    const stack = this.undoHistory.get(resolvedPath);
-    if (!stack || stack.length === 0) {
-      throw new Error('undo_edit failed: no edit history for path');
-    }
-    const entry = stack.pop()!;
-    if (stack.length === 0) {
-      this.undoHistory.delete(resolvedPath);
-    }
-    return entry;
   }
 
   private async readOptionalFile(absPath: string): Promise<string | null> {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -4,7 +4,7 @@ import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
 
 export interface FileEditorResult {
-  command: 'view' | 'create' | 'str_replace' | 'insert';
+  command: 'view' | 'create' | 'str_replace' | 'insert' | 'undo_edit';
   path?: string;
   prev_exist?: boolean;
   old_content?: string | null;
@@ -15,6 +15,7 @@ const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing 
 * State is persistent across command calls and discussions with the user
 * If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists non-hidden files and directories up to 2 levels deep
 * The \`create\` command cannot be used if the specified \`path\` already exists as a file
+* The \`undo_edit\` command undoes the most recent edit for a \`path\` (including undoing a create)
 * If a \`command\` generates a long output, it will be truncated and marked with \`<response clipped>\`
 * This tool can be used for creating and editing files in plain-text format.
 
@@ -45,8 +46,8 @@ Remember: when making multiple file edits in a row to the same file, you should 
 const fileEditorSchema = z
   .object({
     command: z
-      .enum(['view', 'create', 'str_replace', 'insert'])
-      .describe('The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`.'),
+      .enum(['view', 'create', 'str_replace', 'insert', 'undo_edit'])
+      .describe('The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.'),
     path: z.string().describe('Absolute path to file or directory.'),
     file_text: z
       .string()
@@ -109,10 +110,16 @@ const truncateContent = (content: string, limit = 500): string => {
   return `${head}\n<response clipped>\n${tail}`;
 };
 
+type UndoEntry = {
+  prevExist: boolean;
+  oldContent: string | null;
+};
+
 export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, FileEditorResult> {
   readonly name = 'file_editor';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = fileEditorSchema;
+  private readonly undoHistory = new Map<string, UndoEntry[]>();
 
   private async pathExists(absPath: string): Promise<boolean> {
     try {
@@ -147,6 +154,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           throw new Error('create failed: file already exists');
         }
         await ws.writeFile(args.path, args.file_text ?? '');
+        this.pushUndo(resolved, { prevExist: false, oldContent: null });
         return { command: 'create', path: resolved, prev_exist: false, old_content: null, new_content: args.file_text ?? '' };
       }
       case 'str_replace': {
@@ -161,6 +169,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
         await ws.writeFile(args.path, updated);
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
@@ -171,12 +180,51 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
         await ws.writeFile(args.path, updated);
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
+      }
+      case 'undo_edit': {
+        const undo = this.popUndo(resolved);
+        const current = await this.readOptionalFile(resolved);
+
+        if (!undo.prevExist) {
+          await ws.remove(resolved);
+          return { command: 'undo_edit', path: resolved, prev_exist: true, old_content: current, new_content: null };
+        }
+
+        await ws.writeFile(resolved, undo.oldContent ?? '');
+        return { command: 'undo_edit', path: resolved, prev_exist: true, old_content: current, new_content: undo.oldContent };
       }
       default: {
         const unreachable: never = args.command;
         throw new Error(`Unsupported command: ${String(unreachable)}`);
       }
+    }
+  }
+
+  private pushUndo(resolvedPath: string, entry: UndoEntry): void {
+    const stack = this.undoHistory.get(resolvedPath) ?? [];
+    stack.push(entry);
+    this.undoHistory.set(resolvedPath, stack);
+  }
+
+  private popUndo(resolvedPath: string): UndoEntry {
+    const stack = this.undoHistory.get(resolvedPath);
+    if (!stack || stack.length === 0) {
+      throw new Error('undo_edit failed: no edit history for path');
+    }
+    const entry = stack.pop()!;
+    if (stack.length === 0) {
+      this.undoHistory.delete(resolvedPath);
+    }
+    return entry;
+  }
+
+  private async readOptionalFile(absPath: string): Promise<string | null> {
+    try {
+      return await fs.readFile(absPath, 'utf8');
+    } catch {
+      return null;
     }
   }
 }

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -195,11 +195,11 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
 
         const undo = stack[stack.length - 1];
 
-        if (!undo.prevExist) {
-          await this.removeCreatedFile(resolved);
-        } else {
-          await ws.writeFile(resolved, undo.oldContent ?? '');
-        }
+	        if (!undo.prevExist) {
+	          await this.removeCreatedFile(resolved);
+	        } else {
+	          await ws.writeFile(args.path, undo.oldContent ?? '');
+	        }
 
         stack.pop();
         if (stack.length === 0) {

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -129,6 +129,8 @@ describe('FileEditorTool', () => {
 
     await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace }))
       .rejects.toThrowError(/refusing to delete directory/i);
+    await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace }))
+      .rejects.toThrowError(/refusing to delete directory/i);
     expect(fs.statSync(path.join(dir, 'note.txt')).isDirectory()).toBe(true);
   });
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -118,6 +118,43 @@ describe('FileEditorTool', () => {
     await expect(workspace.readFile('note.txt')).rejects.toThrowError();
   });
 
+  it('undo_edit refuses to delete directories when undoing a create', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'content' }), { workspace });
+    await fs.promises.unlink(path.join(dir, 'note.txt'));
+    await fs.promises.mkdir(path.join(dir, 'note.txt'));
+
+    await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace }))
+      .rejects.toThrowError(/refusing to delete directory/i);
+    expect(fs.statSync(path.join(dir, 'note.txt')).isDirectory()).toBe(true);
+  });
+
+  it('caps undo_edit history per path', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'v0' }), { workspace });
+    for (let i = 0; i < 11; i++) {
+      await tool.execute(
+        tool.validate({ command: 'str_replace', path: 'note.txt', old_str: `v${i}`, new_str: `v${i + 1}` }),
+        { workspace },
+      );
+    }
+    expect(await workspace.readFile('note.txt')).toBe('v11');
+
+    for (let i = 0; i < 10; i++) {
+      await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    }
+    expect(await workspace.readFile('note.txt')).toBe('v1');
+
+    await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace }))
+      .rejects.toThrowError(/no edit history/i);
+  });
+
   it('throws undo_edit when there is no history', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -89,6 +89,7 @@ describe('FileEditorTool', () => {
 
     const undo = await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
     expect(undo.command).toBe('undo_edit');
+    expect(undo.prev_exist).toBe(true);
     expect(await workspace.readFile('note.txt')).toBe('v0');
   });
 
@@ -114,7 +115,8 @@ describe('FileEditorTool', () => {
     const tool = new FileEditorTool();
 
     await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'content' }), { workspace });
-    await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    const undo = await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    expect(undo.prev_exist).toBe(false);
     await expect(workspace.readFile('note.txt')).rejects.toThrowError();
   });
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -78,6 +78,55 @@ describe('FileEditorTool', () => {
     expect(head.length).toBeLessThanOrEqual(500 + 20); // small slop for line boundaries
     expect(tail.length).toBeLessThanOrEqual(500 + 20);
   });
+
+  it('supports undo_edit for edits', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'v0' }), { workspace });
+    await tool.execute(tool.validate({ command: 'str_replace', path: 'note.txt', old_str: 'v0', new_str: 'v1' }), { workspace });
+
+    const undo = await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    expect(undo.command).toBe('undo_edit');
+    expect(await workspace.readFile('note.txt')).toBe('v0');
+  });
+
+  it('supports multiple undo_edit calls', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'v0' }), { workspace });
+    await tool.execute(tool.validate({ command: 'str_replace', path: 'note.txt', old_str: 'v0', new_str: 'v1' }), { workspace });
+    await tool.execute(tool.validate({ command: 'str_replace', path: 'note.txt', old_str: 'v1', new_str: 'v2' }), { workspace });
+
+    await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    expect(await workspace.readFile('note.txt')).toBe('v1');
+
+    await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    expect(await workspace.readFile('note.txt')).toBe('v0');
+  });
+
+  it('undo_edit can undo a create by deleting the file', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'content' }), { workspace });
+    await tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace });
+    await expect(workspace.readFile('note.txt')).rejects.toThrowError();
+  });
+
+  it('throws undo_edit when there is no history', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await workspace.writeFile('note.txt', 'content');
+    await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace }))
+      .rejects.toThrowError(/no edit history/i);
+  });
 });
 
 describe('TaskTrackerTool', () => {


### PR DESCRIPTION
Fixes Beads issue oh-tab-nbc.\n\n- Add undo_edit to FileEditorTool schema + implementation (per-path undo stack).\n- Support undoing create (deletes file) and undoing edits (restores previous content).\n- Add Vitest coverage for undo history + no-history error.\n\nTests: npm test -w @openhands/agent-sdk-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added undo functionality for file edits, letting users reverse recent changes and restore prior content.
  * Edit history tracked per file with a configurable cap to limit stored undos.
  * Undoing a create removes the created file; protections prevent accidental directory deletion.
* **Tests**
  * Added comprehensive tests covering single/multiple undos, create-undo deletion, history cap behavior, and empty-history errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->