### PR TITLE
[oh-tab-4so] Cap FileEditorTool undo history paths

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -415,7 +415,8 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     }
     while (this.undoBytesTotal > MAX_UNDO_BYTES_TOTAL) {
       if (this.dropOldestUndoPath(resolvedPath)) continue;
-      if (!this.dropOldestUndoEntryForPath(resolvedPath)) break;
+      if (this.dropOldestUndoEntryForPath(resolvedPath)) continue;
+      if (!this.dropNewestUndoEntryForPath(resolvedPath)) break;
     }
   }
 
@@ -440,13 +441,24 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     if (!stack || stack.length <= 1) return false;
 
     const lastIndex = stack.length - 1;
-    const removableIndex = stack.slice(0, lastIndex).findIndex((entry) => entry.byteSize > 0);
-    const index = removableIndex === -1 ? 0 : removableIndex;
+    const index = stack.slice(0, lastIndex).findIndex((entry) => entry.byteSize > 0);
+    if (index === -1) return false;
     const [removed] = stack.splice(index, 1);
-    if (removed) {
-      this.undoBytesTotal -= removed.byteSize;
+    this.undoBytesTotal -= removed.byteSize;
+    return true;
+  }
+
+  private dropNewestUndoEntryForPath(resolvedPath: string): boolean {
+    const stack = this.undoHistory.get(resolvedPath);
+    if (!stack || stack.length === 0) return false;
+
+    const removed = stack.pop();
+    if (!removed) return false;
+    this.undoBytesTotal -= removed.byteSize;
+    if (stack.length === 0) {
+      this.undoHistory.delete(resolvedPath);
     }
-    return removed !== undefined;
+    return true;
   }
 
   private async readOptionalFile(absPath: string): Promise<string | null> {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -231,7 +231,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: prev.length * 2 });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: Math.max(buffer.length, prev.length * 2) });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
@@ -246,7 +246,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: prev.length * 2 });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: Math.max(buffer.length, prev.length * 2) });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -230,8 +230,12 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           throw new Error('old_str is not unique and matches multiple locations in the file');
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
+        const undoByteSize = Math.max(buffer.length, prev.length * 2);
+        if (undoByteSize > MAX_UNDO_BYTES_TOTAL) {
+          throw new Error('str_replace failed: undo snapshot exceeds total undo history size cap');
+        }
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: Math.max(buffer.length, prev.length * 2) });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: undoByteSize });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
@@ -245,8 +249,12 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         const index = Math.min(args.insert_line ?? 0, lines.length);
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
+        const undoByteSize = Math.max(buffer.length, prev.length * 2);
+        if (undoByteSize > MAX_UNDO_BYTES_TOTAL) {
+          throw new Error('insert failed: undo snapshot exceeds total undo history size cap');
+        }
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: Math.max(buffer.length, prev.length * 2) });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: undoByteSize });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {
@@ -259,11 +267,11 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
 
         const undo = stack[stack.length - 1];
 
-	        if (!undo.prevExist) {
-	          await this.removeCreatedFile(resolved);
-	        } else {
-	          await ws.writeFile(args.path, undo.oldContent ?? '');
-	        }
+        if (!undo.prevExist) {
+          await this.removeCreatedFile(resolved);
+        } else {
+          await ws.writeFile(args.path, undo.oldContent ?? '');
+        }
 
         stack.pop();
         this.undoBytesTotal -= undo.byteSize;
@@ -416,7 +424,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     while (this.undoBytesTotal > MAX_UNDO_BYTES_TOTAL) {
       if (this.dropOldestUndoPath(resolvedPath)) continue;
       if (this.dropOldestUndoEntryForPath(resolvedPath)) continue;
-      if (!this.dropNewestUndoEntryForPath(resolvedPath)) break;
+      break;
     }
   }
 
@@ -445,19 +453,6 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     if (index === -1) return false;
     const [removed] = stack.splice(index, 1);
     this.undoBytesTotal -= removed.byteSize;
