### PR TITLE
[oh-tab-8zn] Align FileEditorTool schema/docs

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -13,7 +13,7 @@ export interface FileEditorResult {
 
 const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
-* If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists non-hidden files and directories up to 2 levels deep
+* If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists the entries in that directory (non-recursive)
 * The \`create\` command cannot be used if the specified \`path\` already exists as a file
 * The \`undo_edit\` command undoes the most recent edit for a \`path\` (including undoing a create)
 * If a \`command\` generates a long output, it will be truncated and marked with \`<response clipped>\`
@@ -28,11 +28,11 @@ Before using this tool:
 When making edits:
    - Ensure the edit results in idiomatic, correct code
    - Do not leave the code in a broken state
-   - Always use absolute file paths (starting with /)
+   - Prefer workspace-relative paths; absolute paths are allowed when they resolve inside the workspace (or other explicitly-allowed roots)
 
 CRITICAL REQUIREMENTS FOR USING THIS TOOL:
 
-1. EXACT MATCHING: The \`old_str\` parameter must match EXACTLY one or more consecutive lines from the file, including all whitespace and indentation. The tool will fail if \`old_str\` matches multiple locations or doesn't match exactly with the file content.
+1. EXACT MATCHING: The \`old_str\` parameter must match EXACTLY a substring of the file, including all whitespace and indentation. It may span multiple lines. The tool will fail if \`old_str\` matches multiple locations or doesn't match exactly.
 
 2. UNIQUENESS: The \`old_str\` must uniquely identify a single instance in the file:
    - Include sufficient context before and after the change point (3-5 lines recommended)
@@ -48,7 +48,9 @@ const fileEditorSchema = z
     command: z
       .enum(['view', 'create', 'str_replace', 'insert', 'undo_edit'])
       .describe('The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.'),
-    path: z.string().describe('Absolute path to file or directory.'),
+    path: z
+      .string()
+      .describe('Workspace-relative path (preferred), or absolute path that resolves inside the workspace (or other explicitly-allowed roots).'),
     file_text: z
       .string()
       .optional()

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -164,11 +164,12 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       case 'str_replace': {
         const prev = await ws.readFile(args.path, 'utf8');
         const oldStr = args.old_str ?? '';
-        const occurrences = oldStr ? prev.split(oldStr).length - 1 : 0;
-        if (occurrences === 0) {
+        const firstMatch = prev.indexOf(oldStr);
+        if (firstMatch === -1) {
           throw new Error('old_str not found in target file');
         }
-        if (occurrences > 1) {
+        const secondMatch = prev.indexOf(oldStr, firstMatch + 1);
+        if (secondMatch !== -1) {
           throw new Error('old_str is not unique and matches multiple locations in the file');
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -79,8 +79,12 @@ const fileEditorSchema = z
     if (value.command === 'create' && value.file_text === undefined) {
       ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'file_text is required for create', path: ['file_text'] });
     }
-    if (value.command === 'str_replace' && value.old_str === undefined) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str is required for str_replace', path: ['old_str'] });
+    if (value.command === 'str_replace') {
+      if (value.old_str === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str is required for str_replace', path: ['old_str'] });
+      } else if (value.old_str.length === 0) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str must be non-empty for str_replace', path: ['old_str'] });
+      }
     }
     if (value.command === 'insert') {
       if (value.new_str === undefined) {
@@ -164,6 +168,9 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       case 'str_replace': {
         const prev = await ws.readFile(args.path, 'utf8');
         const oldStr = args.old_str ?? '';
+        if (oldStr.length === 0) {
+          throw new Error('old_str must be non-empty for str_replace');
+        }
         const firstMatch = prev.indexOf(oldStr);
         if (firstMatch === -1) {
           throw new Error('old_str not found in target file');

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -194,6 +194,17 @@ describe('FileEditorTool', () => {
     ).rejects.toThrowError(/not unique/i);
   });
 
+  it('rejects empty old_str for str_replace', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'content' }), { workspace });
+    expect(() => tool.validate({ command: 'str_replace', path: 'note.txt', old_str: '', new_str: 'x' })).toThrowError(
+      /old_str.*non-empty/i,
+    );
+  });
+
   it('treats overlapping old_str matches as not unique', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -50,6 +50,30 @@ describe('FileEditorTool', () => {
     expect(saved).toContain('first line');
   });
 
+  it('accepts absolute paths that resolve inside the workspace', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const absPath = path.join(dir, 'abs.txt');
+    await tool.execute(tool.validate({ command: 'create', path: absPath, file_text: 'hello' }), { workspace });
+    expect(await workspace.readFile('abs.txt')).toBe('hello');
+  });
+
+  it('rejects absolute paths outside the workspace', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-tools-outside-'));
+    created.push(externalDir);
+    const absOutside = path.join(externalDir, 'outside.txt');
+
+    await expect(
+      tool.execute(tool.validate({ command: 'create', path: absOutside, file_text: 'nope' }), { workspace }),
+    ).rejects.toThrowError(/Path escapes workspace root/i);
+  });
+
   it('views files with line numbers and truncation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -157,6 +181,17 @@ describe('FileEditorTool', () => {
 
     await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'note.txt' }), { workspace }))
       .rejects.toThrowError(/no edit history/i);
+  });
+
+  it('requires old_str to be unique for str_replace', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'dup\ndup' }), { workspace });
+    await expect(
+      tool.execute(tool.validate({ command: 'str_replace', path: 'note.txt', old_str: 'dup', new_str: 'x' }), { workspace }),
+    ).rejects.toThrowError(/not unique/i);
   });
 
   it('throws undo_edit when there is no history', async () => {

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -194,6 +194,17 @@ describe('FileEditorTool', () => {
     ).rejects.toThrowError(/not unique/i);
   });
 
+  it('treats overlapping old_str matches as not unique', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'note.txt', file_text: 'aaa' }), { workspace });
+    await expect(
+      tool.execute(tool.validate({ command: 'str_replace', path: 'note.txt', old_str: 'aa', new_str: 'b' }), { workspace }),
+    ).rejects.toThrowError(/not unique/i);
+  });
+
   it('throws undo_edit when there is no history', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);


### PR DESCRIPTION
Fixes Beads issue oh-tab-8zn.

- Update FileEditorTool docs/schema to match actual path handling (workspace-relative preferred; absolute allowed when resolving inside workspace / allowed roots).
- Clarify str_replace semantics: exact substring match + must be unique.
- Add tests: absolute-path inside/outside workspace + non-unique old_str.

Stacked on PR #245 (base branch `fix/oh-tab-nbc-undo-edit`). Merge #245 first, then retarget/merge this.

Tests: `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Directory listing now returns non-recursive results for clearer output
  * Path handling now prefers workspace-relative paths with enhanced validation
  * String replacement now enforces unique matches to prevent ambiguous operations
  * Enhanced error messages for invalid path and duplicate match scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->