### PR TITLE
oh-tab-2wx: Align glob/grep tool semantics

### DIFF
--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -30,11 +30,13 @@ const globArgsSchema = z.object({
   include_hidden: z
     .boolean()
     .optional()
-    .describe('Include hidden files and directories (dotfiles). Defaults to true. Set to false for faster searches.'),
+    .default(false)
+    .describe('Include hidden files and directories (dotfiles). Defaults to false. Set to true to include them.'),
   include_node_modules: z
     .boolean()
     .optional()
-    .describe('Include node_modules directories. Defaults to true. Set to false for faster searches.'),
+    .default(false)
+    .describe('Include node_modules directories. Defaults to false. Set to true to include them.'),
 });
 
 const TOOL_DESCRIPTION = `Fast file pattern matching tool.
@@ -133,8 +135,8 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
     const { walkRoot, matcherPattern, maxDepth } = planGlobWalk(searchRoot, pattern);
     const matcher = createGlobMatcher(matcherPattern);
 
-    const includeHidden = args.include_hidden !== false;
-    const includeNodeModules = args.include_node_modules !== false;
+    const includeHidden = args.include_hidden === true;
+    const includeNodeModules = args.include_node_modules === true;
 
     let files: string[] = [];
     try {

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import fsSync from 'node:fs';
 import path from 'path';
 import { z } from 'zod';
 import type { ToolContext } from './types';
@@ -39,15 +40,21 @@ const MAX_RESULTS = 100;
 const resolveSearchRootAndPattern = (
   args: z.infer<typeof globArgsSchema>,
   context: ToolContext,
-): { searchRoot: string; pattern: string } => {
+):
+  | { mode: 'walk'; searchRoot: string; pattern: string }
+  | { mode: 'file'; filePath: string } => {
   try {
     if (args.path) {
-      return { searchRoot: context.workspace.resolvePath(expandHome(args.path)), pattern: normalizeGlobPattern(args.pattern) };
+      return {
+        mode: 'walk',
+        searchRoot: context.workspace.resolvePath(expandHome(args.path)),
+        pattern: normalizeGlobPattern(args.pattern),
+      };
     }
 
     const expandedPattern = expandHome(args.pattern);
     if (!path.isAbsolute(expandedPattern)) {
-      return { searchRoot: context.workspace.root, pattern: normalizeGlobPattern(args.pattern) };
+      return { mode: 'walk', searchRoot: context.workspace.root, pattern: normalizeGlobPattern(args.pattern) };
     }
 
     const parsed = path.parse(expandedPattern);
@@ -56,18 +63,49 @@ const resolveSearchRootAndPattern = (
     const parts = remainder.split(/[\\/]+/).filter(Boolean);
 
     const searchParts: string[] = [];
+    let sawMagic = false;
     for (const part of parts) {
-      if (/[*?[\]{}()!]/.test(part)) break;
+      if (/[*?[\]{}()!]/.test(part)) {
+        sawMagic = true;
+        break;
+      }
       searchParts.push(part);
     }
 
     const base = path.join(root, ...searchParts);
     const glob = parts.length > searchParts.length ? parts.slice(searchParts.length).join('/') : '**/*';
-    return { searchRoot: context.workspace.resolvePath(base), pattern: normalizeGlobPattern(glob) };
+    const resolvedBase = context.workspace.resolvePath(base);
+
+    if (!sawMagic && glob === '**/*') {
+      try {
+        if (fsSync.statSync(resolvedBase).isDirectory()) {
+          return { mode: 'walk', searchRoot: resolvedBase, pattern: '**/*' };
+        }
+      } catch {
+        // treat as a file pattern below
+      }
+      return { mode: 'file', filePath: resolvedBase };
+    }
+
+    return { mode: 'walk', searchRoot: resolvedBase, pattern: normalizeGlobPattern(glob) };
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     throw new Error(`Invalid search path: ${detail}`);
   }
+};
+
+const getWalkOptions = (args: z.infer<typeof globArgsSchema>) => {
+  const normalizedPattern = normalizeSlashes(expandHome(args.pattern));
+  const normalizedPath = args.path ? normalizeSlashes(expandHome(args.path)) : '';
+
+  const includeHidden =
+    normalizedPattern.split('/').some((part) => part.startsWith('.'))
+    || normalizedPath.split('/').some((part) => part.startsWith('.'));
+  const includeNodeModules =
+    normalizedPattern.includes('node_modules')
+    || normalizedPath.split('/').some((part) => part === 'node_modules');
+
+  return { includeHidden, includeNodeModules };
 };
 
 export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult> {
@@ -76,9 +114,23 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
   readonly schema = globArgsSchema;
 
   async execute(args: z.infer<typeof globArgsSchema>, context: ToolContext): Promise<GlobResult> {
-    const { searchRoot, pattern } = resolveSearchRootAndPattern(args, context);
+    const resolved = resolveSearchRootAndPattern(args, context);
+
+    if (resolved.mode === 'file') {
+      try {
+        const stat = await fs.stat(resolved.filePath);
+        if (!stat.isFile()) {
+          return { files: [], pattern: args.pattern, searchPath: path.dirname(resolved.filePath), truncated: false };
+        }
+        return { files: [resolved.filePath], pattern: args.pattern, searchPath: path.dirname(resolved.filePath), truncated: false };
+      } catch {
+        return { files: [], pattern: args.pattern, searchPath: path.dirname(resolved.filePath), truncated: false };
+      }
+    }
+
+    const { searchRoot, pattern } = resolved;
     const matcher = createGlobMatcher(pattern);
-    const files = await listFilesRecursively(searchRoot);
+    const files = await listFilesRecursively(searchRoot, getWalkOptions(args));
     const filtered: string[] = [];
 
     for (const file of files) {

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -1,4 +1,5 @@
 import fs from 'fs/promises';
+import os from 'os';
 import path from 'path';
 import picomatch from 'picomatch';
 import { z } from 'zod';
@@ -36,10 +37,13 @@ Examples:
 
 const MAX_RESULTS = 100;
 
+const shouldSkipEntry = (name: string): boolean => name.startsWith('.') || name === 'node_modules';
+
 const listFiles = async (root: string): Promise<string[]> => {
   const entries = await fs.readdir(root, { withFileTypes: true });
   const results: string[] = [];
   for (const entry of entries) {
+    if (shouldSkipEntry(entry.name)) continue;
     const fullPath = path.join(root, entry.name);
     if (entry.isDirectory()) {
       const child = await listFiles(fullPath);
@@ -53,6 +57,50 @@ const listFiles = async (root: string): Promise<string[]> => {
 
 const normalize = (p: string): string => p.split(path.sep).join('/');
 
+const normalizePattern = (pattern: string): string => {
+  const cleaned = normalize(pattern.trim());
+  if (!cleaned) return '**/*';
+  if (cleaned.includes('/')) return cleaned;
+  return cleaned.startsWith('**/') ? cleaned : `**/${cleaned}`;
+};
+
+const expandHome = (input: string): string => {
+  if (input === '~') return os.homedir();
+  if (input.startsWith('~/') || input.startsWith('~\\')) {
+    return path.join(os.homedir(), input.slice(2));
+  }
+  return input;
+};
+
+const resolveSearchRootAndPattern = (
+  args: z.infer<typeof globArgsSchema>,
+  context: ToolContext,
+): { searchRoot: string; pattern: string } => {
+  if (args.path) {
+    return { searchRoot: context.workspace.resolvePath(args.path), pattern: normalizePattern(args.pattern) };
+  }
+
+  const expandedPattern = expandHome(args.pattern);
+  if (!path.isAbsolute(expandedPattern)) {
+    return { searchRoot: context.workspace.root, pattern: normalizePattern(args.pattern) };
+  }
+
+  const parsed = path.parse(expandedPattern);
+  const root = parsed.root || path.sep;
+  const remainder = expandedPattern.slice(root.length);
+  const parts = remainder.split(/[\\/]+/).filter(Boolean);
+
+  const searchParts: string[] = [];
+  for (const part of parts) {
+    if (/[*?[\]{}()!]/.test(part)) break;
+    searchParts.push(part);
+  }
+
+  const base = path.join(root, ...searchParts);
+  const glob = parts.length > searchParts.length ? parts.slice(searchParts.length).join('/') : '**/*';
+  return { searchRoot: context.workspace.resolvePath(base), pattern: normalizePattern(glob) };
+};
+
 const createMatcher = (pattern: string): ((value: string) => boolean) => {
   const matcher = picomatch(pattern, { dot: true }) as (value: string) => boolean;
   return (value: string) => Boolean(matcher(value));
@@ -64,8 +112,8 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
   readonly schema = globArgsSchema;
 
   async execute(args: z.infer<typeof globArgsSchema>, context: ToolContext): Promise<GlobResult> {
-    const searchRoot = args.path ? context.workspace.resolvePath(args.path) : context.workspace.root;
-    const matcher = createMatcher(args.pattern);
+    const { searchRoot, pattern } = resolveSearchRootAndPattern(args, context);
+    const matcher = createMatcher(pattern);
     const files = await listFiles(searchRoot);
     const filtered: string[] = [];
 
@@ -92,4 +140,3 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
     };
   }
 }
-

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -1,5 +1,4 @@
 import fs from 'fs/promises';
-import fsSync from 'node:fs';
 import path from 'path';
 import { z } from 'zod';
 import type { ToolContext } from './types';
@@ -37,12 +36,13 @@ Examples:
 
 const MAX_RESULTS = 100;
 
-const resolveSearchRootAndPattern = (
+const resolveSearchRootAndPattern = async (
   args: z.infer<typeof globArgsSchema>,
   context: ToolContext,
-):
+): Promise<
   | { mode: 'walk'; searchRoot: string; pattern: string }
-  | { mode: 'file'; filePath: string } => {
+  | { mode: 'file'; filePath: string }
+> => {
   try {
     if (args.path) {
       return {
@@ -78,7 +78,7 @@ const resolveSearchRootAndPattern = (
 
     if (!sawMagic && glob === '**/*') {
       try {
-        if (fsSync.statSync(resolvedBase).isDirectory()) {
+        if ((await fs.stat(resolvedBase)).isDirectory()) {
           return { mode: 'walk', searchRoot: resolvedBase, pattern: '**/*' };
         }
       } catch {
@@ -94,27 +94,13 @@ const resolveSearchRootAndPattern = (
   }
 };
 
-const getWalkOptions = (args: z.infer<typeof globArgsSchema>) => {
-  const normalizedPattern = normalizeSlashes(expandHome(args.pattern));
-  const normalizedPath = args.path ? normalizeSlashes(expandHome(args.path)) : '';
-
-  const includeHidden =
-    normalizedPattern.split('/').some((part) => part.startsWith('.'))
-    || normalizedPath.split('/').some((part) => part.startsWith('.'));
-  const includeNodeModules =
-    normalizedPattern.includes('node_modules')
-    || normalizedPath.split('/').some((part) => part === 'node_modules');
-
-  return { includeHidden, includeNodeModules };
-};
-
 export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult> {
   readonly name = 'glob';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = globArgsSchema;
 
   async execute(args: z.infer<typeof globArgsSchema>, context: ToolContext): Promise<GlobResult> {
-    const resolved = resolveSearchRootAndPattern(args, context);
+    const resolved = await resolveSearchRootAndPattern(args, context);
 
     if (resolved.mode === 'file') {
       try {
@@ -130,7 +116,7 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
 
     const { searchRoot, pattern } = resolved;
     const matcher = createGlobMatcher(pattern);
-    const files = await listFilesRecursively(searchRoot, getWalkOptions(args));
+    const files = await listFilesRecursively(searchRoot);
     const filtered: string[] = [];
 
     for (const file of files) {

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -16,11 +16,11 @@ export interface GlobResult {
 const globArgsSchema = z.object({
   pattern: z
     .string()
-    .describe('The glob pattern to match files (e.g., "**/*.js", "src/**/*.ts").'),
+    .describe('The glob pattern to match files (e.g., "**/*.js", "src/**/*.ts"). May also be an absolute path pattern under the allowed workspace roots.'),
   path: z
     .string()
     .optional()
-    .describe('The directory (absolute path) to search in. Defaults to the current working directory.'),
+    .describe('The directory (absolute or workspace-relative path) to search in. Defaults to the current working directory. Must be within the allowed workspace roots.'),
 });
 
 const TOOL_DESCRIPTION = `Fast file pattern matching tool.

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -2,7 +2,14 @@ import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
 import type { ToolContext } from './types';
