### PR TITLE
oh-tab-wc7: Restore pending confirmation after reload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,37 +133,37 @@ Reviews (do not merge without review):
 - Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
 
 **Reviewer workflow** (the OpenHands roasted review via tmux):
-  - Use a clean worktree to avoid clobbering shared branches/uncommitted changes:
-    ```bash
-    WORKTREE="$(mktemp -d -t oh-tab-review.XXXXXX)"
-    git worktree add --detach "$WORKTREE" HEAD
-    ```
-  - Start a named tmux session and capture output to a log file:
-    (use the actual PR number, below is just an example)
-    ```bash
-    SESSION=oh_pr${PR_NUMBER}
-    LOG="/tmp/${SESSION}.log"
-    rm -f "$LOG"
+- Use a clean worktree to avoid clobbering shared branches/uncommitted changes:
+  ```bash
+  WORKTREE="$(mktemp -d -t oh-tab-review.XXXXXX)"
+  git worktree add --detach "$WORKTREE" HEAD
+  ```
+- Start a named tmux session and capture output to a log file:
+  (use the actual PR number, below is just an example)
+  ```bash
+  SESSION=oh_pr${PR_NUMBER}
+  LOG="/tmp/${SESSION}.log"
+  rm -f "$LOG"
 
-    tmux new-session -d -s "$SESSION" -n review -c "$WORKTREE" \
-      "openhands --headless --always-approve -t '/codereview-roasted pr 246'"
-    tmux pipe-pane -o -t "${SESSION}:0.0" "cat >> $LOG"
+  tmux new-session -d -s "$SESSION" -n review -c "$WORKTREE" \
+    "openhands --headless --always-approve -t '/codereview-roasted pr 246'"
+  tmux pipe-pane -o -t "${SESSION}:0.0" "cat >> $LOG"
 
-    # Optional: strip ANSI while viewing
-    tail -f "$LOG" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
-    ```
-  - Send follow-ups / re-review requests to the *same* waiting session:
-    ```bash
-    tmux send-keys -t "${SESSION}:0.0" "Re-review PR ${PR_NUMBER} after latest commits." Enter
-    ```
-  - Stop the session when the PR is merged:
-    ```bash
-    tmux kill-session -t "$SESSION"
-    git worktree remove "$WORKTREE"
-    ```
-  - Pitfalls we hit:
-    - You must pass the task with `-t` (positional args are treated as subcommands).
-    - `--exp` UI is noisy to log/copy (ANSI); `--headless` is easier for paste-back to Mail.
+  # Optional: strip ANSI while viewing
+  tail -f "$LOG" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
+  ```
+- Send follow-ups / re-review requests to the *same* waiting session:
+  ```bash
+  tmux send-keys -t "${SESSION}:0.0" "Re-review PR ${PR_NUMBER} after latest commits." Enter
+  ```
+- Stop the session when the PR is merged:
+  ```bash
+  tmux kill-session -t "$SESSION"
+  git worktree remove "$WORKTREE"
+  ```
+- Pitfalls we hit:
+  - You must pass the task with `-t` (positional args are treated as subcommands).
+  - `--exp` UI is noisy to log/copy (ANSI); `--headless` is easier for paste-back to Mail.
 
 
 ## SDK Package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,20 +116,55 @@ Before opening or updating a PR:
 - Ensure GitHub CI checks are green on the PR
 
 Reviews (do not merge without review):
-- Request an OpenHands review (mandatory): comment `@openhands /codereview-roasted`.
-  - If OpenHands is unresponsive after ~15 minutes, do not block indefinitely: proceed with Gemini + CI green and merge, then follow up if needed.
-  - If OpenHands flags deeper issues, fix and re-request `@openhands /codereview-roasted`.
+- Do **not** request OpenHands review via GitHub comments anymore (e.g. `@openhands /codereview-roasted`).
+- Request review via **Agent Mail** (mandatory):
+  - Requester (e.g., `BlackDog`): send an Agent Mail message to a reviewer with the PR link/number and context; set `ack_required=true`.
+  - Reviewer (e.g., `OrangeCastle`): run the OpenHands roasted review locally (via tmux) and reply in-thread with the full output.
 - Ensure the GitHub AI reviewers are done (or clearly unavailable):
