### PR TITLE
Simplify webview color scheme for VS Code extension

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -29,7 +29,7 @@ describe('Agent-SDK event rendering', () => {
     } as any;
     postToWindow({ type: 'event', event: ev });
     expect(await screen.findByText('Hello world')).toBeInTheDocument();
-    expect(await screen.findByText('Agent')).toBeInTheDocument();
+    expect(await screen.findByText('OpenHands says')).toBeInTheDocument();
   });
 
   it('renders user messages correctly', async () => {

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -132,10 +132,8 @@ function FileEditorActionSummary({ action }: { action: JsonRecord | null }): Rea
       const rangeText = formatLineRange(parseLineRange(action.view_range));
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            The agent wants to read{' '}
-            <InlineFileReference path={path} />.
-          </p>
+          <p>The agent wants to read</p>
+          <InlineFileReference path={path} />
           {rangeText && <p className="text-xs opacity-70">Requested {rangeText}.</p>}
         </div>
       );
@@ -144,10 +142,8 @@ function FileEditorActionSummary({ action }: { action: JsonRecord | null }): Rea
       const planned = formatCharCount(getCharCount(action.file_text));
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            The agent wants to create{' '}
-            <InlineFileReference path={path} />.
-          </p>
+          <p>The agent wants to create</p>
+          <InlineFileReference path={path} />
           {planned && <p className="text-xs opacity-70">They plan to write {planned}.</p>}
         </div>
       );
@@ -158,16 +154,15 @@ function FileEditorActionSummary({ action }: { action: JsonRecord | null }): Rea
       return (
         <div className="text-sm leading-relaxed space-y-1">
           <p>
-            The agent wants to insert text into{' '}
-            <InlineFileReference path={path} />
+            The agent wants to insert text
             {typeof insertLine === 'number' && (
               <>
                 {' '}
                 {insertLine === 0 ? 'at the top of the file' : `after line ${insertLine.toLocaleString()}`}
               </>
             )}
-            .
           </p>
+          <InlineFileReference path={path} />
           {planned && <p className="text-xs opacity-70">They plan to insert {planned}.</p>}
         </div>
       );
