### PR TITLE
[oh-tab-bqd] Expand remote agent-server E2E assertions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,11 @@ import { attachConversationListeners } from './conversation/host/attachConversat
 import { createConfigurationChangeHandler } from './settings/host/createConfigurationChangeHandler';
 import { createWebviewMessageHandler } from './webview/host/createWebviewMessageHandler';
 
-type RenderedEventsInfo = { count: number; eventTypes: string[] };
+type RenderedEventsInfo = {
+  count: number;
+  eventTypes: string[];
+  events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
+};
 type UiStateSnapshot = {
   input: string;
   showContextPicker: boolean;

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -465,19 +465,31 @@ export function App() {
           break;
         }
         case 'queryRenderedEvents': {
-          const eventTypes = events.map(({ event }) => {
+          const eventSnapshots = events.map(({ event }) => {
             if ('kind' in event && typeof event.kind === 'string') return event.kind;
             if ('type' in event && typeof (event as { type?: unknown }).type === 'string') {
               return (event as { type: string }).type;
             }
             return 'unknown';
           });
+          const eventTypes = eventSnapshots;
+          const rendered = events.map(({ event }, index) => {
+            const type = eventSnapshots[index] ?? 'unknown';
+            const marker = (event as { e2e_marker?: unknown }).e2e_marker;
+            const toolCallId = (event as { tool_call_id?: unknown }).tool_call_id;
+            return {
+              type,
+              marker: typeof marker === 'string' ? marker : undefined,
+              toolCallId: typeof toolCallId === 'string' ? toolCallId : undefined,
+            };
+          });
           if (typeof payload.requestId === 'string') {
             postMessage({
               type: 'renderedEventsResponse',
               requestId: payload.requestId,
               count: events.length,
-              eventTypes
+              eventTypes,
+              events: rendered
             });
           }
           break;

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -33,7 +33,13 @@ type WebviewMessage =
   | { type: 'openAttachment'; uri: string }
   | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
   | { type: 'command'; command: string; reason?: string }
-  | { type: 'renderedEventsResponse'; requestId: string; count: number; eventTypes: string[] }
+  | {
+    type: 'renderedEventsResponse';
+    requestId: string;
+    count: number;
+    eventTypes: string[];
+    events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
+  }
   | {
     type: 'uiStateResponse';
     requestId: string;
@@ -216,7 +222,14 @@ export type CreateWebviewMessageHandlerDeps = {
     clientLastSeenSeq?: number;
   }) => void;
 
-  onRenderedEventsResponse: (requestId: string, info: { count: number; eventTypes: string[] }) => void;
+  onRenderedEventsResponse: (
+    requestId: string,
+    info: {
+      count: number;
+      eventTypes: string[];
+      events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
+    }
+  ) => void;
   onUiStateResponse: (
     requestId: string,
     info: {
@@ -599,7 +612,11 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'renderedEventsResponse':
-        deps.onRenderedEventsResponse(message.requestId, { count: message.count, eventTypes: message.eventTypes });
+        deps.onRenderedEventsResponse(message.requestId, {
+          count: message.count,
+          eventTypes: message.eventTypes,
+          events: message.events,
+        });
         break;
       case 'uiStateResponse':
         deps.onUiStateResponse(message.requestId, {

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -211,23 +211,31 @@ export async function run(): Promise<void> {
   }, 10000);
 
   await pollUntil(async () => {
-    const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const rendered = (await vscode.commands.executeCommand('openhands._queryRenderedEvents')) as
+      | { events?: unknown }
+      | null
+      | undefined;
     const snapshots = Array.isArray(rendered?.events) ? rendered.events : null;
     if (!snapshots) {
       return false;
     }
 
+    type RenderedSnapshot = { type: string; marker?: string };
+
     const pairs = snapshots
-      .map((s: any) => ({
-        type: typeof s?.type === 'string' ? s.type : 'unknown',
-        marker: typeof s?.marker === 'string' ? s.marker : undefined,
-      }))
-      .filter((s) => typeof s.marker === 'string')
-      .map((s) => `${s.type}:${s.marker}`);
+      .map((snapshot): RenderedSnapshot => {
+        const record = snapshot as { type?: unknown; marker?: unknown };
+        return {
+          type: typeof record.type === 'string' ? record.type : 'unknown',
+          marker: typeof record.marker === 'string' ? record.marker : undefined,
+        };
+      })
+      .filter((snapshot): snapshot is RenderedSnapshot & { marker: string } => typeof snapshot.marker === 'string')
+      .map((snapshot) => `${snapshot.type}:${snapshot.marker}`);
     const expectedPairs = expectedRendered.map((s) => `${s.type}:${s.marker}`);
     const hasExpected = containsSubsequence(pairs, expectedPairs);
     const hasFiltered =
-      typeof filteredMarker === 'string' ? pairs.some((p) => p.endsWith(`:${filteredMarker}`)) : false;
+      typeof filteredMarker === 'string' ? pairs.some((pair) => pair.endsWith(`:${filteredMarker}`)) : false;
     return hasExpected && !hasFiltered;
   }, 20000);
 

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -17,36 +17,16 @@ async function pollUntil(
   throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
 }
 
-async function waitForRenderedEventsToStabilize(timeoutMs: number = 15000, stableMs: number = 1000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  let lastCount: number | undefined;
-  let lastChange = Date.now();
-
-  while (Date.now() < deadline) {
-    const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
-    const count = typeof rendered?.count === 'number' ? rendered.count : 0;
-    if (lastCount === undefined) {
-      lastCount = count;
-      lastChange = Date.now();
-    } else if (count !== lastCount) {
-      lastCount = count;
-      lastChange = Date.now();
-    } else if (Date.now() - lastChange >= stableMs) {
-      return;
+function containsSubsequence(haystack: unknown[], needle: unknown[]): boolean {
+  if (needle.length === 0) return true;
+  let needleIndex = 0;
+  for (const item of haystack) {
+    if (item === needle[needleIndex]) {
+      needleIndex += 1;
+      if (needleIndex >= needle.length) return true;
     }
-    await sleep(200);
   }
-
-  throw new Error(`Rendered events did not stabilize within ${timeoutMs}ms`);
-}
-
-function endsWithSequence(haystack: unknown[], needle: unknown[]): boolean {
-  if (needle.length > haystack.length) return false;
-  const offset = haystack.length - needle.length;
-  for (let i = 0; i < needle.length; i += 1) {
-    if (haystack[offset + i] !== needle[i]) return false;
-  }
-  return true;
+  return false;
 }
 
 export async function run(): Promise<void> {
@@ -106,10 +86,6 @@ export async function run(): Promise<void> {
     const messageCount = types.filter((t: unknown) => t === 'MessageEvent').length;
     return count > beforeCount && messageCount > beforeMessageCount;
   }, 60000);
-
-  // Wait for remote streaming to settle, then inject a representative set of event kinds to
-  // verify the webview can render them while running in remote mode.
-  await waitForRenderedEventsToStabilize(20000, 1000);
 
   const afterRemote: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
   const baselineCount = typeof afterRemote?.count === 'number' ? afterRemote.count : 0;
@@ -234,7 +210,8 @@ export async function run(): Promise<void> {
     const count = typeof rendered?.count === 'number' ? rendered.count : 0;
     const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
     if (count < baselineCount + expectedRenderedTypes.length) return false;
-    return endsWithSequence(types, expectedRenderedTypes);
+    const tail = types.slice(Math.min(baselineCount, types.length));
+    return containsSubsequence(tail, expectedRenderedTypes);
   }, 20000);
 
   const afterAll: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -212,31 +212,25 @@ export async function run(): Promise<void> {
 
   await pollUntil(async () => {
     const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
-    const count = typeof rendered?.count === 'number' ? rendered.count : 0;
-    const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
-    const snapshots = Array.isArray(rendered?.events) ? rendered.events : undefined;
-    if (Array.isArray(snapshots)) {
-      const pairs = snapshots
-        .map((s: any) => ({
-          type: typeof s?.type === 'string' ? s.type : 'unknown',
-          marker: typeof s?.marker === 'string' ? s.marker : undefined,
-        }))
-        .filter((s) => typeof s.marker === 'string')
-        .map((s) => `${s.type}:${s.marker}`);
-      const expectedPairs = expectedRendered.map((s) => `${s.type}:${s.marker}`);
-      const hasExpected = containsSubsequence(pairs, expectedPairs);
-      const hasFiltered =
-        typeof filteredMarker === 'string' ? pairs.some((p) => p.endsWith(`:${filteredMarker}`)) : false;
-      return hasExpected && !hasFiltered;
+    const snapshots = Array.isArray(rendered?.events) ? rendered.events : null;
+    if (!snapshots) {
+      throw new Error(
+        'E2E requires `openhands._queryRenderedEvents` to return per-event snapshots in `rendered.events`.'
+      );
     }
 
-    // Legacy fallback if webview doesn't return per-event snapshots.
-    if (count < baselineTypes.length + expectedRendered.length) return false;
-    const tail = types.slice(Math.min(baselineTypes.length, types.length));
-    return containsSubsequence(
-      tail,
-      expectedRendered.map((s) => s.type)
-    );
+    const pairs = snapshots
+      .map((s: any) => ({
+        type: typeof s?.type === 'string' ? s.type : 'unknown',
+        marker: typeof s?.marker === 'string' ? s.marker : undefined,
+      }))
+      .filter((s) => typeof s.marker === 'string')
+      .map((s) => `${s.type}:${s.marker}`);
+    const expectedPairs = expectedRendered.map((s) => `${s.type}:${s.marker}`);
+    const hasExpected = containsSubsequence(pairs, expectedPairs);
+    const hasFiltered =
+      typeof filteredMarker === 'string' ? pairs.some((p) => p.endsWith(`:${filteredMarker}`)) : false;
+    return hasExpected && !hasFiltered;
   }, 20000);
 
   const afterAll: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -108,10 +108,12 @@ export async function run(): Promise<void> {
   }
 
   await pollUntil(async () => {
-    const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
     const count = typeof rendered?.count === 'number' ? rendered.count : 0;
-    const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
-    const messageCount = types.filter((t: unknown) => t === 'MessageEvent').length;
+    const types = Array.isArray(rendered?.eventTypes)
+      ? rendered.eventTypes.filter((t): t is string => typeof t === 'string')
+      : [];
+    const messageCount = types.filter((t) => t === 'MessageEvent').length;
     return count > beforeCount && messageCount > beforeMessageCount;
   }, 60000);
 
@@ -224,6 +226,7 @@ export async function run(): Promise<void> {
   const expectedRendered = injectedEvents
     .filter((event) => event.kind !== 'ConversationStateUpdateEvent')
     .map((event) => ({ type: event.kind, marker: event.e2e_marker }));
+  const expectedPairs = expectedRendered.map((s) => `${s.type}:${s.marker}`);
   const filteredMarker = injectedEvents.find((event) => event.kind === 'ConversationStateUpdateEvent')?.e2e_marker;
 
   for (const event of injectedEvents) {
@@ -237,31 +240,41 @@ export async function run(): Promise<void> {
     return size >= backlogBefore + injectedEvents.length;
   }, 10000);
 
-  await pollUntil(async () => {
-    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
-    const snapshots = Array.isArray(rendered?.events) ? rendered.events : null;
-    if (!snapshots) {
-      return false;
-    }
+  let lastPairs: string[] = [];
+  try {
+    await pollUntil(async () => {
+      const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+      const snapshots = Array.isArray(rendered?.events) ? rendered.events : null;
+      if (!snapshots) {
+        lastPairs = [];
+        return false;
+      }
 
-    type RenderedSnapshot = { type: string; marker?: string };
+      type RenderedSnapshot = { type: string; marker?: string };
 
-    const pairs = snapshots
-      .map((snapshot): RenderedSnapshot => {
-        const record = snapshot as RenderedEventSnapshot;
-        return {
-          type: typeof record.type === 'string' ? record.type : 'unknown',
-          marker: typeof record.marker === 'string' ? record.marker : undefined,
-        };
-      })
-      .filter((snapshot): snapshot is RenderedSnapshot & { marker: string } => typeof snapshot.marker === 'string')
-      .map((snapshot) => `${snapshot.type}:${snapshot.marker}`);
-    const expectedPairs = expectedRendered.map((s) => `${s.type}:${s.marker}`);
-    const hasExpected = containsSubsequence(pairs, expectedPairs);
-    const hasFiltered =
-      typeof filteredMarker === 'string' ? pairs.some((pair) => pair.endsWith(`:${filteredMarker}`)) : false;
-    return hasExpected && !hasFiltered;
-  }, 20000);
+      const pairs = snapshots
+        .map((snapshot): RenderedSnapshot => {
+          const record = snapshot as RenderedEventSnapshot;
+          return {
+            type: typeof record.type === 'string' ? record.type : 'unknown',
+            marker: typeof record.marker === 'string' ? record.marker : undefined,
+          };
+        })
+        .filter((snapshot): snapshot is RenderedSnapshot & { marker: string } => typeof snapshot.marker === 'string')
+        .map((snapshot) => `${snapshot.type}:${snapshot.marker}`);
+      lastPairs = pairs;
+
+      const hasExpected = containsSubsequence(pairs, expectedPairs);
+      const hasFiltered =
+        typeof filteredMarker === 'string' ? pairs.some((pair) => pair.endsWith(`:${filteredMarker}`)) : false;
+      return hasExpected && !hasFiltered;
+    }, 20000);
+  } catch (error) {
+    const errorText = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Timed out waiting for injected event markers to render. expectedPairs=${expectedPairs.join(', ')} filteredMarker=${filteredMarker ?? 'none'} lastPairs=${lastPairs.slice(-20).join(', ')} (original error: ${errorText})`
+    );
+  }
 
   const afterAll = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   console.log(

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,5 +1,29 @@
 import * as vscode from 'vscode';
 
+type DiagnosticsInfo = {
+  chat?: { hasView?: boolean; webviewReady?: boolean };
+  mode?: string;
+  serverUrl?: string;
+  status?: string;
+  conversationId?: string;
+  eventBacklog?: { size?: number };
+};
+
+type RenderedEventsInfo = {
+  count?: number;
+  eventTypes?: unknown[];
+  events?: unknown[];
+};
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+type RenderedEventSnapshot = {
+  type?: unknown;
+  marker?: unknown;
+};
+
 const sleep = async (ms: number): Promise<void> => {
   await new Promise((r) => setTimeout(r, ms));
 };
@@ -41,8 +65,8 @@ export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   await vscode.workspace.getConfiguration().update(
@@ -57,24 +81,25 @@ export async function run(): Promise<void> {
   );
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
   }, 15000);
 
   await vscode.commands.executeCommand('openhands.startNewConversation');
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
   }, 45000);
 
-  const before: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  const before = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const beforeCount = typeof before?.count === 'number' ? before.count : 0;
-  const beforeMessageCount = Array.isArray(before?.eventTypes)
-    ? before.eventTypes.filter((t: unknown) => t === 'MessageEvent').length
-    : 0;
+  const beforeTypes = Array.isArray(before?.eventTypes)
+    ? before.eventTypes.filter((t): t is string => typeof t === 'string')
+    : [];
+  const beforeMessageCount = beforeTypes.filter((t) => t === 'MessageEvent').length;
 
-  const send: any = await vscode.commands.executeCommand('openhands._webviewAction', {
+  const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
     action: 'sendMessage',
     payload: { text: 'Hello from E2E (agent-server remote smoke).' }
   });
@@ -90,14 +115,16 @@ export async function run(): Promise<void> {
     return count > beforeCount && messageCount > beforeMessageCount;
   }, 60000);
 
-  const afterRemote: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  const afterRemote = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const baselineCount = typeof afterRemote?.count === 'number' ? afterRemote.count : 0;
-  const baselineTypes = Array.isArray(afterRemote?.eventTypes) ? afterRemote.eventTypes : [];
+  const baselineTypes = Array.isArray(afterRemote?.eventTypes)
+    ? afterRemote.eventTypes.filter((t): t is string => typeof t === 'string')
+    : [];
   console.log(
     `Remote rendered events (post-send): count=${baselineCount} types=${baselineTypes.slice(-10).join(', ')}`
   );
 
-  const diagBefore: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diagBefore = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
   const backlogBefore = typeof diagBefore?.eventBacklog?.size === 'number' ? diagBefore.eventBacklog.size : 0;
 
   const injectedEvents = [
@@ -200,21 +227,18 @@ export async function run(): Promise<void> {
   const filteredMarker = injectedEvents.find((event) => event.kind === 'ConversationStateUpdateEvent')?.e2e_marker;
 
   for (const event of injectedEvents) {
-    await vscode.commands.executeCommand('openhands._sendTestEvent', event as any);
+    await vscode.commands.executeCommand('openhands._sendTestEvent', event);
     await sleep(50);
   }
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     const size = typeof diag?.eventBacklog?.size === 'number' ? diag.eventBacklog.size : 0;
     return size >= backlogBefore + injectedEvents.length;
   }, 10000);
 
   await pollUntil(async () => {
-    const rendered = (await vscode.commands.executeCommand('openhands._queryRenderedEvents')) as
-      | { events?: unknown }
-      | null
-      | undefined;
+    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
     const snapshots = Array.isArray(rendered?.events) ? rendered.events : null;
     if (!snapshots) {
       return false;
@@ -224,7 +248,7 @@ export async function run(): Promise<void> {
 
     const pairs = snapshots
       .map((snapshot): RenderedSnapshot => {
-        const record = snapshot as { type?: unknown; marker?: unknown };
+        const record = snapshot as RenderedEventSnapshot;
         return {
           type: typeof record.type === 'string' ? record.type : 'unknown',
           marker: typeof record.marker === 'string' ? record.marker : undefined,
@@ -239,7 +263,7 @@ export async function run(): Promise<void> {
     return hasExpected && !hasFiltered;
   }, 20000);
 
-  const afterAll: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  const afterAll = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   console.log(
     `Remote rendered events (post-inject): count=${afterAll?.count} types=${Array.isArray(afterAll?.eventTypes) ? afterAll.eventTypes.slice(-20).join(', ') : ''}`
   );

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,5 +1,9 @@
 import * as vscode from 'vscode';
 
+const sleep = async (ms: number): Promise<void> => {
+  await new Promise((r) => setTimeout(r, ms));
+};
+
 async function pollUntil(
   condition: () => Promise<boolean>,
   timeoutMs: number = 10000,
@@ -8,9 +12,41 @@ async function pollUntil(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
+    await sleep(intervalMs);
   }
   throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
+}
+
+async function waitForRenderedEventsToStabilize(timeoutMs: number = 15000, stableMs: number = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastCount: number | undefined;
+  let lastChange = Date.now();
+
+  while (Date.now() < deadline) {
+    const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = typeof rendered?.count === 'number' ? rendered.count : 0;
+    if (lastCount === undefined) {
+      lastCount = count;
+      lastChange = Date.now();
+    } else if (count !== lastCount) {
+      lastCount = count;
+      lastChange = Date.now();
+    } else if (Date.now() - lastChange >= stableMs) {
+      return;
+    }
+    await sleep(200);
+  }
+
+  throw new Error(`Rendered events did not stabilize within ${timeoutMs}ms`);
+}
+
+function endsWithSequence(haystack: unknown[], needle: unknown[]): boolean {
+  if (needle.length > haystack.length) return false;
+  const offset = haystack.length - needle.length;
+  for (let i = 0; i < needle.length; i += 1) {
+    if (haystack[offset + i] !== needle[i]) return false;
+  }
+  return true;
 }
 
 export async function run(): Promise<void> {
@@ -71,8 +107,140 @@ export async function run(): Promise<void> {
     return count > beforeCount && messageCount > beforeMessageCount;
   }, 60000);
 
-  const after: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
-  console.log(`Remote rendered events: count=${after?.count} types=${Array.isArray(after?.eventTypes) ? after.eventTypes.slice(-10).join(', ') : ''}`);
+  // Wait for remote streaming to settle, then inject a representative set of event kinds to
+  // verify the webview can render them while running in remote mode.
+  await waitForRenderedEventsToStabilize(20000, 1000);
+
+  const afterRemote: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  const baselineCount = typeof afterRemote?.count === 'number' ? afterRemote.count : 0;
+  const baselineTypes = Array.isArray(afterRemote?.eventTypes) ? afterRemote.eventTypes : [];
+  console.log(
+    `Remote rendered events (post-send): count=${baselineCount} types=${baselineTypes.slice(-10).join(', ')}`
+  );
+
+  const diagBefore: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const backlogBefore = typeof diagBefore?.eventBacklog?.size === 'number' ? diagBefore.eventBacklog.size : 0;
+
+  const injectedEvents = [
+    {
+      kind: 'SystemPromptEvent',
+      source: 'agent',
+      system_prompt: { type: 'text', text: 'You are a helpful AI assistant' },
+      tools: [{ name: 'terminal' }, { name: 'file_editor' }]
+    },
+    {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'I need to check the current directory' }],
+      reasoning_content: 'To understand the workspace structure',
+      action: { command: 'pwd' },
+      tool_name: 'terminal',
+      tool_call_id: 'call_remote_001',
+      tool_call: {
+        id: 'call_remote_001',
+        type: 'function',
+        function: { name: 'terminal', arguments: '{"command":"pwd"}' }
+      },
+      llm_response_id: 'resp_remote_001',
+      security_risk: 'LOW'
+    },
+    {
+      kind: 'ObservationEvent',
+      source: 'environment',
+      observation: { content: '/tmp', exit_code: 0 },
+      tool_name: 'terminal',
+      tool_call_id: 'call_remote_001',
+      action_id: 'action_remote_001'
+    },
+    {
+      kind: 'UserRejectObservation',
+      source: 'environment',
+      rejection_reason: 'This command looks dangerous',
+      tool_name: 'terminal',
+      tool_call_id: 'call_remote_002',
+      action_id: 'action_remote_002'
+    },
+    {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'Please help me debug this code' }] }
+    },
+    {
+      kind: 'MessageEvent',
+      source: 'agent',
+      llm_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I will help you debug the code. Let me analyze it first.' }],
+        reasoning_content: 'Starting with the smallest repro'
+      }
+    },
+    {
+      kind: 'AgentErrorEvent',
+      source: 'agent',
+      error: 'Failed to execute command: permission denied',
+      tool_name: 'terminal',
+      tool_call_id: 'call_remote_004'
+    },
+    {
+      kind: 'ConversationErrorEvent',
+      source: 'environment',
+      detail: 'Connection lost to server',
+      code: 'ConnectionError'
+    },
+    {
+      kind: 'PauseEvent',
+      source: 'agent'
+    },
+    {
+      kind: 'Condensation',
+      source: 'environment',
+      forgotten_event_ids: ['event_001', 'event_002'],
+      summary: 'Condensed 2 events to save memory'
+    },
+    {
+      kind: 'ConversationStateUpdateEvent',
+      source: 'agent',
+      agent_status: 'running'
+    }
+  ];
+
+  const expectedRenderedTypes = [
+    'SystemPromptEvent',
+    'ActionEvent',
+    'ObservationEvent',
+    'UserRejectObservation',
+    'MessageEvent',
+    'MessageEvent',
+    'AgentErrorEvent',
+    'ConversationErrorEvent',
+    'PauseEvent',
+    'Condensation',
+    // ConversationStateUpdateEvent is filtered out by the webview
+  ];
+
+  for (const event of injectedEvents) {
+    await vscode.commands.executeCommand('openhands._sendTestEvent', event as any);
+    await sleep(50);
+  }
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const size = typeof diag?.eventBacklog?.size === 'number' ? diag.eventBacklog.size : 0;
+    return size >= backlogBefore + injectedEvents.length;
+  }, 10000);
+
+  await pollUntil(async () => {
+    const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+    const count = typeof rendered?.count === 'number' ? rendered.count : 0;
+    const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
+    if (count < baselineCount + expectedRenderedTypes.length) return false;
+    return endsWithSequence(types, expectedRenderedTypes);
+  }, 20000);
+
+  const afterAll: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+  console.log(
+    `Remote rendered events (post-inject): count=${afterAll?.count} types=${Array.isArray(afterAll?.eventTypes) ? afterAll.eventTypes.slice(-20).join(', ') : ''}`
+  );
 
   console.log('✓ Remote agent-server E2E test passed');
 }

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -214,9 +214,7 @@ export async function run(): Promise<void> {
     const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const snapshots = Array.isArray(rendered?.events) ? rendered.events : null;
     if (!snapshots) {
-      throw new Error(
-        'E2E requires `openhands._queryRenderedEvents` to return per-event snapshots in `rendered.events`.'
-      );
+      return false;
     }
 
     const pairs = snapshots

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -35,6 +35,9 @@ export async function run(): Promise<void> {
     throw new Error('Missing required env var: AGENT_SERVER_URL');
   }
 
+  const markerPrefix = `e2e_remote_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+  const markerFor = (index: number) => `${markerPrefix}_${index.toString().padStart(2, '0')}`;
+
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
@@ -101,12 +104,14 @@ export async function run(): Promise<void> {
     {
       kind: 'SystemPromptEvent',
       source: 'agent',
+      e2e_marker: markerFor(1),
       system_prompt: { type: 'text', text: 'You are a helpful AI assistant' },
       tools: [{ name: 'terminal' }, { name: 'file_editor' }]
     },
     {
       kind: 'ActionEvent',
       source: 'agent',
+      e2e_marker: markerFor(2),
       thought: [{ type: 'text', text: 'I need to check the current directory' }],
       reasoning_content: 'To understand the workspace structure',
       action: { command: 'pwd' },
@@ -123,6 +128,7 @@ export async function run(): Promise<void> {
     {
       kind: 'ObservationEvent',
       source: 'environment',
+      e2e_marker: markerFor(3),
       observation: { content: '/tmp', exit_code: 0 },
       tool_name: 'terminal',
       tool_call_id: 'call_remote_001',
@@ -131,6 +137,7 @@ export async function run(): Promise<void> {
     {
       kind: 'UserRejectObservation',
       source: 'environment',
+      e2e_marker: markerFor(4),
       rejection_reason: 'This command looks dangerous',
       tool_name: 'terminal',
       tool_call_id: 'call_remote_002',
@@ -139,11 +146,13 @@ export async function run(): Promise<void> {
     {
       kind: 'MessageEvent',
       source: 'user',
+      e2e_marker: markerFor(5),
       llm_message: { role: 'user', content: [{ type: 'text', text: 'Please help me debug this code' }] }
     },
     {
       kind: 'MessageEvent',
       source: 'agent',
+      e2e_marker: markerFor(6),
       llm_message: {
         role: 'assistant',
         content: [{ type: 'text', text: 'I will help you debug the code. Let me analyze it first.' }],
@@ -153,6 +162,7 @@ export async function run(): Promise<void> {
     {
       kind: 'AgentErrorEvent',
       source: 'agent',
+      e2e_marker: markerFor(7),
       error: 'Failed to execute command: permission denied',
       tool_name: 'terminal',
       tool_call_id: 'call_remote_004'
@@ -160,39 +170,34 @@ export async function run(): Promise<void> {
     {
       kind: 'ConversationErrorEvent',
       source: 'environment',
+      e2e_marker: markerFor(8),
       detail: 'Connection lost to server',
       code: 'ConnectionError'
     },
     {
       kind: 'PauseEvent',
-      source: 'agent'
+      source: 'agent',
+      e2e_marker: markerFor(9)
     },
     {
       kind: 'Condensation',
       source: 'environment',
+      e2e_marker: markerFor(10),
       forgotten_event_ids: ['event_001', 'event_002'],
       summary: 'Condensed 2 events to save memory'
     },
     {
       kind: 'ConversationStateUpdateEvent',
       source: 'agent',
+      e2e_marker: markerFor(11),
       agent_status: 'running'
     }
   ];
 
-  const expectedRenderedTypes = [
-    'SystemPromptEvent',
-    'ActionEvent',
-    'ObservationEvent',
-    'UserRejectObservation',
-    'MessageEvent',
-    'MessageEvent',
-    'AgentErrorEvent',
-    'ConversationErrorEvent',
-    'PauseEvent',
-    'Condensation',
-    // ConversationStateUpdateEvent is filtered out by the webview
-  ];
+  const expectedRendered = injectedEvents
+    .filter((event) => event.kind !== 'ConversationStateUpdateEvent')
+    .map((event) => ({ type: event.kind, marker: event.e2e_marker }));
+  const filteredMarker = injectedEvents.find((event) => event.kind === 'ConversationStateUpdateEvent')?.e2e_marker;
 
   for (const event of injectedEvents) {
     await vscode.commands.executeCommand('openhands._sendTestEvent', event as any);
@@ -209,9 +214,29 @@ export async function run(): Promise<void> {
     const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
     const count = typeof rendered?.count === 'number' ? rendered.count : 0;
     const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
-    if (count < baselineCount + expectedRenderedTypes.length) return false;
-    const tail = types.slice(Math.min(baselineCount, types.length));
-    return containsSubsequence(tail, expectedRenderedTypes);
+    const snapshots = Array.isArray(rendered?.events) ? rendered.events : undefined;
+    if (Array.isArray(snapshots)) {
+      const pairs = snapshots
+        .map((s: any) => ({
+          type: typeof s?.type === 'string' ? s.type : 'unknown',
+          marker: typeof s?.marker === 'string' ? s.marker : undefined,
+        }))
+        .filter((s) => typeof s.marker === 'string')
+        .map((s) => `${s.type}:${s.marker}`);
+      const expectedPairs = expectedRendered.map((s) => `${s.type}:${s.marker}`);
+      const hasExpected = containsSubsequence(pairs, expectedPairs);
+      const hasFiltered =
+        typeof filteredMarker === 'string' ? pairs.some((p) => p.endsWith(`:${filteredMarker}`)) : false;
+      return hasExpected && !hasFiltered;
+    }
+
+    // Legacy fallback if webview doesn't return per-event snapshots.
+    if (count < baselineTypes.length + expectedRendered.length) return false;
+    const tail = types.slice(Math.min(baselineTypes.length, types.length));
+    return containsSubsequence(
+      tail,
+      expectedRendered.map((s) => s.type)
+    );
   }, 20000);
 
   const afterAll: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');


### PR DESCRIPTION
Expands the agent-server remote E2E suite beyond the basic smoke check:

- Sends a remote message and captures a rendered-events baseline
- Injects a representative set of SDK event kinds via `openhands._sendTestEvent` while in remote mode
- Asserts diagnostics backlog growth and that the post-baseline tail contains the expected event-type subsequence (tolerates late/ambient remote events)

Local run:

```bash
E2E_AGENT_SERVER=1 AGENT_SDK_DIR=~/repos/agent-sdk npm run e2e:agent-server
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rendered-event payloads now optionally include richer metadata (markers and tool-call identifiers) to improve event correlation and diagnostics.

* **Tests**
  * E2E tests strengthened with stable event markers, paced injection and polling, subsequence-based validation, and enhanced logging to better verify remote agent-server event flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->