-  - **Gemini-code-assist**: treat as "done" once it has posted two top-level comments and you've checked/resolved its inline threads. Trigger with `/gemini review` if needed.
+  - **Gemini-code-assist**: starts automatically upon PR creation; treat it as "one review done" once it has posted two top-level comments and you've checked/resolved its inline threads. Re-trigger with `/gemini review` if needed.
   - **CodeRabbitAI**: only wait if its ETA is <=10 minutes (pending or rate-limited). If it would block longer than that, proceed without it.
-    - Re-trigger with `@coderabbitai review` if needed.
-- Always read review threads in "Files changed" (OpenHands + bots leave inline comments).
+    - if you waited for its rate-limit to expire (if it was under 10 minutes), you can re-trigger with `@coderabbitai review`.
+- Always read review threads in "Files changed" (bots leave inline comments).
 - Right before merging, do a final pass on GitHub to avoid missing late feedback:
   - "Conversation" tab: scan top-level comments (including bots).
   - "Files changed" tab: scan/resolve inline review threads.
   - Checks: confirm OpenHands/Gemini/CodeRabbit aren't still pending (or explicitly waived per the policy above).
 - If OpenHands feedback is "truly minor" (e.g., wording/typos/formatting only), you can address it without re-requesting review.
 - Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
+
+**Reviewer workflow** (the OpenHands roasted review via tmux):
+  - Use a clean worktree to avoid clobbering shared branches/uncommitted changes:
+    ```bash
+    WORKTREE="$(mktemp -d -t oh-tab-review.XXXXXX)"
+    git worktree add --detach "$WORKTREE" HEAD
+    ```
+  - Start a named tmux session and capture output to a log file:
+    (use the actual PR number, below is just an example)
+    ```bash
+    SESSION=oh_pr${PR_NUMBER}
+    LOG="/tmp/${SESSION}.log"
+    rm -f "$LOG"
+
+    tmux new-session -d -s "$SESSION" -n review -c "$WORKTREE" \
+      "openhands --headless --always-approve -t '/codereview-roasted pr 246'"
+    tmux pipe-pane -o -t "${SESSION}:0.0" "cat >> $LOG"
+
+    # Optional: strip ANSI while viewing
+    tail -f "$LOG" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g'
+    ```
+  - Send follow-ups / re-review requests to the *same* waiting session:
+    ```bash
+    tmux send-keys -t "${SESSION}:0.0" "Re-review PR ${PR_NUMBER} after latest commits." Enter
+    ```
+  - Stop the session when the PR is merged:
+    ```bash
+    tmux kill-session -t "$SESSION"
+    git worktree remove "$WORKTREE"
+    ```
+  - Pitfalls we hit:
+    - You must pass the task with `-t` (positional args are treated as subcommands).
+    - `--exp` UI is noisy to log/copy (ANSI); `--headless` is easier for paste-back to Mail.
+
 
 ## SDK Package
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -6,7 +6,9 @@ import { LocalConversation } from '../conversation';
 import { ConversationState, EventLog, FileStore } from '../runtime';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
 import type { Event, MessageEvent, TextContent } from '../types';
