### PR TITLE
[oh-tab-7d4] FileEditorTool: directory view + binary handling

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -367,7 +367,9 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     const estimatedBase64Length = Math.ceil(buffer.length / 3) * 4;
     if (estimatedBase64Length > MAX_INLINE_IMAGE_BASE64_CHARS) {
       const mb = buffer.length / 1024 / 1024;
-      const text = `Image file ${absPath} is too large to inline (${mb.toFixed(1)}MB).`;
+      const inlineLimitBytes = Math.floor(MAX_INLINE_IMAGE_BASE64_CHARS * 3 / 4);
+      const inlineLimitMb = inlineLimitBytes / 1024 / 1024;
+      const text = `Image file ${absPath} is too large to inline (${mb.toFixed(1)}MB). Files up to 10MB are allowed, but inline image previews are capped at ~${inlineLimitMb.toFixed(1)}MB.`;
       return {
         command: 'view',
         path: absPath,

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,7 +1,10 @@
 import fs from 'fs/promises';
+import path from 'path';
 import { z } from 'zod';
 import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
+
+type FileEditorContent = { type: 'text'; text: string } | { type: 'image'; image_urls?: string[]; detail?: string };
 
 export interface FileEditorResult {
   command: 'view' | 'create' | 'str_replace' | 'insert' | 'undo_edit';
@@ -9,11 +12,16 @@ export interface FileEditorResult {
   prev_exist?: boolean;
   old_content?: string | null;
   new_content?: string | null;
+  content?: FileEditorContent[];
 }
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+const PDF_EXTENSION = '.pdf';
 
 const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
-* If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists the entries in that directory (non-recursive)
+* If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists non-hidden files and directories up to 2 levels deep
 * The \`create\` command cannot be used if the specified \`path\` already exists as a file
 * The \`undo_edit\` command undoes the most recent edit for a \`path\` (including undoing a create)
 * If a \`command\` generates a long output, it will be truncated and marked with \`<response clipped>\`
@@ -116,6 +124,21 @@ const truncateContent = (content: string, limit = 500): string => {
   return `${head}\n<response clipped>\n${tail}`;
 };
 
+const isProbablyBinary = (buffer: Buffer): boolean => {
+  if (buffer.length === 0) return false;
+  const sampleSize = Math.min(buffer.length, 8000);
+  let suspiciousBytes = 0;
+  for (let i = 0; i < sampleSize; i++) {
+    const byte = buffer[i];
+    if (byte === 0) return true;
+    // Count control chars excluding common whitespace (\t \n \r).
+    if ((byte < 7 || (byte > 13 && byte < 32) || byte === 127) && byte !== 9 && byte !== 10 && byte !== 13) {
+      suspiciousBytes++;
+    }
+  }
+  return suspiciousBytes / sampleSize > 0.3;
+};
+
 type UndoEntry = {
   prevExist: boolean;
   oldContent: string | null;
@@ -141,16 +164,20 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
   async execute(args: z.infer<typeof fileEditorSchema>, context: ToolContext): Promise<FileEditorResult> {
     const ws = context.workspace;
     const resolved = ws.resolvePath(args.path);
+    const extension = path.extname(resolved).toLowerCase();
 
     switch (args.command) {
       case 'view': {
         const stat = await fs.stat(resolved);
         if (stat.isDirectory()) {
-          const entries = await ws.list(args.path);
-          const listing = entries.map((entry) => `${entry.isDirectory ? 'd' : 'f'} ${entry.path}`).join('\n');
-          return { command: 'view', path: resolved, prev_exist: true, old_content: null, new_content: listing };
+          const { text } = await this.viewDirectory(resolved);
+          return { command: 'view', path: resolved, prev_exist: true, old_content: null, new_content: text };
         }
-        const content = await ws.readFile(args.path, 'utf8');
+        const buffer = await this.readValidatedFile(resolved, extension);
+        if (IMAGE_EXTENSIONS.has(extension)) {
+          return this.viewImage(resolved, extension, buffer);
+        }
+        const content = buffer.toString('utf8');
         const ranged = applyViewRange(content, args.view_range);
         const numbered = addLineNumbers(ranged);
         const truncated = truncateContent(numbered);
@@ -161,12 +188,16 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         if (exists) {
           throw new Error('create failed: file already exists');
         }
-        await ws.writeFile(args.path, args.file_text ?? '');
+        await ws.writeFile(resolved, args.file_text ?? '');
         this.pushUndo(resolved, { prevExist: false, oldContent: null });
         return { command: 'create', path: resolved, prev_exist: false, old_content: null, new_content: args.file_text ?? '' };
       }
       case 'str_replace': {
-        const prev = await ws.readFile(args.path, 'utf8');
+        if (IMAGE_EXTENSIONS.has(extension)) {
+          throw new Error('str_replace failed: refusing to edit binary image file');
+        }
+        const buffer = await this.readValidatedFile(resolved, extension);
+        const prev = buffer.toString('utf8');
         const oldStr = args.old_str ?? '';
         if (oldStr.length === 0) {
           throw new Error('old_str must be non-empty for str_replace');
@@ -180,18 +211,22 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           throw new Error('old_str is not unique and matches multiple locations in the file');
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
-        await ws.writeFile(args.path, updated);
+        await ws.writeFile(resolved, updated);
         this.pushUndo(resolved, { prevExist: true, oldContent: prev });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
-        const prev = await ws.readFile(args.path, 'utf8');
+        if (IMAGE_EXTENSIONS.has(extension)) {
+          throw new Error('insert failed: refusing to edit binary image file');
+        }
+        const buffer = await this.readValidatedFile(resolved, extension);
+        const prev = buffer.toString('utf8');
         const lines = prev.split(/\r?\n/);
         const insertion = args.new_str ?? '';
         const index = Math.min(args.insert_line ?? 0, lines.length);
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
-        await ws.writeFile(args.path, updated);
+        await ws.writeFile(resolved, updated);
         this.pushUndo(resolved, { prevExist: true, oldContent: prev });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
@@ -226,6 +261,88 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         throw new Error(`Unsupported command: ${String(unreachable)}`);
       }
     }
+  }
+
+  private async readValidatedFile(absPath: string, extension: string): Promise<Buffer> {
+    const stat = await fs.stat(absPath);
+    if (!stat.isFile()) {
+      throw new Error(`Path is not a file: ${absPath}`);
+    }
+    if (stat.size > MAX_FILE_SIZE_BYTES) {
+      const mb = stat.size / 1024 / 1024;
+      throw new Error(`File is too large (${mb.toFixed(1)}MB). Maximum allowed size is 10MB.`);
+    }
+
+    const buffer = await fs.readFile(absPath);
+    const binaryAllowed = IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION;
+    if (!binaryAllowed && isProbablyBinary(buffer)) {
+      throw new Error('File appears to be binary and this file type cannot be read or edited by this tool.');
+    }
+    return buffer;
+  }
+
+  private async viewDirectory(absPath: string): Promise<{ text: string }> {
+    const topEntries = await fs.readdir(absPath, { withFileTypes: true });
+    const hiddenCount = topEntries.filter((entry) => entry.name.startsWith('.')).length;
+
+    const visibleTop = topEntries
+      .filter((entry) => !entry.name.startsWith('.'))
+      .map((entry) => ({ name: entry.name, abs: path.join(absPath, entry.name), isDir: entry.isDirectory() }))
+      .sort((a, b) => a.abs.localeCompare(b.abs));
+
+    const lines: string[] = [`${absPath}/`];
+    for (const entry of visibleTop) {
+      lines.push(entry.isDir ? `${entry.abs}/` : entry.abs);
+      if (!entry.isDir) continue;
+
+      const childEntries = await fs.readdir(entry.abs, { withFileTypes: true });
+      const visibleChildren = childEntries
+        .filter((child) => !child.name.startsWith('.'))
+        .map((child) => ({ abs: path.join(entry.abs, child.name), isDir: child.isDirectory() }))
+        .sort((a, b) => a.abs.localeCompare(b.abs));
+      for (const child of visibleChildren) {
+        lines.push(child.isDir ? `${child.abs}/` : child.abs);
+      }
+    }
+
+    const header = `Here's the files and directories up to 2 levels deep in ${absPath}, excluding hidden items:\n`;
+    const body = lines.join('\n');
+    const hiddenNote =
+      hiddenCount > 0
+        ? `\n\n${hiddenCount} hidden files/directories in this directory are excluded. You can use 'ls -la ${absPath}' to see them.`
+        : '';
+    return { text: truncateContent(`${header}${body}${hiddenNote}`) };
+  }
+
+  private viewImage(absPath: string, extension: string, buffer: Buffer): FileEditorResult {
+    const mime = (() => {
+      switch (extension) {
+        case '.png':
+          return 'image/png';
+        case '.jpg':
+        case '.jpeg':
+          return 'image/jpeg';
+        case '.gif':
+          return 'image/gif';
+        case '.webp':
+          return 'image/webp';
+        case '.bmp':
+          return 'image/bmp';
+        default:
+          return 'image/png';
+      }
+    })();
+    const imageBase64 = buffer.toString('base64');
+    const imageUrl = `data:${mime};base64,${imageBase64}`;
+    const text = `Image file ${absPath} read successfully. Displaying image content.`;
+    return {
+      command: 'view',
+      path: absPath,
+      prev_exist: true,
+      old_content: null,
+      new_content: text,
+      content: [{ type: 'text', text }, { type: 'image', image_urls: [imageUrl] }],
+    };
   }
 
   private pushUndo(resolvedPath: string, entry: UndoEntry): void {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import type { Dirent } from 'node:fs';
 import { z } from 'zod';
 import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
@@ -24,6 +25,7 @@ const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing 
 * If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists non-hidden files and directories up to 2 levels deep
 * The \`create\` command cannot be used if the specified \`path\` already exists as a file
 * The \`undo_edit\` command undoes the most recent edit for a \`path\` (including undoing a create)
+* Files larger than 10MB are rejected
 * If a \`command\` generates a long output, it will be truncated and marked with \`<response clipped>\`
 * This tool can be used for creating and editing files in plain-text format.
 
@@ -193,8 +195,8 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         return { command: 'create', path: resolved, prev_exist: false, old_content: null, new_content: args.file_text ?? '' };
       }
       case 'str_replace': {
-        if (IMAGE_EXTENSIONS.has(extension)) {
-          throw new Error('str_replace failed: refusing to edit binary image file');
+        if (IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION) {
+          throw new Error(`str_replace failed: refusing to edit binary file type: ${extension}`);
         }
         const buffer = await this.readValidatedFile(resolved, extension);
         const prev = buffer.toString('utf8');
@@ -216,8 +218,8 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
-        if (IMAGE_EXTENSIONS.has(extension)) {
-          throw new Error('insert failed: refusing to edit binary image file');
+        if (IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION) {
+          throw new Error(`insert failed: refusing to edit binary file type: ${extension}`);
         }
         const buffer = await this.readValidatedFile(resolved, extension);
         const prev = buffer.toString('utf8');
@@ -291,15 +293,20 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       .sort((a, b) => a.abs.localeCompare(b.abs));
 
     const lines: string[] = [`${absPath}/`];
-    for (const entry of visibleTop) {
-      lines.push(entry.isDir ? `${entry.abs}/` : entry.abs);
-      if (!entry.isDir) continue;
+      for (const entry of visibleTop) {
+        lines.push(entry.isDir ? `${entry.abs}/` : entry.abs);
+        if (!entry.isDir) continue;
 
-      const childEntries = await fs.readdir(entry.abs, { withFileTypes: true });
-      const visibleChildren = childEntries
-        .filter((child) => !child.name.startsWith('.'))
-        .map((child) => ({ abs: path.join(entry.abs, child.name), isDir: child.isDirectory() }))
-        .sort((a, b) => a.abs.localeCompare(b.abs));
+        let childEntries: Dirent[];
+        try {
+          childEntries = await fs.readdir(entry.abs, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+        const visibleChildren = childEntries
+          .filter((child) => !child.name.startsWith('.'))
+          .map((child) => ({ abs: path.join(entry.abs, child.name), isDir: child.isDirectory() }))
+          .sort((a, b) => a.abs.localeCompare(b.abs));
       for (const child of visibleChildren) {
         lines.push(child.isDir ? `${child.abs}/` : child.abs);
       }
@@ -309,7 +316,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     const body = lines.join('\n');
     const hiddenNote =
       hiddenCount > 0
-        ? `\n\n${hiddenCount} hidden files/directories in this directory are excluded. You can use 'ls -la ${absPath}' to see them.`
+        ? `\n\n${hiddenCount} hidden files/directories in the top-level directory are excluded. You can use 'ls -la ${absPath}' to see them.`
         : '';
     return { text: truncateContent(`${header}${body}${hiddenNote}`) };
   }

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -17,6 +17,7 @@ export interface FileEditorResult {
 }
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+const MAX_INLINE_IMAGE_BASE64_CHARS = 4 * 1024 * 1024;
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
 const PDF_EXTENSION = '.pdf';
 
@@ -172,7 +173,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       case 'view': {
         const stat = await fs.stat(resolved);
         if (stat.isDirectory()) {
-          const { text } = await this.viewDirectory(resolved);
+          const { text } = await this.viewDirectory(resolved, ws.root);
           return { command: 'view', path: resolved, prev_exist: true, old_content: null, new_content: text };
         }
         const buffer = await this.readValidatedFile(resolved, extension);
@@ -190,9 +191,21 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         if (exists) {
           throw new Error('create failed: file already exists');
         }
-        await ws.writeFile(resolved, args.file_text ?? '');
+        const fileText = args.file_text ?? '';
+        const sizeBytes = Buffer.byteLength(fileText, 'utf8');
+        if (sizeBytes > MAX_FILE_SIZE_BYTES) {
+          const mb = sizeBytes / 1024 / 1024;
+          throw new Error(`create failed: file is too large (${mb.toFixed(1)}MB). Maximum allowed size is 10MB.`);
+        }
+        await ws.writeFile(resolved, fileText);
         this.pushUndo(resolved, { prevExist: false, oldContent: null });
-        return { command: 'create', path: resolved, prev_exist: false, old_content: null, new_content: args.file_text ?? '' };
+        return {
+          command: 'create',
+          path: resolved,
+          prev_exist: false,
+          old_content: null,
+          new_content: truncateContent(fileText),
+        };
       }
       case 'str_replace': {
         if (IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION) {
@@ -283,40 +296,52 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     return buffer;
   }
 
-  private async viewDirectory(absPath: string): Promise<{ text: string }> {
+  private async viewDirectory(absPath: string, workspaceRoot: string): Promise<{ text: string }> {
+    const toDisplayPath = (absolutePath: string): string => {
+      const relative = path.relative(workspaceRoot, absolutePath);
+      if (!relative || relative === '') return '.';
+      if (relative.startsWith('..') || path.isAbsolute(relative)) return absolutePath;
+      return relative;
+    };
+
     const topEntries = await fs.readdir(absPath, { withFileTypes: true });
     const hiddenCount = topEntries.filter((entry) => entry.name.startsWith('.')).length;
 
     const visibleTop = topEntries
       .filter((entry) => !entry.name.startsWith('.'))
       .map((entry) => ({ name: entry.name, abs: path.join(absPath, entry.name), isDir: entry.isDirectory() }))
-      .sort((a, b) => a.abs.localeCompare(b.abs));
+      .sort((a, b) => a.name.localeCompare(b.name));
 
-    const lines: string[] = [`${absPath}/`];
-      for (const entry of visibleTop) {
-        lines.push(entry.isDir ? `${entry.abs}/` : entry.abs);
-        if (!entry.isDir) continue;
+    const displayRoot = toDisplayPath(absPath);
+    const lines: string[] = [`d ${displayRoot}`];
 
-        let childEntries: Dirent[];
-        try {
-          childEntries = await fs.readdir(entry.abs, { withFileTypes: true });
-        } catch {
-          continue;
-        }
-        const visibleChildren = childEntries
-          .filter((child) => !child.name.startsWith('.'))
-          .map((child) => ({ abs: path.join(entry.abs, child.name), isDir: child.isDirectory() }))
-          .sort((a, b) => a.abs.localeCompare(b.abs));
+    for (const entry of visibleTop) {
+      const displayEntry = toDisplayPath(entry.abs);
+      lines.push(`${entry.isDir ? 'd' : 'f'} ${displayEntry}`);
+      if (!entry.isDir) continue;
+
+      let childEntries: Dirent[];
+      try {
+        childEntries = await fs.readdir(entry.abs, { withFileTypes: true });
+      } catch {
+        lines.push(`skipped unreadable: ${displayEntry}`);
+        continue;
+      }
+      const visibleChildren = childEntries
+        .filter((child) => !child.name.startsWith('.'))
+        .map((child) => ({ name: child.name, abs: path.join(entry.abs, child.name), isDir: child.isDirectory() }))
+        .sort((a, b) => a.name.localeCompare(b.name));
       for (const child of visibleChildren) {
-        lines.push(child.isDir ? `${child.abs}/` : child.abs);
+        const displayChild = toDisplayPath(child.abs);
+        lines.push(`${child.isDir ? 'd' : 'f'} ${displayChild}`);
       }
     }
 
-    const header = `Here's the files and directories up to 2 levels deep in ${absPath}, excluding hidden items:\n`;
+    const header = `Here's the files and directories up to 2 levels deep in ${displayRoot}, excluding hidden items:\n`;
     const body = lines.join('\n');
     const hiddenNote =
       hiddenCount > 0
-        ? `\n\n${hiddenCount} hidden files/directories in the top-level directory are excluded. You can use 'ls -la ${absPath}' to see them.`
+        ? `\n\n${hiddenCount} hidden files/directories in the top-level directory are excluded. You can use 'ls -la ${displayRoot}' to see them.`
         : '';
     return { text: truncateContent(`${header}${body}${hiddenNote}`) };
   }
@@ -339,6 +364,20 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           return 'image/png';
       }
     })();
