### PR TITLE
[oh-tab-nkf] TerminalTool: expose previous command metadata

### DIFF
--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -24,8 +24,8 @@ export interface TerminalResult {
   previous?: {
     command: string;
     exit_code: number | null;
-    // Back-compat for older consumers (e.g. BashEvent adapters).
-    exitCode: number | null;
+    // Back-compat casing for nested consumers (e.g. BashEvent adapters).
+    exitCode?: number | null;
     stdout: string;
     stderr: string;
   };


### PR DESCRIPTION
Adds optional `previous` metadata to TerminalTool results when a prior command completed between calls and its output is inlined into the next stdout. This avoids requiring consumers to parse the stdout header to recover the prior exit code.

- Adds `previous` field (command/exit_code/stdout/stderr)
- Updates TerminalTool session test to assert previous metadata

Tests: npm test -w @openhands/agent-sdk-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the exit code property optional in terminal operation results to improve backward compatibility with existing integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->