### PR TITLE
oh-tab-0w1: fix stale tool_call_id after reject

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { Agent, EventLog } from '../runtime';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
-import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
+import { isActionEvent, isMessageEvent, isObservationEvent, isPauseEvent, type Message } from '../types';
 import type { ToolDefinition } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
 import { FileEditorTool } from '../../tools';
@@ -153,10 +153,10 @@ describe('Agent loop control', () => {
     expect(secondRequest).toBeTruthy();
 
     const messages = secondRequest?.messages ?? [];
-    const assistantIndex = messages.findIndex((m: any) =>
-      m.role === 'assistant' && Array.isArray(m.tool_calls) && m.tool_calls.some((c: any) => c?.id === 'call_1')
+    const assistantIndex = messages.findIndex((m: Message) =>
+      m.role === 'assistant' && m.tool_calls?.some((c) => c.id === 'call_1')
     );
-    const toolIndex = messages.findIndex((m: any) => m.role === 'tool' && m.tool_call_id === 'call_1');
+    const toolIndex = messages.findIndex((m: Message) => m.role === 'tool' && m.tool_call_id === 'call_1');
 
     expect(assistantIndex).toBeGreaterThanOrEqual(0);
     expect(toolIndex).toBeGreaterThan(assistantIndex);

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -35,6 +35,22 @@ class SequencedLLM implements LLMClient {
   }
 }
 
+class RecordingLLM implements LLMClient {
+  private idx = 0;
+  requests: ChatCompletionRequest[] = [];
+
+  constructor(private readonly sequences: LLMStreamChunk[][]) {}
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
+    const seq = this.sequences[this.idx] ?? [];
+    this.idx += 1;
+    for (const chunk of seq) {
+      yield chunk;
+    }
+  }
+}
+
 const baseSettings: OpenHandsSettings = {
   llm: { model: 'test-model' },
   agent: {},
@@ -99,6 +115,51 @@ describe('Agent loop control', () => {
     expect(eventsAfterApproval.some(isObservationEvent)).toBe(true);
     const toolMessages = eventsAfterApproval.filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'tool');
     expect(toolMessages.length).toBe(1);
+  });
+
+  it('emits a tool message when the user rejects a tool call (avoids stale tool_call_id)', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new RecordingLLM([
+      [
+        { type: 'text', text: 'Using tool' },
+        { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'Continuing' },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, confirmation: { policy: 'always' }, conversation: { maxIterations: 2 } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run tool');
+    agent.rejectAction('nope');
+    await agent.run('next message');
+
+    const secondRequest = llm.requests[1];
+    expect(secondRequest).toBeTruthy();
+
+    const messages = secondRequest?.messages ?? [];
+    const assistantIndex = messages.findIndex((m: any) =>
+      m.role === 'assistant' && Array.isArray(m.tool_calls) && m.tool_calls.some((c: any) => c?.id === 'call_1')
+    );
+    const toolIndex = messages.findIndex((m: any) => m.role === 'tool' && m.tool_call_id === 'call_1');
+
+    expect(assistantIndex).toBeGreaterThanOrEqual(0);
+    expect(toolIndex).toBeGreaterThan(assistantIndex);
   });
 
   it('prompts for confirmation before accessing files outside the workspace', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -522,16 +522,32 @@ export class Agent extends EventEmitter {
   rejectAction(reason?: string): void {
     if (!this.pendingAction) return;
     const { actionEvent, toolCall } = this.pendingAction;
+    const rejectionReason = reason ?? 'User rejected the action';
     this.pendingAction = undefined;
     this.pendingWorkspaceAccess = undefined;
     this.events.push({
       kind: 'UserRejectObservation',
       source: 'environment',
-      rejection_reason: reason ?? 'User rejected the action',
+      rejection_reason: rejectionReason,
       tool_name: actionEvent.tool_name,
       tool_call_id: toolCall.id,
       action_id: actionEvent.id!,
     } as Event);
+
+    // OpenAI-compatible providers require that assistant tool_calls are followed by tool messages for each tool_call_id.
+    // If the user rejects a tool call, emit a synthetic tool response so subsequent LLM calls remain valid.
+    const rejectionText = truncateToolMessage(this.maskSecretsInText(`User rejected tool call: ${rejectionReason}`));
+    this.events.push({
+      kind: 'MessageEvent',
+      source: 'environment',
+      llm_message: {
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        name: toolCall.function.name,
+        content: [{ type: 'text', text: rejectionText }],
+      },
+    } as Event);
+
     this.state.setStatus('IDLE');
   }
 


### PR DESCRIPTION
Beads: oh-tab-0w1

Fix: when the user rejects a pending tool call, emit a synthetic tool MessageEvent (role=tool, tool_call_id=...) so OpenAI-compatible providers don’t error on the next user turn.

Adds a unit test that rejects a tool call and asserts the next LLM request includes the matching tool message.

Tests: npx vitest run packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts; npm run lint -w @openhands/agent-sdk-ts; npm run typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of rejected tool calls to ensure proper synchronization of tool references when users reject actions, preventing stale call ID issues.

* **Tests**
  * Added test coverage for tool call rejection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->