-    return true;
-  }
-
-  private dropNewestUndoEntryForPath(resolvedPath: string): boolean {
-    const stack = this.undoHistory.get(resolvedPath);
-    if (!stack || stack.length === 0) return false;
-
-    const removed = stack.pop();
-    if (!removed) return false;
-    this.undoBytesTotal -= removed.byteSize;
-    if (stack.length === 0) {
-      this.undoHistory.delete(resolvedPath);
-    }
     return true;
   }
 

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -145,16 +145,19 @@ const isProbablyBinary = (buffer: Buffer): boolean => {
 type UndoEntry = {
   prevExist: boolean;
   oldContent: string | null;
+  byteSize: number;
 };
 
 const MAX_UNDO_ENTRIES_PER_PATH = 10;
 const MAX_UNDO_PATHS = 100;
+const MAX_UNDO_BYTES_TOTAL = 100 * 1024 * 1024;
 
 export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, FileEditorResult> {
   readonly name = 'file_editor';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = fileEditorSchema;
   private readonly undoHistory = new Map<string, UndoEntry[]>();
+  private undoBytesTotal = 0;
 
   private async pathExists(absPath: string): Promise<boolean> {
     try {
@@ -199,7 +202,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           throw new Error(`create failed: file is too large (${mb.toFixed(1)}MB). Maximum allowed size is 10MB.`);
         }
         await ws.writeFile(resolved, fileText);
-        this.pushUndo(resolved, { prevExist: false, oldContent: null });
+        this.pushUndo(resolved, { prevExist: false, oldContent: null, byteSize: 0 });
         return {
           command: 'create',
           path: resolved,
@@ -228,7 +231,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: buffer.length });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
@@ -243,7 +246,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: buffer.length });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {
@@ -263,6 +266,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
 	        }
 
         stack.pop();
+        this.undoBytesTotal -= undo.byteSize;
         if (stack.length === 0) {
           this.undoHistory.delete(resolved);
         }
@@ -397,18 +401,34 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
   private pushUndo(resolvedPath: string, entry: UndoEntry): void {
     const stack = this.undoHistory.get(resolvedPath) ?? [];
     stack.push(entry);
+    this.undoBytesTotal += entry.byteSize;
     while (stack.length > MAX_UNDO_ENTRIES_PER_PATH) {
-      stack.shift();
+      const removed = stack.shift();
+      if (removed) {
+        this.undoBytesTotal -= removed.byteSize;
+      }
     }
-    if (this.undoHistory.has(resolvedPath)) {
-      this.undoHistory.delete(resolvedPath);
-    }
+    this.undoHistory.delete(resolvedPath);
     this.undoHistory.set(resolvedPath, stack);
     while (this.undoHistory.size > MAX_UNDO_PATHS) {
-      const oldest = this.undoHistory.keys().next();
-      if (oldest.done) break;
-      this.undoHistory.delete(oldest.value);
+      this.dropOldestUndoPath();
     }
+    while (this.undoBytesTotal > MAX_UNDO_BYTES_TOTAL && this.undoHistory.size > 0) {
+      this.dropOldestUndoPath();
+    }
+  }
+
+  private dropOldestUndoPath(): void {
+    const oldest = this.undoHistory.keys().next();
+    if (oldest.done) return;
+
+    const stack = this.undoHistory.get(oldest.value);
+    if (stack) {
+      for (const entry of stack) {
+        this.undoBytesTotal -= entry.byteSize;
+      }
+    }
+    this.undoHistory.delete(oldest.value);
   }
 
   private async readOptionalFile(absPath: string): Promise<string | null> {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -231,7 +231,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: buffer.length });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: prev.length * 2 });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