+    const estimatedBase64Length = Math.ceil(buffer.length / 3) * 4;
+    if (estimatedBase64Length > MAX_INLINE_IMAGE_BASE64_CHARS) {
+      const mb = buffer.length / 1024 / 1024;
+      const text = `Image file ${absPath} is too large to inline (${mb.toFixed(1)}MB).`;
+      return {
+        command: 'view',
+        path: absPath,
+        prev_exist: true,
+        old_content: null,
+        new_content: text,
+        content: [{ type: 'text', text }],
+      };
+    }
+
     const imageBase64 = buffer.toString('base64');
     const imageUrl = `data:${mime};base64,${imageBase64}`;
     const text = `Image file ${absPath} read successfully. Displaying image content.`;

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -103,6 +103,146 @@ describe('FileEditorTool', () => {
     expect(tail.length).toBeLessThanOrEqual(500 + 20);
   });
 
+  it('views directories up to 2 levels deep, excluding hidden items', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await fs.promises.writeFile(path.join(dir, 'visible.txt'), 'visible');
+    await fs.promises.writeFile(path.join(dir, '.hidden.txt'), 'hidden');
+    await fs.promises.mkdir(path.join(dir, 'dirA', 'subdir'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'dirA', 'a.txt'), 'a');
+    await fs.promises.writeFile(path.join(dir, 'dirA', '.hidden2'), 'x');
+    await fs.promises.writeFile(path.join(dir, 'dirA', 'subdir', 'b.txt'), 'b');
+    await fs.promises.mkdir(path.join(dir, '.hiddenDir'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, '.hiddenDir', 'x.txt'), 'x');
+
+    const viewArgs = tool.validate({ command: 'view', path: '.' });
+    const result = await tool.execute(viewArgs, { workspace });
+
+    const listing = result.new_content ?? '';
+    expect(listing).toContain('up to 2 levels deep');
+    expect(listing).toContain(`${dir}/`);
+    expect(listing).toContain(path.join(dir, 'visible.txt'));
+    expect(listing).toContain(`${path.join(dir, 'dirA')}/`);
+    expect(listing).toContain(path.join(dir, 'dirA', 'a.txt'));
+    expect(listing).toContain(`${path.join(dir, 'dirA', 'subdir')}/`);
+
+    // Max depth is 2 (root + children + grandchildren), so b.txt (depth 3) is excluded.
+    expect(listing).not.toContain(path.join(dir, 'dirA', 'subdir', 'b.txt'));
+
+    // Hidden entries excluded (root + depth 2).
+    expect(listing).not.toContain('.hidden.txt');
+    expect(listing).not.toContain('.hiddenDir');
+    expect(listing).not.toContain('.hidden2');
+    expect(listing).toMatch(/2 hidden files\/directories/i);
+  });
+
+  it('rejects binary files (except supported types)', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const binaryPath = path.join(dir, 'binary.bin');
+    await fs.promises.writeFile(binaryPath, Buffer.from('Some text\u0000with binary\u0000content', 'utf8'));
+
+    await expect(tool.execute(tool.validate({ command: 'view', path: 'binary.bin' }), { workspace }))
+      .rejects.toThrowError(/binary/i);
+  });
+
+  it('views PDF files as text', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const pdfContent = Buffer.from(
+      `%PDF-1.4
+1 0 obj
+<<
+/Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Pages
+/Kids [3 0 R]
+/Count 1
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Page
+/Parent 2 0 R
+/MediaBox [0 0 612 792]
+/Contents 4 0 R
+>>
+endobj
+
+4 0 obj
+<<
+/Length 44
+>>
+stream
+BT
+/F1 12 Tf
+72 720 Td
+(Printer-Friendly Caltrain Schedule) Tj
+ET
+endstream
+endobj
+
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000206 00000 n 
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+299
+%%EOF`,
+      'utf8',
+    );
+    await fs.promises.writeFile(path.join(dir, 'sample.pdf'), pdfContent);
+
+    const result = await tool.execute(tool.validate({ command: 'view', path: 'sample.pdf' }), { workspace });
+    expect(result.new_content).toContain('Printer-Friendly Caltrain Schedule');
+  });
+
+  it('views image files by returning image content URLs', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const pngData = Buffer.from(
+      [
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // signature
+        0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x02, 0x00, 0x00, 0x00,
+        0x90, 0x77, 0x53, 0xde,
+        0x00, 0x00, 0x00, 0x0c, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x63, 0xf8, 0xcf, 0xc0, 0x00, 0x00,
+        0x00, 0x03, 0x00, 0x01, 0x00, 0x18, 0xdd, 0x8d, 0xb4,
+        0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82, // IEND
+      ],
+    );
+    await fs.promises.writeFile(path.join(dir, 'test.png'), pngData);
+
+    const result = await tool.execute(tool.validate({ command: 'view', path: 'test.png' }), { workspace });
+    expect(result.new_content).toContain('Image file');
+    expect(result.content).toBeDefined();
+    expect(result.content?.some((c) => c.type === 'image')).toBe(true);
+    const image = result.content?.find((c) => c.type === 'image') as { image_urls?: string[] } | undefined;
+    expect(image?.image_urls?.[0]).toMatch(/^data:image\/png;base64,/);
+  });
+
   it('supports undo_edit for edits', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -138,6 +138,31 @@ describe('FileEditorTool', () => {
     expect(listing).toMatch(/2 hidden files\/directories/i);
   });
 
+  it('directory view skips unreadable child directories', async () => {
+    if (process.platform === 'win32') return;
+
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await fs.promises.writeFile(path.join(dir, 'visible.txt'), 'visible');
+    await fs.promises.mkdir(path.join(dir, 'unreadable'), { recursive: true });
+    await fs.promises.writeFile(path.join(dir, 'unreadable', 'secret.txt'), 'secret');
+
+    try {
+      await fs.promises.chmod(path.join(dir, 'unreadable'), 0o000);
+
+      const viewArgs = tool.validate({ command: 'view', path: '.' });
+      const result = await tool.execute(viewArgs, { workspace });
+
+      const listing = result.new_content ?? '';
+      expect(listing).toContain(path.join(dir, 'visible.txt'));
+      expect(listing).toContain(`${path.join(dir, 'unreadable')}/`);
+    } finally {
+      await fs.promises.chmod(path.join(dir, 'unreadable'), 0o755);
+    }
+  });
+
   it('rejects binary files (except supported types)', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -215,6 +240,22 @@ startxref
 
     const result = await tool.execute(tool.validate({ command: 'view', path: 'sample.pdf' }), { workspace });
     expect(result.new_content).toContain('Printer-Friendly Caltrain Schedule');
+  });
+
+  it('rejects editing PDF files', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await fs.promises.writeFile(path.join(dir, 'sample.pdf'), Buffer.from('%PDF-1.4\nHello', 'utf8'));
+
+    await expect(
+      tool.execute(tool.validate({ command: 'str_replace', path: 'sample.pdf', old_str: 'Hello', new_str: 'World' }), { workspace }),
+    ).rejects.toThrowError(/refusing to edit binary/i);
+
+    await expect(
+      tool.execute(tool.validate({ command: 'insert', path: 'sample.pdf', insert_line: 1, new_str: 'x' }), { workspace }),
+    ).rejects.toThrowError(/refusing to edit binary/i);
   });
 
   it('views image files by returning image content URLs', async () => {

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -74,6 +74,17 @@ describe('FileEditorTool', () => {
     ).rejects.toThrowError(/Path escapes workspace root/i);
   });
 
+  it('rejects create when file_text exceeds 10MB', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const oversized = 'a'.repeat(10 * 1024 * 1024 + 1);
+    await expect(
+      tool.execute(tool.validate({ command: 'create', path: 'big.txt', file_text: oversized }), { workspace }),
+    ).rejects.toThrowError(/Maximum allowed size is 10MB/i);
+  });
+
   it('views files with line numbers and truncation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -122,14 +133,15 @@ describe('FileEditorTool', () => {
 
     const listing = result.new_content ?? '';
     expect(listing).toContain('up to 2 levels deep');
-    expect(listing).toContain(`${dir}/`);
-    expect(listing).toContain(path.join(dir, 'visible.txt'));
-    expect(listing).toContain(`${path.join(dir, 'dirA')}/`);
-    expect(listing).toContain(path.join(dir, 'dirA', 'a.txt'));
-    expect(listing).toContain(`${path.join(dir, 'dirA', 'subdir')}/`);
+    expect(listing).toContain('d .');
+    expect(listing).toContain('f visible.txt');
+    expect(listing).toContain('d dirA');
+    expect(listing).toContain(`f ${path.join('dirA', 'a.txt')}`);
+    expect(listing).toContain(`d ${path.join('dirA', 'subdir')}`);
+    expect(listing).not.toContain(dir);
 
     // Max depth is 2 (root + children + grandchildren), so b.txt (depth 3) is excluded.
-    expect(listing).not.toContain(path.join(dir, 'dirA', 'subdir', 'b.txt'));
+    expect(listing).not.toContain(path.join('dirA', 'subdir', 'b.txt'));
 
     // Hidden entries excluded (root + depth 2).
     expect(listing).not.toContain('.hidden.txt');
@@ -156,8 +168,9 @@ describe('FileEditorTool', () => {
       const result = await tool.execute(viewArgs, { workspace });
 
       const listing = result.new_content ?? '';
-      expect(listing).toContain(path.join(dir, 'visible.txt'));
-      expect(listing).toContain(`${path.join(dir, 'unreadable')}/`);
+      expect(listing).toContain('f visible.txt');
+      expect(listing).toContain('d unreadable');
+      expect(listing).toContain('skipped unreadable: unreadable');
     } finally {
       await fs.promises.chmod(path.join(dir, 'unreadable'), 0o755);
     }


### PR DESCRIPTION
Implements FileEditorTool parity for directory view (2-level listing excluding hidden) and binary file handling (size limit, reject unknown binary, allow PDF, view images as data URLs).

- Adds FileEditorTool helpers for directory listing + binary validation
- Adds unit tests for directory view + binary/PDF/image view

Tests: 
> @openhands/agent-sdk-ts@0.1.0 test
> vitest run


 RUN  v3.2.4 /Users/enyst/repos/oh-tab/packages/agent-sdk-ts

 ✓ src/sdk/__tests__/remoteConversation.test.ts (3 tests) 32ms
 ✓ src/workspace/__tests__/local.workspace.test.ts (4 tests) 20ms
 ✓ src/sdk/context/skills/__tests__/skill.test.ts (37 tests) 24ms
 ✓ src/sdk/__tests__/persistence.test.ts (11 tests) 14ms
 ✓ src/tools/__tests__/new-tools.test.ts (12 tests) 65ms
 ✓ src/sdk/__tests__/agent.loop.test.ts (7 tests) 22ms
 ✓ src/sdk/runtime/__tests__/Agent.debug-mode.test.ts (6 tests) 9ms
 ✓ src/sdk/conversation/LocalConversation.test.ts (6 tests) 18ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-errors.test.ts (4 tests) 6ms
 ✓ src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts (2 tests) 8ms
 ✓ src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts (3 tests) 6ms
stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers keyword skills
Skill 'react-skill' triggered by keyword 'react'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers multiple skills
Skill 'react-skill' triggered by keyword 'react'
Skill 'typescript-skill' triggered by keyword 'typescript'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > appends custom user message suffix to triggered skills
Skill 'test-skill' triggered by keyword 'test'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles multiple text content blocks
Skill 'test-skill' triggered by keyword 'keyword'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles task triggers
Skill 'refactor' triggered by keyword '/refactor'

 ✓ src/sdk/context/__tests__/agent-context.test.ts (26 tests) 9ms
 ✓ src/sdk/runtime/__tests__/Agent.security-risk.test.ts (1 test) 3ms
 ✓ src/tools/__tests__/tools.test.ts (19 tests) 308ms
 ✓ src/sdk/runtime/__tests__/truncateError.unit.test.ts (5 tests) 2ms
 ✓ src/sdk/__tests__/registry.test.ts (3 tests) 3ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts (1 test) 4ms
 ✓ src/sdk/__tests__/runtime.test.ts (3 tests) 2ms
 ✓ src/sdk/runtime/__tests__/Agent.redaction.test.ts (2 tests) 4ms
 ✓ src/sdk/__tests__/metrics.test.ts (4 tests) 2ms
 ✓ src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts (2 tests) 1ms
 ✓ src/sdk/__tests__/conversation-stats.test.ts (3 tests) 4ms
 ✓ src/sdk/__tests__/agent-sdk.guards.test.ts (5 tests) 2ms
 ✓ src/sdk/__tests__/llm.orchestrator.test.ts (5 tests | 1 skipped) 1014ms
   ✓ OpenAICompatibleClient streaming > propagates failure after retries  756ms

 Test Files  24 passed (24)
      Tests  173 passed | 1 skipped (174)
   Start at  18:29:29
   Duration  1.42s (transform 485ms, setup 0ms, collect 1.64s, tests 1.58s, environment 2ms, prepare 1.08s)