### PR TITLE
oh-tab-n4p: add ElevenLabs settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -288,12 +288,12 @@
         "openhands.elevenlabs.voiceAId": {
           "type": "string",
           "default": "",
-          "markdownDescription": "ElevenLabs voice id for HAL (`voice_hal`)."
+          "markdownDescription": "ElevenLabs voice ID for HAL (voice A)."
         },
         "openhands.elevenlabs.voiceUserId": {
           "type": "string",
           "default": "",
-          "markdownDescription": "ElevenLabs voice id for the user (`voice_user`, used in `tts_only`)."
+          "markdownDescription": "ElevenLabs voice ID for the user (voice B, used in `tts_only` mode)."
         },
         "openhands.elevenlabs.modelId": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -265,6 +265,53 @@
           "default": "default-llm",
           "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
         },
+        "openhands.elevenlabs.enabled": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable the HAL high-risk confirmation flow."
+        },
+        "openhands.elevenlabs.mode": {
+          "type": "string",
+          "enum": [
+            "bundled",
+            "tts_only",
+            "voice_confirm"
+          ],
+          "default": "tts_only",
+          "markdownDescription": "HAL mode when enabled: `bundled` (E2E/CI), `tts_only` (TTS + buttons), `voice_confirm` (TTS + mic + Gemini)."
+        },
+        "openhands.elevenlabs.userName": {
+          "type": "string",
+          "default": "Engel",
+          "markdownDescription": "User name used only in templated HAL script lines."
+        },
+        "openhands.elevenlabs.voiceAId": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "ElevenLabs voice id for HAL (`voice_hal`)."
+        },
+        "openhands.elevenlabs.voiceUserId": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "ElevenLabs voice id for the user (`voice_user`, used in `tts_only`)."
+        },
+        "openhands.elevenlabs.modelId": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Optional ElevenLabs model id (e.g., `eleven_turbo_v2`)."
+        },
+        "openhands.elevenlabs.volume": {
+          "type": "number",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 1,
+          "markdownDescription": "Playback volume (0.0–1.0)."
+        },
+        "openhands.elevenlabs.cache": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Enable caching for generated ElevenLabs audio."
+        },
         "openhands.secrets.githubToken": {
           "type": "string",
           "default": "",

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -5,11 +5,25 @@ export interface SavedServer {
   label?: string;
 }
 
+export type ElevenLabsMode = 'bundled' | 'tts_only' | 'voice_confirm';
+
+export type ElevenLabsSettings = {
+  enabled: boolean;
+  mode: ElevenLabsMode;
+  userName: string;
+  voiceAId?: string;
+  voiceUserId?: string;
+  modelId?: string;
+  volume: number;
+  cache: boolean;
+};
+
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
+  elevenlabs: ElevenLabsSettings;
   servers: SavedServer[];
   secrets: {
     sessionApiKey?: string;
@@ -31,6 +45,7 @@ const DEFAULTS: OpenHandsSettings = {
   agent: { enableSecurityAnalyzer: false, debug: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
+  elevenlabs: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },
   secrets: {}
 };
 
@@ -58,6 +73,23 @@ const normalizeLlmProvider = (value: unknown): LLMSettings['provider'] | undefin
     default:
       return undefined;
   }
+};
+
+const normalizeElevenLabsMode = (value: unknown, defaultValue: ElevenLabsMode): ElevenLabsMode => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  switch (trimmed) {
+    case 'bundled':
+    case 'tts_only':
+    case 'voice_confirm':
+      return trimmed;
+    default:
+      return defaultValue;
+  }
+};
+
+const clampUnitInterval = (value: number | null | undefined, defaultValue: number): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
+  return Math.min(1, Math.max(0, value));
 };
 
 export class SettingsManager {
@@ -116,6 +148,24 @@ export class SettingsManager {
       riskyThreshold: this.adapter.get<'LOW' | 'MEDIUM' | 'HIGH'>('openhands.confirmation.risky.threshold', DEFAULTS.confirmation.riskyThreshold) ?? DEFAULTS.confirmation.riskyThreshold,
       confirmUnknown: this.adapter.get<boolean>('openhands.confirmation.risky.confirmUnknown', DEFAULTS.confirmation.confirmUnknown) ?? DEFAULTS.confirmation.confirmUnknown,
     };
+    const elevenlabs: ElevenLabsSettings = {
+      enabled: this.adapter.get<boolean>('openhands.elevenlabs.enabled', DEFAULTS.elevenlabs.enabled) ?? DEFAULTS.elevenlabs.enabled,
+      mode: normalizeElevenLabsMode(
+        this.adapter.get<unknown>('openhands.elevenlabs.mode', DEFAULTS.elevenlabs.mode) ?? DEFAULTS.elevenlabs.mode,
+        DEFAULTS.elevenlabs.mode
+      ),
+      userName: normalizeNonEmptyString(
+        this.adapter.get<string | null>('openhands.elevenlabs.userName', DEFAULTS.elevenlabs.userName) ?? DEFAULTS.elevenlabs.userName
+      ) ?? DEFAULTS.elevenlabs.userName,
+      voiceAId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.elevenlabs.voiceAId', null) ?? undefined),
+      voiceUserId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.elevenlabs.voiceUserId', null) ?? undefined),
+      modelId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.elevenlabs.modelId', null) ?? undefined),
+      volume: clampUnitInterval(
+        this.adapter.get<number | null>('openhands.elevenlabs.volume', DEFAULTS.elevenlabs.volume) ?? DEFAULTS.elevenlabs.volume,
+        DEFAULTS.elevenlabs.volume
+      ),
+      cache: this.adapter.get<boolean>('openhands.elevenlabs.cache', DEFAULTS.elevenlabs.cache) ?? DEFAULTS.elevenlabs.cache,
+    };
     const secrets = {
       sessionApiKey: await this.adapter.getSecret('openhands.sessionApiKey'),
       llmApiKey: await this.adapter.getSecret('openhands.llmApiKey'),
@@ -127,7 +177,7 @@ export class SettingsManager {
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
       customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
     };
-    return { serverUrl, servers, llm, agent, conversation, confirmation, secrets };
+    return { serverUrl, servers, llm, agent, conversation, confirmation, elevenlabs, secrets };
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
@@ -182,6 +232,33 @@ export class SettingsManager {
       }
       if (partial.confirmation.confirmUnknown !== undefined) {
         ops.push(this.adapter.update('openhands.confirmation.risky.confirmUnknown', partial.confirmation.confirmUnknown, target));
+      }
+    }
+
+    if (partial.elevenlabs) {
+      if (partial.elevenlabs.enabled !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.enabled', partial.elevenlabs.enabled, target));
+      }
+      if (partial.elevenlabs.mode !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.mode', partial.elevenlabs.mode, target));
+      }
+      if (partial.elevenlabs.userName !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.userName', partial.elevenlabs.userName, target));
+      }
+      if (partial.elevenlabs.voiceAId !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.voiceAId', partial.elevenlabs.voiceAId, target));
+      }
+      if (partial.elevenlabs.voiceUserId !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.voiceUserId', partial.elevenlabs.voiceUserId, target));
+      }
+      if (partial.elevenlabs.modelId !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.modelId', partial.elevenlabs.modelId, target));
+      }
+      if (partial.elevenlabs.volume !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.volume', partial.elevenlabs.volume, target));
+      }
+      if (partial.elevenlabs.cache !== undefined) {
+        ops.push(this.adapter.update('openhands.elevenlabs.cache', partial.elevenlabs.cache, target));
       }
     }
 

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -32,6 +32,14 @@ describe('SettingsManager', () => {
     expect(s.llm.model).toBe('claude-sonnet-4-20250514');
     expect(s.agent.enableSecurityAnalyzer).toBe(false);
     expect(s.agent.debug).toBe(false);
+    expect(s.elevenlabs.enabled).toBe(false);
+    expect(s.elevenlabs.mode).toBe('tts_only');
+    expect(s.elevenlabs.userName).toBe('Engel');
+    expect(s.elevenlabs.voiceAId).toBeUndefined();
+    expect(s.elevenlabs.voiceUserId).toBeUndefined();
+    expect(s.elevenlabs.modelId).toBeUndefined();
+    expect(s.elevenlabs.volume).toBe(1);
+    expect(s.elevenlabs.cache).toBe(true);
   });
 
   it('includes a default model in remote mode', async () => {
@@ -56,6 +64,16 @@ describe('SettingsManager', () => {
       agent: { enableSecurityAnalyzer: true, debug: true },
       conversation: { maxIterations: 42 },
       confirmation: { policy: 'risky', riskyThreshold: 'MEDIUM', confirmUnknown: false },
+      elevenlabs: {
+        enabled: true,
+        mode: 'voice_confirm',
+        userName: 'Alice',
+        voiceAId: 'voice_hal',
+        voiceUserId: 'voice_user',
+        modelId: 'eleven_turbo_v2',
+        volume: 0.25,
+        cache: false,
+      },
       secrets: { sessionApiKey: 'sess', llmApiKey: 'key' }
     });
     const s = await mgr.get();
@@ -72,8 +90,38 @@ describe('SettingsManager', () => {
     expect(s.confirmation.policy).toBe('risky');
     expect(s.confirmation.riskyThreshold).toBe('MEDIUM');
     expect(s.confirmation.confirmUnknown).toBe(false);
+    expect(s.elevenlabs.enabled).toBe(true);
+    expect(s.elevenlabs.mode).toBe('voice_confirm');
+    expect(s.elevenlabs.userName).toBe('Alice');
+    expect(s.elevenlabs.voiceAId).toBe('voice_hal');
+    expect(s.elevenlabs.voiceUserId).toBe('voice_user');
+    expect(s.elevenlabs.modelId).toBe('eleven_turbo_v2');
+    expect(s.elevenlabs.volume).toBe(0.25);
+    expect(s.elevenlabs.cache).toBe(false);
     expect(s.secrets.sessionApiKey).toBe('sess');
     expect(s.secrets.llmApiKey).toBe('key');
+  });
+
+  it('sanitizes invalid ElevenLabs mode and clamps volume', async () => {
+    await mgr.update({
+      elevenlabs: {
+        mode: 'wat' as any,
+        userName: '   ' as any,
+        volume: 2 as any,
+      } as any,
+    });
+
+    const s = await mgr.get();
+    expect(s.elevenlabs.mode).toBe('tts_only');
+    expect(s.elevenlabs.userName).toBe('Engel');
+    expect(s.elevenlabs.volume).toBe(1);
+
+    await mgr.update({
+      elevenlabs: { volume: -1 as any } as any,
+    });
+
+    const s2 = await mgr.get();
+    expect(s2.elevenlabs.volume).toBe(0);
   });
 
   it('clears secret when undefined is provided', async () => {


### PR DESCRIPTION
Implements non-secret ElevenLabs/HAL settings from docs/hal/elevenlabs_prd.md.

- Adds `openhands.elevenlabs.*` schema entries in `package.json`
- Extends `SettingsManager` with an `elevenlabs` section + sanitization (mode fallback, volume clamp)
- Adds unit tests for defaults + sanitization

Beads: oh-tab-n4p