### PR TITLE
oh-tab-94f: Best-effort TOCTOU hardening for LocalWorkspace

### DIFF
--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import type { SpawnOptions } from 'child_process';
 import * as fs from 'fs';
-import { readFile as readFileAsync, mkdir, rm, readdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import path from 'path';
 import os from 'os';
 
@@ -164,6 +164,38 @@ export class LocalWorkspace {
       }
     }
     return best;
+  }
+
+  private static isContainedInRoot(root: string, candidate: string): boolean {
+    const relative = path.relative(root, candidate);
+    return (
+      relative === ''
+      || (!relative.startsWith(`..${path.sep}`) && relative !== '..' && !path.isAbsolute(relative))
+    );
+  }
+
+  private async resolveOpenedPath(fd: number, fallbackPath: string): Promise<string | null> {
+    if (os.platform() !== 'win32') {
+      const candidates = [`/proc/self/fd/${fd}`, `/dev/fd/${fd}`];
+      for (const candidate of candidates) {
+        try {
+          const resolved = await fs.promises.realpath(candidate);
+          // macOS `realpath(/dev/fd/<n>)` can return a synthetic `/dev/fd/<name>` path
+          // that does not reflect the underlying file location; fall back to resolving
+          // the original path in that case.
+          if (resolved.startsWith('/dev/fd/')) continue;
+          return resolved;
+        } catch {
+          // Ignore.
+        }
+      }
+    }
+
+    try {
+      return await fs.promises.realpath(fallbackPath);
+    } catch {
+      return null;
+    }
   }
 
   private async ensureSafeDirectory(root: string, dirPath: string): Promise<void> {
@@ -418,7 +450,25 @@ export class LocalWorkspace {
 
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
-    return readFileAsync(resolved, encoding);
+    const root = this.getContainingDirRoot(resolved);
+
+    const constants = fs.constants as Record<string, number>;
+    const noFollow =
+      os.platform() === 'win32'
+        ? 0
+        : typeof constants.O_NOFOLLOW === 'number'
+          ? constants.O_NOFOLLOW
+          : 0;
+    const handle = await fs.promises.open(resolved, constants.O_RDONLY | noFollow);
+    try {
+      const openedPath = await this.resolveOpenedPath(handle.fd, resolved);
+      if (root && openedPath && !LocalWorkspace.isContainedInRoot(root, openedPath)) {
+        throw new Error(`Path escapes workspace root: ${targetPath}`);
+      }
+      return await handle.readFile({ encoding });
+    } finally {
+      await handle.close();
+    }
   }
 
   async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
@@ -451,17 +501,49 @@ export class LocalWorkspace {
 
   async remove(targetPath: string): Promise<void> {
     const resolved = this.resolvePath(targetPath);
+    try {
+      await fs.promises.lstat(resolved);
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    }
+
+    const root = this.getContainingDirRoot(resolved);
+    if (root) {
+      const parentDir = path.dirname(resolved);
+      const canonicalParentDir = await fs.promises.realpath(parentDir);
+      if (!LocalWorkspace.isContainedInRoot(root, canonicalParentDir)) {
+        throw new Error(`Path escapes workspace root: ${targetPath}`);
+      }
+    }
+
     await rm(resolved, { force: true, recursive: true });
   }
 
   async list(targetPath = '.'): Promise<DirectoryEntry[]> {
     const resolved = this.resolvePath(targetPath);
-    const entries = await readdir(resolved, { withFileTypes: true });
-    return entries.map((entry) => ({
-      name: entry.name,
-      path: path.join(targetPath, entry.name),
-      isDirectory: entry.isDirectory(),
-    }));
+    const root = this.getContainingDirRoot(resolved);
+    const dir = await fs.promises.opendir(resolved);
+    try {
+      const openedPath = await this.resolveOpenedPath((dir as unknown as { fd?: number }).fd ?? -1, resolved);
+      if (root && openedPath && !LocalWorkspace.isContainedInRoot(root, openedPath)) {
+        throw new Error(`Path escapes workspace root: ${targetPath}`);
+      }
+
+      const entries: DirectoryEntry[] = [];
+      for await (const entry of dir) {
+        entries.push({
+          name: entry.name,
+          path: path.join(targetPath, entry.name),
+          isDirectory: entry.isDirectory(),
+        });
+      }
+      return entries;
+    } finally {
+      await dir.close();
+    }
   }
 
   async ensureDirectory(targetPath: string): Promise<string> {

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -527,6 +527,10 @@ export class LocalWorkspace {
     const root = this.getContainingDirRoot(resolved);
     const dir = await fs.promises.opendir(resolved);
     try {
+      // NOTE: `fs.Dir` does not document an `fd` property, but Node currently exposes it.
+      // We intentionally use it as best-effort defense-in-depth to verify that the opened
+      // directory handle still resolves within the workspace root after opendir().
+      // If unavailable, `resolveOpenedPath` will fall back to a path-based check.
       const openedPath = await this.resolveOpenedPath((dir as unknown as { fd?: number }).fd ?? -1, resolved);
       if (root && openedPath && !LocalWorkspace.isContainedInRoot(root, openedPath)) {
         throw new Error(`Path escapes workspace root: ${targetPath}`);

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -277,6 +277,83 @@ describe('LocalWorkspace', () => {
         lstatSpy.mockRestore();
       }
     });
+
+    it('rejects reads when the parent becomes a symlink mid-read', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      await workspace.ensureDirectory('parent');
+      await workspace.writeFile('parent/inside.txt', 'hello');
+
+      const canonicalFilePath = workspace.resolvePath('parent/inside.txt');
+      const canonicalParentDir = path.dirname(canonicalFilePath);
+
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-read-'));
+      created.push(redirectDir);
+      await fs.promises.writeFile(path.join(redirectDir, 'inside.txt'), 'outside', 'utf8');
+
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
+
+      const originalOpen = fs.promises.open;
+      const openSpy = vi.spyOn(fs.promises, 'open').mockImplementation(async (target, ...args) => {
+        const targetString = target instanceof Buffer ? target.toString() : String(target);
+        if (!swapped && targetString === canonicalFilePath) {
+          await swapParent();
+        }
+        return originalOpen.call(fs.promises, target as never, ...(args as never[]));
+      });
+
+      try {
+        await expect(workspace.readFile('parent/inside.txt')).rejects.toThrowError(/symlink|escapes|Path escapes/i);
+      } finally {
+        openSpy.mockRestore();
+      }
+    });
+
+    it('rejects directory listings when the directory becomes a symlink mid-list', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      await workspace.ensureDirectory('parent');
+      await workspace.writeFile('parent/inside.txt', 'hello');
+
+      const canonicalParentDir = workspace.resolvePath('parent');
+
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-list-'));
+      created.push(redirectDir);
+      await fs.promises.writeFile(path.join(redirectDir, 'inside.txt'), 'outside', 'utf8');
+
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
+
+      const originalOpendir = fs.promises.opendir;
+      const opendirSpy = vi.spyOn(fs.promises, 'opendir').mockImplementation(async (target, ...args) => {
+        const targetString = target instanceof Buffer ? target.toString() : String(target);
+        if (!swapped && targetString === canonicalParentDir) {
+          await swapParent();
+        }
+        return originalOpendir.call(fs.promises, target as never, ...(args as never[]));
+      });
+
+      try {
+        await expect(workspace.list('parent')).rejects.toThrowError(/symlink|escapes|Path escapes/i);
+      } finally {
+        opendirSpy.mockRestore();
+      }
+    });
   });
 
   describe('commands', () => {


### PR DESCRIPTION
This PR is a **best-effort** (pure Node) hardening pass for the remaining TOCTOU/symlink-swap window in `LocalWorkspace` file ops.

Changes
- Harden `LocalWorkspace.readFile` and `LocalWorkspace.list` by adding post-open containment verification (fd-based when possible; fallback to resolving the original path).
- Harden `LocalWorkspace.remove` with an existence guard + parent canonicalization check (still best-effort; cannot anchor unlink/rm to a dirfd in Node).
- Add deterministic tests for mid-read and mid-list parent→symlink swaps.

Notes / limitations
- This does **not** provide a true dirfd/openat solution; Node’s fs APIs don’t expose unlinkat/openat-style primitives.
- Intended as defense-in-depth for VS Code local mode; needs a human call on whether this is “good enough” vs deferring to a native helper.

Beads: oh-tab-94f
Local verification: npm test -w @openhands/agent-sdk-ts && npm run lint -w @openhands/agent-sdk-ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of workspace file reading, directory listing, and removal operations with enhanced validation and better error handling for edge cases.

* **Tests**
  * Added tests for workspace operation edge cases and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->