### PR TITLE
Fix remote-mode switch restore + server URL normalization

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -188,4 +188,50 @@ describe('RemoteConversation', () => {
     expect(received.map((e) => e.id)).toEqual(['e-1', 'e-2', 'e-3']);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toMatch(/^http:\/\/localhost:3000\//);
+      expect(url).toContain('/events/search');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [], next_page_id: null }),
+        text: async () => '',
+      } as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    const ws = getEventWS();
+    expect(ws.url).toMatch(/^ws:\/\/localhost:3000\/sockets\/events\/abc\?/);
+    expect(ws.url).toContain('resend_all=true');
+  });
+
+  it('does not attempt WebSocket connect when history fetch fails', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('fetch failed');
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    const statuses: string[] = [];
+    const errors: unknown[] = [];
+    conversation.on('status', (s) => statuses.push(s));
+    conversation.on('error', (e) => errors.push(e));
+
+    await conversation.restoreConversation('abc');
+
+    expect(conversation.getStatus()).toBe('offline');
+    expect(statuses).toContain('connecting');
+    expect(statuses).toContain('offline');
+    expect(errors).toHaveLength(1);
+    expect(wsInstances).toHaveLength(0);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -11,6 +11,17 @@ interface ConversationHistoryPage {
   next_page_id?: string | null;
 }
 
+const normalizeRemoteServerUrl = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (!trimmed) return trimmed;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
+    if (trimmed.startsWith('ws://')) return `http://${trimmed.slice('ws://'.length)}`.replace(/\/+$/, '');
+    if (trimmed.startsWith('wss://')) return `https://${trimmed.slice('wss://'.length)}`.replace(/\/+$/, '');
+    return trimmed.replace(/\/+$/, '');
+  }
+  return `http://${trimmed}`.replace(/\/+$/, '');
+};
+
 export interface RemoteConversationOptions {
   serverUrl: string;
   settings: OpenHandsSettings;
@@ -46,14 +57,18 @@ export class RemoteConversation extends EventEmitter {
 
   constructor(options: RemoteConversationOptions) {
     super();
-    this.serverUrl = options.serverUrl;
+    this.serverUrl = normalizeRemoteServerUrl(options.serverUrl);
     this.settings = options.settings;
     this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
       this.emit('conversationStarted', this.conversationId);
-      void this.replayHistory().then(() => {
+      void this.replayHistory().then((ok) => {
+        if (!ok) {
+          this.setStatus('offline');
+          return;
+        }
         if (this.conversationId === options.conversationId) {
           this.connect();
         }
@@ -74,7 +89,7 @@ export class RemoteConversation extends EventEmitter {
   }
 
   setServerUrl(url: string) {
-    this.serverUrl = url;
+    this.serverUrl = normalizeRemoteServerUrl(url);
   }
 
     async startNewConversation(): Promise<string | undefined> {
@@ -196,8 +211,13 @@ export class RemoteConversation extends EventEmitter {
   async restoreConversation(id: string) {
     this.conversationId = id;
     this.seenEventIds.clear();
+    this.setStatus('connecting');
     this.emit('conversationStarted', id);
-    await this.replayHistory();
+    const ok = await this.replayHistory();
+    if (!ok) {
+      this.setStatus('offline');
+      return;
+    }
     this.connect();
   }
 
@@ -435,8 +455,8 @@ export class RemoteConversation extends EventEmitter {
     this.emit('event', event);
   }
 
-  private async replayHistory(): Promise<void> {
-    if (!this.conversationId) return;
+  private async replayHistory(): Promise<boolean> {
+    if (!this.conversationId) return true;
     const base = this.serverUrl.replace(/\/$/, '');
     const headers = this.getAuthHeaders();
     let pageId: string | undefined;
@@ -448,7 +468,7 @@ export class RemoteConversation extends EventEmitter {
         if (!res.ok) {
           const info = await res.text().catch(() => '');
           this.emit('error', new Error(`Failed to fetch conversation history (HTTP ${res.status})${info ? `: ${info}` : ''}`));
-          return;
+          return false;
         }
         const body = await res.json() as ConversationHistoryPage;
         const items = Array.isArray(body.items) ? body.items : [];
@@ -462,8 +482,10 @@ export class RemoteConversation extends EventEmitter {
         if (!next || typeof next !== 'string') break;
         pageId = next;
       }
+      return true;
     } catch (e) {
       this.emit('error', e instanceof Error ? e : new Error(String(e)));
+      return false;
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -12,14 +12,14 @@ interface ConversationHistoryPage {
 }
 
 const normalizeRemoteServerUrl = (raw: string): string => {
-  const trimmed = raw.trim();
-  if (!trimmed) return trimmed;
-  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) {
-    if (trimmed.startsWith('ws://')) return `http://${trimmed.slice('ws://'.length)}`.replace(/\/+$/, '');
-    if (trimmed.startsWith('wss://')) return `https://${trimmed.slice('wss://'.length)}`.replace(/\/+$/, '');
-    return trimmed.replace(/\/+$/, '');
-  }
-  return `http://${trimmed}`.replace(/\/+$/, '');
+  let url = raw.trim();
+  if (!url) return url;
+
+  if (url.startsWith('ws://')) url = `http://${url.slice('ws://'.length)}`;
+  else if (url.startsWith('wss://')) url = `https://${url.slice('wss://'.length)}`;
+  else if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) url = `http://${url}`;
+
+  return url.replace(/\/+$/, '');
 };
 
 export interface RemoteConversationOptions {
@@ -438,7 +438,7 @@ export class RemoteConversation extends EventEmitter {
       try {
         const str = buf.toString('utf8');
         const data = JSON.parse(str) as unknown;
-        const normalized = this.normalizeEventPayload(data);
+        const normalized = this.cloneEventPayload(data);
         if (isAgentEvent(normalized)) this.emitIfNewEvent(normalized);
         else this.emit('error', new Error(`Invalid event payload: ${JSON.stringify(normalized)}`));
       } catch (e) {
@@ -473,7 +473,7 @@ export class RemoteConversation extends EventEmitter {
         const body = await res.json() as ConversationHistoryPage;
         const items = Array.isArray(body.items) ? body.items : [];
         for (const raw of items) {
-          const normalized = this.normalizeEventPayload(raw);
+          const normalized = this.cloneEventPayload(raw);
           if (isAgentEvent(normalized)) {
             this.emitIfNewEvent(normalized);
           }
@@ -489,13 +489,13 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
-  private normalizeEventPayload(payload: unknown): unknown {
+  private cloneEventPayload(payload: unknown): unknown {
     if (!payload || typeof payload !== 'object') return payload;
-    if (Array.isArray(payload)) return payload.map((item) => this.normalizeEventPayload(item));
+    if (Array.isArray(payload)) return payload.map((item) => this.cloneEventPayload(item));
     const obj = payload as Record<string, unknown>;
     const normalized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
-      normalized[key] = this.normalizeEventPayload(value);
+      normalized[key] = this.cloneEventPayload(value);
     }
     return normalized;
   }

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -110,6 +110,9 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     streamingState = initialLlmStreamingState;
 
     deps.resetConversationEventBacklog(id);
+    const mode = deps.getConversationMode();
+    const scopedKey = mode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
+    void deps.context.workspaceState.update(scopedKey, id);
     void deps.context.workspaceState.update('openhands.conversationId', id);
     if (id) {
       postToChatIfVisible(deps, { type: 'conversationStarted', conversationId: id });
@@ -118,4 +121,3 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
 
   conversation.on('terminal', (event: BashEvent) => deps.handleTerminalEvent(event));
 }
-

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -113,7 +113,6 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     const mode = deps.getConversationMode();
     const scopedKey = mode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
     void deps.context.workspaceState.update(scopedKey, id);
-    void deps.context.workspaceState.update('openhands.conversationId', id);
     if (id) {
       postToChatIfVisible(deps, { type: 'conversationStarted', conversationId: id });
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -733,17 +733,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     const desiredMode: 'local' | 'remote' = settings.serverUrl ? 'remote' : 'local';
     const savedIdKey = desiredMode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
-    const legacySavedId = context.workspaceState.get<string>('openhands.conversationId');
     let savedId = options?.uiJustCreated ? undefined : context.workspaceState.get<string>(savedIdKey);
-
-    if (!savedId && !options?.uiJustCreated && legacySavedId) {
-      const legacyLooksLocal = legacySavedId.startsWith('local-');
-      const matchesDesiredMode = desiredMode === 'local' ? legacyLooksLocal : !legacyLooksLocal;
-      if (matchesDesiredMode) {
-        savedId = legacySavedId;
-        void context.workspaceState.update(savedIdKey, legacySavedId);
-      }
-    }
 
     if (savedId) {
       const looksLocal = savedId.startsWith('local-');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -732,8 +732,24 @@ export function activate(context: vscode.ExtensionContext) {
     (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = workspaceRoot;
 
     const desiredMode: 'local' | 'remote' = settings.serverUrl ? 'remote' : 'local';
-    const rawSavedId = context.workspaceState.get<string>('openhands.conversationId');
-    const savedId = options?.uiJustCreated ? undefined : rawSavedId;
+    const savedIdKey = desiredMode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
+    const legacySavedId = context.workspaceState.get<string>('openhands.conversationId');
+    let savedId = options?.uiJustCreated ? undefined : context.workspaceState.get<string>(savedIdKey);
+
+    if (!savedId && !options?.uiJustCreated && legacySavedId) {
+      const legacyLooksLocal = legacySavedId.startsWith('local-');
+      const matchesDesiredMode = desiredMode === 'local' ? legacyLooksLocal : !legacyLooksLocal;
+      if (matchesDesiredMode) {
+        savedId = legacySavedId;
+        void context.workspaceState.update(savedIdKey, legacySavedId);
+      }
+    }
+
+    if (savedId) {
+      const looksLocal = savedId.startsWith('local-');
+      const matchesDesiredMode = desiredMode === 'local' ? looksLocal : !looksLocal;
+      if (!matchesDesiredMode) savedId = undefined;
+    }
     const needsNewConversation = !conversation || conversationMode !== desiredMode;
 
     if (needsNewConversation) {
@@ -755,7 +771,6 @@ export function activate(context: vscode.ExtensionContext) {
         serverUrl: settings.serverUrl ?? undefined,
         settings,
         workspaceRoot,
-        conversationId: savedId,
         tools: settings.serverUrl ? undefined : createDefaultLocalTools(),
         persistenceDir,
       };


### PR DESCRIPTION
Fixes noisy errors when switching from local to remote mode (e.g., server URL 'localhost:3000' and server not running).

Changes
- Store last conversation id per mode (local/remote) to avoid restoring local ids against a remote server
- Use only per-mode workspaceState keys: `openhands.conversationId.local` / `openhands.conversationId.remote`
- Normalize RemoteConversation serverUrl (adds http:// when protocol missing; handles ws:// and wss:// inputs)
- Skip WebSocket connect when remote history replay fails (prevents double-error spam)

Tests
- npm test
- npm run build