### PR TITLE
oh-tab-l48: show VS Code diff for file_editor edits

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -333,6 +333,23 @@ describe('Command handlers', () => {
     expect(conversationInstance.rejectAction).toHaveBeenCalledWith('nope');
   });
 
+  it('opens a diff view for openWorkspaceDiff messages', async () => {
+    const handler = chatView._messageHandler;
+    expect(handler).toBeTypeOf('function');
+
+    (vscode.commands.executeCommand as Mock).mockClear();
+
+    await handler({ type: 'openWorkspaceDiff', path: 'README.md', oldContent: 'before', newContent: 'after' });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'vscode.diff',
+      expect.anything(),
+      expect.anything(),
+      expect.stringContaining('Diff:'),
+      expect.objectContaining({ preview: false }),
+    );
+  });
+
   it('returns history from the stable conversation store', async () => {
     const handler = chatView._messageHandler;
     expect(handler).toBeTypeOf('function');

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import React from 'react';
 import { App } from '../components/App';
@@ -15,6 +15,14 @@ afterEach(() => {
 function postToWindow(payload: any) {
   window.postMessage(payload, '*');
 }
+
+const mockApi = { postMessage: vi.fn() } as any;
+
+beforeEach(() => {
+  // @ts-expect-error -- VS Code API is injected by host environment during runtime
+  window.acquireVsCodeApi = () => mockApi;
+  mockApi.postMessage.mockClear();
+});
 
 describe('Agent-SDK event rendering', () => {
   it('renders text content from MessageEvent', async () => {
@@ -195,6 +203,38 @@ describe('Agent-SDK event rendering', () => {
     postToWindow({ type: 'event', event: observationEvent });
     expect(await screen.findByText(/Agent read/)).toBeInTheDocument();
     expect(screen.queryByText(/SECRET FILE CONTENT/)).toBeNull();
+  });
+
+  it('opens a VS Code diff for file_editor edit observations', async () => {
+    render(<App />);
+
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        command: 'str_replace',
+        path: '/tmp/README.md',
+        prev_exist: true,
+        old_content: 'old content',
+        new_content: 'new content',
+      },
+      tool_name: 'file_editor',
+      tool_call_id: 'call_file_editor_diff',
+      action_id: 'action_file_editor_diff',
+    } as any;
+
+    postToWindow({ type: 'event', event: observationEvent });
+    const button = await screen.findByRole('button', { name: 'View diff for /tmp/README.md' });
+    fireEvent.click(button);
+
+    expect(mockApi.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'openWorkspaceDiff',
+        path: '/tmp/README.md',
+        oldContent: 'old content',
+        newContent: 'new content',
+      })
+    );
   });
 
   it('allows viewing raw file_editor payloads on demand', async () => {

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -88,6 +88,11 @@ const openWorkspaceFile = (path: string) => {
   api.postMessage({ type: 'openWorkspaceFile', path });
 };
 
+const openWorkspaceDiff = (path: string, oldContent: string, newContent: string) => {
+  const api = getVscodeApi();
+  api.postMessage({ type: 'openWorkspaceDiff', path, oldContent, newContent });
+};
+
 function InlineFileReference({ path }: { path?: string }) {
   if (!path) {
     return <span className="font-mono text-xs text-stone-400">this path</span>;
@@ -101,6 +106,38 @@ function InlineFileReference({ path }: { path?: string }) {
       title={`Open ${path}`}
     >
       <span className="codicon codicon-file text-brand-400/70" />
+      <span className="truncate max-w-[16rem]">{path}</span>
+      <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
+    </button>
+  );
+}
+
+const normalizeDiffContent = (value: unknown): string | undefined => {
+  if (typeof value === 'string') return value;
+  if (value === null) return '';
+  return undefined;
+};
+
+function InlineFileDiffReference({ path, oldContent, newContent }: { path?: string; oldContent: unknown; newContent: unknown }) {
+  if (!path) {
+    return <span className="font-mono text-xs text-stone-400">this path</span>;
+  }
+
+  const oldText = normalizeDiffContent(oldContent);
+  const newText = normalizeDiffContent(newContent);
+  if (oldText === undefined || newText === undefined) {
+    return <InlineFileReference path={path} />;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => openWorkspaceDiff(path, oldText, newText)}
+      className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.06] hover:border-white/[0.1] text-xs font-mono text-brand-300 align-middle max-w-full transition-all duration-150 group"
+      aria-label={`View diff for ${path}`}
+      title={`View diff for ${path}`}
+    >
+      <span className="codicon codicon-diff text-brand-400/70" />
       <span className="truncate max-w-[16rem]">{path}</span>
       <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
     </button>
@@ -213,7 +250,7 @@ function FileEditorObservationSummary({ observation }: { observation: JsonRecord
       return (
         <div className="text-sm leading-relaxed space-y-1">
           <p>Agent {verb}</p>
-          <InlineFileReference path={path} />
+          <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
           {sizeText && <p className="text-xs opacity-70">File now contains {sizeText}.</p>}
         </div>
       );
@@ -224,7 +261,7 @@ function FileEditorObservationSummary({ observation }: { observation: JsonRecord
       return (
         <div className="text-sm leading-relaxed space-y-1">
           <p>Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}</p>
-          <InlineFileReference path={path} />
+          <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
           {detail && <p className="text-xs opacity-70">{detail}</p>}
         </div>
       );

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -22,6 +22,7 @@ type WebviewMessage =
   | { type: 'requestSkills' }
   | { type: 'openSkill'; path: string }
   | { type: 'openWorkspaceFile'; path: string }
+  | { type: 'openWorkspaceDiff'; path: string; oldContent: string; newContent: string }
   | { type: 'requestHistory' }
   | { type: 'restoreConversation'; id: string }
   | { type: 'getConfig' }
@@ -59,6 +60,47 @@ type WebviewMessage =
 
 const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES = 500 * 1024;
+
+const OPENHANDS_DIFF_SCHEME = 'openhands-diff';
+const MAX_STORED_DIFF_DOCUMENTS = 30;
+
+const diffContentByUri = new Map<string, string>();
+const diffUriQueue: string[] = [];
+let diffProviderRegistered = false;
+let diffSequence = 0;
+
+const diffEmitter = new vscode.EventEmitter<vscode.Uri>();
+const diffProvider: vscode.TextDocumentContentProvider = {
+  onDidChange: diffEmitter.event,
+  provideTextDocumentContent: (uri) => diffContentByUri.get(uri.toString()) ?? '',
+};
+
+function ensureDiffProviderRegistered(context: vscode.ExtensionContext): void {
+  if (diffProviderRegistered) return;
+  diffProviderRegistered = true;
+  context.subscriptions.push(diffEmitter);
+  context.subscriptions.push(vscode.workspace.registerTextDocumentContentProvider(OPENHANDS_DIFF_SCHEME, diffProvider));
+}
+
+function storeDiffDocument(uri: vscode.Uri, content: string): void {
+  const key = uri.toString();
+  diffContentByUri.set(key, content);
+  diffUriQueue.push(key);
+  diffEmitter.fire(uri);
+
+  while (diffUriQueue.length > MAX_STORED_DIFF_DOCUMENTS * 2) {
+    const drop = diffUriQueue.shift();
+    if (drop) diffContentByUri.delete(drop);
+  }
+}
+
+function createDiffUris(label: string): { beforeUri: vscode.Uri; afterUri: vscode.Uri } {
+  const id = `${Date.now().toString(36)}-${(diffSequence++).toString(36)}`;
+  const safeName = path.basename(label).replace(/[^a-zA-Z0-9._-]/g, '_') || 'file';
+  const beforeUri = vscode.Uri.parse(`${OPENHANDS_DIFF_SCHEME}:/before/${id}/${safeName}`);
+  const afterUri = vscode.Uri.parse(`${OPENHANDS_DIFF_SCHEME}:/after/${id}/${safeName}`);
+  return { beforeUri, afterUri };
+}
 
 function isProbablyBinary(bytes: Uint8Array): boolean {
   // Heuristic: treat NUL bytes as binary.
@@ -345,6 +387,49 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           void vscode.window.showErrorMessage(`Failed to open file: ${reason}`);
+        }
+        break;
+      }
+      case 'openWorkspaceDiff': {
+        const p = message.path;
+        if (!p) break;
+        if (typeof message.oldContent !== 'string' || typeof message.newContent !== 'string') {
+          void vscode.window.showErrorMessage('Failed to open diff: missing diff content.');
+          break;
+        }
+        try {
+          ensureDiffProviderRegistered(context);
+
+          const isAbs = path.isAbsolute(p);
+          const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+          let resolved: string | undefined;
+          if (!isAbs && wsRoot) {
+            const candidate = path.resolve(wsRoot, p);
+            const rel = path.relative(wsRoot, candidate);
+            if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+              resolved = candidate;
+            }
+          }
+          if (!resolved) {
+            resolved = path.resolve(p);
+          }
+
+          const displayPath = wsRoot
+            ? (() => {
+              const rel = path.relative(wsRoot, resolved);
+              if (rel && !rel.startsWith('..') && !path.isAbsolute(rel)) return rel;
+              return resolved;
+            })()
+            : resolved;
+
+          const { beforeUri, afterUri } = createDiffUris(displayPath);
+          storeDiffDocument(beforeUri, message.oldContent);
+          storeDiffDocument(afterUri, message.newContent);
+
+          await vscode.commands.executeCommand('vscode.diff', beforeUri, afterUri, `Diff: ${displayPath}`, { preview: false });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void vscode.window.showErrorMessage(`Failed to open diff: ${reason}`);
         }
         break;
       }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -62,7 +62,7 @@ const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES = 500 * 1024;
 
 const OPENHANDS_DIFF_SCHEME = 'openhands-diff';
-const MAX_STORED_DIFF_DOCUMENTS = 30;
+const MAX_STORED_DIFF_DOCUMENTS = 60;
 
 const diffContentByUri = new Map<string, string>();
 const diffUriQueue: string[] = [];
@@ -88,7 +88,7 @@ function storeDiffDocument(uri: vscode.Uri, content: string): void {
   diffUriQueue.push(key);
   diffEmitter.fire(uri);
 
-  while (diffUriQueue.length > MAX_STORED_DIFF_DOCUMENTS * 2) {
+  while (diffUriQueue.length > MAX_STORED_DIFF_DOCUMENTS) {
     const drop = diffUriQueue.shift();
     if (drop) diffContentByUri.delete(drop);
   }

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -16,6 +16,7 @@ export const workspace = {
     inspect: vi.fn(),
     update: vi.fn(),
   })),
+  registerTextDocumentContentProvider: vi.fn(() => ({ dispose: vi.fn() })),
   onDidChangeConfiguration: vi.fn((listener: Function) => {
     mockConfigListeners.push(listener);
     const disposable = { dispose: vi.fn() };
@@ -151,6 +152,7 @@ export function __resetMocks() {
   mockWebviewViewProviders.clear();
   // Reset common spies to default implementations
   ;(workspace.getConfiguration as any).mockClear();
+  ;(workspace.registerTextDocumentContentProvider as any).mockClear();
   ;(workspace.onDidChangeConfiguration as any).mockClear();
   ;(window.showInformationMessage as any).mockClear();
   ;(window.showErrorMessage as any).mockClear();


### PR DESCRIPTION
Beads: oh-tab-l48

- Clicking an edited file (file_editor create/insert/str_replace Tool Result) now opens a VS Code diff instead of the file.
- Adds openWorkspaceDiff message + host handler using an in-memory TextDocumentContentProvider (openhands-diff: scheme).
- Adds unit tests (webview + extension mock).

Tests: npx vitest run src/webview-src/__tests__/event.rendering.test.tsx src/__tests__/extension.test.ts; npm run typecheck; npm run lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now view side-by-side diffs of file changes directly in VS Code by clicking a "View diff" button on file editor observations in the webview.

* **Tests**
  * Added test coverage for diff viewing functionality and webview integration with VS Code.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->