+import { isObservationEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
+import type { ToolDefinition } from '../types/tools';
 
 class MockLLM implements LLMClient {
   constructor(private readonly chunks: LLMStreamChunk[]) {}
@@ -136,6 +138,54 @@ describe('LocalConversation persistence', () => {
     const messagesAfter = restoredEvents.length;
 
     expect(messagesAfter).toBeGreaterThan(messagesBefore);
+  });
+
+  it('restores pending confirmations so approveAction works after restore', async () => {
+    const dir = makeTempDir('local-confirmation-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const settings: OpenHandsSettings = { ...baseSettings, confirmation: { policy: 'always' } };
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const conversation = new LocalConversation({
+      settings,
+      workspaceRoot,
+      llmClient: llm,
+      tools: [tool],
+      persistenceDir: dir,
+    });
+
+    const id = await conversation.startNewConversation();
+    await conversation.sendUserMessage('run tool');
+    const stateAfterRun = (conversation as unknown as { state: ConversationState }).state.snapshot;
+    expect(stateAfterRun.status).toBe('WAITING_FOR_CONFIRMATION');
+
+    const restoredEvents: Event[] = [];
+    const restored = new LocalConversation({
+      settings,
+      workspaceRoot,
+      llmClient: new MockLLM([{ type: 'finish' }]),
+      tools: [tool],
+      persistenceDir: dir,
+    });
+    restored.on('event', (e) => restoredEvents.push(e));
+    restored.restoreConversation(id!);
+
+    const before = restoredEvents.length;
+    await restored.approveAction();
+    const newEvents = restoredEvents.slice(before);
+
+    const observation = newEvents.find((e) => isObservationEvent(e) && e.tool_name === 'echo');
+    expect(observation).toBeDefined();
+    expect(JSON.stringify(observation?.observation ?? {})).toContain('hi');
   });
 });
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -142,22 +142,22 @@ describe('LocalConversation persistence', () => {
   });
 
   it('restores pending confirmations so approveAction works after restore', async () => {
-	    const dir = makeTempDir('local-confirmation-');
-	    const workspaceRoot = makeTempDir('local-workspace-');
-	    const settings: OpenHandsSettings = { ...baseSettings, confirmation: { policy: 'always' } };
-	    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
-	      name: 'echo',
-	      validate: (input: unknown) => {
-	        if (input && typeof input === 'object' && 'value' in input) {
-	          const value = (input as { value?: unknown }).value;
-	          if (typeof value === 'string') {
-	            return { value };
-	          }
-	        }
-	        throw new Error('Invalid input for echo tool');
-	      },
-	      execute: async (args) => ({ echoed: args.value }),
-	    };
+    const dir = makeTempDir('local-confirmation-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const settings: OpenHandsSettings = { ...baseSettings, confirmation: { policy: 'always' } };
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input: unknown) => {
+        if (input && typeof input === 'object' && 'value' in input) {
+          const value = (input as { value?: unknown }).value;
+          if (typeof value === 'string') {
+            return { value };
+          }
+        }
+        throw new Error('Invalid input for echo tool');
+      },
+      execute: async (args) => ({ echoed: args.value }),
+    };
     const llm = new MockLLM([
       { type: 'text', text: 'Using tool' },
       { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -258,6 +258,67 @@ describe('LocalConversation persistence', () => {
       (event) => event.kind === 'ConversationStateUpdateEvent' && (event as unknown as { key?: unknown }).key === 'restore_pending_confirmation',
     );
     expect(diagnostic).toBeDefined();
+
+    const restoredState = (restored as unknown as { state: ConversationState }).state.snapshot;
+    expect(restoredState.status).toBe('IDLE');
+
+    const restoreError = restoredEvents.find(
+      (event) =>
+        event.kind === 'ConversationErrorEvent' &&
+        (event as unknown as { code?: unknown }).code === 'restore_pending_confirmation_failed',
+    );
+    expect(restoreError).toBeDefined();
+  });
+
+  it('clears stale WAITING_FOR_CONFIRMATION snapshots when the tool call is already resolved', () => {
+    const dir = makeTempDir('local-stale-waiting-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+
+    const conversationId = 'local-stale-waiting';
+    const store = new FileStore({ rootDir: dir, conversationId });
+    store.writeState({ status: 'WAITING_FOR_CONFIRMATION', iteration: 0, values: {} });
+    store.appendEvent({
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [],
+      action: { command: 'echo', value: 'hi' },
+      tool_name: 'echo',
+      tool_call_id: 'call_1',
+    } as Event);
+    store.appendEvent({ kind: 'PauseEvent', source: 'agent' } as Event);
+    store.appendEvent({
+      kind: 'ObservationEvent',
+      source: 'environment',
+      observation: { echoed: 'hi' },
+      tool_name: 'echo',
+      tool_call_id: 'call_1',
+      action_id: 'action_1',
+    } as Event);
+
+    const restoredEvents: Event[] = [];
+    const restored = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: new MockLLM([{ type: 'finish' }]),
+      persistenceDir: dir,
+    });
+    restored.on('event', (e) => restoredEvents.push(e));
+    restored.restoreConversation(conversationId);
+
+    const diagnostic = restoredEvents.find(
+      (event) => event.kind === 'ConversationStateUpdateEvent' && (event as unknown as { key?: unknown }).key === 'restore_pending_confirmation',
+    );
+    expect(diagnostic).toBeDefined();
+
+    const restoredState = (restored as unknown as { state: ConversationState }).state.snapshot;
+    expect(restoredState.status).toBe('IDLE');
+
+    const restoreError = restoredEvents.find(
+      (event) =>
+        event.kind === 'ConversationErrorEvent' &&
+        (event as unknown as { code?: unknown }).code === 'restore_pending_confirmation_failed',
+    );
+    expect(restoreError).toBeUndefined();
   });
 });
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -142,14 +142,22 @@ describe('LocalConversation persistence', () => {
   });
 
   it('restores pending confirmations so approveAction works after restore', async () => {
-    const dir = makeTempDir('local-confirmation-');
-    const workspaceRoot = makeTempDir('local-workspace-');
-    const settings: OpenHandsSettings = { ...baseSettings, confirmation: { policy: 'always' } };
-    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
-      name: 'echo',
-      validate: (input) => ({ value: (input as { value: string }).value }),
-      execute: async (args) => ({ echoed: args.value }),
-    };
+	    const dir = makeTempDir('local-confirmation-');
+	    const workspaceRoot = makeTempDir('local-workspace-');
+	    const settings: OpenHandsSettings = { ...baseSettings, confirmation: { policy: 'always' } };
+	    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+	      name: 'echo',
+	      validate: (input: unknown) => {
+	        if (input && typeof input === 'object' && 'value' in input) {
+	          const value = (input as { value?: unknown }).value;
+	          if (typeof value === 'string') {
+	            return { value };
+	          }
+	        }
+	        throw new Error('Invalid input for echo tool');
+	      },
+	      execute: async (args) => ({ echoed: args.value }),
+	    };
     const llm = new MockLLM([
       { type: 'text', text: 'Using tool' },
       { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -9,6 +9,7 @@ import type { Event, MessageEvent, TextContent } from '../types';
 import { isObservationEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
+import { FileEditorTool } from '../../tools/FileEditorTool';
 
 class MockLLM implements LLMClient {
   constructor(private readonly chunks: LLMStreamChunk[]) {}
@@ -186,6 +187,77 @@ describe('LocalConversation persistence', () => {
     const observation = newEvents.find((e) => isObservationEvent(e) && e.tool_name === 'echo');
     expect(observation).toBeDefined();
     expect(JSON.stringify(observation?.observation ?? {})).toContain('hi');
+  });
+
+  it('restores pending workspace access confirmations so approveAction allows file_editor paths after restore', async () => {
+    const dir = makeTempDir('local-workspace-access-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const outsideDir = makeTempDir('local-outside-workspace-');
+    const outsideFile = path.join(outsideDir, 'outside.txt');
+    const fileEditor = new FileEditorTool();
+
+    const llm = new MockLLM([
+      { type: 'tool_call_delta', id: 'call_1', name: 'file_editor', arguments: JSON.stringify({ command: 'create', path: outsideFile, file_text: 'hello' }) },
+      { type: 'finish' },
+    ]);
+
+    const conversation = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: llm,
+      tools: [fileEditor],
+      persistenceDir: dir,
+    });
+
+    const id = await conversation.startNewConversation();
+    await conversation.sendUserMessage('create file');
+    const stateAfterRun = (conversation as unknown as { state: ConversationState }).state.snapshot;
+    expect(stateAfterRun.status).toBe('WAITING_FOR_CONFIRMATION');
+    expect(fs.existsSync(outsideFile)).toBe(false);
+
+    const restoredEvents: Event[] = [];
+    const restored = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: new MockLLM([{ type: 'finish' }]),
+      tools: [fileEditor],
+      persistenceDir: dir,
+    });
+    restored.on('event', (e) => restoredEvents.push(e));
+    restored.restoreConversation(id!);
+
+    const before = restoredEvents.length;
+    await restored.approveAction();
+    const newEvents = restoredEvents.slice(before);
+
+    expect(fs.readFileSync(outsideFile, 'utf8')).toBe('hello');
+    const observation = newEvents.find((e) => isObservationEvent(e) && e.tool_name === 'file_editor');
+    expect(observation).toBeDefined();
+  });
+
+  it('emits a diagnostic when restoring a WAITING_FOR_CONFIRMATION snapshot without a matching ActionEvent', () => {
+    const dir = makeTempDir('local-missing-action-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+
+    const conversationId = 'local-missing-action';
+    const store = new FileStore({ rootDir: dir, conversationId });
+    store.writeState({ status: 'WAITING_FOR_CONFIRMATION', iteration: 0, values: {} });
+    store.appendEvent({ kind: 'PauseEvent', source: 'agent' } as Event);
+
+    const restoredEvents: Event[] = [];
+    const restored = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: new MockLLM([{ type: 'finish' }]),
+      persistenceDir: dir,
+    });
+    restored.on('event', (e) => restoredEvents.push(e));
+    restored.restoreConversation(conversationId);
+
+    const diagnostic = restoredEvents.find(
+      (event) => event.kind === 'ConversationStateUpdateEvent' && (event as unknown as { key?: unknown }).key === 'restore_pending_confirmation',
+    );
+    expect(diagnostic).toBeDefined();
   });
 });
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -151,6 +151,8 @@ export class LocalConversation extends EventEmitter {
       } else {
         this.state.loadEvents(loadedEvents);
       }
