### PR TITLE
oh-tab-bcu: Plain-text tool messages + secret masking

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -44,6 +44,8 @@ const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 // Simple utility to cap logged/tool result sizes
 const TRUNCATE_LIMIT = 2000;
 const ELLIPSIS = '…(truncated)';
+const TOOL_MESSAGE_MAX_CHARS = 30_000;
+const TOOL_MESSAGE_CLIP_MARKER = '<response clipped>';
 function truncateString(input: string): string {
   return input.length > TRUNCATE_LIMIT ? input.slice(0, TRUNCATE_LIMIT) + ELLIPSIS : input;
 }
@@ -64,6 +66,15 @@ function toOptionalNonEmptyString(value: unknown): string | undefined {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
   return trimmed ? trimmed : undefined;
+}
+
+function truncateToolMessage(text: string, maxChars = TOOL_MESSAGE_MAX_CHARS): string {
+  if (text.length <= maxChars) return text;
+  const available = maxChars - TOOL_MESSAGE_CLIP_MARKER.length - 2;
+  const half = Math.max(0, Math.floor(available / 2));
+  const head = text.slice(0, half);
+  const tail = text.slice(-half);
+  return `${head}\n${TOOL_MESSAGE_CLIP_MARKER}\n${tail}`;
 }
 
 function stringifyErrorWithCause(error: unknown, maxDepth = 4): string {
@@ -189,6 +200,99 @@ export class Agent extends EventEmitter {
     this.confirmation.riskyThreshold = settings?.confirmation?.riskyThreshold ?? 'MEDIUM';
     this.confirmation.confirmUnknown = settings?.confirmation?.confirmUnknown ?? true;
     this.debug = settings?.agent?.debug ?? false;
+  }
+
+  private getSecretValuesForMasking(): string[] {
+    const values = new Set<string>();
+    const maybePush = (candidate: unknown) => {
+      if (typeof candidate !== 'string') return;
+      const trimmed = candidate.trim();
+      if (!trimmed) return;
+      if (/^[A-Z0-9_]+$/.test(trimmed)) {
+        const envValue = process.env[trimmed];
+        if (envValue) values.add(envValue);
+      } else {
+        values.add(trimmed);
+      }
+    };
+
+    for (const secret of Object.values(this.options.settings?.secrets ?? {})) {
+      maybePush(secret);
+    }
+
+    const commonEnvSecrets = [
+      'OPENAI_API_KEY',
+      'OPENROUTER_API_KEY',
+      'LITELLM_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'LLM_API_KEY',
+      'GITHUB_TOKEN',
+      'GH_TOKEN',
+    ];
+    for (const key of commonEnvSecrets) {
+      const value = process.env[key];
+      if (value) values.add(value);
+    }
+
+    return Array.from(values)
+      .filter((value) => value.length >= 8)
+      .sort((a, b) => b.length - a.length);
+  }
+
+  private maskSecretsInText(text: string): string {
+    let masked = text;
+    for (const secret of this.getSecretValuesForMasking()) {
+      masked = masked.replaceAll(secret, '***');
+    }
+    return redactStringHeuristics(masked);
+  }
+
+  private formatToolMessageText(toolCall: ToolCall, result: unknown): string {
+    const toolName = toolCall.function.name;
+    const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+      value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+
+    if (toolName === 'terminal') {
+      const record = asRecord(result) ?? {};
+      const command = toOptionalNonEmptyString(record.command) ?? toOptionalNonEmptyString(toolCall.function.arguments);
+      const stdout = typeof record.stdout === 'string' ? record.stdout.trimEnd() : '';
+      const stderr = typeof record.stderr === 'string' ? record.stderr.trimEnd() : '';
+      const exitCode = typeof record.exit_code === 'number' ? record.exit_code : undefined;
+      const timedOut = record.timeout === true;
+
+      const parts: string[] = [];
+      if (command) {
+        parts.push(command.startsWith('$') ? command : `$ ${command}`);
+      }
+      const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
+      if (output) parts.push(output);
+      if (typeof exitCode === 'number') {
+        parts.push(`[Command finished with exit code ${exitCode}]`);
+      } else {
+        parts.push('[Command finished]');
+      }
+      if (timedOut) parts.push('[Command timed out]');
+      return parts.join('\n');
+    }
+
+    if (toolName === 'file_editor') {
+      const record = asRecord(result) ?? {};
+      const command = toOptionalNonEmptyString(record.command);
+      const targetPath = toOptionalNonEmptyString(record.path);
+      const header = targetPath
+        ? `file_editor${command ? ` ${command}` : ''} ${targetPath}`
+        : `file_editor${command ? ` ${command}` : ''}`;
+      const content = typeof record.new_content === 'string' ? record.new_content : record.new_content === null ? '<file removed>' : '';
+      return content ? `${header}\n${content}` : header;
+    }
+
+    if (typeof result === 'string') return result;
+    if (result === null || result === undefined) return String(result);
+    try {
+      return JSON.stringify(result, null, 2);
+    } catch {
+      return Object.prototype.toString.call(result);
+    }
   }
 
   /**
@@ -712,6 +816,10 @@ export class Agent extends EventEmitter {
       } as Event;
       this.events.push(observation);
 
+      const formatted = this.formatToolMessageText(toolCall, result);
+      const masked = this.maskSecretsInText(formatted);
+      const clipped = truncateToolMessage(masked);
+
       const toolMessage: MessageEvent = {
         kind: 'MessageEvent',
         source: 'environment',
@@ -719,7 +827,7 @@ export class Agent extends EventEmitter {
           role: 'tool',
           tool_call_id: toolCall.id,
           name: toolCall.function.name,
-          content: [{ type: 'text', text: truncateString(JSON.stringify(result)) }],
+          content: [{ type: 'text', text: clipped }],
         },
       };
       this.events.push(toolMessage);

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -175,6 +175,7 @@ export class Agent extends EventEmitter {
   private readonly registry?: import('../llm').LLMRegistry;
   private readonly conversationStats?: import('./ConversationStats').ConversationStats;
   private debug: boolean;
+  private secretValuesForMaskingCache: { signature: string; values: string[] } | null = null;
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -203,6 +204,16 @@ export class Agent extends EventEmitter {
   }
 
   private getSecretValuesForMasking(): string[] {
+    const configuredSecrets = Object.values(this.options.settings?.secrets ?? {})
+      .filter((secret): secret is string => typeof secret === 'string')
+      .map((secret) => secret.trim())
+      .filter(Boolean);
+    const registeredSecrets = this.secrets.getRegisteredValues();
+    const signature = `${configuredSecrets.join('\u0000')}\u0001${registeredSecrets.join('\u0000')}`;
+    if (this.secretValuesForMaskingCache?.signature === signature) {
+      return this.secretValuesForMaskingCache.values;
+    }
+
     const values = new Set<string>();
     const maybePush = (candidate: unknown) => {
       if (typeof candidate !== 'string') return;
@@ -219,11 +230,11 @@ export class Agent extends EventEmitter {
       }
     };
 
-    for (const secret of Object.values(this.options.settings?.secrets ?? {})) {
+    for (const secret of configuredSecrets) {
       maybePush(secret);
     }
 
-    for (const secret of this.secrets.getRegisteredValues()) {
+    for (const secret of registeredSecrets) {
       maybePush(secret);
     }
 
@@ -234,9 +245,11 @@ export class Agent extends EventEmitter {
       values.add(value);
     }
 
-    return Array.from(values)
+    const computed = Array.from(values)
       .filter((value) => value.length >= 8)
       .sort((a, b) => b.length - a.length);
+    this.secretValuesForMaskingCache = { signature, values: computed };
+    return computed;
   }
 
   private maskSecretsInText(text: string): string {
@@ -289,9 +302,10 @@ export class Agent extends EventEmitter {
       const record = asRecord(result) ?? {};
       const command = toOptionalNonEmptyString(record.command);
       const targetPath = toOptionalNonEmptyString(record.path);
-      const header = targetPath
-        ? `file_editor${command ? ` ${command}` : ''} ${targetPath}`
-        : `file_editor${command ? ` ${command}` : ''}`;
+      const headerParts = ['file_editor'];
+      if (command) headerParts.push(command);
+      if (targetPath) headerParts.push(targetPath);
+      const header = headerParts.join(' ');
       const content = typeof record.new_content === 'string' ? record.new_content : record.new_content === null ? '<file removed>' : '';
       return content ? `${header}\n${content}` : header;
     }

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -203,21 +203,21 @@ export class Agent extends EventEmitter {
   }
 
   private getSecretValuesForMasking(): string[] {
-	    const values = new Set<string>();
-	    const maybePush = (candidate: unknown) => {
-	      if (typeof candidate !== 'string') return;
-	      const trimmed = candidate.trim();
-	      if (!trimmed) return;
-	      if (/^[A-Z0-9_]+$/.test(trimmed)) {
-	        values.add(trimmed);
-	        const envValue = process.env[trimmed];
-	        if (envValue) {
-	          values.add(envValue);
-	        }
-	      } else {
-	        values.add(trimmed);
-	      }
-	    };
+    const values = new Set<string>();
+    const maybePush = (candidate: unknown) => {
+      if (typeof candidate !== 'string') return;
+      const trimmed = candidate.trim();
+      if (!trimmed) return;
+      if (/^[A-Z0-9_]+$/.test(trimmed)) {
+        values.add(trimmed);
+        const envValue = process.env[trimmed];
+        if (envValue) {
+          values.add(envValue);
+        }
+      } else {
+        values.add(trimmed);
+      }
+    };
 
     for (const secret of Object.values(this.options.settings?.secrets ?? {})) {
       maybePush(secret);

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -203,22 +203,21 @@ export class Agent extends EventEmitter {
   }
 
   private getSecretValuesForMasking(): string[] {
-    const values = new Set<string>();
-    const maybePush = (candidate: unknown) => {
-      if (typeof candidate !== 'string') return;
-      const trimmed = candidate.trim();
-      if (!trimmed) return;
-      if (/^[A-Z0-9_]+$/.test(trimmed)) {
-        const envValue = process.env[trimmed];
-        if (envValue) {
-          values.add(envValue);
-        } else {
-          values.add(trimmed);
-        }
-      } else {
-        values.add(trimmed);
-      }
-    };
+	    const values = new Set<string>();
+	    const maybePush = (candidate: unknown) => {
+	      if (typeof candidate !== 'string') return;
+	      const trimmed = candidate.trim();
+	      if (!trimmed) return;
+	      if (/^[A-Z0-9_]+$/.test(trimmed)) {
+	        values.add(trimmed);
+	        const envValue = process.env[trimmed];
+	        if (envValue) {
+	          values.add(envValue);
+	        }
+	      } else {
+	        values.add(trimmed);
+	      }
+	    };
 
     for (const secret of Object.values(this.options.settings?.secrets ?? {})) {
       maybePush(secret);

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -210,7 +210,11 @@ export class Agent extends EventEmitter {
       if (!trimmed) return;
       if (/^[A-Z0-9_]+$/.test(trimmed)) {
         const envValue = process.env[trimmed];
-        if (envValue) values.add(envValue);
+        if (envValue) {
+          values.add(envValue);
+        } else {
+          values.add(trimmed);
+        }
       } else {
         values.add(trimmed);
       }

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -44,7 +44,7 @@ const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 // Simple utility to cap logged/tool result sizes
 const TRUNCATE_LIMIT = 2000;
 const ELLIPSIS = '…(truncated)';
-const TOOL_MESSAGE_MAX_CHARS = 30_000;
+const TOOL_MESSAGE_MAX_CHARS = 8_000;
 const TOOL_MESSAGE_CLIP_MARKER = '<response clipped>';
 function truncateString(input: string): string {
   return input.length > TRUNCATE_LIMIT ? input.slice(0, TRUNCATE_LIMIT) + ELLIPSIS : input;
@@ -220,18 +220,15 @@ export class Agent extends EventEmitter {
       maybePush(secret);
     }
 
-    const commonEnvSecrets = [
-      'OPENAI_API_KEY',
-      'OPENROUTER_API_KEY',
-      'LITELLM_API_KEY',
-      'ANTHROPIC_API_KEY',
-      'LLM_API_KEY',
-      'GITHUB_TOKEN',
-      'GH_TOKEN',
-    ];
-    for (const key of commonEnvSecrets) {
-      const value = process.env[key];
-      if (value) values.add(value);
+    for (const secret of this.secrets.getRegisteredValues()) {
+      maybePush(secret);
+    }
+
+    const envKeyLooksSensitive = /(?:^|_)(?:API_?KEY|ACCESS_TOKEN|REFRESH_TOKEN|TOKEN|SECRET|PASSWORD)(?:$|_)/i;
+    for (const [key, value] of Object.entries(process.env)) {
+      if (!value) continue;
+      if (!envKeyLooksSensitive.test(key)) continue;
+      values.add(value);
     }
 
     return Array.from(values)
@@ -254,7 +251,17 @@ export class Agent extends EventEmitter {
 
     if (toolName === 'terminal') {
       const record = asRecord(result) ?? {};
-      const command = toOptionalNonEmptyString(record.command) ?? toOptionalNonEmptyString(toolCall.function.arguments);
+      const commandFromArgs = (() => {
+        const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
+        if (!rawArgs) return undefined;
+        try {
+          const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
+          return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
+        } catch {
+          return rawArgs;
+        }
+      })();
+      const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs;
       const stdout = typeof record.stdout === 'string' ? record.stdout.trimEnd() : '';
       const stderr = typeof record.stderr === 'string' ? record.stderr.trimEnd() : '';
       const exitCode = typeof record.exit_code === 'number' ? record.exit_code : undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts
@@ -29,14 +29,24 @@ export class SecretRegistry {
     }
 
     const envKey = name.toUpperCase();
-    if (process.env[envKey]) {
-      return process.env[envKey];
+    const envValue = process.env[envKey];
+    if (envValue) {
+      this.secrets.set(name, envValue);
+      return envValue;
     }
 
     if (this.storage) {
-      return this.storage.get(name);
+      const stored = await this.storage.get(name);
+      if (stored) {
+        this.secrets.set(name, stored);
+      }
+      return stored;
     }
 
     return undefined;
+  }
+
+  getRegisteredValues(): string[] {
+    return Array.from(this.secrets.values());
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
 import { isMessageEvent, type TextContent } from '../../types';
@@ -20,7 +20,19 @@ class MockLLM implements LLMClient {
   }
 }
 
-const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-messages-'));
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-messages-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe('Agent tool message formatting', () => {
   it('formats terminal tool output as plain text and masks configured secrets', async () => {
@@ -75,11 +87,11 @@ describe('Agent tool message formatting', () => {
     expect(text.trimStart().startsWith('{')).toBe(false);
   });
 
-	  it('masks uppercase secrets even when they resemble env var names', async () => {
-	    const secretValue = 'TOPSECRETUPPERCASE1234567890';
-	    const envKey = secretValue;
-	    const previousEnvValue = process.env[envKey];
-	    delete process.env[envKey];
+  it('masks uppercase secrets even when they resemble env var names', async () => {
+    const secretValue = 'TOPSECRETUPPERCASE1234567890';
+    const envKey = secretValue;
+    const previousEnvValue = process.env[envKey];
+    delete process.env[envKey];
 
     try {
       const settings: OpenHandsSettings = {
@@ -134,77 +146,77 @@ describe('Agent tool message formatting', () => {
       } else {
         process.env[envKey] = previousEnvValue;
       }
-	    }
-	  });
+    }
+  });
 
-	  it('masks uppercase secrets when an env var of the same name exists with a different value', async () => {
-	    const secretValue = 'TOPSECRETUPPERCASE1234567890';
-	    const envKey = secretValue;
-	    const envValue = 'DIFFERENT_ENV_SECRET_1234567890';
-	    const previousEnvValue = process.env[envKey];
-	    process.env[envKey] = envValue;
+  it('masks uppercase secrets when an env var of the same name exists with a different value', async () => {
+    const secretValue = 'TOPSECRETUPPERCASE1234567890';
+    const envKey = secretValue;
+    const envValue = 'DIFFERENT_ENV_SECRET_1234567890';
+    const previousEnvValue = process.env[envKey];
+    process.env[envKey] = envValue;
 
-	    try {
-	      const settings: OpenHandsSettings = {
-	        llm: { model: 'test-model' },
-	        agent: {},
-	        conversation: { maxIterations: 1 },
-	        confirmation: {},
-	        secrets: { githubToken: secretValue },
-	      };
-	      const log = new EventLog();
+    try {
+      const settings: OpenHandsSettings = {
+        llm: { model: 'test-model' },
+        agent: {},
+        conversation: { maxIterations: 1 },
+        confirmation: {},
+        secrets: { githubToken: secretValue },
+      };
+      const log = new EventLog();
 
-	      const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
-	        name: 'terminal',
-	        validate: (input) => input as Record<string, unknown>,
-	        execute: async () => ({
-	          command: 'echo hello',
-	          exit_code: 0,
-	          stdout: `hello ${secretValue} ${envValue}`,
-	          stderr: '',
-	          timeout: false,
-	        }),
-	      };
+      const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+        name: 'terminal',
+        validate: (input) => input as Record<string, unknown>,
+        execute: async () => ({
+          command: 'echo hello',
+          exit_code: 0,
+          stdout: `hello ${secretValue} ${envValue}`,
+          stderr: '',
+          timeout: false,
+        }),
+      };
 
-	      const llm = new MockLLM([
-	        { type: 'text', text: 'Running terminal' },
-	        { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hello"}' },
-	        { type: 'finish' },
-	      ]);
+      const llm = new MockLLM([
+        { type: 'text', text: 'Running terminal' },
+        { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hello"}' },
+        { type: 'finish' },
+      ]);
 
-	      const agent = new Agent({
-	        settings,
-	        events: log,
-	        workspaceRoot: createWorkspaceRoot(),
-	        llmClient: llm,
-	        tools: [tool],
-	      });
+      const agent = new Agent({
+        settings,
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+        tools: [tool],
+      });
 
-	      await agent.run('run terminal');
+      await agent.run('run terminal');
 
-	      const toolMessages = log
-	        .list()
-	        .filter(isMessageEvent)
-	        .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
-	      expect(toolMessages).toHaveLength(1);
+      const toolMessages = log
+        .list()
+        .filter(isMessageEvent)
+        .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+      expect(toolMessages).toHaveLength(1);
 
-	      const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
-	      expect(text).not.toContain(secretValue);
-	      expect(text).not.toContain(envValue);
-	      expect(text).toContain('***');
-	    } finally {
-	      if (previousEnvValue === undefined) {
-	        delete process.env[envKey];
-	      } else {
-	        process.env[envKey] = previousEnvValue;
-	      }
-	    }
-	  });
+      const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+      expect(text).not.toContain(secretValue);
+      expect(text).not.toContain(envValue);
+      expect(text).toContain('***');
+    } finally {
+      if (previousEnvValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = previousEnvValue;
+      }
+    }
+  });
 
-	  it('truncates long terminal tool outputs using <response clipped>', async () => {
-	    const log = new EventLog();
-	    const longOutput = 'A'.repeat(35_000);
-	    const settings: OpenHandsSettings = {
+  it('truncates long terminal tool outputs using <response clipped>', async () => {
+    const log = new EventLog();
+    const longOutput = 'A'.repeat(35_000);
+    const settings: OpenHandsSettings = {
       llm: { model: 'test-model' },
       agent: {},
       conversation: { maxIterations: 1 },

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -7,6 +7,7 @@ import { Agent, EventLog } from '..';
 import { isMessageEvent, type TextContent } from '../../types';
 import type { ToolDefinition } from '../../types/tools';
 import type { OpenHandsSettings } from '../../types/settings';
+import { SecretRegistry } from '../SecretRegistry';
 
 class MockLLM implements LLMClient {
   constructor(private readonly chunks: LLMStreamChunk[]) {}
@@ -113,6 +114,100 @@ describe('Agent tool message formatting', () => {
     const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
     expect(text).toContain('<response clipped>');
     expect(text.length).toBeLessThan(longOutput.length);
+    expect(text.length).toBeLessThanOrEqual(8_000);
+  });
+
+  it('masks secrets registered in SecretRegistry', async () => {
+    const secretValue = 'tok_SUPERSECRET_1234567890';
+    const registry = new SecretRegistry();
+    registry.register('custom', secretValue);
+
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const log = new EventLog();
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: 'echo hi',
+        exit_code: 0,
+        stdout: `leak ${secretValue}`,
+        stderr: '',
+      }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Run terminal' },
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+      secrets: registry,
+    });
+
+    await agent.run('run');
+
+    const toolMessages = log
+      .list()
+      .filter(isMessageEvent)
+      .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+    expect(toolMessages).toHaveLength(1);
+
+    const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+    expect(text).not.toContain(secretValue);
+    expect(text).toContain('***');
+  });
+
+  it('parses terminal command from tool call args when tool result omits it', async () => {
+    const log = new EventLog();
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({ stdout: 'ok', stderr: '', exit_code: 0 }),
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Run terminal' },
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hello"}' },
+      { type: 'finish' },
+    ]);
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run');
+
+    const toolMessages = log
+      .list()
+      .filter(isMessageEvent)
+      .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+    expect(toolMessages).toHaveLength(1);
+
+    const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+    expect(text).toContain('$ echo hello');
+    expect(text).not.toContain('{"command"');
   });
 
   it('formats file_editor tool output as plain text', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -75,11 +75,11 @@ describe('Agent tool message formatting', () => {
     expect(text.trimStart().startsWith('{')).toBe(false);
   });
 
-  it('masks uppercase secrets even when they resemble env var names', async () => {
-    const secretValue = 'TOPSECRETUPPERCASE1234567890';
-    const envKey = secretValue;
-    const previousEnvValue = process.env[envKey];
-    delete process.env[envKey];
+	  it('masks uppercase secrets even when they resemble env var names', async () => {
+	    const secretValue = 'TOPSECRETUPPERCASE1234567890';
+	    const envKey = secretValue;
+	    const previousEnvValue = process.env[envKey];
+	    delete process.env[envKey];
 
     try {
       const settings: OpenHandsSettings = {
@@ -134,13 +134,77 @@ describe('Agent tool message formatting', () => {
       } else {
         process.env[envKey] = previousEnvValue;
       }
-    }
-  });
+	    }
+	  });
 
-  it('truncates long terminal tool outputs using <response clipped>', async () => {
-    const log = new EventLog();
-    const longOutput = 'A'.repeat(35_000);
-    const settings: OpenHandsSettings = {
+	  it('masks uppercase secrets when an env var of the same name exists with a different value', async () => {
+	    const secretValue = 'TOPSECRETUPPERCASE1234567890';
+	    const envKey = secretValue;
+	    const envValue = 'DIFFERENT_ENV_SECRET_1234567890';
+	    const previousEnvValue = process.env[envKey];
+	    process.env[envKey] = envValue;
+
+	    try {
+	      const settings: OpenHandsSettings = {
+	        llm: { model: 'test-model' },
+	        agent: {},
+	        conversation: { maxIterations: 1 },
+	        confirmation: {},
+	        secrets: { githubToken: secretValue },
+	      };
+	      const log = new EventLog();
+
+	      const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+	        name: 'terminal',
+	        validate: (input) => input as Record<string, unknown>,
+	        execute: async () => ({
+	          command: 'echo hello',
+	          exit_code: 0,
+	          stdout: `hello ${secretValue} ${envValue}`,
+	          stderr: '',
+	          timeout: false,
+	        }),
+	      };
+
+	      const llm = new MockLLM([
+	        { type: 'text', text: 'Running terminal' },
+	        { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hello"}' },
+	        { type: 'finish' },
+	      ]);
+
+	      const agent = new Agent({
+	        settings,
+	        events: log,
+	        workspaceRoot: createWorkspaceRoot(),
+	        llmClient: llm,
+	        tools: [tool],
+	      });
+
+	      await agent.run('run terminal');
+
+	      const toolMessages = log
+	        .list()
+	        .filter(isMessageEvent)
+	        .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+	      expect(toolMessages).toHaveLength(1);
+
+	      const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+	      expect(text).not.toContain(secretValue);
+	      expect(text).not.toContain(envValue);
+	      expect(text).toContain('***');
+	    } finally {
+	      if (previousEnvValue === undefined) {
+	        delete process.env[envKey];
+	      } else {
+	        process.env[envKey] = previousEnvValue;
+	      }
+	    }
+	  });
+
+	  it('truncates long terminal tool outputs using <response clipped>', async () => {
+	    const log = new EventLog();
+	    const longOutput = 'A'.repeat(35_000);
+	    const settings: OpenHandsSettings = {
       llm: { model: 'test-model' },
       agent: {},
       conversation: { maxIterations: 1 },

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -1,0 +1,165 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import { isMessageEvent, type TextContent } from '../../types';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-messages-'));
+
+describe('Agent tool message formatting', () => {
+  it('formats terminal tool output as plain text and masks configured secrets', async () => {
+    const secretValue = 'ghp_TOPSECRET1234567890';
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: { githubToken: secretValue },
+    };
+    const log = new EventLog();
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: 'echo hello',
+        exit_code: 0,
+        stdout: `hello ${secretValue}`,
+        stderr: '',
+        timeout: false,
+      }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Running terminal' },
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hello"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run terminal');
+
+    const toolMessages = log
+      .list()
+      .filter(isMessageEvent)
+      .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+    expect(toolMessages).toHaveLength(1);
+
+    const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+    expect(text).toContain('hello');
+    expect(text).not.toContain(secretValue);
+    expect(text).toContain('***');
+    expect(text.trimStart().startsWith('{')).toBe(false);
+  });
+
+  it('truncates long terminal tool outputs using <response clipped>', async () => {
+    const log = new EventLog();
+    const longOutput = 'A'.repeat(35_000);
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({ command: 'echo big', exit_code: 0, stdout: longOutput, stderr: '' }),
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Big output' },
+      { type: 'tool_call_delta', id: 'call_terminal_big', name: 'terminal', arguments: '{"command":"echo big"}' },
+      { type: 'finish' },
+    ]);
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run big');
+
+    const toolMessages = log
+      .list()
+      .filter(isMessageEvent)
+      .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+    expect(toolMessages).toHaveLength(1);
+
+    const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+    expect(text).toContain('<response clipped>');
+    expect(text.length).toBeLessThan(longOutput.length);
+  });
+
+  it('formats file_editor tool output as plain text', async () => {
+    const log = new EventLog();
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'file_editor',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: 'view',
+        path: 'note.txt',
+        prev_exist: true,
+        old_content: 'line-1\nline-2',
+        new_content: '1\tline-1\n2\tline-2',
+      }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'View file' },
+      { type: 'tool_call_delta', id: 'call_view', name: 'file_editor', arguments: '{"command":"view","path":"note.txt"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('view');
+
+    const toolMessages = log
+      .list()
+      .filter(isMessageEvent)
+      .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'file_editor');
+    expect(toolMessages).toHaveLength(1);
+
+    const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+    expect(text).toContain('1\tline-1');
+    expect(text.trimStart().startsWith('{')).toBe(false);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -75,6 +75,68 @@ describe('Agent tool message formatting', () => {
     expect(text.trimStart().startsWith('{')).toBe(false);
   });
 
+  it('masks uppercase secrets even when they resemble env var names', async () => {
+    const secretValue = 'TOPSECRETUPPERCASE1234567890';
+    const envKey = secretValue;
+    const previousEnvValue = process.env[envKey];
+    delete process.env[envKey];
+
+    try {
+      const settings: OpenHandsSettings = {
+        llm: { model: 'test-model' },
+        agent: {},
+        conversation: { maxIterations: 1 },
+        confirmation: {},
+        secrets: { githubToken: secretValue },
+      };
+      const log = new EventLog();
+
+      const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+        name: 'terminal',
+        validate: (input) => input as Record<string, unknown>,
+        execute: async () => ({
+          command: 'echo hello',
+          exit_code: 0,
+          stdout: `hello ${secretValue}`,
+          stderr: '',
+          timeout: false,
+        }),
+      };
+
+      const llm = new MockLLM([
+        { type: 'text', text: 'Running terminal' },
+        { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"echo hello"}' },
+        { type: 'finish' },
+      ]);
+
+      const agent = new Agent({
+        settings,
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+        llmClient: llm,
+        tools: [tool],
+      });
+
+      await agent.run('run terminal');
+
+      const toolMessages = log
+        .list()
+        .filter(isMessageEvent)
+        .filter((evt) => evt.llm_message.role === 'tool' && evt.llm_message.name === 'terminal');
+      expect(toolMessages).toHaveLength(1);
+
+      const text = (toolMessages[0].llm_message.content[0] as TextContent).text;
+      expect(text).not.toContain(secretValue);
+      expect(text).toContain('***');
+    } finally {
+      if (previousEnvValue === undefined) {
+        delete process.env[envKey];
+      } else {
+        process.env[envKey] = previousEnvValue;
+      }
+    }
+  });
+
   it('truncates long terminal tool outputs using <response clipped>', async () => {
     const log = new EventLog();
     const longOutput = 'A'.repeat(35_000);

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts
@@ -24,7 +24,7 @@ const baseSettings: OpenHandsSettings = {
 };
 
 const LONG = 'x'.repeat(2500);
-const LONG_STDOUT = 'o'.repeat(5000);
+const LONG_STDOUT = 'o'.repeat(50_000);
 
 describe('Agent truncates tool logs and observations', () => {
   it('truncates llm_tool_call_raw arguments value', async () => {
@@ -58,10 +58,11 @@ describe('Agent truncates tool logs and observations', () => {
 
   it('deep truncates ObservationEvent payload and tool message content', async () => {
     const log = new EventLog();
+    const veryLong = 'x'.repeat(35_000);
     const tool: ToolDefinition<{ foo: string }, { deep: { s: string }, arr: string[] }> = {
       name: 'makeLong',
       validate: (input) => input as { foo: string },
-      execute: async () => ({ deep: { s: LONG }, arr: [LONG, 'ok'] }),
+      execute: async () => ({ deep: { s: veryLong }, arr: [veryLong, 'ok'] }),
     };
 
     const llm = new MockLLM([
@@ -84,8 +85,8 @@ describe('Agent truncates tool logs and observations', () => {
     const toolMsg = events.filter(isMessageEvent).find((m) => m.llm_message.role === 'tool');
     expect(toolMsg).toBeTruthy();
     const txt = toolMsg!.llm_message.content.find((c) => c.type === 'text') as { type: 'text'; text: string };
-    expect(txt.text.length).toBeLessThanOrEqual(2015);
-    expect(txt.text.endsWith('…(truncated)')).toBe(true);
+    expect(txt.text).toContain('<response clipped>');
+    expect(txt.text.length).toBeLessThanOrEqual(30_000);
   });
 
   it('truncates large stdout results in ObservationEvent and tool message', async () => {
@@ -115,7 +116,7 @@ describe('Agent truncates tool logs and observations', () => {
     const toolMsg = events.filter(isMessageEvent).find((m) => m.llm_message.tool_call_id === 'c3');
     expect(toolMsg).toBeTruthy();
     const txt = toolMsg!.llm_message.content.find((c) => c.type === 'text') as { type: 'text'; text: string };
-    expect(txt.text.length).toBeLessThanOrEqual(2015);
-    expect(txt.text.endsWith('…(truncated)')).toBe(true);
+    expect(txt.text).toContain('<response clipped>');
+    expect(txt.text.length).toBeLessThanOrEqual(30_000);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts
@@ -86,7 +86,7 @@ describe('Agent truncates tool logs and observations', () => {
     expect(toolMsg).toBeTruthy();
     const txt = toolMsg!.llm_message.content.find((c) => c.type === 'text') as { type: 'text'; text: string };
     expect(txt.text).toContain('<response clipped>');
-    expect(txt.text.length).toBeLessThanOrEqual(30_000);
+    expect(txt.text.length).toBeLessThanOrEqual(8_000);
   });
 
   it('truncates large stdout results in ObservationEvent and tool message', async () => {
@@ -117,6 +117,6 @@ describe('Agent truncates tool logs and observations', () => {
     expect(toolMsg).toBeTruthy();
     const txt = toolMsg!.llm_message.content.find((c) => c.type === 'text') as { type: 'text'; text: string };
     expect(txt.text).toContain('<response clipped>');
-    expect(txt.text.length).toBeLessThanOrEqual(30_000);
+    expect(txt.text.length).toBeLessThanOrEqual(8_000);
   });
 });


### PR DESCRIPTION
Fixes Beads oh-tab-bcu.

What changed:
- Agent tool MessageEvent content is now plain text for core tools (terminal, file_editor) instead of JSON-only.
- Tool message text is secret-masked (settings secrets + common env keys + token heuristics) and clipped with a <response clipped> marker when oversized.
- Updated truncation tests to reflect new tool-message clipping semantics; added new unit tests for terminal/file_editor formatting + masking.

Local checks:
- npm test
- npm test -w @openhands/agent-sdk-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool outputs are formatted for clearer, human-friendly display; secrets are automatically detected and redacted/masked; long outputs are clipped with a "<response clipped>" indicator and updated truncation limits.

* **Tests**
  * Added comprehensive tests covering formatting, masking across env/registry heuristics, truncation behavior for much larger outputs, and command extraction for multiple tool types.

* **Chores**
  * Secret registry now exposes current registered secret values and more reliably caches environment/storage secrets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->