### PR TITLE
Fix LLM registry collision on settings change

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -47,7 +47,7 @@ describe('LLMRegistry and TrackedLLMClient', () => {
     expect(() => registry.add(t2)).toThrow(/already exists/);
   });
 
-  it('can upsert a usageId and updates the registry entry', async () => {
+  it('can switch a usageId and updates the registry entry', async () => {
     const registry = new LLMRegistry();
     const events: string[] = [];
     registry.subscribe((e) => events.push(`${e.llm.usageId}:${e.llm.modelName}`));

--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -56,11 +56,12 @@ describe('LLMRegistry and TrackedLLMClient', () => {
     const c1 = await factory1.createClient();
     expect(registry.get('default-llm')).toBe(c1);
 
-    const factory2 = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline2', usageId: 'default-llm' }, { registry });
+    const factory2 = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', apiKey: 'sk-inline2', usageId: 'default-llm' }, { registry });
     const c2 = await factory2.createClient();
+    expect(c2).not.toBe(c1);
     expect(registry.get('default-llm')).toBe(c2);
 
-    expect(events).toEqual(['default-llm:gpt-5-mini', 'default-llm:gpt-5-mini']);
+    expect(events).toEqual(['default-llm:gpt-5-mini', 'default-llm:gpt-4o-mini']);
   });
 
   it('notifies subscriber and ConversationStats can register', () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { LLMRegistry, TrackedLLMClient } from '../llm/registry';
+import { LLMFactory } from '../llm/factory';
 import type { LLMClient, LLMStreamChunk } from '../llm/types';
 import { Metrics } from '../llm/metrics';
 
@@ -44,6 +45,22 @@ describe('LLMRegistry and TrackedLLMClient', () => {
     const t2 = new TrackedLLMClient({ inner: { async *streamChat() {} }, usageId: 'dup', modelName: 'm', metrics: new Metrics('m') });
     registry.add(t1);
     expect(() => registry.add(t2)).toThrow(/already exists/);
+  });
+
+  it('can upsert a usageId and updates the registry entry', async () => {
+    const registry = new LLMRegistry();
+    const events: string[] = [];
+    registry.subscribe((e) => events.push(`${e.llm.usageId}:${e.llm.modelName}`));
+
+    const factory1 = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline', usageId: 'default-llm' }, { registry });
+    const c1 = await factory1.createClient();
+    expect(registry.get('default-llm')).toBe(c1);
+
+    const factory2 = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline2', usageId: 'default-llm' }, { registry });
+    const c2 = await factory2.createClient();
+    expect(registry.get('default-llm')).toBe(c2);
+
+    expect(events).toEqual(['default-llm:gpt-5-mini', 'default-llm:gpt-5-mini']);
   });
 
   it('notifies subscriber and ConversationStats can register', () => {

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -47,7 +47,7 @@ export class LLMFactory {
     if (this.config.usageId) {
       const metrics = new Metrics(this.config.model);
       const tracked = new TrackedLLMClient({ inner: base, usageId: this.config.usageId, modelName: this.config.model, metrics, onMetricsUpdate: this.onMetricsUpdate });
-      this.registry?.upsert(tracked);
+      this.registry?.switchLlm(tracked);
       return tracked;
     }
 

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -47,7 +47,7 @@ export class LLMFactory {
     if (this.config.usageId) {
       const metrics = new Metrics(this.config.model);
       const tracked = new TrackedLLMClient({ inner: base, usageId: this.config.usageId, modelName: this.config.model, metrics, onMetricsUpdate: this.onMetricsUpdate });
-      this.registry?.add(tracked);
+      this.registry?.upsert(tracked);
       return tracked;
     }
 

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -23,6 +23,11 @@ export class LLMRegistry {
   add(llm: TrackedLLMClient): void {
     const id = llm.usageId;
     if (this.usageToLLM.has(id)) throw new Error(`Usage ID '${id}' already exists in registry`);
+    this.upsert(llm);
+  }
+
+  upsert(llm: TrackedLLMClient): void {
+    const id = llm.usageId;
     this.usageToLLM.set(id, llm);
     this.notify({ llm });
   }

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -23,10 +23,10 @@ export class LLMRegistry {
   add(llm: TrackedLLMClient): void {
     const id = llm.usageId;
     if (this.usageToLLM.has(id)) throw new Error(`Usage ID '${id}' already exists in registry`);
-    this.upsert(llm);
+    this.switchLlm(llm);
   }
 
-  upsert(llm: TrackedLLMClient): void {
+  switchLlm(llm: TrackedLLMClient): void {
     const id = llm.usageId;
     this.usageToLLM.set(id, llm);
     this.notify({ llm });


### PR DESCRIPTION
Allows replacing an existing tracked LLM client for the same usageId (e.g. "default-llm") so switching provider/model in settings doesn't error.
- Add LLMRegistry.switchLlm() and use it from LLMFactory
- Add unit coverage for re-registering the same usageId
 
Repro: change LLM provider in VS Code settings mid-session, then send a new prompt -> previously threw "Usage ID 'default-llm' already exists in registry".