@@ -246,7 +246,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: buffer.length });
+        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: prev.length * 2 });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {
@@ -413,22 +413,40 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     while (this.undoHistory.size > MAX_UNDO_PATHS) {
       this.dropOldestUndoPath();
     }
-    while (this.undoBytesTotal > MAX_UNDO_BYTES_TOTAL && this.undoHistory.size > 0) {
-      this.dropOldestUndoPath();
+    while (this.undoBytesTotal > MAX_UNDO_BYTES_TOTAL) {
+      if (this.dropOldestUndoPath(resolvedPath)) continue;
+      if (!this.dropOldestUndoEntryForPath(resolvedPath)) break;
     }
   }
 
-  private dropOldestUndoPath(): void {
-    const oldest = this.undoHistory.keys().next();
-    if (oldest.done) return;
+  private dropOldestUndoPath(excludePath?: string): boolean {
+    for (const key of this.undoHistory.keys()) {
+      if (excludePath && key === excludePath) continue;
 
-    const stack = this.undoHistory.get(oldest.value);
-    if (stack) {
-      for (const entry of stack) {
-        this.undoBytesTotal -= entry.byteSize;
+      const stack = this.undoHistory.get(key);
+      if (stack) {
+        for (const entry of stack) {
+          this.undoBytesTotal -= entry.byteSize;
+        }
       }
+      this.undoHistory.delete(key);
+      return true;
     }
-    this.undoHistory.delete(oldest.value);
+    return false;
+  }
+
+  private dropOldestUndoEntryForPath(resolvedPath: string): boolean {
+    const stack = this.undoHistory.get(resolvedPath);
+    if (!stack || stack.length <= 1) return false;
+
+    const lastIndex = stack.length - 1;
+    const removableIndex = stack.slice(0, lastIndex).findIndex((entry) => entry.byteSize > 0);
+    const index = removableIndex === -1 ? 0 : removableIndex;
+    const [removed] = stack.splice(index, 1);
+    if (removed) {
+      this.undoBytesTotal -= removed.byteSize;
+    }
+    return removed !== undefined;
   }
 
   private async readOptionalFile(absPath: string): Promise<string | null> {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -148,6 +148,7 @@ type UndoEntry = {
 };
 
 const MAX_UNDO_ENTRIES_PER_PATH = 10;
+const MAX_UNDO_PATHS = 100;
 
 export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, FileEditorResult> {
   readonly name = 'file_editor';
@@ -399,7 +400,15 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     while (stack.length > MAX_UNDO_ENTRIES_PER_PATH) {
       stack.shift();
     }
+    if (this.undoHistory.has(resolvedPath)) {
+      this.undoHistory.delete(resolvedPath);
+    }
     this.undoHistory.set(resolvedPath, stack);
+    while (this.undoHistory.size > MAX_UNDO_PATHS) {
+      const oldest = this.undoHistory.keys().next();
+      if (oldest.done) break;
+      this.undoHistory.delete(oldest.value);
+    }
   }
 
   private async readOptionalFile(absPath: string): Promise<string | null> {

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -377,6 +377,23 @@ startxref
       .rejects.toThrowError(/no edit history/i);
   });
 
+  it('caps undo_edit history across paths', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const maxPaths = 100;
+    for (let i = 0; i < maxPaths + 1; i++) {
+      await tool.execute(tool.validate({ command: 'create', path: `file-${i}.txt`, file_text: String(i) }), { workspace });
+    }
+
+    await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'file-0.txt' }), { workspace }))
+      .rejects.toThrowError(/no edit history/i);
+
+    await tool.execute(tool.validate({ command: 'undo_edit', path: `file-${maxPaths}.txt` }), { workspace });
+    await expect(workspace.readFile(`file-${maxPaths}.txt`)).rejects.toThrowError();
+  });
+
   it('requires old_str to be unique for str_replace', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -394,6 +394,35 @@ startxref
     await expect(workspace.readFile(`file-${maxPaths}.txt`)).rejects.toThrowError();
   });
 
+  it('prunes undo_edit history by byte cap without losing the latest edit', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    const baseSizeBytes = 6 * 1024 * 1024;
+    const marker0 = 'MARK0';
+    const padding = 'A'.repeat(baseSizeBytes - marker0.length);
+    await tool.execute(tool.validate({ command: 'create', path: 'big.txt', file_text: `${padding}${marker0}` }), { workspace });
+
+    for (let i = 0; i < 9; i++) {
+      await tool.execute(
+        tool.validate({ command: 'str_replace', path: 'big.txt', old_str: `MARK${i}`, new_str: `MARK${i + 1}` }),
+        { workspace },
+      );
+    }
+    expect(await workspace.readFile('big.txt')).toContain('MARK9');
+
+    for (let i = 9; i >= 2; i--) {
+      await tool.execute(tool.validate({ command: 'undo_edit', path: 'big.txt' }), { workspace });
+      expect(await workspace.readFile('big.txt')).toContain(`MARK${i - 1}`);
+    }
+
+    await tool.execute(tool.validate({ command: 'undo_edit', path: 'big.txt' }), { workspace });
+    await expect(workspace.readFile('big.txt')).rejects.toThrowError();
+    await expect(tool.execute(tool.validate({ command: 'undo_edit', path: 'big.txt' }), { workspace }))
+      .rejects.toThrowError(/no edit history/i);
+  });
+
   it('requires old_str to be unique for str_replace', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);


### PR DESCRIPTION
Caps FileEditorTool undo history across distinct file paths (LRU) to avoid unbounded memory growth during long sessions.

- Adds `MAX_UNDO_PATHS` LRU cap
- Adds `MAX_UNDO_BYTES_TOTAL` cap to bound total stored undo content
- Adds Vitest coverage for path-pruning behavior

Beads: oh-tab-4so


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Undo system now tracks byte-size and enforces per-file and global limits; oldest entries are pruned automatically so recent edits remain undoable.

* **Tests**
  * Added tests verifying undo history capping across files and byte-size–based pruning that preserves the latest edits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->