### PR TITLE
Increase file_editor view output and fix dev launch task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,7 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "npm: compile"
+      "preLaunchTask": "npm: build"
     },
     {
       "type": "extensionHost",
@@ -26,7 +26,7 @@
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "npm: compile"
+      "preLaunchTask": "npm: build"
     },
     {
       "name": "OH-Tab-Tests",
@@ -42,7 +42,7 @@
         "${workspaceFolder}/dist/test/**/*.js",
         "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "npm: compile"
+      "preLaunchTask": "npm: build"
     }
   ]
 }

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -20,6 +20,8 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const MAX_INLINE_IMAGE_BASE64_CHARS = 4 * 1024 * 1024;
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
 const PDF_EXTENSION = '.pdf';
+const MAX_OUTPUT_CHARS = 8_000;
+const OUTPUT_CLIP_MARKER = '<response clipped>';
 
 const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
@@ -120,11 +122,13 @@ const addLineNumbers = (content: string): string => {
   return lines.map((line, idx) => `${idx + 1}\t${line}`).join('\n');
 };
 
-const truncateContent = (content: string, limit = 500): string => {
-  if (content.length <= limit * 2) return content;
-  const head = content.slice(0, limit);
-  const tail = content.slice(-limit);
-  return `${head}\n<response clipped>\n${tail}`;
+const truncateContent = (content: string, maxChars = MAX_OUTPUT_CHARS): string => {
+  if (content.length <= maxChars) return content;
+  const available = maxChars - OUTPUT_CLIP_MARKER.length - 2;
+  const half = Math.max(0, Math.floor(available / 2));
+  const head = content.slice(0, half);
+  const tail = content.slice(-half);
+  return `${head}\n${OUTPUT_CLIP_MARKER}\n${tail}`;
 };
 
 const isProbablyBinary = (buffer: Buffer): boolean => {

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -20,7 +20,7 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const MAX_INLINE_IMAGE_BASE64_CHARS = 4 * 1024 * 1024;
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
 const PDF_EXTENSION = '.pdf';
-const MAX_OUTPUT_CHARS = 8_000;
+const MAX_OUTPUT_CHARS = 50_000;
 const OUTPUT_CLIP_MARKER = '<response clipped>';
 
 const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -20,8 +20,8 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 const MAX_INLINE_IMAGE_BASE64_CHARS = 4 * 1024 * 1024;
 const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
 const PDF_EXTENSION = '.pdf';
-const MAX_OUTPUT_CHARS = 50_000;
-const OUTPUT_CLIP_MARKER = '<response clipped>';
+export const MAX_OUTPUT_CHARS = 50_000;
+export const OUTPUT_CLIP_MARKER = '<response clipped>';
 
 const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format
 * State is persistent across command calls and discussions with the user
@@ -124,10 +124,14 @@ const addLineNumbers = (content: string): string => {
 
 const truncateContent = (content: string, maxChars = MAX_OUTPUT_CHARS): string => {
   if (content.length <= maxChars) return content;
+  const minRequired = OUTPUT_CLIP_MARKER.length + 2;
+  if (maxChars < minRequired) {
+    return content.slice(0, maxChars);
+  }
   const available = maxChars - OUTPUT_CLIP_MARKER.length - 2;
   const half = Math.max(0, Math.floor(available / 2));
   const head = content.slice(0, half);
-  const tail = content.slice(-half);
+  const tail = content.slice(content.length - half);
   return `${head}\n${OUTPUT_CLIP_MARKER}\n${tail}`;
 };
 
@@ -162,6 +166,16 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
   readonly schema = fileEditorSchema;
   private readonly undoHistory = new Map<string, UndoEntry[]>();
   private undoBytesTotal = 0;
+  private readonly maxOutputChars: number;
+
+  constructor(options: { maxOutputChars?: number } = {}) {
+    super();
+    const configured = options.maxOutputChars;
+    this.maxOutputChars =
+      typeof configured === 'number' && Number.isFinite(configured) && configured > 0
+        ? Math.floor(configured)
+        : MAX_OUTPUT_CHARS;
+  }
 
   private async pathExists(absPath: string): Promise<boolean> {
     try {
@@ -191,7 +205,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         const content = buffer.toString('utf8');
         const ranged = applyViewRange(content, args.view_range);
         const numbered = addLineNumbers(ranged);
-        const truncated = truncateContent(numbered);
+        const truncated = truncateContent(numbered, this.maxOutputChars);
         return { command: 'view', path: resolved, prev_exist: true, old_content: content, new_content: truncated };
       }
       case 'create': {
@@ -212,7 +226,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           path: resolved,
           prev_exist: false,
           old_content: null,
-          new_content: truncateContent(fileText),
+          new_content: truncateContent(fileText, this.maxOutputChars),
         };
       }
       case 'str_replace': {
@@ -360,7 +374,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       hiddenCount > 0
         ? `\n\n${hiddenCount} hidden files/directories in the top-level directory are excluded. You can use 'ls -la ${displayRoot}' to see them.`
         : '';
-    return { text: truncateContent(`${header}${body}${hiddenNote}`) };
+    return { text: truncateContent(`${header}${body}${hiddenNote}`, this.maxOutputChars) };
   }
 
   private viewImage(absPath: string, extension: string, buffer: Buffer): FileEditorResult {

--- a/packages/agent-sdk-ts/src/tools/PlanningFileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/PlanningFileEditorTool.ts
@@ -34,7 +34,12 @@ export class PlanningFileEditorTool extends ZodTool<z.infer<typeof planningSchem
   readonly name = 'planning_file_editor';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = planningSchema;
-  private readonly fileEditor = new FileEditorTool();
+  private readonly fileEditor: FileEditorTool;
+
+  constructor(options: { maxOutputChars?: number } = {}) {
+    super();
+    this.fileEditor = new FileEditorTool(options);
+  }
 
   private ensurePlanTarget(command: PlanningCommand, resolvedPath: string): void {
     if (command === 'view') return;

--- a/packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts
@@ -160,7 +160,7 @@ describe('PlanningFileEditorTool', () => {
     created.push(dir);
     const tool = new PlanningFileEditorTool();
 
-    const longContent = Array.from({ length: 2000 }, (_, i) => `plan-line-${i + 1}`).join('\n');
+    const longContent = Array.from({ length: 10_000 }, (_, i) => `plan-line-${i + 1} ${'x'.repeat(20)}`).join('\n');
     const createArgs = tool.validate({ command: 'create', path: 'PLAN.md', file_text: longContent });
     await tool.execute(createArgs, { workspace });
 
@@ -176,12 +176,12 @@ describe('PlanningFileEditorTool', () => {
 
     // Truncation marker present for long content
     expect(viewed).toContain('<response clipped>');
-    expect(viewed.length).toBeLessThanOrEqual(8_000);
+    expect(viewed.length).toBeLessThanOrEqual(50_000);
 
     const parts = viewed.split('\n<response clipped>\n');
     expect(parts.length).toBe(2);
     const [head, tail] = parts;
-    const maxChars = 8_000;
+    const maxChars = 50_000;
     const clipMarker = '<response clipped>';
     const half = Math.floor((maxChars - clipMarker.length - 2) / 2);
     expect(head.length).toBeLessThanOrEqual(half);

--- a/packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts
@@ -176,12 +176,16 @@ describe('PlanningFileEditorTool', () => {
 
     // Truncation marker present for long content
     expect(viewed).toContain('<response clipped>');
+    expect(viewed.length).toBeLessThanOrEqual(8_000);
 
     const parts = viewed.split('\n<response clipped>\n');
     expect(parts.length).toBe(2);
     const [head, tail] = parts;
-    expect(head.length).toBeLessThanOrEqual(500 + 20);
-    expect(tail.length).toBeLessThanOrEqual(500 + 20);
+    const maxChars = 8_000;
+    const clipMarker = '<response clipped>';
+    const half = Math.floor((maxChars - clipMarker.length - 2) / 2);
+    expect(head.length).toBeLessThanOrEqual(half);
+    expect(tail.length).toBeLessThanOrEqual(half);
   });
 
   it('rejects create when file already exists', async () => {

--- a/packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts
@@ -8,6 +8,7 @@ import {
   DelegateTool,
   GlobTool,
   GrepTool,
+  OUTPUT_CLIP_MARKER,
   PlanningFileEditorTool,
   ZodTool,
 } from '..';
@@ -158,9 +159,10 @@ describe('PlanningFileEditorTool', () => {
   it('views PLAN.md with line numbers and truncation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
-    const tool = new PlanningFileEditorTool();
+    const maxOutputChars = 2_000;
+    const tool = new PlanningFileEditorTool({ maxOutputChars });
 
-    const longContent = Array.from({ length: 10_000 }, (_, i) => `plan-line-${i + 1} ${'x'.repeat(20)}`).join('\n');
+    const longContent = Array.from({ length: 500 }, (_, i) => `plan-line-${i + 1} ${'x'.repeat(20)}`).join('\n');
     const createArgs = tool.validate({ command: 'create', path: 'PLAN.md', file_text: longContent });
     await tool.execute(createArgs, { workspace });
 
@@ -175,15 +177,13 @@ describe('PlanningFileEditorTool', () => {
     expect(viewed.startsWith('1\tplan-line-1')).toBe(true);
 
     // Truncation marker present for long content
-    expect(viewed).toContain('<response clipped>');
-    expect(viewed.length).toBeLessThanOrEqual(50_000);
+    expect(viewed).toContain(OUTPUT_CLIP_MARKER);
+    expect(viewed.length).toBeLessThanOrEqual(maxOutputChars);
 
-    const parts = viewed.split('\n<response clipped>\n');
+    const parts = viewed.split(`\n${OUTPUT_CLIP_MARKER}\n`);
     expect(parts.length).toBe(2);
     const [head, tail] = parts;
-    const maxChars = 50_000;
-    const clipMarker = '<response clipped>';
-    const half = Math.floor((maxChars - clipMarker.length - 2) / 2);
+    const half = Math.floor((maxOutputChars - OUTPUT_CLIP_MARKER.length - 2) / 2);
     expect(head.length).toBeLessThanOrEqual(half);
     expect(tail.length).toBeLessThanOrEqual(half);
   });

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { describe, expect, it, afterEach } from 'vitest';
-import { BrowserTool, FileEditorTool, TaskTrackerTool, TerminalTool } from '..';
+import { BrowserTool, FileEditorTool, OUTPUT_CLIP_MARKER, TaskTrackerTool, TerminalTool } from '..';
 import { LocalWorkspace } from '../../workspace';
 
 const makeWorkspace = async () => {
@@ -88,9 +88,10 @@ describe('FileEditorTool', () => {
   it('views files with line numbers and truncation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
-    const tool = new FileEditorTool();
+    const maxOutputChars = 2_000;
+    const tool = new FileEditorTool({ maxOutputChars });
 
-    const longContent = Array.from({ length: 10_000 }, (_, i) => `line-${i + 1} ${'x'.repeat(20)}`).join('\n');
+    const longContent = Array.from({ length: 500 }, (_, i) => `line-${i + 1} ${'x'.repeat(20)}`).join('\n');
     const createArgs = tool.validate({ command: 'create', path: 'note.txt', file_text: longContent });
     await tool.execute(createArgs, { workspace });
 
@@ -105,15 +106,13 @@ describe('FileEditorTool', () => {
     expect(viewed.startsWith('1\tline-1')).toBe(true);
 
     // Truncation marker present for long content
-    expect(viewed).toContain('<response clipped>');
-    expect(viewed.length).toBeLessThanOrEqual(50_000);
+    expect(viewed).toContain(OUTPUT_CLIP_MARKER);
+    expect(viewed.length).toBeLessThanOrEqual(maxOutputChars);
 
-    const parts = viewed.split('\n<response clipped>\n');
+    const parts = viewed.split(`\n${OUTPUT_CLIP_MARKER}\n`);
     expect(parts.length).toBe(2);
     const [head, tail] = parts;
-    const maxChars = 50_000;
-    const clipMarker = '<response clipped>';
-    const half = Math.floor((maxChars - clipMarker.length - 2) / 2);
+    const half = Math.floor((maxOutputChars - OUTPUT_CLIP_MARKER.length - 2) / 2);
     expect(head.length).toBeLessThanOrEqual(half);
     expect(tail.length).toBeLessThanOrEqual(half);
   });

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -90,7 +90,7 @@ describe('FileEditorTool', () => {
     created.push(dir);
     const tool = new FileEditorTool();
 
-    const longContent = Array.from({ length: 2000 }, (_, i) => `line-${i + 1}`).join('\n');
+    const longContent = Array.from({ length: 10_000 }, (_, i) => `line-${i + 1} ${'x'.repeat(20)}`).join('\n');
     const createArgs = tool.validate({ command: 'create', path: 'note.txt', file_text: longContent });
     await tool.execute(createArgs, { workspace });
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -106,7 +106,7 @@ describe('FileEditorTool', () => {
 
     // Truncation marker present for long content
     expect(viewed).toContain('<response clipped>');
-    expect(viewed.length).toBeLessThanOrEqual(8_000);
+    expect(viewed.length).toBeLessThanOrEqual(50_000);
 
     const parts = viewed.split('\n<response clipped>\n');
     expect(parts.length).toBe(2);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -111,7 +111,7 @@ describe('FileEditorTool', () => {
     const parts = viewed.split('\n<response clipped>\n');
     expect(parts.length).toBe(2);
     const [head, tail] = parts;
-    const maxChars = 8_000;
+    const maxChars = 50_000;
     const clipMarker = '<response clipped>';
     const half = Math.floor((maxChars - clipMarker.length - 2) / 2);
     expect(head.length).toBeLessThanOrEqual(half);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -106,12 +106,16 @@ describe('FileEditorTool', () => {
 
     // Truncation marker present for long content
     expect(viewed).toContain('<response clipped>');
+    expect(viewed.length).toBeLessThanOrEqual(8_000);
 
     const parts = viewed.split('\n<response clipped>\n');
     expect(parts.length).toBe(2);
     const [head, tail] = parts;
-    expect(head.length).toBeLessThanOrEqual(500 + 20); // small slop for line boundaries
-    expect(tail.length).toBeLessThanOrEqual(500 + 20);
+    const maxChars = 8_000;
+    const clipMarker = '<response clipped>';
+    const half = Math.floor((maxChars - clipMarker.length - 2) / 2);
+    expect(head.length).toBeLessThanOrEqual(half);
+    expect(tail.length).toBeLessThanOrEqual(half);
   });
 
   it('views directories up to 2 levels deep, excluding hidden items', async () => {


### PR DESCRIPTION
Two small dev UX fixes discovered while debugging agent runs:

1) FileEditorTool `view` output was truncated very aggressively (500 head/tail chars), which clips docs like `AGENTS.md` mid-sentence. Truncation is now capped at 8k total (same `<response clipped>` marker) so agents can read substantially more before needing `view_range`.

2) VS Code `.vscode/launch.json` now uses `npm: build` as `preLaunchTask` so the workspace `@openhands/agent-sdk-ts` `dist/` is rebuilt before running the extension host (prevents stale-SDK behavior after pulls).

Tests: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased file editor tool output limit to 50,000 characters and standardized truncation with a visible clip marker.

* **Tests**
  * Updated test cases to validate the new 50,000-character output cap and adjusted truncation boundary checks.

* **Chores**
  * Updated VS Code launch configurations to use the build pre-launch task.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->