+
+      this.agent.restorePendingConfirmation();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       this.emit('error', err);

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -8,7 +8,7 @@ import { EventLog } from './EventLog';
 import type { LLMClient, LLMToolDefinition } from '../llm';
 import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMFactory } from '../llm';
 import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
-import { isMessageEvent, isSystemPromptEvent, isTextContent, type SecurityRisk } from '../types';
+import { isActionEvent, isMessageEvent, isSystemPromptEvent, isTextContent, type SecurityRisk } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
@@ -210,6 +210,24 @@ export class Agent extends EventEmitter {
 
   get pendingActionId(): string | undefined {
     return this.pendingAction?.actionEvent.id;
+  }
+
+  restorePendingConfirmation(): void {
+    if (this.pendingAction) return;
+    if (this.state.snapshot.status !== 'WAITING_FOR_CONFIRMATION') return;
+
+    const events = this.events.list();
+    for (let i = events.length - 1; i >= 0; i--) {
+      const event = events[i];
+      if (!isActionEvent(event)) continue;
+
+      const actionArgs: Record<string, unknown> = event.action ?? {};
+      const workspaceAccess = this.getRequiredWorkspaceAccess(event.tool_name, actionArgs);
+
+      this.pendingAction = { toolCall: event.tool_call, actionEvent: event, args: actionArgs };
+      this.pendingWorkspaceAccess = workspaceAccess;
+      return;
+    }
   }
 
   async run(input: AgentRunInput): Promise<Message | undefined> {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -8,7 +8,17 @@ import { EventLog } from './EventLog';
 import type { LLMClient, LLMToolDefinition } from '../llm';
 import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMFactory } from '../llm';
 import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
-import { isActionEvent, isMessageEvent, isSystemPromptEvent, isTextContent, type SecurityRisk } from '../types';
+import {
+  isActionEvent,
+  isAgentErrorEvent,
+  isMessageEvent,
+  isObservationEvent,
+  isPauseEvent,
+  isSystemPromptEvent,
+  isTextContent,
+  isUserRejectObservation,
+  type SecurityRisk,
+} from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
@@ -212,22 +222,67 @@ export class Agent extends EventEmitter {
     return this.pendingAction?.actionEvent.id;
   }
 
+  private emitRestorePendingConfirmationDiagnostic(reason: string, detail?: Record<string, unknown>): void {
+    this.events.push({
+      kind: 'ConversationStateUpdateEvent',
+      source: 'agent',
+      key: 'restore_pending_confirmation',
+      value: { restored: false, reason, ...detail },
+    } as Event);
+  }
+
   restorePendingConfirmation(): void {
     if (this.pendingAction) return;
     if (this.state.snapshot.status !== 'WAITING_FOR_CONFIRMATION') return;
 
     const events = this.events.list();
+    let pauseIndex = -1;
     for (let i = events.length - 1; i >= 0; i--) {
       const event = events[i];
-      if (!isActionEvent(event)) continue;
+      if (isPauseEvent(event) && event.source === 'agent') {
+        pauseIndex = i;
+        break;
+      }
+    }
 
-      const actionArgs: Record<string, unknown> = event.action ?? {};
-      const workspaceAccess = this.getRequiredWorkspaceAccess(event.tool_name, actionArgs);
-
-      this.pendingAction = { toolCall: event.tool_call, actionEvent: event, args: actionArgs };
-      this.pendingWorkspaceAccess = workspaceAccess;
+    if (pauseIndex === -1) {
+      this.emitRestorePendingConfirmationDiagnostic('missing_pause_event');
       return;
     }
+
+    let action: ActionEvent | undefined;
+    let actionIndex = -1;
+    for (let i = pauseIndex - 1; i >= 0; i--) {
+      const event = events[i];
+      if (!isActionEvent(event)) continue;
+      action = event;
+      actionIndex = i;
+      break;
+    }
+
+    if (!action || actionIndex < 0) {
+      this.emitRestorePendingConfirmationDiagnostic('missing_action_event', { pauseIndex });
+      return;
+    }
+
+    const toolCallId = action.tool_call_id;
+    const alreadyResolved = events.slice(actionIndex + 1).some((event) => {
+      if (isObservationEvent(event) || isUserRejectObservation(event) || isAgentErrorEvent(event)) {
+        return event.tool_call_id === toolCallId;
+      }
+      return false;
+    });
+
+    if (alreadyResolved) {
+      this.emitRestorePendingConfirmationDiagnostic('tool_call_already_resolved', { toolCallId });
+      return;
+    }
+
+    const actionArgs: Record<string, unknown> = action.action ?? {};
+    const workspaceAccess = this.getRequiredWorkspaceAccess(action.tool_name, actionArgs);
+
+    this.pendingAction = { toolCall: action.tool_call, actionEvent: action, args: actionArgs };
+    this.pendingWorkspaceAccess = workspaceAccess;
   }
 
   async run(input: AgentRunInput): Promise<Message | undefined> {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -231,6 +231,24 @@ export class Agent extends EventEmitter {
     } as Event);
   }
 
