### PR TITLE
[oh-tab-32z] Mask secrets in ObservationEvent payloads

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -69,7 +69,11 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 
 function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === 'string') return truncateString(value);
-  if (Array.isArray(value)) return value.map((v) => deepTruncate(v, seen));
+  if (Array.isArray(value)) {
+    if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
+    seen.add(value);
+    return value.map((v) => deepTruncate(v, seen));
+  }
   if (value && typeof value === 'object') {
     const entries = Object.entries(value as Record<string, unknown>);
     if (!entries.length) return value;
@@ -287,6 +291,8 @@ export class Agent extends EventEmitter {
       return this.maskSecretsInText(value);
     }
     if (Array.isArray(value)) {
+      if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
+      seen.add(value);
       return value.map((item) => this.maskSecretsInUnknown(item, seen));
     }
     if (value && typeof value === 'object') {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -70,11 +70,13 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === 'string') return truncateString(value);
   if (Array.isArray(value)) return value.map((v) => deepTruncate(v, seen));
-  if (isPlainRecord(value)) {
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (!entries.length) return value;
     if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
     seen.add(value);
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) {
+    for (const [k, v] of entries) {
       out[k] = deepTruncate(v, seen);
     }
     return out;
@@ -287,11 +289,13 @@ export class Agent extends EventEmitter {
     if (Array.isArray(value)) {
       return value.map((item) => this.maskSecretsInUnknown(item, seen));
     }
-    if (isPlainRecord(value)) {
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value as Record<string, unknown>);
+      if (!entries.length) return value;
       if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
       seen.add(value);
       const masked: Record<string, unknown> = {};
-      for (const [key, inner] of Object.entries(value)) {
+      for (const [key, inner] of entries) {
         masked[key] = this.maskSecretsInUnknown(inner, seen);
       }
       return masked;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -270,6 +270,26 @@ export class Agent extends EventEmitter {
     return redactStringHeuristics(masked);
   }
 
+  private maskSecretsInUnknown(value: unknown, seen = new WeakSet<object>()): unknown {
+    if (typeof value === 'string') {
+      return this.maskSecretsInText(value);
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => this.maskSecretsInUnknown(item, seen));
+    }
+    if (value && typeof value === 'object') {
+      if (seen.has(value)) return value;
+      seen.add(value);
+      const record = value as Record<string, unknown>;
+      const masked: Record<string, unknown> = {};
+      for (const [key, inner] of Object.entries(record)) {
+        masked[key] = this.maskSecretsInUnknown(inner, seen);
+      }
+      return masked;
+    }
+    return value;
+  }
+
   private formatToolMessageText(toolCall: ToolCall, result: unknown): string {
     const toolName = toolCall.function.name;
     const asRecord = (value: unknown): Record<string, unknown> | undefined =>
@@ -924,7 +944,7 @@ export class Agent extends EventEmitter {
       const observation = {
         kind: 'ObservationEvent',
         source: 'environment',
-        observation: deepTruncate(result) as Record<string, unknown>,
+        observation: this.maskSecretsInUnknown(deepTruncate(result)) as Record<string, unknown>,
         tool_name: toolCall.function.name,
         tool_call_id: toolCall.id,
         action_id: actionEvent.id ?? randomUUID(),

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -54,18 +54,28 @@ const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 // Simple utility to cap logged/tool result sizes
 const TRUNCATE_LIMIT = 2000;
 const ELLIPSIS = '…(truncated)';
+const CIRCULAR_REFERENCE_MARKER = '[Circular]';
 const TOOL_MESSAGE_MAX_CHARS = 8_000;
 const TOOL_MESSAGE_CLIP_MARKER = '<response clipped>';
 function truncateString(input: string): string {
   return input.length > TRUNCATE_LIMIT ? input.slice(0, TRUNCATE_LIMIT) + ELLIPSIS : input;
 }
-function deepTruncate(value: unknown): unknown {
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const proto = Object.getPrototypeOf(value) as unknown;
+  return proto === Object.prototype || proto === null;
+}
+
+function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === 'string') return truncateString(value);
-  if (Array.isArray(value)) return value.map((v) => deepTruncate(v));
-  if (value && typeof value === 'object') {
+  if (Array.isArray(value)) return value.map((v) => deepTruncate(v, seen));
+  if (isPlainRecord(value)) {
+    if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
+    seen.add(value);
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = deepTruncate(v);
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = deepTruncate(v, seen);
     }
     return out;
   }
@@ -277,12 +287,11 @@ export class Agent extends EventEmitter {
     if (Array.isArray(value)) {
       return value.map((item) => this.maskSecretsInUnknown(item, seen));
     }
-    if (value && typeof value === 'object') {
-      if (seen.has(value)) return value;
+    if (isPlainRecord(value)) {
+      if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
       seen.add(value);
-      const record = value as Record<string, unknown>;
       const masked: Record<string, unknown> = {};
-      for (const [key, inner] of Object.entries(record)) {
+      for (const [key, inner] of Object.entries(value)) {
         masked[key] = this.maskSecretsInUnknown(inner, seen);
       }
       return masked;
@@ -941,10 +950,15 @@ export class Agent extends EventEmitter {
         this.emitTerminalEvents(toolCall, result);
       }
 
+      const maskedObservation = this.maskSecretsInUnknown(deepTruncate(result));
+      const observationPayload: Record<string, unknown> = isPlainRecord(maskedObservation)
+        ? maskedObservation
+        : { value: maskedObservation };
+
       const observation = {
         kind: 'ObservationEvent',
         source: 'environment',
-        observation: this.maskSecretsInUnknown(deepTruncate(result)) as Record<string, unknown>,
+        observation: observationPayload,
         tool_name: toolCall.function.name,
         tool_call_id: toolCall.id,
         action_id: actionEvent.id ?? randomUUID(),

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -61,12 +61,6 @@ function truncateString(input: string): string {
   return input.length > TRUNCATE_LIMIT ? input.slice(0, TRUNCATE_LIMIT) + ELLIPSIS : input;
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-  const proto = Object.getPrototypeOf(value) as unknown;
-  return proto === Object.prototype || proto === null;
-}
-
 function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === 'string') return truncateString(value);
   if (Array.isArray(value)) {
@@ -75,8 +69,15 @@ function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
     return value.map((v) => deepTruncate(v, seen));
   }
   if (value && typeof value === 'object') {
+    if (value instanceof Date) {
+      try {
+        return value.toISOString();
+      } catch {
+        return String(value);
+      }
+    }
     const entries = Object.entries(value as Record<string, unknown>);
-    if (!entries.length) return value;
+    if (!entries.length) return {};
     if (seen.has(value)) return CIRCULAR_REFERENCE_MARKER;
     seen.add(value);
     const out: Record<string, unknown> = {};
@@ -960,15 +961,10 @@ export class Agent extends EventEmitter {
         this.emitTerminalEvents(toolCall, result);
       }
 
-      const maskedObservation = this.maskSecretsInUnknown(deepTruncate(result));
-      const observationPayload: Record<string, unknown> = isPlainRecord(maskedObservation)
-        ? maskedObservation
-        : { value: maskedObservation };
-
       const observation = {
         kind: 'ObservationEvent',
         source: 'environment',
-        observation: observationPayload,
+        observation: deepTruncate(this.maskSecretsInUnknown(result)) as Record<string, unknown>,
         tool_name: toolCall.function.name,
         tool_call_id: toolCall.id,
         action_id: actionEvent.id ?? randomUUID(),

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -181,6 +181,46 @@ describe('Agent tool message formatting', () => {
     expect(JSON.stringify(observation.observation)).toContain('…(truncated)');
   });
 
+  it('handles circular arrays in ObservationEvent payloads', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const log = new EventLog();
+    const circular: unknown[] = [];
+    circular.push(circular);
+
+    const tool: ToolDefinition<Record<string, unknown>, unknown> = {
+      name: 'circular_array',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => circular,
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Returning a circular array' },
+      { type: 'tool_call_delta', id: 'call_circular', name: 'circular_array', arguments: '{}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run circular array tool');
+
+    const observations = log.list().filter((evt) => evt.kind === 'ObservationEvent');
+    expect(observations).toHaveLength(1);
+    const observation = observations[0] as unknown as { observation?: Record<string, unknown> };
+    expect(JSON.stringify(observation.observation)).toContain('[Circular]');
+  });
+
   it('masks uppercase secrets even when they resemble env var names', async () => {
     const secretValue = 'TOPSECRETUPPERCASE1234567890';
     const envKey = secretValue;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -133,6 +133,54 @@ describe('Agent tool message formatting', () => {
     expect(JSON.stringify(observation.observation)).toContain('2025-01-02T03:04:05.000Z');
   });
 
+  it('masks secrets inside class-instance tool results in ObservationEvent payloads', async () => {
+    const secretValue = 'ghp_CLASSSECRET1234567890';
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: { githubToken: secretValue },
+    };
+    const log = new EventLog();
+
+    class ResultWithSecret {
+      constructor(
+        readonly token: string,
+        readonly notes: string,
+      ) {}
+    }
+
+    const tool: ToolDefinition<Record<string, unknown>, unknown> = {
+      name: 'custom_result',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => new ResultWithSecret(secretValue, 'x'.repeat(2100)),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Returning a class instance' },
+      { type: 'tool_call_delta', id: 'call_custom', name: 'custom_result', arguments: '{}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run custom tool');
+
+    const observations = log.list().filter((evt) => evt.kind === 'ObservationEvent');
+    expect(observations).toHaveLength(1);
+    const observation = observations[0] as unknown as { observation?: Record<string, unknown> };
+    expect(JSON.stringify(observation.observation)).not.toContain(secretValue);
+    expect(JSON.stringify(observation.observation)).toContain('***');
+    expect(JSON.stringify(observation.observation)).toContain('…(truncated)');
+  });
+
   it('masks uppercase secrets even when they resemble env var names', async () => {
     const secretValue = 'TOPSECRETUPPERCASE1234567890';
     const envKey = secretValue;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -85,6 +85,12 @@ describe('Agent tool message formatting', () => {
     expect(text).not.toContain(secretValue);
     expect(text).toContain('***');
     expect(text.trimStart().startsWith('{')).toBe(false);
+
+    const observations = log.list().filter((evt) => evt.kind === 'ObservationEvent');
+    expect(observations).toHaveLength(1);
+    const observation = observations[0] as unknown as { observation?: Record<string, unknown> };
+    expect(JSON.stringify(observation.observation)).not.toContain(secretValue);
+    expect(JSON.stringify(observation.observation)).toContain('***');
   });
 
   it('masks uppercase secrets even when they resemble env var names', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -93,7 +93,7 @@ describe('Agent tool message formatting', () => {
     expect(JSON.stringify(observation.observation)).toContain('***');
   });
 
-  it('preserves non-plain tool results in ObservationEvent payloads', async () => {
+  it('serializes non-plain tool results in ObservationEvent payloads', async () => {
     const settings: OpenHandsSettings = {
       llm: { model: 'test-model' },
       agent: {},
@@ -128,9 +128,9 @@ describe('Agent tool message formatting', () => {
 
     const observations = log.list().filter((evt) => evt.kind === 'ObservationEvent');
     expect(observations).toHaveLength(1);
-    const observation = observations[0] as unknown as { observation?: Record<string, unknown> };
-    expect(observation.observation?.value).toBeInstanceOf(Date);
-    expect(JSON.stringify(observation.observation)).toContain('2025-01-02T03:04:05.000Z');
+    const observation = observations[0] as unknown as { observation?: unknown };
+    expect(observation.observation).toBeTypeOf('string');
+    expect(String(observation.observation)).toContain('2025-01-02T03:04:05.000Z');
   });
 
   it('masks secrets inside class-instance tool results in ObservationEvent payloads', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -93,6 +93,46 @@ describe('Agent tool message formatting', () => {
     expect(JSON.stringify(observation.observation)).toContain('***');
   });
 
+  it('preserves non-plain tool results in ObservationEvent payloads', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const log = new EventLog();
+    const date = new Date('2025-01-02T03:04:05.000Z');
+
+    const tool: ToolDefinition<Record<string, unknown>, unknown> = {
+      name: 'date_tool',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => date,
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Returning a date' },
+      { type: 'tool_call_delta', id: 'call_date', name: 'date_tool', arguments: '{}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run date tool');
+
+    const observations = log.list().filter((evt) => evt.kind === 'ObservationEvent');
+    expect(observations).toHaveLength(1);
+    const observation = observations[0] as unknown as { observation?: Record<string, unknown> };
+    expect(observation.observation?.value).toBeInstanceOf(Date);
+    expect(JSON.stringify(observation.observation)).toContain('2025-01-02T03:04:05.000Z');
+  });
+
   it('masks uppercase secrets even when they resemble env var names', async () => {
     const secretValue = 'TOPSECRETUPPERCASE1234567890';
     const envKey = secretValue;


### PR DESCRIPTION
Masks secret values in ObservationEvent payloads before persisting to EventLog/UI.

- Recursively masks string values using existing SecretRegistry + heuristics
- Adds regression test to ensure ObservationEvent is redacted

Beads: oh-tab-32z

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Secrets are now consistently redacted from tool results and observation payloads; circular structures are handled safely and non-plain values (e.g., dates, class instances) are preserved while still masking sensitive fields.

* **Tests**
  * Expanded test coverage validating masking, truncation, circular-reference handling, preservation/serialization of non-plain values, and various secret formats and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->