### PR TITLE
Fix llm_stream carrying over between responses

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -53,6 +53,38 @@ describe('OpenAICompatibleClient streaming', () => {
     expect(state.snapshot.values.llm_tool_call).toBe('call_1');
   });
 
+  it('does not prepend previous llm_stream content on subsequent chats', async () => {
+    const first = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Hello"}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+    const second = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Bye"}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(createStreamResponse(first))
+      .mockResolvedValueOnce(createStreamResponse(second));
+
+    const state = new ConversationState({ eventLog: new EventLog() });
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key');
+    const orchestrator = new AgentOrchestrator(client, { state });
+
+    const response1 = await orchestrator.runChat(buildRequest());
+    expect(response1.message.content[0]).toEqual({ type: 'text', text: 'Hello' });
+    expect(state.snapshot.values.llm_stream).toBe('Hello');
+
+    const response2 = await orchestrator.runChat(buildRequest());
+    expect(response2.message.content[0]).toEqual({ type: 'text', text: 'Bye' });
+    expect(state.snapshot.values.llm_stream).toBe('Bye');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('retries on server errors', async () => {
     const stream = 'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Hi"}]},"finish_reason":"stop"}]}' + '\n' + 'data: [DONE]';
     const fetchMock = vi

--- a/packages/agent-sdk-ts/src/sdk/runtime/AgentOrchestrator.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/AgentOrchestrator.ts
@@ -22,9 +22,10 @@ export class AgentOrchestrator {
     const message: Message = { role: 'assistant', content: [] };
     const toolCalls: Record<string, ToolCall> = {};
     let usage: LLMResponse['usage'];
+    let streamText = '';
 
     for await (const chunk of this.llm.streamChat(request)) {
-      this.applyStateUpdate(chunk);
+      streamText = this.applyStateUpdate(chunk, streamText);
       switch (chunk.type) {
         case 'text': {
           const existingText = message.content.find((item) => item.type === 'text');
@@ -71,15 +72,17 @@ export class AgentOrchestrator {
     return { message, usage };
   }
 
-  private applyStateUpdate(chunk: LLMStreamChunk): void {
+  private applyStateUpdate(chunk: LLMStreamChunk, streamText: string): string {
     switch (chunk.type) {
-      case 'text':
+      case 'text': {
+        const nextText = `${streamText}${chunk.text}`;
         this.state.setValue(
           'llm_stream',
-          `${typeof this.state.snapshot.values.llm_stream === 'string' ? this.state.snapshot.values.llm_stream : ''}${chunk.text}`,
+          nextText,
           false,
         );
-        break;
+        return nextText;
+      }
       case 'tool_call_delta':
         this.state.setValue('llm_tool_call', chunk.id, false);
         break;
@@ -94,5 +97,7 @@ export class AgentOrchestrator {
       default:
         break;
     }
+
+    return streamText;
   }
 }


### PR DESCRIPTION
Fixes a UX bug where, during streaming, the webview temporarily showed the previous assistant response text prefixed to the new response.

Root cause: AgentOrchestrator built `llm_stream` by appending to `state.snapshot.values.llm_stream`, which still contained the prior response.

Change:
- Track streamed text per `runChat()` invocation and set `llm_stream` from that accumulator.

Tests:
- Added a regression test ensuring consecutive chats don’t prepend prior `llm_stream` content.

Run locally: `npm test`