+  private clearWaitingForConfirmation(reason: string, detail?: Record<string, unknown>, emitError = false): void {
+    this.emitRestorePendingConfirmationDiagnostic(reason, detail);
+    if (emitError) {
+      const lines = [
+        'Pending confirmation could not be restored after reload; clearing WAITING_FOR_CONFIRMATION state.',
+        `Reason: ${reason}`,
+        detail ? `Context: ${JSON.stringify(detail)}` : undefined,
+      ].filter(Boolean) as string[];
+      this.events.push({
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        code: 'restore_pending_confirmation_failed',
+        detail: lines.join('\n'),
+      } as Event);
+    }
+    this.state.setStatus('IDLE');
+  }
+
   restorePendingConfirmation(): void {
     if (this.pendingAction) return;
     if (this.state.snapshot.status !== 'WAITING_FOR_CONFIRMATION') return;
@@ -246,7 +264,7 @@ export class Agent extends EventEmitter {
     }
 
     if (pauseIndex === -1) {
-      this.emitRestorePendingConfirmationDiagnostic('missing_pause_event');
+      this.clearWaitingForConfirmation('missing_pause_event', undefined, true);
       return;
     }
 
@@ -261,7 +279,7 @@ export class Agent extends EventEmitter {
     }
 
     if (!action || actionIndex < 0) {
-      this.emitRestorePendingConfirmationDiagnostic('missing_action_event', { pauseIndex });
+      this.clearWaitingForConfirmation('missing_action_event', { pauseIndex }, true);
       return;
     }
 
@@ -274,7 +292,7 @@ export class Agent extends EventEmitter {
     });
 
     if (alreadyResolved) {
-      this.emitRestorePendingConfirmationDiagnostic('tool_call_already_resolved', { toolCallId });
+      this.clearWaitingForConfirmation('tool_call_already_resolved', { toolCallId });
       return;
     }
 


### PR DESCRIPTION
Fixes Beads issue oh-tab-wc7.
- Reconstruct Agent pendingAction when restoring a persisted conversation in WAITING_FOR_CONFIRMATION.
- Call restorePendingConfirmation() after LocalConversation.restoreConversation() loads events/state.
- Add regression test: approveAction works after restore.

- Tests: npm test -w @openhands/agent-sdk-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now restore pending user confirmations when recovered from persistence so paused workflows can be resumed.

* **Bug Fixes**
  * Stale or inconsistent pending-confirmation states are cleared and diagnostics emitted to prevent stuck conversations.

* **Tests**
  * Expanded persistence test coverage for restore, confirmation flows, workspace access and diagnostic handling.

* **Documentation**
  * Formatting improvements to developer review/workflow guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->