### PR TITLE
oh-tab-c43: Add Conversation factory cross-tests

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/Conversation.factory.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/Conversation.factory.test.ts
@@ -1,0 +1,100 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileEditorTool } from '../../tools';
+import type { Event } from '../types';
+import { isActionEvent, isMessageEvent, isObservationEvent } from '../types';
+import type { OpenHandsSettings } from '../types/settings';
+import { Conversation, LocalConversation, RemoteConversation } from './index';
+
+vi.mock('../llm', async () => {
+  const actual = await vi.importActual<typeof import('../llm')>('../llm');
+
+  class MockLLMFactory {
+    createClient() {
+      let callIndex = 0;
+      const sequences = [
+        [
+          { type: 'text', text: 'Creating file' },
+          {
+            type: 'tool_call_delta',
+            id: 'call_1',
+            name: 'file_editor',
+            arguments: JSON.stringify({ command: 'create', path: 'hello.py', file_text: 'print("Hello, World!")' }),
+          },
+          { type: 'finish' },
+        ],
+        [{ type: 'text', text: 'Done' }, { type: 'finish' }],
+      ];
+
+      return {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async *streamChat(_request: unknown) {
+          void _request;
+          const next = sequences[callIndex] ?? [];
+          callIndex += 1;
+          for (const chunk of next) {
+            yield chunk;
+          }
+        },
+      };
+    }
+  }
+
+  return { ...actual, LLMFactory: MockLLMFactory };
+});
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 5 },
+  confirmation: {},
+  secrets: {},
+};
+
+const created: string[] = [];
+
+afterEach(() => {
+  for (const dir of created) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  created.length = 0;
+});
+
+describe('Conversation factory', () => {
+  it('returns LocalConversation when serverUrl is omitted', () => {
+    const conversation = Conversation({ settings: baseSettings });
+    expect(conversation.mode).toBe('local');
+    expect(conversation).toBeInstanceOf(LocalConversation);
+  });
+
+  it('returns RemoteConversation when serverUrl is provided', () => {
+    const conversation = Conversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+    expect(conversation.mode).toBe('remote');
+    expect(conversation).toBeInstanceOf(RemoteConversation);
+  });
+
+  it('supports local hello-world tool flow via Conversation()', async () => {
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'conversation-factory-'));
+    created.push(workspaceRoot);
+
+    const conversation = Conversation({
+      settings: baseSettings,
+      workspaceRoot,
+      tools: [new FileEditorTool()],
+    });
+
+    const events: Event[] = [];
+    conversation.on('event', (event: Event) => events.push(event));
+
+    await conversation.sendUserMessage('Create hello.py');
+
+    expect(events.some(isActionEvent)).toBe(true);
+    expect(events.some(isObservationEvent)).toBe(true);
+    expect(events.some(isMessageEvent)).toBe(true);
+
+    const filePath = path.join(workspaceRoot, 'hello.py');
+    expect(fs.readFileSync(filePath, 'utf8')).toContain('Hello, World!');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/conversation/Conversation.factory.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/Conversation.factory.test.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -55,10 +55,8 @@ const baseSettings: OpenHandsSettings = {
 
 const created: string[] = [];
 
-afterEach(() => {
-  for (const dir of created) {
-    fs.rmSync(dir, { recursive: true, force: true });
-  }
+afterEach(async () => {
+  await Promise.all(created.map((dir) => fs.rm(dir, { recursive: true, force: true })));
   created.length = 0;
 });
 
@@ -76,7 +74,7 @@ describe('Conversation factory', () => {
   });
 
   it('supports local hello-world tool flow via Conversation()', async () => {
-    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'conversation-factory-'));
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'conversation-factory-'));
     created.push(workspaceRoot);
 
     const conversation = Conversation({
@@ -95,6 +93,7 @@ describe('Conversation factory', () => {
     expect(events.some(isMessageEvent)).toBe(true);
 
     const filePath = path.join(workspaceRoot, 'hello.py');
-    expect(fs.readFileSync(filePath, 'utf8')).toContain('Hello, World!');
+    const fileContent = await fs.readFile(filePath, 'utf8');
+    expect(fileContent).toContain('Hello, World!');
   });
 });


### PR DESCRIPTION
Adds a small cross-suite Vitest that exercises the Conversation factory (local vs remote) plus a minimal local hello-world tool flow via mocked LLMFactory.

- Beads: closed oh-tab-c43
- Tests: npm test -w @openhands/agent-sdk-ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for the Conversation factory covering local vs remote conversation creation.
  * Mocks LLM streaming (including tool-invoked file edits) and validates emitted events (actions, observations, messages).
  * Verifies end-to-end local flow where a file is created with expected content and cleans up test artifacts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->