-import { createGlobMatcher, expandHome, listFilesRecursively, normalizeGlobPattern, normalizeSlashes } from './searchUtils';
+import {
+  createGlobMatcher,
+  expandHome,
+  listFilesRecursively,
+  normalizeGlobPattern,
+  normalizeSlashes,
+  planGlobWalk,
+} from './searchUtils';
 import { ZodTool } from './zod-tool';
 
 export interface GlobResult {
@@ -20,6 +27,14 @@ const globArgsSchema = z.object({
     .string()
     .optional()
     .describe('The directory (absolute or workspace-relative path) to search in. Defaults to the current working directory. Must be within the allowed workspace roots.'),
+  include_hidden: z
+    .boolean()
+    .optional()
+    .describe('Include hidden files and directories (dotfiles). Defaults to true. Set to false for faster searches.'),
+  include_node_modules: z
+    .boolean()
+    .optional()
+    .describe('Include node_modules directories. Defaults to true. Set to false for faster searches.'),
 });
 
 const TOOL_DESCRIPTION = `Fast file pattern matching tool.
@@ -115,12 +130,22 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
     }
 
     const { searchRoot, pattern } = resolved;
-    const matcher = createGlobMatcher(pattern);
-    const files = await listFilesRecursively(searchRoot);
+    const { walkRoot, matcherPattern, maxDepth } = planGlobWalk(searchRoot, pattern);
+    const matcher = createGlobMatcher(matcherPattern);
+
+    const includeHidden = args.include_hidden !== false;
+    const includeNodeModules = args.include_node_modules !== false;
+
+    let files: string[] = [];
+    try {
+      files = await listFilesRecursively(walkRoot, { includeHidden, includeNodeModules, maxDepth });
+    } catch {
+      files = [];
+    }
     const filtered: string[] = [];
 
     for (const file of files) {
-      const relative = normalizeSlashes(path.relative(searchRoot, file));
+      const relative = normalizeSlashes(path.relative(walkRoot, file));
       if (matcher(relative)) {
         filtered.push(file);
       }

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -1,9 +1,8 @@
 import fs from 'fs/promises';
-import os from 'os';
 import path from 'path';
-import picomatch from 'picomatch';
 import { z } from 'zod';
 import type { ToolContext } from './types';
+import { createGlobMatcher, expandHome, listFilesRecursively, normalizeGlobPattern, normalizeSlashes } from './searchUtils';
 import { ZodTool } from './zod-tool';
 
 export interface GlobResult {
@@ -37,73 +36,38 @@ Examples:
 
 const MAX_RESULTS = 100;
 
-const shouldSkipEntry = (name: string): boolean => name.startsWith('.') || name === 'node_modules';
-
-const listFiles = async (root: string): Promise<string[]> => {
-  const entries = await fs.readdir(root, { withFileTypes: true });
-  const results: string[] = [];
-  for (const entry of entries) {
-    if (shouldSkipEntry(entry.name)) continue;
-    const fullPath = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      const child = await listFiles(fullPath);
-      results.push(...child);
-    } else {
-      results.push(fullPath);
-    }
-  }
-  return results;
-};
-
-const normalize = (p: string): string => p.split(path.sep).join('/');
-
-const normalizePattern = (pattern: string): string => {
-  const cleaned = normalize(pattern.trim());
-  if (!cleaned) return '**/*';
-  if (cleaned.includes('/')) return cleaned;
-  return cleaned.startsWith('**/') ? cleaned : `**/${cleaned}`;
-};
-
-const expandHome = (input: string): string => {
-  if (input === '~') return os.homedir();
-  if (input.startsWith('~/') || input.startsWith('~\\')) {
-    return path.join(os.homedir(), input.slice(2));
-  }
-  return input;
-};
-
 const resolveSearchRootAndPattern = (
   args: z.infer<typeof globArgsSchema>,
   context: ToolContext,
 ): { searchRoot: string; pattern: string } => {
-  if (args.path) {
-    return { searchRoot: context.workspace.resolvePath(args.path), pattern: normalizePattern(args.pattern) };
+  try {
+    if (args.path) {
+      return { searchRoot: context.workspace.resolvePath(expandHome(args.path)), pattern: normalizeGlobPattern(args.pattern) };
+    }
+
+    const expandedPattern = expandHome(args.pattern);
+    if (!path.isAbsolute(expandedPattern)) {
+      return { searchRoot: context.workspace.root, pattern: normalizeGlobPattern(args.pattern) };
+    }
+
+    const parsed = path.parse(expandedPattern);
+    const root = parsed.root || path.sep;
+    const remainder = expandedPattern.slice(root.length);
+    const parts = remainder.split(/[\\/]+/).filter(Boolean);
+
+    const searchParts: string[] = [];
+    for (const part of parts) {
+      if (/[*?[\]{}()!]/.test(part)) break;
+      searchParts.push(part);
+    }
+
+    const base = path.join(root, ...searchParts);
+    const glob = parts.length > searchParts.length ? parts.slice(searchParts.length).join('/') : '**/*';
+    return { searchRoot: context.workspace.resolvePath(base), pattern: normalizeGlobPattern(glob) };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid search path: ${detail}`);
   }