@@ -177,10 +172,8 @@ function FileEditorActionSummary({ action }: { action: JsonRecord | null }): Rea
       const replacementLength = getCharCount(action.new_str) ?? 0;
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            The agent wants to replace text inside{' '}
-            <InlineFileReference path={path} />.
-          </p>
+          <p>The agent wants to replace text inside</p>
+          <InlineFileReference path={path} />
           {removed !== undefined && (
             <p className="text-xs opacity-70">
               Replacing {formatCharCount(removed)} with {formatCharCount(replacementLength)}.
@@ -209,10 +202,8 @@ function FileEditorObservationSummary({ observation }: { observation: JsonRecord
       const listedDirectory = rawOld === null && typeof rawNew === 'string';
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            Agent {listedDirectory ? 'listed the contents of' : 'read'}{' '}
-            <InlineFileReference path={path} />.
-          </p>
+          <p>Agent {listedDirectory ? 'listed the contents of' : 'read'}</p>
+          <InlineFileReference path={path} />
         </div>
       );
     }
@@ -221,10 +212,8 @@ function FileEditorObservationSummary({ observation }: { observation: JsonRecord
       const verb = prevExist === true ? 'overwrote' : 'created';
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            Agent {verb}{' '}
-            <InlineFileReference path={path} />.
-          </p>
+          <p>Agent {verb}</p>
+          <InlineFileReference path={path} />
           {sizeText && <p className="text-xs opacity-70">File now contains {sizeText}.</p>}
         </div>
       );
@@ -234,10 +223,8 @@ function FileEditorObservationSummary({ observation }: { observation: JsonRecord
       const detail = formatSizeDelta(oldLength, newLength);
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}{' '}
-            <InlineFileReference path={path} />.
-          </p>
+          <p>Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}</p>
+          <InlineFileReference path={path} />
           {detail && <p className="text-xs opacity-70">{detail}</p>}
         </div>
       );

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -111,7 +111,7 @@ const TerminalCommandPreview = ({ command }: { command?: string }): React.ReactE
   if (!command) return null;
   return (
     <pre className="text-xs font-mono bg-black/30 border border-white/[0.04] rounded-lg p-3 overflow-x-auto text-stone-300">
-      <span className="text-teal-400/70 select-none">$ </span>{command}
+      <span className="text-stone-500 select-none">$ </span>{command}
     </pre>
   );
 };
@@ -276,21 +276,19 @@ function TerminalObservationSummary({ observation }: { observation: JsonRecord }
 
 /**
  * Event color tokens - CSS custom properties defined in tailwind.css
- * Design Philosophy: "Warm Technical Refinement"
- * - Agent/AI: Warm gold (protagonist, signature OpenHands color)
- * - User: Warm stone (supporting role, understated)
- * - System: Soft lavender (informational)
- * - Action: Teal (operational, cool accent for contrast)
- * - Observation: Soft mint (results/completion)
- * - Error: Warm coral (alerting without harshness)
+ * Design Philosophy: "Simplified Warm Palette"
+ * - Agent/Actions/Observations: OpenHands golden (the main voice)
+ * - User: Warm grey (understated)
+ * - Error: Warm coral (alerting)
  */
 const USER_ACCENT_COLOR = 'var(--event-user)';
 const AGENT_ACCENT_COLOR = 'var(--event-agent)';
 const DEFAULT_ACCENT_COLOR = 'var(--event-default)';
 const ERROR_ACCENT_COLOR = 'var(--event-error)';
-const SYSTEM_ACCENT_COLOR = 'var(--event-system)';
-const ACTION_ACCENT_COLOR = 'var(--event-action)';
-const OBSERVATION_ACCENT_COLOR = 'var(--event-observation)';
+// Use agent golden for all OpenHands actions/observations/system events
+const SYSTEM_ACCENT_COLOR = AGENT_ACCENT_COLOR;
+const ACTION_ACCENT_COLOR = AGENT_ACCENT_COLOR;
+const OBSERVATION_ACCENT_COLOR = AGENT_ACCENT_COLOR;
 
 /** Mix a CSS color with transparency - use instead of appending hex alpha to CSS vars */
 const withAlpha = (color: string, percent: number) =>
@@ -301,7 +299,7 @@ function SecurityBadge({ risk }: { risk: 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN' }
   const styles = {
     HIGH: 'bg-red-500/15 text-red-300 border-red-400/30 shadow-[0_0_8px_rgba(248,113,113,0.15)]',
     MEDIUM: 'bg-amber-500/15 text-amber-300 border-amber-400/30',
-    LOW: 'bg-teal-500/15 text-teal-300 border-teal-400/30',
+    LOW: 'bg-stone-500/15 text-stone-400 border-stone-400/20',
     UNKNOWN: 'bg-stone-500/15 text-stone-400 border-stone-400/20',
   };
 
@@ -468,7 +466,7 @@ export function ActionEventBlock({ event, index }: { event: ActionEvent; index?:
           <div className="flex items-center justify-between mb-2">
             <div className="flex items-center gap-2 font-mono text-sm">
               <span className="codicon codicon-symbol-method" style={{ color: ACTION_ACCENT_COLOR }} />
-              <span className="text-teal-300">{event.tool_name}</span>
+              <span className="text-amber-300">{event.tool_name}</span>
             </div>
             <button
               onClick={() => setIsExpanded(!isExpanded)}
@@ -519,7 +517,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
           <span className="codicon codicon-eye text-sm" style={{ color: OBSERVATION_ACCENT_COLOR }} />
         </div>
         <div className="font-semibold text-sm text-stone-200">Tool Result</div>
-        <span className="font-mono text-xs text-emerald-400/80 bg-emerald-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
+        <span className="font-mono text-xs text-amber-400/80 bg-amber-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
         {showHeaderToggle && (
           <button
             onClick={() => setIsExpanded(!isExpanded)}
@@ -740,14 +738,14 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const accentColor = isUser ? USER_ACCENT_COLOR : isAgent ? AGENT_ACCENT_COLOR : DEFAULT_ACCENT_COLOR;
   const icon = isUser ? 'account' : isAgent ? 'hubot' : 'info';
   const roleLabel = message.role === 'assistant'
-    ? 'Agent'
+    ? 'OpenHands says'
     : message.role.charAt(0).toUpperCase() + message.role.slice(1);
   const showRoleLabel = !isUser;
 
   const handleOpenFile = (file: string) => openWorkspaceFile(file);
 
-  // User messages get extra contrast; agent messages stay prominent
-  const bgOpacity = isUser ? 0.08 : isAgent ? 0.06 : 0.04;
+  // User messages get lighter background for better contrast with agent actions
+  const bgOpacity = isUser ? 0.06 : isAgent ? 0.05 : 0.04;
 
   return (
     <EventContainer accentColor={accentColor} bgOpacity={bgOpacity} index={index} dataTestId="message-event">
@@ -859,7 +857,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
               {event.activated_skills.map((skill) => (
                 <span
                   key={skill}
-                  className="inline-flex items-center px-2.5 py-1 rounded-md text-xs bg-violet-500/15 text-violet-300 border border-violet-400/20"
+                  className="inline-flex items-center px-2.5 py-1 rounded-md text-xs bg-amber-500/15 text-amber-300 border border-amber-400/20"
                 >
                   <span className="codicon codicon-mortar-board mr-1.5 text-[10px]" />
                   {skill}
@@ -919,7 +917,7 @@ export function StreamingMessageBlock({ content }: { content: string }) {
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-2">
-            <div className="font-semibold text-sm text-amber-200">Agent</div>
+            <div className="font-semibold text-sm text-amber-200">OpenHands says</div>
             <div className="flex items-center gap-1.5">
               <span
                 className="inline-block w-1.5 h-1.5 rounded-full animate-pulse"

--- a/src/webview-src/tailwind.css
+++ b/src/webview-src/tailwind.css
@@ -7,23 +7,17 @@
 @layer base {
   /*
    * Event color tokens - single source of truth for theming
-   * Philosophy: Warm palette with amber/gold as the protagonist color
+   * Philosophy: Simplified warm palette focused on OpenHands golden
    */
   :root {
-    /* Agent/AI - signature warm gold (the main voice) */
+    /* Agent/AI/Actions/Observations - signature warm gold (OpenHands voice) */
     --event-agent: #E8A642;
-    /* User - warm stone (understated, supporting) */
-    --event-user: #A8A29E;
-    /* System - soft lavender (informational, ambient) */
-    --event-system: #A78BFA;
-    /* Actions - teal (operational, cool accent contrast) */
-    --event-action: #2DD4BF;
-    /* Observations - soft mint (results, completion) */
-    --event-observation: #86EFAC;
+    /* User - lighter warm grey for better contrast */
+    --event-user: #78716C;
     /* Errors - warm coral (alerting without harshness) */
     --event-error: #F87171;
-    /* Default fallback */
-    --event-default: #78716C;
+    /* Default fallback - medium grey */
+    --event-default: #57534E;
 
     /* Surface colors for warm dark theme */
     --surface-0: #0C0A09;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -23,24 +23,16 @@ module.exports = {
           800: '#92400E',
           900: '#78350F',
         },
-        // Refined semantic event colors - cohesive warm palette
+        // Simplified event colors - focused on OpenHands golden
         event: {
-          // Agent/AI responses - signature amber (protagonist)
-          agent: '#E8A642',       // Warm gold - the AI's voice
-          // User messages - warm slate (supporting role)
-          user: '#94A3B8',        // Warm gray-blue, understated
-          // System information - soft lavender (informational)
-          system: '#A78BFA',      // Muted violet
-          // Actions/Operations - teal (operational, cool accent)
-          action: '#2DD4BF',      // Teal - stands out against warm palette
-          // Results/Observations - sage green (successful completion)
-          observation: '#86EFAC', // Soft mint green
+          // Agent/AI/Actions/Observations - signature warm gold (OpenHands voice)
+          agent: '#E8A642',       // Warm gold - the main voice
+          // User messages - warm grey (understated)
+          user: '#78716C',        // Medium warm grey
           // Errors - warm coral (alert without harshness)
           error: '#F87171',       // Soft coral red
-          // Success states - emerald
-          success: '#34D399',     // Emerald green
-          // Pause/waiting - amber
-          pause: '#FBBF24',       // Amber (matches brand)
+          // Default fallback - darker grey
+          default: '#57534E',     // Dark warm grey
         },
         // Warm dark surface colors (not cold grays)
         surface: {


### PR DESCRIPTION
- Remove purple, teal, and mint colors from the palette
- Use OpenHands golden (#E8A642) for all agent actions, observations, and system events
- Simplify event colors to: golden (agent), grey (user), coral (error)
- Change "Agent" label to "OpenHands says" in message blocks
- Adjust user message background opacity (0.08 → 0.06) for better contrast
- Update security badge LOW risk to use grey instead of teal
- Update tool name badges and activated skills to use golden/amber colors
- Remove terminal prompt teal color in favor of grey

This creates a more focused design that emphasizes the OpenHands brand color while maintaining good visual hierarchy in the sidebar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified warm golden color palette and unified accent usage for a more consistent look
  * Adjusted background opacities and contrast for improved message readability
  * Updated tool name and badge colors to match the new palette
* **UI / Copy**
  * Replaced "Agent" label with "OpenHands says" in message headers and streaming views
  * Tweaked message/summary layout so file references render on their own line for clearer reading
* **Tests**
  * Updated rendering test expectations to match the new assistant label and copy changes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->