### PR TITLE
[oh-tab-wmn] TerminalTool persistent session + is_input/reset

### DIFF
--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -58,7 +58,7 @@ type RunningTerminalProcess = {
 
 class TerminalSession {
   private cwd: string;
-  private env: Record<string, string>;
+  private env: Record<string, string> = {};
   private running: RunningTerminalProcess | null = null;
 
   constructor(workDir: string) {

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -220,6 +220,12 @@ class TerminalSession {
     }
 
     if (running) {
+      if (!args.is_input && args.command.trim().length > 0) {
+        throw new Error(
+          `Cannot start a new terminal command while another is running ($ ${running.command}). ` +
+            `Poll with command="" or send input with is_input=true (e.g., "C-c" to interrupt).`,
+        );
+      }
       if (args.is_input) {
         const input = args.command ?? '';
         const trimmed = input.trim();

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -375,6 +375,7 @@ const TOOL_DESCRIPTION = `Execute a bash command in the terminal within a persis
 
 ### Command Execution
 * One command at a time: You can only execute one bash command at a time. If you need to run multiple commands sequentially, use \`&&\` or \`;\` to chain them together.
+  - If a command is still running (exit code \`-1\`), starting a different non-empty \`command\` will fail. Poll with \`command: ""\` or use \`is_input: true\` to interact with the running process.
 * Persistent session: Commands execute in a persistent shell session where environment variables, virtual environments, and working directory persist between commands.
 * Soft timeout: Commands have a soft timeout of 10 seconds, once that's reached, you have the option to continue or interrupt the command (see section below for details)
 * Shell options: Do NOT use \`set -e\`, \`set -eu\`, or \`set -euo pipefail\` in shell scripts or commands in this environment. The runtime may not support them and can cause unusable shell sessions. If you want to run multi-line bash commands, write the commands to a file and then run it, instead.
@@ -401,7 +402,11 @@ const TOOL_DESCRIPTION = `Execute a bash command in the terminal within a persis
 `;
 
 const terminalSchema = z.object({
-  command: z.string().describe('The bash command to execute. Can be empty string to view additional logs when previous exit code is `-1`. Can be `C-c` (Ctrl+C) to interrupt the currently running process. Note: You can only execute one bash command at a time. If you need to run multiple commands sequentially, you can use `&&` or `;` to chain them together.'),
+  command: z
+    .string()
+    .describe(
+      'The bash command to execute. Can be empty string to poll additional logs when the previous exit code is `-1`. Can be `C-c` (Ctrl+C) to interrupt the currently running process (use with `is_input=true`). Note: You can only execute one bash command at a time. If a command is still running, starting a different non-empty command will fail.',
+    ),
   is_input: z.boolean().optional().default(false).describe('If True, the command is an input to the running process. If False, the command is a bash command to be executed in the terminal. Default is False.'),
   timeout: z.number().nonnegative().optional().nullable().describe('Optional. Sets a maximum time limit (in seconds) for running the command. If the command takes longer than this limit, you’ll be asked whether to continue or stop it. If you don’t set a value, the command will instead pause and ask for confirmation when it produces no new output for 10 seconds. Use a higher value if the command is expected to take a long time (like installation or testing), or if it has a known fixed duration (like sleep).'),
   reset: z.boolean().optional().default(false).describe('If True, reset the terminal by creating a new session. Use this only when the terminal becomes unresponsive. Note that all previously set environment variables and session state will be lost after reset. Cannot be used with is_input=True.'),

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -210,16 +210,16 @@ class TerminalSession {
   async execute(args: { command: string; is_input: boolean; timeoutSeconds: number }): Promise<{ stdout: string; stderr: string; exitCode: number | null; done: boolean; command: string | null }> {
     const timeoutMs = Math.max(0, Math.floor(args.timeoutSeconds * 1000));
 
-    const running = this.running;
-    if (running) {
-      if (running.done) {
-        const drained = this.drain(running);
-        const exitCode = running.exitCode;
-        const command = running.command;
-        this.running = null;
-        return { ...drained, exitCode, done: true, command };
-      }
+    let completed: { stdout: string; stderr: string; exitCode: number | null; command: string } | null = null;
+    let running = this.running;
+    if (running?.done) {
+      const drained = this.drain(running);
+      completed = { ...drained, exitCode: running.exitCode, command: running.command };
+      this.running = null;
+      running = null;
+    }
 
+    if (running) {
       if (args.is_input) {
         const input = args.command ?? '';
         const trimmed = input.trim();
@@ -246,7 +246,14 @@ class TerminalSession {
     }
 
     if (args.is_input) {
+      if (completed) {
+        return { stdout: completed.stdout, stderr: completed.stderr, exitCode: completed.exitCode, done: true, command: completed.command };
+      }
       return { stdout: '', stderr: 'No running terminal command to send input to.', exitCode: null, done: true, command: null };
+    }
+
+    if (completed && !args.command.trim()) {
+      return { stdout: completed.stdout, stderr: completed.stderr, exitCode: completed.exitCode, done: true, command: completed.command };
     }
 
     const id = randomUUID();
@@ -342,10 +349,18 @@ class TerminalSession {
     const drained = this.drain(cmd);
     const done = status === 'done';
     const exitCode = done ? cmd.exitCode : -1;
+    let stdout = drained.stdout;
+    const stderr = drained.stderr;
+    if (completed) {
+      const completedText = [completed.stdout, completed.stderr].filter(Boolean).join('');
+      const header = `[Below is the output of the previous command ($ ${completed.command}, exit_code: ${completed.exitCode ?? 0}).]\n`;
+      const spacer = completedText && !completedText.endsWith('\n') ? '\n' : '';
+      stdout = `${header}${completedText}${spacer}${stdout}`;
+    }
     if (done) {
       this.running = null;
     }
-    return { ...drained, exitCode, done, command: args.command };
+    return { stdout, stderr, exitCode, done, command: args.command };
   }
 }
 

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -21,6 +21,14 @@ export interface TerminalResult {
   timeout?: boolean;
   stdout?: string;
   stderr?: string;
+  previous?: {
+    command: string;
+    exit_code: number | null;
+    // Back-compat for older consumers (e.g. BashEvent adapters).
+    exitCode: number | null;
+    stdout: string;
+    stderr: string;
+  };
 }
 
 const DEFAULT_NO_CHANGE_TIMEOUT_SECONDS = 10;
@@ -207,7 +215,18 @@ class TerminalSession {
     return { stdout, stderr };
   }
 
-  async execute(args: { command: string; is_input: boolean; timeoutSeconds: number }): Promise<{ stdout: string; stderr: string; exitCode: number | null; done: boolean; command: string | null }> {
+  async execute(args: {
+    command: string;
+    is_input: boolean;
+    timeoutSeconds: number;
+  }): Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number | null;
+    done: boolean;
+    command: string | null;
+    previous: { stdout: string; stderr: string; exitCode: number | null; command: string } | null;
+  }> {
     const timeoutMs = Math.max(0, Math.floor(args.timeoutSeconds * 1000));
 
     let completed: { stdout: string; stderr: string; exitCode: number | null; command: string } | null = null;
@@ -248,18 +267,39 @@ class TerminalSession {
       if (done) {
         this.running = null;
       }
-      return { ...drained, exitCode, done, command };
+      return { ...drained, exitCode, done, command, previous: null };
     }
 
     if (args.is_input) {
       if (completed) {
-        return { stdout: completed.stdout, stderr: completed.stderr, exitCode: completed.exitCode, done: true, command: completed.command };
+        return {
+          stdout: completed.stdout,
+          stderr: completed.stderr,
+          exitCode: completed.exitCode,
+          done: true,
+          command: completed.command,
+          previous: completed,
+        };
       }
-      return { stdout: '', stderr: 'No running terminal command to send input to.', exitCode: null, done: true, command: null };
+      return {
+        stdout: '',
+        stderr: 'No running terminal command to send input to.',
+        exitCode: null,
+        done: true,
+        command: null,
+        previous: null,
+      };
     }
 
     if (completed && !args.command.trim()) {
-      return { stdout: completed.stdout, stderr: completed.stderr, exitCode: completed.exitCode, done: true, command: completed.command };
+      return {
+        stdout: completed.stdout,
+        stderr: completed.stderr,
+        exitCode: completed.exitCode,
+        done: true,
+        command: completed.command,
+        previous: completed,
+      };
     }
 
     const id = randomUUID();
@@ -357,16 +397,18 @@ class TerminalSession {
     const exitCode = done ? cmd.exitCode : -1;
     let stdout = drained.stdout;
     const stderr = drained.stderr;
+    let previous: { stdout: string; stderr: string; exitCode: number | null; command: string } | null = null;
     if (completed) {
       const completedText = [completed.stdout, completed.stderr].filter(Boolean).join('');
       const header = `[Below is the output of the previous command ($ ${completed.command}, exit_code: ${completed.exitCode ?? 0}).]\n`;
       const spacer = completedText && !completedText.endsWith('\n') ? '\n' : '';
       stdout = `${header}${completedText}${spacer}${stdout}`;
+      previous = completed;
     }
     if (done) {
       this.running = null;
     }
-    return { stdout, stderr, exitCode, done, command: args.command };
+    return { stdout, stderr, exitCode, done, command: args.command, previous };
   }
 }
 
@@ -454,6 +496,15 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
         exit_code: exitCode,
         exitCode,
         timeout: exitCode === -1,
+        previous: result.previous
+          ? {
+              command: result.previous.command,
+              exit_code: result.previous.exitCode,
+              exitCode: result.previous.exitCode,
+              stdout: result.previous.stdout,
+              stderr: result.previous.stderr,
+            }
+          : undefined,
       };
     };
 

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -207,119 +207,145 @@ class TerminalSession {
     return { stdout, stderr };
   }
 
-  takeCompleted(): { stdout: string; stderr: string; exitCode: number | null } | null {
-    const cmd = this.running;
-    if (!cmd || !cmd.done) return null;
-    const drained = this.drain(cmd);
-    const exitCode = cmd.exitCode;
-    this.running = null;
-    return { ...drained, exitCode };
-  }
-
-  async execute(args: { command: string; is_input: boolean; timeoutSeconds: number }): Promise<{ stdout: string; stderr: string; exitCode: number | null; done: boolean }> {
+  async execute(args: { command: string; is_input: boolean; timeoutSeconds: number }): Promise<{ stdout: string; stderr: string; exitCode: number | null; done: boolean; command: string | null }> {
     const timeoutMs = Math.max(0, Math.floor(args.timeoutSeconds * 1000));
 
-    if (!args.is_input) {
-      if (this.running && !this.running.done) {
-        const status = await this.waitForNoChangeOrDone(this.running, timeoutMs);
-        const drained = this.drain(this.running);
-        return { ...drained, exitCode: status === 'done' ? this.running.exitCode : -1, done: status === 'done' };
+    const running = this.running;
+    if (running) {
+      if (running.done) {
+        const drained = this.drain(running);
+        const exitCode = running.exitCode;
+        const command = running.command;
+        this.running = null;
+        return { ...drained, exitCode, done: true, command };
       }
 
-      const id = randomUUID();
-      const meta = {
-        begin: `__OPENHANDS_META_${id}__BEGIN__`,
-        end: `__OPENHANDS_META_${id}__END__`,
-        exit: `__OPENHANDS_EXIT_${id}__`,
-        pwd: `__OPENHANDS_PWD_${id}__`,
-        env: `__OPENHANDS_ENV_${id}__`,
-      };
+      if (args.is_input) {
+        const input = args.command ?? '';
+        const trimmed = input.trim();
+        if (trimmed === 'C-c') {
+          this.sendSignal(running.process, 'SIGINT');
+        } else if (trimmed === 'C-z') {
+          this.sendSignal(running.process, 'SIGTSTP');
+        } else if (trimmed === 'C-d') {
+          running.process.stdin.write('\u0004');
+        } else if (input.length > 0) {
+          running.process.stdin.write(`${input}\n`);
+        }
+      }
 
-      const scriptLines = [
-        args.command,
-        'openhands_ec=$?',
-        `printf '\\n${meta.begin}\\n'`,
-        `printf '${meta.exit}%s\\n' "$openhands_ec"`,
-        `printf '${meta.pwd}%s\\n' "$(pwd)"`,
-        `printf '${meta.env}'`,
-        `${JSON.stringify(process.execPath)} -e 'process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString("base64"))'`,
-        "printf '\\n'",
-        `printf '${meta.end}\\n'`,
-        'exit $openhands_ec',
-      ];
-      const script = scriptLines.join('\n');
-
-      const shellPath = os.platform() === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/bash';
-      const child = spawn(shellPath, ['-c', script], {
-        cwd: this.cwd,
-        env: this.env,
-        stdio: 'pipe',
-        detached: os.platform() !== 'win32',
-      });
-      child.stdout.setEncoding('utf8');
-      child.stderr.setEncoding('utf8');
-
-      const cmd: RunningTerminalProcess = {
-        id,
-        command: args.command,
-        process: child,
-        stdout: '',
-        stderr: '',
-        stdoutOffset: 0,
-        stderrOffset: 0,
-        lastActivityTs: Date.now(),
-        exitCode: null,
-        done: false,
-        meta,
-        waiters: new Set(),
-      };
-      this.running = cmd;
-
-      child.stdout.on('data', (data: Buffer | string) => {
-        cmd.stdout += data.toString();
-        cmd.lastActivityTs = Date.now();
-        this.tryParseMeta(cmd);
-        this.signal(cmd);
-      });
-
-      child.stderr.on('data', (data: Buffer | string) => {
-        cmd.stderr += data.toString();
-        cmd.lastActivityTs = Date.now();
-        this.signal(cmd);
-      });
-
-      child.on('close', (code) => {
-        cmd.done = true;
-        cmd.exitCode = typeof code === 'number' ? code : cmd.exitCode ?? 0;
-        this.tryParseMeta(cmd);
-        this.signal(cmd);
-      });
-
-      const status = await this.waitForNoChangeOrDone(cmd, timeoutMs);
-      const drained = this.drain(cmd);
-      return { ...drained, exitCode: status === 'done' ? cmd.exitCode : -1, done: status === 'done' };
+      const status = await this.waitForNoChangeOrDone(running, timeoutMs);
+      const drained = this.drain(running);
+      const done = status === 'done';
+      const exitCode = done ? running.exitCode : -1;
+      const command = running.command;
+      if (done) {
+        this.running = null;
+      }
+      return { ...drained, exitCode, done, command };
     }
 
-    const cmd = this.running;
-    if (!cmd || cmd.done) {
-      return { stdout: '', stderr: 'No running terminal command to send input to.', exitCode: null, done: true };
+    if (args.is_input) {
+      return { stdout: '', stderr: 'No running terminal command to send input to.', exitCode: null, done: true, command: null };
     }
 
-    const input = args.command ?? '';
-    const trimmed = input.trim();
-    if (trimmed === 'C-c') {
-      this.sendSignal(cmd.process, 'SIGINT');
-    } else if (trimmed === 'C-z') {
-      this.sendSignal(cmd.process, 'SIGTSTP');
-    } else if (trimmed === 'C-d') {
-      cmd.process.stdin.write('\u0004');
-    } else if (input.length > 0) {
-      cmd.process.stdin.write(`${input}\n`);
-    }
+    const id = randomUUID();
+    const meta = {
+      begin: `__OPENHANDS_META_${id}__BEGIN__`,
+      end: `__OPENHANDS_META_${id}__END__`,
+      exit: `__OPENHANDS_EXIT_${id}__`,
+      pwd: `__OPENHANDS_PWD_${id}__`,
+      env: `__OPENHANDS_ENV_${id}__`,
+    };
+
+    const platform = os.platform();
+    const nodeExecutable = platform === 'win32' ? `"${process.execPath.replaceAll('"', '""')}"` : JSON.stringify(process.execPath);
+
+    const scriptLines =
+      platform === 'win32'
+        ? [
+            args.command,
+            'set openhands_ec=%errorlevel%',
+            `echo ${meta.begin}`,
+            `echo ${meta.exit}%openhands_ec%`,
+            `echo ${meta.pwd}%CD%`,
+            `<nul set /p "=${meta.env}"`,
+            `${nodeExecutable} -e "process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString('base64'))"`,
+            'echo.',
+            `echo ${meta.end}`,
+            'exit /b %openhands_ec%',
+          ]
+        : [
+            args.command,
+            'openhands_ec=$?',
+            `printf '\\n${meta.begin}\\n'`,
+            `printf '${meta.exit}%s\\n' "$openhands_ec"`,
+            `printf '${meta.pwd}%s\\n' "$(pwd)"`,
+            `printf '${meta.env}'`,
+            `${nodeExecutable} -e 'process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString("base64"))'`,
+            "printf '\\n'",
+            `printf '${meta.end}\\n'`,
+            'exit $openhands_ec',
+          ];
+
+    const script = scriptLines.join(platform === 'win32' ? '\r\n' : '\n');
+
+    const shellPath = platform === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/bash';
+    const shellArgs = platform === 'win32' ? ['/d', '/s', '/c', script] : ['-c', script];
+
+    const child = spawn(shellPath, shellArgs, {
+      cwd: this.cwd,
+      env: this.env,
+      stdio: 'pipe',
+      detached: platform !== 'win32',
+    });
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+
+    const cmd: RunningTerminalProcess = {
+      id,
+      command: args.command,
+      process: child,
+      stdout: '',
+      stderr: '',
+      stdoutOffset: 0,
+      stderrOffset: 0,
+      lastActivityTs: Date.now(),
+      exitCode: null,
+      done: false,
+      meta,
+      waiters: new Set(),
+    };
+    this.running = cmd;
+
+    child.stdout.on('data', (data: Buffer | string) => {
+      cmd.stdout += data.toString();
+      cmd.lastActivityTs = Date.now();
+      this.tryParseMeta(cmd);
+      this.signal(cmd);
+    });
+
+    child.stderr.on('data', (data: Buffer | string) => {
+      cmd.stderr += data.toString();
+      cmd.lastActivityTs = Date.now();
+      this.signal(cmd);
+    });
+
+    child.on('close', (code) => {
+      cmd.done = true;
+      cmd.exitCode = typeof code === 'number' ? code : cmd.exitCode ?? 0;
+      this.tryParseMeta(cmd);
+      this.signal(cmd);
+    });
 
     const status = await this.waitForNoChangeOrDone(cmd, timeoutMs);
     const drained = this.drain(cmd);
-    return { ...drained, exitCode: status === 'done' ? cmd.exitCode : -1, done: status === 'done' };
+    const done = status === 'done';
+    const exitCode = done ? cmd.exitCode : -1;
+    if (done) {
+      this.running = null;
+    }
+    return { ...drained, exitCode, done, command: args.command };
   }
 }
 
@@ -387,28 +413,18 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
           ? args.timeout
           : DEFAULT_NO_CHANGE_TIMEOUT_SECONDS;
 
-      const prior = this.session.takeCompleted();
-      const priorText = prior ? [prior.stdout, prior.stderr].filter(Boolean).join('') : '';
-
       const result = await this.session.execute({
         command: args.command ?? '',
         is_input: args.is_input ?? false,
         timeoutSeconds,
       });
 
-      const stdoutParts: string[] = [];
-      const stderrParts: string[] = [];
-      if (priorText) {
-        stdoutParts.push('[Below is the output of the previous command.]\n', priorText);
-      }
-      if (result.stdout) stdoutParts.push(result.stdout);
-      if (result.stderr) stderrParts.push(result.stderr);
-
       const exitCode = result.exitCode;
+      const command = result.command ?? args.command ?? '';
       return {
-        command: args.command ?? '',
-        stdout: stdoutParts.join(''),
-        stderr: stderrParts.join(''),
+        command,
+        stdout: result.stdout,
+        stderr: result.stderr,
         exit_code: exitCode,
         exitCode,
         timeout: exitCode === -1,

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -63,14 +63,16 @@ class TerminalSession {
 
   constructor(workDir: string) {
     this.cwd = workDir;
-    this.env = Object.fromEntries(
-      Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
-    );
+    this.initializeEnv();
   }
 
   reset(workDir: string): void {
     this.killRunning('SIGTERM');
     this.cwd = workDir;
+    this.initializeEnv();
+  }
+
+  private initializeEnv(): void {
     this.env = Object.fromEntries(
       Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
     );
@@ -140,11 +142,9 @@ class TerminalSession {
         try {
           const decoded = Buffer.from(payload, 'base64').toString('utf8');
           const parsed = JSON.parse(decoded) as Record<string, unknown>;
-          const filtered: Record<string, string> = {};
-          for (const [k, v] of Object.entries(parsed)) {
-            if (typeof v === 'string') filtered[k] = v;
-          }
-          this.env = filtered;
+          this.env = Object.fromEntries(
+            Object.entries(parsed).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+          );
         } catch {
           // Ignore env parse failures; keep previous env.
         }

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -242,7 +242,7 @@ class TerminalSession {
         `printf '${meta.exit}%s\\n' "$openhands_ec"`,
         `printf '${meta.pwd}%s\\n' "$(pwd)"`,
         `printf '${meta.env}'`,
-        `node -e 'process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString("base64"))'`,
+        `${JSON.stringify(process.execPath)} -e 'process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString("base64"))'`,
         "printf '\\n'",
         `printf '${meta.end}\\n'`,
         'exit $openhands_ec',

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -66,8 +66,8 @@ class TerminalSession {
     this.initializeEnv();
   }
 
-  reset(workDir: string): void {
-    this.killRunning('SIGTERM');
+  async reset(workDir: string): Promise<void> {
+    await this.killRunning('SIGTERM');
     this.cwd = workDir;
     this.initializeEnv();
   }
@@ -78,13 +78,40 @@ class TerminalSession {
     );
   }
 
-  private killRunning(signal: SupportedSignal): void {
-    if (!this.running) return;
+  private async killRunning(signal: SupportedSignal): Promise<void> {
+    const running = this.running;
+    if (!running) return;
+
     try {
-      this.sendSignal(this.running.process, signal);
+      this.sendSignal(running.process, signal);
     } catch {
       // Ignore.
     }
+
+    await new Promise<void>((resolve) => {
+      if (running.done || running.process.exitCode !== null) {
+        resolve();
+        return;
+      }
+
+      const onClose = () => {
+        cleanup();
+        resolve();
+      };
+
+      const timer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, 2000);
+
+      const cleanup = () => {
+        clearTimeout(timer);
+        running.process.off('close', onClose);
+      };
+
+      running.process.on('close', onClose);
+    });
+
     this.running = null;
   }
 
@@ -322,7 +349,7 @@ class TerminalSession {
             `echo ${meta.begin}`,
             `echo ${meta.exit}%openhands_ec%`,
             `echo ${meta.pwd}%CD%`,
-            `<nul set /p "=${meta.env}"`,
+            `<nul set /p=${meta.env}`,
             `${nodeExecutable} -e "process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString('base64'))"`,
             'echo.',
             `echo ${meta.end}`,
@@ -467,7 +494,7 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
         if (args.is_input) {
           throw new Error('reset cannot be used with is_input=true');
         }
-        this.session?.reset(context.workspace.root);
+        await this.session?.reset(context.workspace.root);
         this.session = null;
         return { command: args.command ?? '', exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: 'Terminal session reset.' };
       }

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -1,5 +1,8 @@
+import type { ChildProcessWithoutNullStreams } from 'child_process';
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import os from 'os';
 import { z } from 'zod';
-import { IntegratedTerminalRunner } from './IntegratedTerminalRunner';
 import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
 
@@ -13,9 +16,311 @@ export interface TerminalArgs {
 export interface TerminalResult {
   command?: string | null;
   exit_code?: number | null;
+  // Back-compat for older consumers (e.g. BashEvent adapters).
+  exitCode?: number | null;
   timeout?: boolean;
   stdout?: string;
   stderr?: string;
+}
+
+const DEFAULT_NO_CHANGE_TIMEOUT_SECONDS = 10;
+
+type SupportedSignal = 'SIGTERM' | 'SIGINT' | 'SIGTSTP';
+
+type RunningTerminalProcess = {
+  id: string;
+  command: string;
+  process: ChildProcessWithoutNullStreams;
+  stdout: string;
+  stderr: string;
+  stdoutOffset: number;
+  stderrOffset: number;
+  lastActivityTs: number;
+  exitCode: number | null;
+  done: boolean;
+  meta: {
+    begin: string;
+    end: string;
+    exit: string;
+    pwd: string;
+    env: string;
+  };
+  waiters: Set<() => void>;
+};
+
+class TerminalSession {
+  private cwd: string;
+  private env: Record<string, string>;
+  private running: RunningTerminalProcess | null = null;
+
+  constructor(workDir: string) {
+    this.cwd = workDir;
+    this.env = Object.fromEntries(
+      Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+    );
+  }
+
+  reset(workDir: string): void {
+    this.killRunning('SIGTERM');
+    this.cwd = workDir;
+    this.env = Object.fromEntries(
+      Object.entries(process.env).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+    );
+  }
+
+  private killRunning(signal: SupportedSignal): void {
+    if (!this.running) return;
+    try {
+      this.sendSignal(this.running.process, signal);
+    } catch {
+      // Ignore.
+    }
+    this.running = null;
+  }
+
+  private sendSignal(proc: ChildProcessWithoutNullStreams, signal: SupportedSignal): void {
+    if (!proc.pid) return;
+    if (os.platform() !== 'win32') {
+      try {
+        process.kill(-proc.pid, signal);
+        return;
+      } catch {
+        // Fall back to signaling the immediate process.
+      }
+    }
+    try {
+      proc.kill(signal);
+    } catch {
+      // Ignore.
+    }
+  }
+
+  private signal(cmd: RunningTerminalProcess): void {
+    if (cmd.waiters.size === 0) return;
+    for (const waiter of cmd.waiters) {
+      try {
+        waiter();
+      } catch {
+        // Ignore waiter failures.
+      }
+    }
+    cmd.waiters.clear();
+  }
+
+  private tryParseMeta(cmd: RunningTerminalProcess): void {
+    const beginIndex = cmd.stdout.indexOf(cmd.meta.begin);
+    if (beginIndex === -1) return;
+    const endIndex = cmd.stdout.indexOf(cmd.meta.end, beginIndex);
+    if (endIndex === -1) return;
+
+    const blockStart = beginIndex + cmd.meta.begin.length;
+    const block = cmd.stdout.slice(blockStart, endIndex);
+    const lines = block.split(/\r?\n/).map((line) => line.trimEnd());
+
+    const exitLine = lines.find((line) => line.startsWith(cmd.meta.exit));
+    const pwdLine = lines.find((line) => line.startsWith(cmd.meta.pwd));
+    const envLine = lines.find((line) => line.startsWith(cmd.meta.env));
+
+    if (pwdLine) {
+      const pwd = pwdLine.slice(cmd.meta.pwd.length).trim();
+      if (pwd) this.cwd = pwd;
+    }
+
+    if (envLine) {
+      const payload = envLine.slice(cmd.meta.env.length).trim();
+      if (payload) {
+        try {
+          const decoded = Buffer.from(payload, 'base64').toString('utf8');
+          const parsed = JSON.parse(decoded) as Record<string, unknown>;
+          const filtered: Record<string, string> = {};
+          for (const [k, v] of Object.entries(parsed)) {
+            if (typeof v === 'string') filtered[k] = v;
+          }
+          this.env = filtered;
+        } catch {
+          // Ignore env parse failures; keep previous env.
+        }
+      }
+    }
+
+    if (exitLine) {
+      const raw = exitLine.slice(cmd.meta.exit.length).trim();
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isFinite(parsed)) {
+        cmd.exitCode = parsed;
+      }
+    }
+
+    let removeEnd = endIndex + cmd.meta.end.length;
+    if (cmd.stdout.slice(removeEnd, removeEnd + 2) === '\r\n') removeEnd += 2;
+    else if (cmd.stdout.slice(removeEnd, removeEnd + 1) === '\n') removeEnd += 1;
+
+    const oldOffset = cmd.stdoutOffset;
+    const removedLength = removeEnd - beginIndex;
+    cmd.stdout = cmd.stdout.slice(0, beginIndex) + cmd.stdout.slice(removeEnd);
+
+    if (oldOffset <= beginIndex) {
+      cmd.stdoutOffset = oldOffset;
+    } else if (oldOffset >= removeEnd) {
+      cmd.stdoutOffset = oldOffset - removedLength;
+    } else {
+      cmd.stdoutOffset = beginIndex;
+    }
+  }
+
+  private async waitForNoChangeOrDone(cmd: RunningTerminalProcess, timeoutMs: number): Promise<'done' | 'no_change'> {
+    if (cmd.done) return 'done';
+
+    while (!cmd.done) {
+      const elapsed = Date.now() - cmd.lastActivityTs;
+      const remaining = timeoutMs - elapsed;
+      if (remaining <= 0) return 'no_change';
+
+      await new Promise<void>((resolve) => {
+        const waiter = () => {
+          cleanup();
+          resolve();
+        };
+        const timer = setTimeout(() => {
+          cleanup();
+          resolve();
+        }, remaining);
+        const cleanup = () => {
+          clearTimeout(timer);
+          cmd.waiters.delete(waiter);
+        };
+        cmd.waiters.add(waiter);
+      });
+
+      if (cmd.done) return 'done';
+      if (Date.now() - cmd.lastActivityTs >= timeoutMs) return 'no_change';
+    }
+
+    return 'done';
+  }
+
+  private drain(cmd: RunningTerminalProcess): { stdout: string; stderr: string } {
+    const stdout = cmd.stdout.slice(cmd.stdoutOffset);
+    const stderr = cmd.stderr.slice(cmd.stderrOffset);
+    cmd.stdoutOffset = cmd.stdout.length;
+    cmd.stderrOffset = cmd.stderr.length;
+    return { stdout, stderr };
+  }
+
+  takeCompleted(): { stdout: string; stderr: string; exitCode: number | null } | null {
+    const cmd = this.running;
+    if (!cmd || !cmd.done) return null;
+    const drained = this.drain(cmd);
+    const exitCode = cmd.exitCode;
+    this.running = null;
+    return { ...drained, exitCode };
+  }
+
+  async execute(args: { command: string; is_input: boolean; timeoutSeconds: number }): Promise<{ stdout: string; stderr: string; exitCode: number | null; done: boolean }> {
+    const timeoutMs = Math.max(0, Math.floor(args.timeoutSeconds * 1000));
+
+    if (!args.is_input) {
+      if (this.running && !this.running.done) {
+        const status = await this.waitForNoChangeOrDone(this.running, timeoutMs);
+        const drained = this.drain(this.running);
+        return { ...drained, exitCode: status === 'done' ? this.running.exitCode : -1, done: status === 'done' };
+      }
+
+      const id = randomUUID();
+      const meta = {
+        begin: `__OPENHANDS_META_${id}__BEGIN__`,
+        end: `__OPENHANDS_META_${id}__END__`,
+        exit: `__OPENHANDS_EXIT_${id}__`,
+        pwd: `__OPENHANDS_PWD_${id}__`,
+        env: `__OPENHANDS_ENV_${id}__`,
+      };
+
+      const scriptLines = [
+        args.command,
+        'openhands_ec=$?',
+        `printf '\\n${meta.begin}\\n'`,
+        `printf '${meta.exit}%s\\n' "$openhands_ec"`,
+        `printf '${meta.pwd}%s\\n' "$(pwd)"`,
+        `printf '${meta.env}'`,
+        `node -e 'process.stdout.write(Buffer.from(JSON.stringify(process.env)).toString("base64"))'`,
+        "printf '\\n'",
+        `printf '${meta.end}\\n'`,
+        'exit $openhands_ec',
+      ];
+      const script = scriptLines.join('\n');
+
+      const shellPath = os.platform() === 'win32' ? (process.env.ComSpec ?? 'cmd.exe') : '/bin/bash';
+      const child = spawn(shellPath, ['-c', script], {
+        cwd: this.cwd,
+        env: this.env,
+        stdio: 'pipe',
+        detached: os.platform() !== 'win32',
+      });
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+
+      const cmd: RunningTerminalProcess = {
+        id,
+        command: args.command,
+        process: child,
+        stdout: '',
+        stderr: '',
+        stdoutOffset: 0,
+        stderrOffset: 0,
+        lastActivityTs: Date.now(),
+        exitCode: null,
+        done: false,
+        meta,
+        waiters: new Set(),
+      };
+      this.running = cmd;
+
+      child.stdout.on('data', (data: Buffer | string) => {
+        cmd.stdout += data.toString();
+        cmd.lastActivityTs = Date.now();
+        this.tryParseMeta(cmd);
+        this.signal(cmd);
+      });
+
+      child.stderr.on('data', (data: Buffer | string) => {
+        cmd.stderr += data.toString();
+        cmd.lastActivityTs = Date.now();
+        this.signal(cmd);
+      });
+
+      child.on('close', (code) => {
+        cmd.done = true;
+        cmd.exitCode = typeof code === 'number' ? code : cmd.exitCode ?? 0;
+        this.tryParseMeta(cmd);
+        this.signal(cmd);
+      });
+
+      const status = await this.waitForNoChangeOrDone(cmd, timeoutMs);
+      const drained = this.drain(cmd);
+      return { ...drained, exitCode: status === 'done' ? cmd.exitCode : -1, done: status === 'done' };
+    }
+
+    const cmd = this.running;
+    if (!cmd || cmd.done) {
+      return { stdout: '', stderr: 'No running terminal command to send input to.', exitCode: null, done: true };
+    }
+
+    const input = args.command ?? '';
+    const trimmed = input.trim();
+    if (trimmed === 'C-c') {
+      this.sendSignal(cmd.process, 'SIGINT');
+    } else if (trimmed === 'C-z') {
+      this.sendSignal(cmd.process, 'SIGTSTP');
+    } else if (trimmed === 'C-d') {
+      cmd.process.stdin.write('\u0004');
+    } else if (input.length > 0) {
+      cmd.process.stdin.write(`${input}\n`);
+    }
+
+    const status = await this.waitForNoChangeOrDone(cmd, timeoutMs);
+    const drained = this.drain(cmd);
+    return { ...drained, exitCode: status === 'done' ? cmd.exitCode : -1, done: status === 'done' };
+  }
 }
 
 const TOOL_DESCRIPTION = `Execute a bash command in the terminal within a persistent shell session.
@@ -59,37 +364,62 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
   readonly name = 'terminal';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = terminalSchema;
+  private session: TerminalSession | null = null;
+  private queue: Promise<TerminalResult> = Promise.resolve({ command: null, exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: '' });
 
   async execute(args: z.infer<typeof terminalSchema>, context: ToolContext): Promise<TerminalResult> {
-    // This TS SDK provides a per-invocation shell execution. Interactive input to a
-    // running process is not supported in this environment.
-    if (args.is_input) {
-      return { command: args.command ?? '', exit_code: null, timeout: false, stderr: 'Interactive input to a running process is not supported in this environment.' };
-    }
+    const run = async (): Promise<TerminalResult> => {
+      if (args.reset) {
+        if (args.is_input) {
+          throw new Error('reset cannot be used with is_input=true');
+        }
+        this.session?.reset(context.workspace.root);
+        this.session = null;
+        return { command: args.command ?? '', exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: 'Terminal session reset.' };
+      }
 
-    const runner = new IntegratedTerminalRunner(context.workspace);
-    const seconds = typeof args.timeout === 'number' && Number.isFinite(args.timeout) ? args.timeout : undefined;
-    const timeoutMs = seconds !== undefined ? Math.max(0, Math.floor(seconds * 1000)) : undefined;
+      if (!this.session) {
+        this.session = new TerminalSession(context.workspace.root);
+      }
 
-    let controller: AbortController | undefined;
-    let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutSeconds =
+        typeof args.timeout === 'number' && Number.isFinite(args.timeout)
+          ? args.timeout
+          : DEFAULT_NO_CHANGE_TIMEOUT_SECONDS;
 
-    if (timeoutMs && timeoutMs > 0) {
-      controller = new AbortController();
-      timer = setTimeout(() => controller?.abort(new Error('Command timed out')), timeoutMs);
-    }
+      const prior = this.session.takeCompleted();
+      const priorText = prior ? [prior.stdout, prior.stderr].filter(Boolean).join('') : '';
 
-    try {
-      const result = await runner.execute(args.command, { signal: controller?.signal });
+      const result = await this.session.execute({
+        command: args.command ?? '',
+        is_input: args.is_input ?? false,
+        timeoutSeconds,
+      });
+
+      const stdoutParts: string[] = [];
+      const stderrParts: string[] = [];
+      if (priorText) {
+        stdoutParts.push('[Below is the output of the previous command.]\n', priorText);
+      }
+      if (result.stdout) stdoutParts.push(result.stdout);
+      if (result.stderr) stderrParts.push(result.stderr);
+
+      const exitCode = result.exitCode;
       return {
-        command: result.command,
-        stdout: result.stdout,
-        stderr: controller?.signal.aborted ? (result.stderr || 'Command timed out') : result.stderr,
-        exit_code: controller?.signal.aborted ? (result.exitCode || -1) : result.exitCode,
-        timeout: controller?.signal.aborted || false,
+        command: args.command ?? '',
+        stdout: stdoutParts.join(''),
+        stderr: stderrParts.join(''),
+        exit_code: exitCode,
+        exitCode,
+        timeout: exitCode === -1,
       };
-    } finally {
-      if (timer) clearTimeout(timer);
-    }
+    };
+
+    const resultPromise = this.queue.then(run, run);
+    this.queue = resultPromise.then(
+      () => ({ command: null, exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: '' }),
+      () => ({ command: null, exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: '' }),
+    );
+    return resultPromise;
   }
 }

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -126,4 +126,22 @@ describe('TerminalTool session behavior', () => {
 
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
   });
+
+  it('executes a new command even if the previous one completed between calls', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const started = await tool.execute(tool.validate({ command: 'sleep 0.15; echo first', timeout: 0.05 }), { workspace });
+    expect(started.exit_code).toBe(-1);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+
+    const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
+    expect(next.exit_code).toBe(0);
+    expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('first');
+    expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('second');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
 });

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -160,4 +160,30 @@ describe('TerminalTool session behavior', () => {
 
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
   });
+
+  it('returns previous metadata when a timed-out command finishes before the next command', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const started = await tool.execute(
+      tool.validate({ command: 'sleep 0.15; echo first; false', timeout: 0.05 }),
+      { workspace },
+    );
+    expect(started.exit_code).toBe(-1);
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+
+    const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
+    expect(next.exit_code).toBe(0);
+    expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('first');
+    expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('second');
+
+    expect(next.previous).toBeDefined();
+    expect(next.previous?.exit_code).toBe(1);
+    expect(next.previous?.exitCode).toBe(1);
+    expect(next.previous?.command).toContain('sleep 0.15');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
 });

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -1,0 +1,106 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { TerminalTool } from '../TerminalTool';
+import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+
+const makeWorkspace = async () => {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'terminal-tool-session-'));
+  return { dir, workspace: new LocalWorkspace(dir) };
+};
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
+
+describe('TerminalTool session behavior', () => {
+  it('persists working directory across commands', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const first = await tool.execute(tool.validate({ command: 'pwd', timeout: 0.2 }), { workspace });
+    expect(first.exit_code).toBe(0);
+    expect((first.stdout ?? '').trim()).toBe(workspace.root);
+
+    await tool.execute(tool.validate({ command: 'mkdir -p subdir && cd subdir', timeout: 0.2 }), { workspace });
+    const second = await tool.execute(tool.validate({ command: 'pwd', timeout: 0.2 }), { workspace });
+    expect(second.exit_code).toBe(0);
+    expect((second.stdout ?? '').trim()).toBe(path.join(workspace.root, 'subdir'));
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
+
+  it('supports is_input for interactive commands', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const start = await tool.execute(
+      tool.validate({
+        command: 'echo "Enter name:"; read name; echo "Hello $name"',
+        timeout: 0.1,
+      }),
+      { workspace },
+    );
+    expect(start.exit_code).toBe(-1);
+    const combinedStart = `${start.stdout ?? ''}${start.stderr ?? ''}`;
+    expect(combinedStart).toContain('Enter name:');
+
+    const reply = await tool.execute(
+      tool.validate({
+        command: 'John',
+        is_input: true,
+        timeout: 0.2,
+      }),
+      { workspace },
+    );
+    expect(reply.exit_code).toBe(0);
+    expect(`${reply.stdout ?? ''}${reply.stderr ?? ''}`).toContain('Hello John');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
+
+  it('reset clears session state', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    await tool.execute(tool.validate({ command: 'export OH_TAB_TEST_VAR=bar', timeout: 0.2 }), { workspace });
+    const before = await tool.execute(tool.validate({ command: 'echo $OH_TAB_TEST_VAR', timeout: 0.2 }), { workspace });
+    expect((before.stdout ?? '').trim()).toBe('bar');
+
+    const reset = await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+    expect(reset.exit_code).toBe(0);
+
+    const after = await tool.execute(tool.validate({ command: 'echo $OH_TAB_TEST_VAR', timeout: 0.2 }), { workspace });
+    expect((after.stdout ?? '').trim()).toBe('');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
+
+  it('C-c interrupts a long-running command and allows subsequent commands', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const started = await tool.execute(tool.validate({ command: 'sleep 2', timeout: 0.1 }), { workspace });
+    expect(started.exit_code).toBe(-1);
+
+    let interrupted = await tool.execute(tool.validate({ command: 'C-c', is_input: true, timeout: 0.2 }), { workspace });
+    for (let i = 0; i < 5 && interrupted.exit_code === -1; i++) {
+      interrupted = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.2 }), { workspace });
+    }
+    expect(interrupted.exit_code).not.toBe(-1);
+
+    const next = await tool.execute(tool.validate({ command: 'echo ok', timeout: 0.2 }), { workspace });
+    expect(next.exit_code).toBe(0);
+    expect((next.stdout ?? '').trim()).toBe('ok');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
+});

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -104,6 +104,22 @@ describe('TerminalTool session behavior', () => {
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
   });
 
+  it('rejects a new command while another command is still running', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const started = await tool.execute(tool.validate({ command: 'sleep 2', timeout: 0.05 }), { workspace });
+    expect(started.exit_code).toBe(-1);
+
+    await expect(tool.execute(tool.validate({ command: 'echo nope', timeout: 0.05 }), { workspace })).rejects.toThrowError(
+      /Cannot start a new terminal command/i,
+    );
+
+    await tool.execute(tool.validate({ command: 'C-c', is_input: true, timeout: 0.2 }), { workspace });
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
+
   it('returns the final exit code when a timed-out command completes later', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -103,4 +103,27 @@ describe('TerminalTool session behavior', () => {
 
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
   });
+
+  it('returns the final exit code when a timed-out command completes later', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const started = await tool.execute(tool.validate({ command: 'sleep 0.2; echo done', timeout: 0.05 }), { workspace });
+    expect(started.exit_code).toBe(-1);
+
+    let polled = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.4 }), { workspace });
+    for (let i = 0; i < 10 && polled.exit_code === -1; i++) {
+      polled = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.2 }), { workspace });
+    }
+
+    expect(polled.exit_code).toBe(0);
+    expect(`${polled.stdout ?? ''}${polled.stderr ?? ''}`).toContain('done');
+
+    const next = await tool.execute(tool.validate({ command: 'echo ok', timeout: 0.2 }), { workspace });
+    expect(next.exit_code).toBe(0);
+    expect((next.stdout ?? '').trim()).toBe('ok');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
 });


### PR DESCRIPTION
Implements TerminalTool session semantics for VS Code local-mode parity.

- Persists working directory and exported environment variables across calls (captures after each command).
- Supports interactive follow-ups via `is_input` (stdin + control commands like C-c / C-z / C-d).
- Supports `reset` to start a fresh session.
- Adds unit tests: `packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts`.

Beads: oh-tab-wmn


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent terminal sessions across commands with preserved working directory and environment.
  * Serialized command execution with interactive input support, reset workflow, cross-platform shell behavior, timeouts, and safe interrupt handling.
  * Enhanced command results now include exit codes and prior-command metadata for improved context.

* **Tests**
  * Added comprehensive tests for session persistence, serialized execution, interactive input, resets, interrupts, and timeout behaviors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->