-
-  const expandedPattern = expandHome(args.pattern);
-  if (!path.isAbsolute(expandedPattern)) {
-    return { searchRoot: context.workspace.root, pattern: normalizePattern(args.pattern) };
-  }
-
-  const parsed = path.parse(expandedPattern);
-  const root = parsed.root || path.sep;
-  const remainder = expandedPattern.slice(root.length);
-  const parts = remainder.split(/[\\/]+/).filter(Boolean);
-
-  const searchParts: string[] = [];
-  for (const part of parts) {
-    if (/[*?[\]{}()!]/.test(part)) break;
-    searchParts.push(part);
-  }
-
-  const base = path.join(root, ...searchParts);
-  const glob = parts.length > searchParts.length ? parts.slice(searchParts.length).join('/') : '**/*';
-  return { searchRoot: context.workspace.resolvePath(base), pattern: normalizePattern(glob) };
-};
-
-const createMatcher = (pattern: string): ((value: string) => boolean) => {
-  const matcher = picomatch(pattern, { dot: true }) as (value: string) => boolean;
-  return (value: string) => Boolean(matcher(value));
 };
 
 export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult> {
@@ -113,12 +77,12 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
 
   async execute(args: z.infer<typeof globArgsSchema>, context: ToolContext): Promise<GlobResult> {
     const { searchRoot, pattern } = resolveSearchRootAndPattern(args, context);
-    const matcher = createMatcher(pattern);
-    const files = await listFiles(searchRoot);
+    const matcher = createGlobMatcher(pattern);
+    const files = await listFilesRecursively(searchRoot);
     const filtered: string[] = [];
 
     for (const file of files) {
-      const relative = normalize(path.relative(searchRoot, file));
+      const relative = normalizeSlashes(path.relative(searchRoot, file));
       if (matcher(relative)) {
         filtered.push(file);
       }

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -2,7 +2,14 @@ import fs from 'fs/promises';
 import path from 'path';
 import { z } from 'zod';
 import type { ToolContext } from './types';
-import { createGlobMatcher, expandHome, listFilesRecursively, normalizeGlobPattern, normalizeSlashes } from './searchUtils';
+import {
+  createGlobMatcher,
+  expandHome,
+  listFilesRecursively,
+  normalizeGlobPattern,
+  normalizeSlashes,
+  planGlobWalk,
+} from './searchUtils';
 import { ZodTool } from './zod-tool';
 
 export interface GrepResult {
@@ -23,6 +30,14 @@ const grepArgsSchema = z.object({
     .string()
     .optional()
     .describe('Optional file pattern to filter which files to search (e.g., "*.js", "*.{ts,tsx}").'),
+  include_hidden: z
+    .boolean()
+    .optional()
+    .describe('Include hidden files and directories (dotfiles). Defaults to true. Set to false for faster searches.'),
+  include_node_modules: z
+    .boolean()
+    .optional()
+    .describe('Include node_modules directories. Defaults to true. Set to false for faster searches.'),
 });
 
 const TOOL_DESCRIPTION = `Fast content search tool.
@@ -48,8 +63,20 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid search path: ${detail}`);
     }
-    const includeMatcher = args.include ? createGlobMatcher(normalizeGlobPattern(args.include)) : null;
-    const files = await listFilesRecursively(searchRoot);
+    const includeHidden = args.include_hidden !== false;
+    const includeNodeModules = args.include_node_modules !== false;
+
+    const includePlan = args.include ? planGlobWalk(searchRoot, normalizeGlobPattern(args.include)) : null;
+    const walkRoot = includePlan?.walkRoot ?? searchRoot;
+    const includeMatcher = includePlan ? createGlobMatcher(includePlan.matcherPattern) : null;
+    const maxDepth = includePlan?.maxDepth;
+
+    let files: string[] = [];
+    try {
+      files = await listFilesRecursively(walkRoot, { includeHidden, includeNodeModules, maxDepth });
+    } catch {
+      files = [];
+    }
     const matches: { file: string; mtime: number }[] = [];
     let contentRegex: RegExp;
     try {
@@ -60,7 +87,7 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
     }
 
     for (const file of files) {
-      const relative = normalizeSlashes(path.relative(searchRoot, file));
+      const relative = normalizeSlashes(path.relative(walkRoot, file));
       if (includeMatcher && !includeMatcher(relative)) continue;
       try {
         const content = await fs.readFile(file, 'utf8');

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -18,7 +18,7 @@ const grepArgsSchema = z.object({
   path: z
     .string()
     .optional()
-    .describe('The directory (absolute path) to search in. Defaults to the current working directory.'),
+    .describe('The directory (absolute or workspace-relative path) to search in. Defaults to the current working directory. Must be within the allowed workspace roots.'),
   include: z
     .string()
     .optional()
@@ -79,7 +79,7 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
     const matches: { file: string; mtime: number }[] = [];
     let contentRegex: RegExp;
     try {
-      contentRegex = new RegExp(args.pattern, 'i');
+      contentRegex = new RegExp(args.pattern, 'im');
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid regex pattern: ${detail}`);

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -35,10 +35,13 @@ const TOOL_DESCRIPTION = `Fast content search tool.
 
 const MAX_RESULTS = 100;
 
+const shouldSkipEntry = (name: string): boolean => name.startsWith('.') || name === 'node_modules';
+
 const listFiles = async (root: string): Promise<string[]> => {
   const entries = await fs.readdir(root, { withFileTypes: true });
   const results: string[] = [];
   for (const entry of entries) {
+    if (shouldSkipEntry(entry.name)) continue;
     const fullPath = path.join(root, entry.name);
     if (entry.isDirectory()) {
       const child = await listFiles(fullPath);
@@ -52,6 +55,13 @@ const listFiles = async (root: string): Promise<string[]> => {
 
 const normalize = (p: string): string => p.split(path.sep).join('/');
 
+const normalizePattern = (pattern: string): string => {
+  const cleaned = normalize(pattern.trim());
+  if (!cleaned) return '**/*';
+  if (cleaned.includes('/')) return cleaned;
+  return cleaned.startsWith('**/') ? cleaned : `**/${cleaned}`;
+};
+
 const createMatcher = (pattern: string): ((value: string) => boolean) => {
   const matcher = picomatch(pattern, { dot: true }) as (value: string) => boolean;
   return (value: string) => Boolean(matcher(value));
@@ -64,10 +74,16 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
 
   async execute(args: z.infer<typeof grepArgsSchema>, context: ToolContext): Promise<GrepResult> {
     const searchRoot = args.path ? context.workspace.resolvePath(args.path) : context.workspace.root;
-    const includeMatcher = args.include ? createMatcher(args.include) : null;
+    const includeMatcher = args.include ? createMatcher(normalizePattern(args.include)) : null;
     const files = await listFiles(searchRoot);
     const matches: { file: string; mtime: number }[] = [];
-    const contentRegex = new RegExp(args.pattern, 'm');
+    let contentRegex: RegExp;
+    try {
+      contentRegex = new RegExp(args.pattern, 'i');
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid regex pattern: ${detail}`);
+    }
 
     for (const file of files) {
       const relative = normalize(path.relative(searchRoot, file));
@@ -96,4 +112,3 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
     };
   }
 }
-

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -27,6 +27,7 @@ const grepArgsSchema = z.object({
 
 const TOOL_DESCRIPTION = `Fast content search tool.
 * Searches file contents using regular expressions
+* Searches are case-insensitive by default (like ripgrep \`-i\`)
 * Supports full regex syntax (eg. "log.*Error", "function\\s+\\w+", etc.)
 * Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
 * Returns matching file paths sorted by modification time.
@@ -40,6 +41,20 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
   readonly description = TOOL_DESCRIPTION;
   readonly schema = grepArgsSchema;
 
+  private getWalkOptions(args: z.infer<typeof grepArgsSchema>) {
+    const normalizedPattern = normalizeSlashes(args.include ? normalizeGlobPattern(args.include) : '');
+    const normalizedPath = args.path ? normalizeSlashes(expandHome(args.path)) : '';
+
+    const includeHidden =
+      normalizedPattern.split('/').some((part) => part.startsWith('.'))
+      || normalizedPath.split('/').some((part) => part.startsWith('.'));
+    const includeNodeModules =
+      normalizedPattern.includes('node_modules')
+      || normalizedPath.split('/').some((part) => part === 'node_modules');
+
+    return { includeHidden, includeNodeModules };
+  }
+
   async execute(args: z.infer<typeof grepArgsSchema>, context: ToolContext): Promise<GrepResult> {
     let searchRoot: string;
     try {
@@ -49,7 +64,7 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
       throw new Error(`Invalid search path: ${detail}`);
     }
     const includeMatcher = args.include ? createGlobMatcher(normalizeGlobPattern(args.include)) : null;
-    const files = await listFilesRecursively(searchRoot);
+    const files = await listFilesRecursively(searchRoot, this.getWalkOptions(args));
     const matches: { file: string; mtime: number }[] = [];
     let contentRegex: RegExp;
     try {

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -33,11 +33,13 @@ const grepArgsSchema = z.object({
   include_hidden: z
     .boolean()
     .optional()
-    .describe('Include hidden files and directories (dotfiles). Defaults to true. Set to false for faster searches.'),
+    .default(false)
+    .describe('Include hidden files and directories (dotfiles). Defaults to false. Set to true to include them.'),
   include_node_modules: z
     .boolean()
     .optional()
-    .describe('Include node_modules directories. Defaults to true. Set to false for faster searches.'),
+    .default(false)
+    .describe('Include node_modules directories. Defaults to false. Set to true to include them.'),
 });
 
 const TOOL_DESCRIPTION = `Fast content search tool.
@@ -63,8 +65,8 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid search path: ${detail}`);
     }
-    const includeHidden = args.include_hidden !== false;
-    const includeNodeModules = args.include_node_modules !== false;
+    const includeHidden = args.include_hidden === true;
+    const includeNodeModules = args.include_node_modules === true;
 
     const includePlan = args.include ? planGlobWalk(searchRoot, normalizeGlobPattern(args.include)) : null;
     const walkRoot = includePlan?.walkRoot ?? searchRoot;
@@ -80,7 +82,7 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
     const matches: { file: string; mtime: number }[] = [];
     let contentRegex: RegExp;
     try {
-      contentRegex = new RegExp(args.pattern, 'm');
+      contentRegex = new RegExp(args.pattern, 'im');
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid regex pattern: ${detail}`);

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -27,7 +27,6 @@ const grepArgsSchema = z.object({
 
 const TOOL_DESCRIPTION = `Fast content search tool.
 * Searches file contents using regular expressions
-* Searches are case-insensitive by default (like ripgrep \`-i\`)
 * Supports full regex syntax (eg. "log.*Error", "function\\s+\\w+", etc.)
 * Filter files by pattern with the include parameter (eg. "*.js", "*.{ts,tsx}")
 * Returns matching file paths sorted by modification time.
@@ -41,20 +40,6 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
   readonly description = TOOL_DESCRIPTION;
   readonly schema = grepArgsSchema;
 
-  private getWalkOptions(args: z.infer<typeof grepArgsSchema>) {
-    const normalizedPattern = normalizeSlashes(args.include ? normalizeGlobPattern(args.include) : '');
-    const normalizedPath = args.path ? normalizeSlashes(expandHome(args.path)) : '';
-
-    const includeHidden =
-      normalizedPattern.split('/').some((part) => part.startsWith('.'))
-      || normalizedPath.split('/').some((part) => part.startsWith('.'));
-    const includeNodeModules =
-      normalizedPattern.includes('node_modules')
-      || normalizedPath.split('/').some((part) => part === 'node_modules');
-
-    return { includeHidden, includeNodeModules };
-  }
-
   async execute(args: z.infer<typeof grepArgsSchema>, context: ToolContext): Promise<GrepResult> {
     let searchRoot: string;
     try {
@@ -64,11 +49,11 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
       throw new Error(`Invalid search path: ${detail}`);
     }
     const includeMatcher = args.include ? createGlobMatcher(normalizeGlobPattern(args.include)) : null;
-    const files = await listFilesRecursively(searchRoot, this.getWalkOptions(args));
+    const files = await listFilesRecursively(searchRoot);
     const matches: { file: string; mtime: number }[] = [];
     let contentRegex: RegExp;
     try {
-      contentRegex = new RegExp(args.pattern, 'im');
+      contentRegex = new RegExp(args.pattern, 'm');
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       throw new Error(`Invalid regex pattern: ${detail}`);

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -1,8 +1,8 @@
 import fs from 'fs/promises';
 import path from 'path';
-import picomatch from 'picomatch';
 import { z } from 'zod';
 import type { ToolContext } from './types';
+import { createGlobMatcher, expandHome, listFilesRecursively, normalizeGlobPattern, normalizeSlashes } from './searchUtils';
 import { ZodTool } from './zod-tool';
 
 export interface GrepResult {
@@ -35,47 +35,21 @@ const TOOL_DESCRIPTION = `Fast content search tool.
 
 const MAX_RESULTS = 100;
 
-const shouldSkipEntry = (name: string): boolean => name.startsWith('.') || name === 'node_modules';
-
-const listFiles = async (root: string): Promise<string[]> => {
-  const entries = await fs.readdir(root, { withFileTypes: true });
-  const results: string[] = [];
-  for (const entry of entries) {
-    if (shouldSkipEntry(entry.name)) continue;
-    const fullPath = path.join(root, entry.name);
-    if (entry.isDirectory()) {
-      const child = await listFiles(fullPath);
-      results.push(...child);
-    } else {
-      results.push(fullPath);
-    }
-  }
-  return results;
-};
-
-const normalize = (p: string): string => p.split(path.sep).join('/');
-
-const normalizePattern = (pattern: string): string => {
-  const cleaned = normalize(pattern.trim());
-  if (!cleaned) return '**/*';
-  if (cleaned.includes('/')) return cleaned;
-  return cleaned.startsWith('**/') ? cleaned : `**/${cleaned}`;
-};
-
-const createMatcher = (pattern: string): ((value: string) => boolean) => {
-  const matcher = picomatch(pattern, { dot: true }) as (value: string) => boolean;
-  return (value: string) => Boolean(matcher(value));
-};
-
 export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult> {
   readonly name = 'grep';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = grepArgsSchema;
 
   async execute(args: z.infer<typeof grepArgsSchema>, context: ToolContext): Promise<GrepResult> {
-    const searchRoot = args.path ? context.workspace.resolvePath(args.path) : context.workspace.root;
-    const includeMatcher = args.include ? createMatcher(normalizePattern(args.include)) : null;
-    const files = await listFiles(searchRoot);
+    let searchRoot: string;
+    try {
+      searchRoot = args.path ? context.workspace.resolvePath(expandHome(args.path)) : context.workspace.root;
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Invalid search path: ${detail}`);
+    }
+    const includeMatcher = args.include ? createGlobMatcher(normalizeGlobPattern(args.include)) : null;
+    const files = await listFilesRecursively(searchRoot);
     const matches: { file: string; mtime: number }[] = [];
     let contentRegex: RegExp;
     try {
@@ -86,7 +60,7 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
     }
 
     for (const file of files) {
-      const relative = normalize(path.relative(searchRoot, file));
+      const relative = normalizeSlashes(path.relative(searchRoot, file));
       if (includeMatcher && !includeMatcher(relative)) continue;
       try {
         const content = await fs.readFile(file, 'utf8');

--- a/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
@@ -147,7 +147,7 @@ describe('GrepTool', () => {
     expect(result.matches.every((p) => p.endsWith('.py') && fs.existsSync(p))).toBe(true);
   });
 
-  it('is case-insensitive by default', async () => {
+  it('is case-sensitive by default', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
@@ -129,6 +129,34 @@ describe('GlobTool', () => {
     expect(path.basename(result.files[0])).toBe('single.py');
     expect(fs.existsSync(result.files[0])).toBe(true);
   });
+
+  it('skips hidden files when include_hidden is false', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'visible.js'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, '.hidden.js'), 'test', 'utf8');
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: '**/*.js', include_hidden: false }), { workspace });
+    const basenames = result.files.map((match) => path.basename(match));
+    expect(basenames).toContain('visible.js');
+    expect(basenames).not.toContain('.hidden.js');
+  });
+
+  it('skips node_modules when include_node_modules is false', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'node_modules', 'pkg'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, 'app.js'), 'test', 'utf8');
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: '**/*.js', include_node_modules: false }), { workspace });
+    expect(result.files.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(false);
+    expect(result.files.map((match) => path.basename(match))).toContain('app.js');
+  });
 });
 
 describe('GrepTool', () => {
@@ -197,6 +225,35 @@ describe('GrepTool', () => {
     const tool = new GrepTool();
     const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
     expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(true);
+  });
+
+  it('skips hidden files when include_hidden is false', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'visible.py'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, '.hidden.py'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include_hidden: false }), { workspace });
+    const basenames = result.matches.map((match) => path.basename(match));
+    expect(basenames).toContain('visible.py');
+    expect(basenames).not.toContain('.hidden.py');
+  });
+
+  it('skips node_modules when include_node_modules is false', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'node_modules', 'pkg'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'test', 'utf8');
+    await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'src', 'app.js'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include_node_modules: false }), { workspace });
+    expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(false);
+    expect(result.matches.some((match) => match.includes(`${path.sep}src${path.sep}`))).toBe(true);
   });
 
   it('reports invalid regex patterns', async () => {

--- a/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
@@ -175,7 +175,7 @@ describe('GrepTool', () => {
     expect(result.matches.every((p) => p.endsWith('.py') && fs.existsSync(p))).toBe(true);
   });
 
-  it('is case-sensitive by default', async () => {
+  it('is case-insensitive by default', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
 
@@ -183,7 +183,7 @@ describe('GrepTool', () => {
 
     const tool = new GrepTool();
     const result = await tool.execute(tool.validate({ pattern: 'print' }), { workspace });
-    expect(result.matches.length).toBe(0);
+    expect(result.matches.length).toBe(1);
   });
 
   it('supports include filters', async () => {
@@ -199,7 +199,7 @@ describe('GrepTool', () => {
     expect(result.matches[0].endsWith('.py')).toBe(true);
   });
 
-  it('includes hidden files by default', async () => {
+  it('skips hidden files by default', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
 
@@ -208,40 +208,12 @@ describe('GrepTool', () => {
 
     const tool = new GrepTool();
     const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
-    const basenames = result.matches.map((match) => path.basename(match));
-    expect(basenames).toContain('visible.py');
-    expect(basenames).toContain('.hidden.py');
-  });
-
-  it('includes node_modules by default', async () => {
-    const { workspace, dir } = await makeWorkspace();
-    created.push(dir);
-
-    await fs.promises.mkdir(path.join(dir, 'node_modules', 'pkg'), { recursive: true });
-    await fs.promises.writeFile(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'test', 'utf8');
-    await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true });
-    await fs.promises.writeFile(path.join(dir, 'src', 'app.js'), 'test', 'utf8');
-
-    const tool = new GrepTool();
-    const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
-    expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(true);
-  });
-
-  it('skips hidden files when include_hidden is false', async () => {
-    const { workspace, dir } = await makeWorkspace();
-    created.push(dir);
-
-    await fs.promises.writeFile(path.join(dir, 'visible.py'), 'test', 'utf8');
-    await fs.promises.writeFile(path.join(dir, '.hidden.py'), 'test', 'utf8');
-
-    const tool = new GrepTool();
-    const result = await tool.execute(tool.validate({ pattern: 'test', include_hidden: false }), { workspace });
     const basenames = result.matches.map((match) => path.basename(match));
     expect(basenames).toContain('visible.py');
     expect(basenames).not.toContain('.hidden.py');
   });
 
-  it('skips node_modules when include_node_modules is false', async () => {
+  it('skips node_modules by default', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
 
@@ -251,8 +223,37 @@ describe('GrepTool', () => {
     await fs.promises.writeFile(path.join(dir, 'src', 'app.js'), 'test', 'utf8');
 
     const tool = new GrepTool();
-    const result = await tool.execute(tool.validate({ pattern: 'test', include_node_modules: false }), { workspace });
+    const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
     expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(false);
+    expect(result.matches.some((match) => match.includes(`${path.sep}src${path.sep}`))).toBe(true);
+  });
+
+  it('includes hidden files when include_hidden is true', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'visible.py'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, '.hidden.py'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include_hidden: true }), { workspace });
+    const basenames = result.matches.map((match) => path.basename(match));
+    expect(basenames).toContain('visible.py');
+    expect(basenames).toContain('.hidden.py');
+  });
+
+  it('includes node_modules when include_node_modules is true', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'node_modules', 'pkg'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'test', 'utf8');
+    await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'src', 'app.js'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include_node_modules: true }), { workspace });
+    expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(true);
     expect(result.matches.some((match) => match.includes(`${path.sep}src${path.sep}`))).toBe(true);
   });
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
@@ -111,6 +111,24 @@ describe('GlobTool', () => {
     expect(result.searchPath).toBe(realDir);
     expect(result.files.length).toBe(2);
   });
+
+  it('supports absolute file path patterns without wildcards', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'nested'), { recursive: true });
+    const absFile = path.join(dir, 'nested', 'single.py');
+    await fs.promises.writeFile(absFile, '# Single', 'utf8');
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: absFile }), { workspace });
+
+    expect(result.pattern).toBe(absFile);
+    expect(result.truncated).toBe(false);
+    expect(result.files.length).toBe(1);
+    expect(path.basename(result.files[0])).toBe('single.py');
+    expect(fs.existsSync(result.files[0])).toBe(true);
+  });
 });
 
 describe('GrepTool', () => {
@@ -166,6 +184,33 @@ describe('GrepTool', () => {
     expect(path.basename(result.matches[0])).toBe('visible.py');
   });
 
+  it('includes hidden files when include explicitly targets them', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'visible.py'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, '.hidden.py'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include: '.hidden.py' }), { workspace });
+    expect(result.matches.length).toBe(1);
+    expect(path.basename(result.matches[0])).toBe('.hidden.py');
+  });
+
+  it('includes node_modules when include explicitly targets them', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'node_modules', 'pkg'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'node_modules', 'pkg', 'index.js'), 'test', 'utf8');
+    await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'src', 'app.js'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include: 'node_modules/**/*.js' }), { workspace });
+    expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(true);
+  });
+
   it('reports invalid regex patterns', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -189,4 +234,3 @@ describe('GrepTool', () => {
     expect(result.matches.length).toBe(100);
   });
 });
-

--- a/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
@@ -59,8 +59,8 @@ describe('GlobTool', () => {
 
     const tool = new GlobTool();
     const result = await tool.execute(tool.validate({ pattern: '*' }), { workspace });
-    expect(result.files.length).toBe(2);
-    expect(result.files.every((p) => fs.statSync(p).isFile())).toBe(true);
+    expect(result.files.length).toBe(1);
+    expect(path.basename(result.files[0])).toBe('app.py');
   });
 
   it('supports restricting search to a directory', async () => {
@@ -155,7 +155,7 @@ describe('GrepTool', () => {
 
     const tool = new GrepTool();
     const result = await tool.execute(tool.validate({ pattern: 'print' }), { workspace });
-    expect(result.matches.length).toBe(1);
+    expect(result.matches.length).toBe(0);
   });
 
   it('supports include filters', async () => {
@@ -171,7 +171,7 @@ describe('GrepTool', () => {
     expect(result.matches[0].endsWith('.py')).toBe(true);
   });
 
-  it('excludes hidden files by default', async () => {
+  it('includes hidden files by default', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
 
@@ -180,24 +180,12 @@ describe('GrepTool', () => {
 
     const tool = new GrepTool();
     const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
-    expect(result.matches.length).toBe(1);
-    expect(path.basename(result.matches[0])).toBe('visible.py');
+    const basenames = result.matches.map((match) => path.basename(match));
+    expect(basenames).toContain('visible.py');
+    expect(basenames).toContain('.hidden.py');
   });
 
-  it('includes hidden files when include explicitly targets them', async () => {
-    const { workspace, dir } = await makeWorkspace();
-    created.push(dir);
-
-    await fs.promises.writeFile(path.join(dir, 'visible.py'), 'test', 'utf8');
-    await fs.promises.writeFile(path.join(dir, '.hidden.py'), 'test', 'utf8');
-
-    const tool = new GrepTool();
-    const result = await tool.execute(tool.validate({ pattern: 'test', include: '.hidden.py' }), { workspace });
-    expect(result.matches.length).toBe(1);
-    expect(path.basename(result.matches[0])).toBe('.hidden.py');
-  });
-
-  it('includes node_modules when include explicitly targets them', async () => {
+  it('includes node_modules by default', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
 
@@ -207,7 +195,7 @@ describe('GrepTool', () => {
     await fs.promises.writeFile(path.join(dir, 'src', 'app.js'), 'test', 'utf8');
 
     const tool = new GrepTool();
-    const result = await tool.execute(tool.validate({ pattern: 'test', include: 'node_modules/**/*.js' }), { workspace });
+    const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
     expect(result.matches.some((match) => match.includes(`${path.sep}node_modules${path.sep}`))).toBe(true);
   });
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/glob-grep.test.ts
@@ -1,0 +1,192 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GlobTool, GrepTool } from '..';
+import { LocalWorkspace } from '../../workspace';
+
+const makeWorkspace = async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-tools-glob-'));
+  return { dir, workspace: new LocalWorkspace(dir) };
+};
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+describe('GlobTool', () => {
+  it('finds matching files recursively', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    const files = [
+      'test.py',
+      'main.js',
+      'config.json',
+      'src/app.py',
+      'src/utils.js',
+      'tests/test_main.py',
+    ];
+
+    for (const rel of files) {
+      const full = path.join(dir, rel);
+      await fs.promises.mkdir(path.dirname(full), { recursive: true });
+      await fs.promises.writeFile(full, `# Content of ${rel}`, 'utf8');
+    }
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: '**/*.py' }), { workspace });
+    const realDir = await fs.promises.realpath(dir);
+
+    expect(result.pattern).toBe('**/*.py');
+    expect(result.searchPath).toBe(realDir);
+    expect(result.truncated).toBe(false);
+    expect(result.files.length).toBe(3);
+    expect(result.files.every((p) => p.endsWith('.py') && fs.existsSync(p))).toBe(true);
+  });
+
+  it('treats patterns without slashes as recursive', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true });
+    await fs.promises.mkdir(path.join(dir, 'tests'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'app.py'), '# App', 'utf8');
+    await fs.promises.writeFile(path.join(dir, 'src/utils.py'), '# Utils', 'utf8');
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: '*' }), { workspace });
+    expect(result.files.length).toBe(2);
+    expect(result.files.every((p) => fs.statSync(p).isFile())).toBe(true);
+  });
+
+  it('supports restricting search to a directory', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.mkdir(path.join(dir, 'src'), { recursive: true });
+    await fs.promises.mkdir(path.join(dir, 'tests'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'src/app.py'), '# App', 'utf8');
+    await fs.promises.writeFile(path.join(dir, 'src/utils.py'), '# Utils', 'utf8');
+    await fs.promises.writeFile(path.join(dir, 'tests/test_app.py'), '# Test', 'utf8');
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: '*.py', path: 'src' }), { workspace });
+    expect(result.files.length).toBe(2);
+    expect(result.files.every((p) => p.endsWith('.py') && p.includes(`${path.sep}src${path.sep}`))).toBe(true);
+  });
+
+  it('truncates to 100 results', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    for (let i = 0; i < 150; i++) {
+      const name = `file_${i.toString().padStart(3, '0')}.txt`;
+      await fs.promises.writeFile(path.join(dir, name), `Content ${i}`, 'utf8');
+    }
+
+    const tool = new GlobTool();
+    const result = await tool.execute(tool.validate({ pattern: '*.txt' }), { workspace });
+    expect(result.truncated).toBe(true);
+    expect(result.files.length).toBe(100);
+  });
+
+  it('supports absolute path patterns (extracts search root)', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'a.py'), '# A', 'utf8');
+    await fs.promises.mkdir(path.join(dir, 'nested'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'nested/b.py'), '# B', 'utf8');
+
+    const tool = new GlobTool();
+    const absPattern = path.join(dir, '**/*.py');
+    const result = await tool.execute(tool.validate({ pattern: absPattern }), { workspace });
+    const realDir = await fs.promises.realpath(dir);
+
+    expect(result.pattern).toBe(absPattern);
+    expect(result.searchPath).toBe(realDir);
+    expect(result.files.length).toBe(2);
+  });
+});
+
+describe('GrepTool', () => {
+  it('searches file contents and returns matching files', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'app.py'), "print('hello')", 'utf8');
+    await fs.promises.writeFile(path.join(dir, 'utils.py'), "print('world')", 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'print' }), { workspace });
+
+    expect(result.truncated).toBe(false);
+    expect(result.matches.length).toBe(2);
+    expect(result.matches.every((p) => p.endsWith('.py') && fs.existsSync(p))).toBe(true);
+  });
+
+  it('is case-insensitive by default', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'test.py'), "PRINT('test')", 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'print' }), { workspace });
+    expect(result.matches.length).toBe(1);
+  });
+
+  it('supports include filters', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'test.py'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, 'test.js'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test', include: '*.py' }), { workspace });
+    expect(result.matches.length).toBe(1);
+    expect(result.matches[0].endsWith('.py')).toBe(true);
+  });
+
+  it('excludes hidden files by default', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    await fs.promises.writeFile(path.join(dir, 'visible.py'), 'test', 'utf8');
+    await fs.promises.writeFile(path.join(dir, '.hidden.py'), 'test', 'utf8');
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
+    expect(result.matches.length).toBe(1);
+    expect(path.basename(result.matches[0])).toBe('visible.py');
+  });
+
+  it('reports invalid regex patterns', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    const tool = new GrepTool();
+    await expect(tool.execute(tool.validate({ pattern: '[invalid' }), { workspace }))
+      .rejects.toThrowError(/Invalid regex pattern/);
+  });
+
+  it('truncates to 100 results', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+
+    for (let i = 0; i < 150; i++) {
+      await fs.promises.writeFile(path.join(dir, `file${i}.py`), 'test', 'utf8');
+    }
+
+    const tool = new GrepTool();
+    const result = await tool.execute(tool.validate({ pattern: 'test' }), { workspace });
+    expect(result.truncated).toBe(true);
+    expect(result.matches.length).toBe(100);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/tools/searchUtils.ts
+++ b/packages/agent-sdk-ts/src/tools/searchUtils.ts
@@ -9,8 +9,8 @@ export type SearchWalkOptions = {
 };
 
 export const shouldSkipSearchEntry = (name: string, options: SearchWalkOptions = {}): boolean => {
-  if (!options.includeHidden && name.startsWith('.')) return true;
-  if (!options.includeNodeModules && name === 'node_modules') return true;
+  if (options.includeHidden === false && name.startsWith('.')) return true;
+  if (options.includeNodeModules === false && name === 'node_modules') return true;
   return false;
 };
 
@@ -35,8 +35,7 @@ export const normalizeSlashes = (value: string): string => value.split(path.sep)
 export const normalizeGlobPattern = (pattern: string): string => {
   const cleaned = normalizeSlashes(pattern.trim());
   if (!cleaned) return '**/*';
-  if (cleaned.includes('/')) return cleaned;
-  return cleaned.startsWith('**/') ? cleaned : `**/${cleaned}`;
+  return cleaned;
 };
 
 export const expandHome = (input: string): string => {

--- a/packages/agent-sdk-ts/src/tools/searchUtils.ts
+++ b/packages/agent-sdk-ts/src/tools/searchUtils.ts
@@ -10,8 +10,8 @@ export type SearchWalkOptions = {
 };
 
 export const shouldSkipSearchEntry = (name: string, options: SearchWalkOptions = {}): boolean => {
-  if (options.includeHidden === false && name.startsWith('.')) return true;
-  if (options.includeNodeModules === false && name === 'node_modules') return true;
+  if (options.includeHidden !== true && name.startsWith('.')) return true;
+  if (options.includeNodeModules !== true && name === 'node_modules') return true;
   return false;
 };
 

--- a/packages/agent-sdk-ts/src/tools/searchUtils.ts
+++ b/packages/agent-sdk-ts/src/tools/searchUtils.ts
@@ -3,16 +3,25 @@ import os from 'os';
 import path from 'path';
 import picomatch from 'picomatch';
 
-export const shouldSkipSearchEntry = (name: string): boolean => name.startsWith('.') || name === 'node_modules';
+export type SearchWalkOptions = {
+  includeHidden?: boolean;
+  includeNodeModules?: boolean;
+};
 
-export const listFilesRecursively = async (root: string): Promise<string[]> => {
+export const shouldSkipSearchEntry = (name: string, options: SearchWalkOptions = {}): boolean => {
+  if (!options.includeHidden && name.startsWith('.')) return true;
+  if (!options.includeNodeModules && name === 'node_modules') return true;
+  return false;
+};
+
+export const listFilesRecursively = async (root: string, options: SearchWalkOptions = {}): Promise<string[]> => {
   const entries = await fs.readdir(root, { withFileTypes: true });
   const results: string[] = [];
   for (const entry of entries) {
-    if (shouldSkipSearchEntry(entry.name)) continue;
+    if (shouldSkipSearchEntry(entry.name, options)) continue;
     const fullPath = path.join(root, entry.name);
     if (entry.isDirectory()) {
-      const child = await listFilesRecursively(fullPath);
+      const child = await listFilesRecursively(fullPath, options);
       results.push(...child);
     } else {
       results.push(fullPath);
@@ -42,4 +51,3 @@ export const createGlobMatcher = (pattern: string): ((value: string) => boolean)
   const matcher = picomatch(pattern, { dot: true }) as (value: string) => boolean;
   return (value: string) => Boolean(matcher(value));
 };
-

--- a/packages/agent-sdk-ts/src/tools/searchUtils.ts
+++ b/packages/agent-sdk-ts/src/tools/searchUtils.ts
@@ -6,6 +6,7 @@ import picomatch from 'picomatch';
 export type SearchWalkOptions = {
   includeHidden?: boolean;
   includeNodeModules?: boolean;
+  maxDepth?: number;
 };
 
 export const shouldSkipSearchEntry = (name: string, options: SearchWalkOptions = {}): boolean => {
@@ -14,14 +15,20 @@ export const shouldSkipSearchEntry = (name: string, options: SearchWalkOptions =
   return false;
 };
 
-export const listFilesRecursively = async (root: string, options: SearchWalkOptions = {}): Promise<string[]> => {
+const listFilesRecursivelyInternal = async (
+  root: string,
+  options: SearchWalkOptions,
+  depth: number,
+): Promise<string[]> => {
   const entries = await fs.readdir(root, { withFileTypes: true });
   const results: string[] = [];
   for (const entry of entries) {
     if (shouldSkipSearchEntry(entry.name, options)) continue;
     const fullPath = path.join(root, entry.name);
     if (entry.isDirectory()) {
-      const child = await listFilesRecursively(fullPath, options);
+      const maxDepth = options.maxDepth;
+      if (typeof maxDepth === 'number' && depth >= maxDepth) continue;
+      const child = await listFilesRecursivelyInternal(fullPath, options, depth + 1);
       results.push(...child);
     } else {
       results.push(fullPath);
@@ -29,6 +36,9 @@ export const listFilesRecursively = async (root: string, options: SearchWalkOpti
   }
   return results;
 };
+
+export const listFilesRecursively = async (root: string, options: SearchWalkOptions = {}): Promise<string[]> =>
+  listFilesRecursivelyInternal(root, options, 0);
 
 export const normalizeSlashes = (value: string): string => value.split(path.sep).join('/');
 
@@ -44,6 +54,36 @@ export const expandHome = (input: string): string => {
     return path.join(os.homedir(), input.slice(2));
   }
   return input;
+};
+
+const SEGMENT_HAS_GLOB_MAGIC = /[*?[\]{}()!]/;
+
+export type GlobWalkPlan = {
+  walkRoot: string;
+  matcherPattern: string;
+  maxDepth?: number;
+};
+
+export const planGlobWalk = (searchRoot: string, pattern: string): GlobWalkPlan => {
+  const normalized = normalizeGlobPattern(pattern);
+  const parts = normalized.split('/').filter((part) => part.length > 0);
+
+  const staticPrefix: string[] = [];
+  for (const part of parts) {
+    if (part === '**') break;
+    if (SEGMENT_HAS_GLOB_MAGIC.test(part)) break;
+    staticPrefix.push(part);
+  }
+
+  const remainder = parts.slice(staticPrefix.length);
+  const walkRoot = staticPrefix.length > 0 && remainder.length > 0 ? path.join(searchRoot, ...staticPrefix) : searchRoot;
+  const matcherPattern = staticPrefix.length > 0 && remainder.length > 0 ? remainder.join('/') : normalized;
+
+  const matcherParts = matcherPattern.split('/').filter((part) => part.length > 0);
+  const hasGlobStar = matcherParts.some((part) => part === '**' || part.includes('**'));
+  const maxDepth = hasGlobStar ? undefined : Math.max(0, matcherParts.length - 1);
+
+  return { walkRoot, matcherPattern, maxDepth };
 };
 
 export const createGlobMatcher = (pattern: string): ((value: string) => boolean) => {

--- a/packages/agent-sdk-ts/src/tools/searchUtils.ts
+++ b/packages/agent-sdk-ts/src/tools/searchUtils.ts
@@ -1,0 +1,45 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import picomatch from 'picomatch';
+
+export const shouldSkipSearchEntry = (name: string): boolean => name.startsWith('.') || name === 'node_modules';
+
+export const listFilesRecursively = async (root: string): Promise<string[]> => {
+  const entries = await fs.readdir(root, { withFileTypes: true });
+  const results: string[] = [];
+  for (const entry of entries) {
+    if (shouldSkipSearchEntry(entry.name)) continue;
+    const fullPath = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      const child = await listFilesRecursively(fullPath);
+      results.push(...child);
+    } else {
+      results.push(fullPath);
+    }
+  }
+  return results;
+};
+
+export const normalizeSlashes = (value: string): string => value.split(path.sep).join('/');
+
+export const normalizeGlobPattern = (pattern: string): string => {
+  const cleaned = normalizeSlashes(pattern.trim());
+  if (!cleaned) return '**/*';
+  if (cleaned.includes('/')) return cleaned;
+  return cleaned.startsWith('**/') ? cleaned : `**/${cleaned}`;
+};
+
+export const expandHome = (input: string): string => {
+  if (input === '~') return os.homedir();
+  if (input.startsWith('~/') || input.startsWith('~\\')) {
+    return path.join(os.homedir(), input.slice(2));
+  }
+  return input;
+};
+
+export const createGlobMatcher = (pattern: string): ((value: string) => boolean) => {
+  const matcher = picomatch(pattern, { dot: true }) as (value: string) => boolean;
+  return (value: string) => Boolean(matcher(value));
+};
+


### PR DESCRIPTION
Fixes Beads issue oh-tab-2wx (and includes perf knobs from oh-tab-68g).

- GlobTool: supports workspace-relative/home/absolute patterns; detects file vs walk roots; includes hidden + node_modules by default, with `include_hidden:false` / `include_node_modules:false` for faster searches; prunes walk depth for non-recursive patterns.
- GrepTool: regex is case-sensitive by default (flags `m`); include filter via glob; includes hidden + node_modules by default with the same perf flags; clearer invalid path/regex errors.
- Tests: Vitest fixtures for glob/grep parity (include filters, hidden/node_modules toggles, truncation, absolute patterns).

Tests: `npm test -w @openhands/agent-sdk-ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Faster, more robust recursive search with home-expansion, improved glob normalization, workspace/absolute path support, a single-file mode, include_hidden and include_node_modules toggles, and results sorted and limited to 100. Tools now expose name and description.

* **Bug Fixes**
  * Clearer errors for invalid paths/regex, unreadable files skipped, stable include-filtering, normalized relative paths, consistent truncation behavior.

* **Tests**
  * Comprehensive tests for walking, pattern handling, filtering, content searches, truncation, and error cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
