### PR TITLE
oh-tab-iyc: HAL Phase 0 bundled overlay

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,6 +37,19 @@ type UiStateSnapshot = {
   attachmentsCount: number;
 };
 
+type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
+type HalEye = 'off' | 'dim' | 'pulsating';
+type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
+
+type HalStateSnapshot = {
+  enabled: boolean;
+  phase: HalPhase;
+  eye: HalEye;
+  stepIndex: number | null;
+  decision: HalDecision | null;
+  lastError: string | null;
+};
+
 const DEFAULT_UI_STATE: UiStateSnapshot = {
   input: '',
   showContextPicker: false,
@@ -48,6 +61,35 @@ const DEFAULT_UI_STATE: UiStateSnapshot = {
   attachmentsCount: 0,
 };
 
+const DEFAULT_HAL_STATE: HalStateSnapshot = {
+  enabled: false,
+  phase: 'idle',
+  eye: 'off',
+  stepIndex: null,
+  decision: null,
+  lastError: null,
+};
+
+function isHalPhase(value: unknown): value is HalPhase {
+  return (
+    value === 'idle' ||
+    value === 'dialogue' ||
+    value === 'awaiting_user' ||
+    value === 'listening' ||
+    value === 'classifying' ||
+    value === 'waiting_remote' ||
+    value === 'error'
+  );
+}
+
+function isHalEye(value: unknown): value is HalEye {
+  return value === 'off' || value === 'dim' || value === 'pulsating';
+}
+
+function isHalDecision(value: unknown): value is HalDecision {
+  return value === 'approve_local' || value === 'teleport_remote' || value === 'reject';
+}
+
 let chatView: vscode.WebviewView | undefined;
 let conversation: ConversationInstance | undefined;
 let conversationMode: 'local' | 'remote' = 'remote';
@@ -56,6 +98,7 @@ let terminalLogPty: OpenHandsTerminalLogPseudoterminal | undefined;
 let nextE2ERequestId = 0;
 const pendingRenderedEventsRequests = new Map<string, (info: RenderedEventsInfo) => void>();
 const pendingUiStateRequests = new Map<string, (info: UiStateSnapshot) => void>();
+const pendingHalStateRequests = new Map<string, (info: HalStateSnapshot) => void>();
 let chatWebviewReady = false; // Track if chat WebviewView is ready
 let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
@@ -633,6 +676,19 @@ export function activate(context: vscode.ExtensionContext) {
         onUiStateResponse: (requestId, info) => {
           pendingUiStateRequests.get(requestId)?.(info);
         },
+        onHalStateResponse: (requestId, info) => {
+          const phase = isHalPhase(info.phase) ? info.phase : DEFAULT_HAL_STATE.phase;
+          const eye = isHalEye(info.eye) ? info.eye : DEFAULT_HAL_STATE.eye;
+          const decision = isHalDecision(info.decision) ? info.decision : null;
+          pendingHalStateRequests.get(requestId)?.({
+            enabled: info.enabled === true,
+            phase,
+            eye,
+            stepIndex: typeof info.stepIndex === 'number' ? info.stepIndex : null,
+            decision,
+            lastError: typeof info.lastError === 'string' ? info.lastError : null,
+          });
+        },
         isDevBridgeEnabled: () => devBridgeEnabled,
         getOutputChannel: () => outputChannel,
         fileLog,
@@ -925,6 +981,24 @@ export function activate(context: vscode.ExtensionContext) {
     return (await pending.promise) ?? DEFAULT_UI_STATE;
   });
 
+  // Query HAL presentation state from webview for E2E testing (no DOM automation)
+  const queryHalState = vscode.commands.registerCommand('openhands._queryHalState', async () => {
+    if (!chatView) {
+      return DEFAULT_HAL_STATE;
+    }
+
+    void chatView.show?.(true);
+    const requestId = nextRequestId('halState');
+    const pending = createPendingResponse(pendingHalStateRequests, requestId, 5000);
+    const posted = await chatView.webview.postMessage({ type: 'queryHalState', requestId });
+    if (!posted) {
+      pending.cancel();
+      return DEFAULT_HAL_STATE;
+    }
+
+    return (await pending.promise) ?? DEFAULT_HAL_STATE;
+  });
+
   // Send a test action to the webview for E2E testing (UI flows without DOM automation)
   const webviewAction = vscode.commands.registerCommand(
     'openhands._webviewAction',
@@ -1115,7 +1189,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   // Listen for runtime configuration changes
-  const onConfigurationChange = createConfigurationChangeHandler({
+  const onConfigurationChangeBase = createConfigurationChangeHandler({
     ensureConversationAndConnection: () => ensureConversationAndConnection(),
     getConversation: () => conversation,
     setConversation: (next) => {
@@ -1139,6 +1213,21 @@ export function activate(context: vscode.ExtensionContext) {
     getOutputChannel: () => outputChannel,
     renderError,
   });
+  const onConfigurationChange = async (e: vscode.ConfigurationChangeEvent) => {
+    await onConfigurationChangeBase(e);
+
+    if (e.affectsConfiguration('openhands.elevenlabs')) {
+      try {
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+        const settings = await settingsMgr.get();
+        if (chatView && chatWebviewReady) {
+          void chatView.webview.postMessage({ type: 'elevenlabsSettings', elevenlabs: settings.elevenlabs });
+        }
+      } catch (err: unknown) {
+        outputChannel?.appendLine(`[settings] Failed to apply elevenlabs settings update: ${renderError(err)}`);
+      }
+    }
+  };
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(onConfigurationChange));
 
   context.subscriptions.push(
@@ -1147,6 +1236,7 @@ export function activate(context: vscode.ExtensionContext) {
     sendTestEvent,
     queryRenderedEvents,
     queryUiState,
+    queryHalState,
     webviewAction,
     startNew,
     configure,
@@ -1173,6 +1263,7 @@ export function deactivate() {
   terminalLogPty = undefined;
   pendingRenderedEventsRequests.clear();
   pendingUiStateRequests.clear();
+  pendingHalStateRequests.clear();
   chatWebviewReady = false;
   chatLastConversationId = undefined;
   chatLastSeenSeq = undefined;

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   isEvent,
   isSystemPromptEvent,
@@ -23,6 +23,7 @@ import { InputArea, ContextPicker, SkillsPopover } from './InputArea';
 import { ConfirmationPrompt } from './ConfirmationPrompt';
 import { StatusBanner } from './StatusBanner';
 import { HistoryView } from './HistoryView';
+import { HalOverlay, type HalEye } from './HalOverlay';
 import {
   SystemPromptEventBlock,
   ActionEventBlock,
@@ -56,6 +57,36 @@ type StatusBannerState = {
   message: string;
   level: 'info' | 'warn' | 'error';
   dismissible?: boolean;
+};
+
+type ElevenLabsMode = 'bundled' | 'tts_only' | 'voice_confirm';
+
+type ElevenLabsSettingsSnapshot = {
+  enabled: boolean;
+  mode: ElevenLabsMode;
+  userName: string;
+};
+
+type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
+type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
+
+type HalStateSnapshot = {
+  enabled: boolean;
+  phase: HalPhase;
+  eye: HalEye;
+  stepIndex: number | null;
+  decision: HalDecision | null;
+  lastError: string | null;
+};
+
+const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel' };
+const DEFAULT_HAL_STATE: HalStateSnapshot = {
+  enabled: false,
+  phase: 'idle',
+  eye: 'off',
+  stepIndex: null,
+  decision: null,
+  lastError: null,
 };
 
 /**
@@ -154,6 +185,25 @@ export function App() {
   const [servers, setServers] = useState<{ url: string; label?: string }[]>([]);
   const [currentServerUrl, setCurrentServerUrl] = useState<string | undefined>(undefined);
 
+  // HAL / ElevenLabs settings + state (Phase 0: bundled mode only)
+  const [elevenlabs, setElevenlabs] = useState<ElevenLabsSettingsSnapshot>(DEFAULT_ELEVENLABS_SETTINGS);
+  const [halPhase, setHalPhase] = useState<HalPhase>('idle');
+  const [halEye, setHalEye] = useState<HalEye>('off');
+  const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
+  const [halDecision, setHalDecision] = useState<HalDecision | null>(null);
+  const [halLastError, setHalLastError] = useState<string | null>(null);
+  const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const halActiveKeyRef = useRef<string | null>(null);
+  const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
+  const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
+  const halEnabledRef = useRef<boolean>(false);
+  const halPhaseRef = useRef<HalPhase>('idle');
+  const halSuppressedKeyRef = useRef<string | null>(null);
+  const pendingActionsRef = useRef<ActionEvent[]>([]);
+  const agentStatusRef = useRef<string | undefined>(undefined);
+  const conversationIdRef = useRef<string | undefined>(undefined);
+  const elevenlabsRef = useRef<ElevenLabsSettingsSnapshot>(DEFAULT_ELEVENLABS_SETTINGS);
+
   // Refs
   const endRef = useRef<HTMLDivElement | null>(null);
   const lastAgentStatusRef = useRef<string | undefined>(undefined);
@@ -190,6 +240,47 @@ export function App() {
     };
   }, [attachments.length, input, selectedContextFiles, showContextPicker, showHistory, showSkillsPopover, skills.length, workspaceFiles.length]);
 
+  const halEnabled = elevenlabs.enabled && elevenlabs.mode === 'bundled';
+
+  useEffect(() => {
+    halEnabledRef.current = halEnabled;
+  }, [halEnabled]);
+
+  useEffect(() => {
+    halPhaseRef.current = halPhase;
+  }, [halPhase]);
+
+  useEffect(() => {
+    halSuppressedKeyRef.current = halSuppressedKey;
+  }, [halSuppressedKey]);
+
+  useEffect(() => {
+    pendingActionsRef.current = pendingActions;
+  }, [pendingActions]);
+
+  useEffect(() => {
+    agentStatusRef.current = agentStatus;
+  }, [agentStatus]);
+
+  useEffect(() => {
+    conversationIdRef.current = conversationId;
+  }, [conversationId]);
+
+  useEffect(() => {
+    elevenlabsRef.current = elevenlabs;
+  }, [elevenlabs]);
+
+  useEffect(() => {
+    halStateRef.current = {
+      enabled: halEnabled,
+      phase: halPhase,
+      eye: halEye,
+      stepIndex: halPhase === 'dialogue' ? halStepIndex : null,
+      decision: halDecision,
+      lastError: halLastError,
+    };
+  }, [halDecision, halEnabled, halEye, halLastError, halPhase, halStepIndex]);
+
   // Show status message with debouncing
   const showStatusMessage = useCallback((level: 'info' | 'warn' | 'error', message: string) => {
     const now = Date.now();
@@ -204,6 +295,7 @@ export function App() {
     if (!isConversationStateUpdateEvent(event)) return false;
 
     if (event.agent_status) {
+      agentStatusRef.current = event.agent_status;
       setAgentStatus(event.agent_status);
       if (event.agent_status === 'WAITING_FOR_CONFIRMATION' && lastAgentStatusRef.current !== 'WAITING_FOR_CONFIRMATION') {
         showStatusMessage('warn', 'Agent is waiting for confirmation');
@@ -233,12 +325,20 @@ export function App() {
     };
 
     if (isActionEvent(event)) {
-      setPendingActions((prev) => {
-        const exists = prev.some((a) => a.tool_call_id === event.tool_call_id);
-        return exists ? prev : [...prev, event];
-      });
+      const prev = pendingActionsRef.current;
+      const exists = prev.some((a) => a.tool_call_id === event.tool_call_id);
+      if (!exists) {
+        const next = [...prev, event];
+        pendingActionsRef.current = next;
+        setPendingActions(next);
+      }
     } else if (isObservationEvent(event) || isUserRejectObservation(event)) {
-      setPendingActions((prev) => prev.filter((a) => a.tool_call_id !== event.tool_call_id));
+      const prev = pendingActionsRef.current;
+      const next = prev.filter((a) => a.tool_call_id !== event.tool_call_id);
+      if (next.length !== prev.length) {
+        pendingActionsRef.current = next;
+        setPendingActions(next);
+      }
       clearSubmissionState();
     } else if (isAgentErrorEvent(event)) {
       showStatusMessage('error', event.error);
@@ -247,6 +347,101 @@ export function App() {
       showStatusMessage('warn', 'Conversation paused');
     }
   }, [showStatusMessage]);
+
+  const clearHalTimer = useCallback(() => {
+    if (halTimerRef.current) {
+      clearTimeout(halTimerRef.current);
+      halTimerRef.current = null;
+    }
+  }, []);
+
+  const halDialogueLines = useMemo(() => {
+    const safeUserName = elevenlabs.userName.trim() || DEFAULT_ELEVENLABS_SETTINGS.userName;
+    return [
+      `I'm sorry, ${safeUserName}, I can't let you do that.`,
+      'Do you want me to teleport your conversation to the remote runtime?',
+      'Of course not. It\'s for your own good. Your agent will have more freedom in the remote runtime without affecting your local machine. Want me to transfer you?',
+    ];
+  }, [elevenlabs.userName]);
+
+  const maybeUpdateHalFlow = useCallback(() => {
+    const enabled = halEnabledRef.current;
+    const status = agentStatusRef.current;
+    const pending = pendingActionsRef.current;
+    const firstHighRisk = pending.find((action) => action.security_risk === 'HIGH');
+    const nextKey =
+      enabled && status === 'WAITING_FOR_CONFIRMATION' && firstHighRisk?.tool_call_id
+        ? `${conversationIdRef.current ?? 'unknown'}:${firstHighRisk.tool_call_id}`
+        : null;
+
+    if (!nextKey) {
+      if (halActiveKeyRef.current !== null || halPhaseRef.current !== 'idle' || halSuppressedKeyRef.current !== null) {
+        clearHalTimer();
+        halActiveKeyRef.current = null;
+        halSuppressedKeyRef.current = null;
+        halPhaseRef.current = 'idle';
+        setHalSuppressedKey(null);
+        setHalPhase('idle');
+        setHalEye('off');
+        setHalStepIndex(null);
+        setHalDecision(null);
+        setHalLastError(null);
+      }
+      return;
+    }
+
+    const isNewSession = halActiveKeyRef.current !== nextKey;
+    if (isNewSession) {
+      halActiveKeyRef.current = nextKey;
+      halSuppressedKeyRef.current = null;
+      setHalSuppressedKey(null);
+    }
+
+    if (halSuppressedKeyRef.current === nextKey) {
+      if (halPhaseRef.current !== 'idle') {
+        clearHalTimer();
+        halPhaseRef.current = 'idle';
+        setHalPhase('idle');
+        setHalEye('off');
+        setHalStepIndex(null);
+        setHalDecision(null);
+        setHalLastError(null);
+      }
+      return;
+    }
+
+    if (halPhaseRef.current === 'idle') {
+      clearHalTimer();
+      halPhaseRef.current = 'dialogue';
+      setHalDecision(null);
+      setHalLastError(null);
+      setHalEye('pulsating');
+      setHalPhase('dialogue');
+      setHalStepIndex(0);
+    }
+  }, [clearHalTimer]);
+
+  useEffect(() => {
+    if (halPhase !== 'dialogue') return;
+    if (halStepIndex === null) return;
+
+    clearHalTimer();
+
+    const delayMs = 650;
+    halTimerRef.current = setTimeout(() => {
+      const lastIndex = halDialogueLines.length - 1;
+      if (halStepIndex >= lastIndex) {
+        setHalPhase('awaiting_user');
+        setHalStepIndex(null);
+        return;
+      }
+      setHalStepIndex(halStepIndex + 1);
+    }, delayMs);
+
+    return () => {
+      clearHalTimer();
+    };
+  }, [clearHalTimer, halDialogueLines.length, halPhase, halStepIndex]);
 
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
@@ -260,11 +455,15 @@ export function App() {
 
     const event = incomingEvent;
     handleStreamingUpdate(event);
-    if (handleConversationStateUpdate(event)) return;
+    if (handleConversationStateUpdate(event)) {
+      maybeUpdateHalFlow();
+      return;
+    }
 
     handlePendingActions(event);
+    maybeUpdateHalFlow();
     handleRenderableEvent(event);
-  }, [handleConversationStateUpdate, handlePendingActions, handleRenderableEvent, handleStreamingUpdate]);
+  }, [handleConversationStateUpdate, handlePendingActions, handleRenderableEvent, handleStreamingUpdate, maybeUpdateHalFlow]);
 
   // Signal webview is ready on mount
   useEffect(() => {
@@ -303,6 +502,7 @@ export function App() {
         serverUrl?: string | null;
         mode?: 'local' | 'remote';
         llmModel?: string | null;
+        elevenlabs?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
         seq?: unknown;
         error?: unknown;
@@ -358,6 +558,26 @@ export function App() {
             setCurrentServerUrl(payload.serverUrl || undefined);
           }
           break;
+        case 'elevenlabsSettings':
+          if (payload.elevenlabs && typeof payload.elevenlabs === 'object') {
+            const prev = elevenlabsRef.current;
+            const next: ElevenLabsSettingsSnapshot = { ...prev };
+            if (typeof payload.elevenlabs?.enabled === 'boolean') next.enabled = payload.elevenlabs.enabled;
+            if (
+              payload.elevenlabs?.mode === 'bundled' ||
+              payload.elevenlabs?.mode === 'tts_only' ||
+              payload.elevenlabs?.mode === 'voice_confirm'
+            ) {
+              next.mode = payload.elevenlabs.mode;
+            }
+            if (typeof payload.elevenlabs?.userName === 'string') next.userName = payload.elevenlabs.userName;
+
+            elevenlabsRef.current = next;
+            halEnabledRef.current = next.enabled && next.mode === 'bundled';
+            setElevenlabs(next);
+            maybeUpdateHalFlow();
+          }
+          break;
         case 'attachmentsSelected':
           if (Array.isArray(payload.attachments)) {
             setAttachments((prev) => {
@@ -392,15 +612,19 @@ export function App() {
           break;
         case 'conversationStarted':
           if (typeof payload.conversationId === 'string') {
+            conversationIdRef.current = payload.conversationId;
             setConversationId(payload.conversationId);
             setEvents([]);
+            pendingActionsRef.current = [];
             setPendingActions([]);
+            agentStatusRef.current = undefined;
             setAgentStatus(undefined);
             setStreamingContent(null);
             eventId.current = 1;
             // No toast: UI clears and restored/started messages will render naturally
             const api = getVscodeApi();
             api.setState?.({ conversationId: payload.conversationId, lastSeenSeq: 0 });
+            maybeUpdateHalFlow();
           }
           break;
         case 'workspaceFiles':
@@ -416,6 +640,12 @@ export function App() {
         case 'queryUiState': {
           if (typeof payload.requestId === 'string') {
             postMessage({ type: 'uiStateResponse', requestId: payload.requestId, ...uiStateRef.current });
+          }
+          break;
+        }
+        case 'queryHalState': {
+          if (typeof payload.requestId === 'string') {
+            postMessage({ type: 'halStateResponse', requestId: payload.requestId, ...halStateRef.current });
           }
           break;
         }
@@ -461,6 +691,29 @@ export function App() {
               postMessage({ type: 'send', text: normalized, contextFiles: [], attachments: [] });
               break;
             }
+            case 'halApprove':
+              setHalDecision('approve_local');
+              postMessage({ type: 'command', command: 'approveAction' });
+              break;
+            case 'halReject':
+              setHalDecision('reject');
+              postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
+              break;
+            case 'halExit': {
+              clearHalTimer();
+              const key = halActiveKeyRef.current;
+              if (key) {
+                halSuppressedKeyRef.current = key;
+                setHalSuppressedKey(key);
+              }
+              halPhaseRef.current = 'idle';
+              setHalPhase('idle');
+              setHalEye('off');
+              setHalStepIndex(null);
+              setHalDecision(null);
+              setHalLastError(null);
+              break;
+            }
           }
           break;
         }
@@ -504,7 +757,7 @@ export function App() {
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [events, handleEvent, postMessage, showStatusMessage]);
+  }, [clearHalTimer, events, handleEvent, maybeUpdateHalFlow, postMessage, showStatusMessage]);
 
   // Auto-scroll to bottom when events change or streaming updates
   useEffect(() => {
@@ -629,6 +882,48 @@ export function App() {
     showStatusMessage('info', 'Rejection submitted');
   }, [isSubmitting, postMessage, showStatusMessage]);
 
+  const handleHalExit = useCallback(() => {
+    clearHalTimer();
+    const key = halActiveKeyRef.current;
+    if (key) {
+      halSuppressedKeyRef.current = key;
+      setHalSuppressedKey(key);
+    }
+    halPhaseRef.current = 'idle';
+    setHalPhase('idle');
+    setHalEye('off');
+    setHalStepIndex(null);
+    setHalDecision(null);
+    setHalLastError(null);
+  }, [clearHalTimer]);
+
+  const handleHalApprove = useCallback(() => {
+    setHalDecision('approve_local');
+    handleApprove();
+  }, [handleApprove]);
+
+  const handleHalReject = useCallback((reason?: string) => {
+    setHalDecision('reject');
+    handleReject(reason);
+  }, [handleReject]);
+
+  const handleHalTeleport = useCallback(() => {
+    setHalDecision('teleport_remote');
+    clearHalTimer();
+    const key = halActiveKeyRef.current;
+    if (key) {
+      halSuppressedKeyRef.current = key;
+      setHalSuppressedKey(key);
+    }
+    halPhaseRef.current = 'idle';
+    setHalPhase('idle');
+    setHalEye('off');
+    setHalStepIndex(null);
+    setHalLastError(null);
+    showStatusMessage('warn', 'Teleport to remote runtime is not implemented yet');
+    postMessage({ type: 'command', command: 'teleportAction' });
+  }, [clearHalTimer, postMessage, showStatusMessage]);
+
   // Context picker handlers
   const handleOpenContext = useCallback(() => {
     setShowSkillsPopover(false);
@@ -738,6 +1033,17 @@ export function App() {
   const llmModelLabel = llmModel === undefined
     ? undefined
     : (llmModel || (mode === 'remote' ? 'server default' : 'default'));
+  const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
+  const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
+  const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');
+  const halSessionKey =
+    halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
+      ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
+      : null;
+  const shouldShowHalOverlay = halEnabled && hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey;
+  const halUiPhase: HalPhase = halPhase === 'idle' && shouldShowHalOverlay ? 'dialogue' : halPhase;
+  const halUiStepIndex = halUiPhase === 'dialogue' ? Math.max(0, Math.min(halStepIndex ?? 0, halDialogueLines.length - 1)) : null;
+  const halUiLine = halUiPhase === 'dialogue' ? halDialogueLines[halUiStepIndex ?? 0] ?? null : null;
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -786,8 +1092,25 @@ export function App() {
         )}
       </div>
 
+      {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}
+      {shouldShowHalOverlay && (
+        <HalOverlay
+          userName={elevenlabs.userName.trim() || DEFAULT_ELEVENLABS_SETTINGS.userName}
+          phase={halUiPhase}
+          eye={halEye}
+          line={halUiLine}
+          decision={halDecision}
+          lastError={halLastError}
+          isSubmitting={isSubmitting}
+          onApprove={handleHalApprove}
+          onTeleport={handleHalTeleport}
+          onReject={handleHalReject}
+          onExit={handleHalExit}
+        />
+      )}
+
       {/* Confirmation prompt (modal overlay) */}
-      {agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0 && (
+      {hasPendingConfirmation && !shouldShowHalOverlay && (
         <ConfirmationPrompt
           pendingActions={pendingActions}
           onApprove={handleApprove}

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from 'react';
+
+export type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
+export type HalEye = 'off' | 'dim' | 'pulsating';
+
+type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
+
+type HalOverlayProps = {
+  userName: string;
+  phase: HalPhase;
+  eye: HalEye;
+  line: string | null;
+  decision: HalDecision | null;
+  lastError: string | null;
+  isSubmitting: boolean;
+  onApprove: () => void;
+  onTeleport: () => void;
+  onReject: (reason?: string) => void;
+  onExit: () => void;
+};
+
+export function HalOverlay({
+  userName,
+  phase,
+  eye,
+  line,
+  decision,
+  lastError,
+  isSubmitting,
+  onApprove,
+  onTeleport,
+  onReject,
+  onExit,
+}: HalOverlayProps) {
+  const [showRejectInput, setShowRejectInput] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  const title = useMemo(() => {
+    if (phase === 'waiting_remote') return 'Teleporting…';
+    if (phase === 'error') return 'HAL Error';
+    return 'Restricted Area Protocol';
+  }, [phase]);
+
+  const subtitle = useMemo(() => {
+    if (phase === 'dialogue') return `Hello, ${userName}.`;
+    if (phase === 'awaiting_user') return 'Please choose an action.';
+    if (phase === 'waiting_remote') return 'Preparing remote runtime…';
+    if (phase === 'error') return 'The HAL flow encountered an error.';
+    return '';
+  }, [phase, userName]);
+
+  const showDecisionButtons = phase === 'awaiting_user' && !showRejectInput;
+
+  const canSubmit = !isSubmitting && phase === 'awaiting_user';
+
+  const handleRejectClick = () => {
+    if (!canSubmit) return;
+    setShowRejectInput(true);
+  };
+
+  const handleCancelReject = () => {
+    setShowRejectInput(false);
+    setRejectReason('');
+  };
+
+  const handleConfirmReject = () => {
+    if (!canSubmit) return;
+    onReject(rejectReason.trim() || undefined);
+    setShowRejectInput(false);
+    setRejectReason('');
+  };
+
+  const isPulsating = eye === 'pulsating';
+
+  return (
+    <div className="fixed inset-0 z-50 pointer-events-none">
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-xs" aria-hidden="true" />
+
+      <div className="absolute left-1/2 -translate-x-1/2 bottom-[124px] flex flex-col items-center gap-4 pointer-events-auto">
+        <div
+          className={[
+            'relative w-20 h-20 rounded-full border border-red-400/40',
+            'bg-[radial-gradient(circle_at_50%_45%,rgba(255,255,255,0.35),rgba(239,68,68,0.35)_35%,rgba(0,0,0,0.85)_70%)]',
+            isPulsating ? 'animate-pulse shadow-[0_0_24px_rgba(239,68,68,0.35)]' : 'shadow-[0_0_12px_rgba(239,68,68,0.25)]',
+          ].join(' ')}
+          aria-label="HAL eye"
+        >
+          <div className="absolute inset-3 rounded-full bg-black/40 border border-red-500/20" />
+          <div className="absolute left-1/2 top-[54%] -translate-x-1/2 -translate-y-1/2 w-2 h-2 rounded-full bg-red-200/80 blur-[0.5px]" />
+        </div>
+
+        <div
+          className="w-[min(560px,calc(100vw-32px))] rounded-2xl border border-red-400/25 bg-stone-950/90 shadow-2xl overflow-hidden"
+          role="dialog"
+          aria-modal="true"
+          aria-label="HAL protocol"
+        >
+          <div className="px-5 py-4 border-b border-white/[0.06] flex items-start justify-between gap-4">
+            <div>
+              <div className="text-sm font-semibold text-stone-100">{title}</div>
+              <div className="text-xs text-stone-400 mt-1">{subtitle}</div>
+            </div>
+
+            <button
+              type="button"
+              onClick={onExit}
+              disabled={isSubmitting}
+              className="shrink-0 px-3 py-1.5 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:text-stone-200 text-xs font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Exit
+            </button>
+          </div>
+
+          <div className="px-5 py-4">
+            {lastError && (
+              <div className="mb-3 text-xs text-red-300 bg-red-500/10 border border-red-400/20 rounded-lg p-3">
+                {lastError}
+              </div>
+            )}
+
+            {line && (
+              <div className="font-mono text-sm text-stone-200 bg-black/30 border border-white/[0.06] rounded-xl p-4">
+                {line}
+              </div>
+            )}
+
+            {phase === 'dialogue' && (
+              <div className="mt-3 text-xs text-stone-500">
+                {decision ? `Decision: ${decision}` : '…'}
+              </div>
+            )}
+
+            {showDecisionButtons && (
+              <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={handleRejectClick}
+                  disabled={!canSubmit}
+                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:text-stone-200 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                >
+                  <span className="codicon codicon-close" />
+                  Reject
+                </button>
+
+                <button
+                  type="button"
+                  onClick={onTeleport}
+                  disabled={!canSubmit}
+                  className="px-4 py-2 rounded-lg bg-red-500/10 border border-red-400/25 text-red-200 hover:bg-red-500/20 hover:text-red-100 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                >
+                  <span className="codicon codicon-run-all" />
+                  Teleport to Remote
+                </button>
+
+                <button
+                  type="button"
+                  onClick={onApprove}
+                  disabled={!canSubmit}
+                  className="px-4 py-2.5 rounded-lg bg-gradient-to-b from-brand-500 to-brand-600 text-white text-sm font-medium transition-all shadow-glow-sm hover:from-brand-400 hover:to-brand-500 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <span className="codicon codicon-check" />
+                  Approve Locally
+                </button>
+              </div>
+            )}
+
+            {phase === 'awaiting_user' && showRejectInput && (
+              <div className="mt-4 p-4 bg-white/[0.03] border border-white/[0.06] rounded-xl animate-slide-down">
+                <label htmlFor="hal-reject-reason" className="block text-sm font-medium text-stone-300 mb-2">
+                  Reason for rejection (optional):
+                </label>
+                <textarea
+                  id="hal-reject-reason"
+                  value={rejectReason}
+                  onChange={(e) => setRejectReason(e.target.value)}
+                  placeholder="Reason for rejection (optional)"
+                  rows={3}
+                  className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 resize-none focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500/30"
+                  autoFocus
+                />
+                <div className="mt-3 flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCancelReject}
+                    disabled={isSubmitting}
+                    className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleConfirmReject}
+                    disabled={isSubmitting}
+                    className="px-4 py-2 rounded-lg bg-red-500/15 hover:bg-red-500/25 text-red-300 text-sm font-medium transition-all border border-red-400/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Confirm Rejection
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -53,6 +53,16 @@ type WebviewMessage =
     skillsCount: number;
     attachmentsCount: number;
   }
+  | {
+    type: 'halStateResponse';
+    requestId: string;
+    enabled: boolean;
+    phase: string;
+    eye: string;
+    stepIndex: number | null;
+    decision: string | null;
+    lastError: string | null;
+  }
   | { type: 'webviewConsole'; level: string; args: unknown[] }
   | { type: 'webviewError'; message: string; stack?: string }
   | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
@@ -285,6 +295,17 @@ export type CreateWebviewMessageHandlerDeps = {
       attachmentsCount: number;
     }
   ) => void;
+  onHalStateResponse: (
+    requestId: string,
+    info: {
+      enabled: boolean;
+      phase: string;
+      eye: string;
+      stepIndex: number | null;
+      decision: string | null;
+      lastError: string | null;
+    }
+  ) => void;
 
   isDevBridgeEnabled: () => boolean;
   getOutputChannel: () => vscode.OutputChannel | undefined;
@@ -320,6 +341,11 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           type: 'serverListUpdated',
           servers: initSettings.servers,
           serverUrl: initSettings.serverUrl ?? '',
+        });
+
+        void host.postMessage({
+          type: 'elevenlabsSettings',
+          elevenlabs: initSettings.elevenlabs,
         });
 
         deps.flushConversationEventBacklog({
@@ -690,6 +716,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           case 'rejectAction':
             await conversation?.rejectAction(message.reason);
             break;
+          case 'teleportAction':
+            void vscode.window.showInformationMessage('Teleport to remote runtime is not implemented yet.');
+            break;
           default:
             console.warn(`Unknown command received from webview: ${message.command}`);
             break;
@@ -713,6 +742,16 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           selectedContextFiles: message.selectedContextFiles,
           skillsCount: message.skillsCount,
           attachmentsCount: message.attachmentsCount,
+        });
+        break;
+      case 'halStateResponse':
+        deps.onHalStateResponse(message.requestId, {
+          enabled: message.enabled,
+          phase: message.phase,
+          eye: message.eye,
+          stepIndex: message.stepIndex,
+          decision: message.decision,
+          lastError: message.lastError,
         });
         break;
       case 'webviewConsole': {

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -170,5 +170,58 @@ export async function run(): Promise<void> {
     return hal?.phase === 'idle';
   }, 15000);
 
+  // Also cover deterministic reject path.
+  const rejectToolCallId = `call_hal_reject_${Date.now()}`;
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'High-risk action (reject)' }],
+    action: { command: 'rm -rf /tmp/test-reject' },
+    tool_name: 'terminal',
+    tool_call_id: rejectToolCallId,
+    tool_call: {
+      id: rejectToolCallId,
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"rm -rf /tmp/test-reject"}' }
+    },
+    llm_response_id: 'resp_hal_reject',
+    security_risk: 'HIGH'
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION'
+  });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'awaiting_user';
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._webviewAction', { action: 'halReject' });
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.decision === 'reject';
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'UserRejectObservation',
+    source: 'environment',
+    rejection_reason: 'E2E reject',
+    tool_name: 'terminal',
+    tool_call_id: rejectToolCallId,
+    action_id: 'action_hal_reject'
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'IDLE'
+  });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'idle';
+  }, 15000);
+
   console.log('✓ All ui flow tests passed');
 }

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -95,5 +95,80 @@ export async function run(): Promise<void> {
     return typeof state?.attachmentsCount === 'number' && state.attachmentsCount >= 1;
   }, 15000);
 
+  // HAL: Phase 0 bundled flow (no network calls)
+  const cfg = vscode.workspace.getConfiguration();
+  await cfg.update('openhands.elevenlabs.enabled', true, vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.elevenlabs.mode', 'bundled', vscode.ConfigurationTarget.Global);
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.enabled === true;
+  }, 15000);
+
+  const highRiskToolCallId = `call_hal_high_${Date.now()}`;
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'High-risk action' }],
+    action: { command: 'rm -rf /tmp/test' },
+    tool_name: 'terminal',
+    tool_call_id: highRiskToolCallId,
+    tool_call: {
+      id: highRiskToolCallId,
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"rm -rf /tmp/test"}' }
+    },
+    llm_response_id: 'resp_hal_high',
+    security_risk: 'HIGH'
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION'
+  });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'dialogue';
+  }, 15000);
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'awaiting_user';
+  }, 15000);
+
+  // Ensure the HAL overlay doesn't restart on repeated state updates.
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION'
+  });
+  await new Promise((r) => setTimeout(r, 200));
+  const halAfterRepeat: any = await vscode.commands.executeCommand('openhands._queryHalState');
+  if (halAfterRepeat?.phase !== 'awaiting_user') {
+    throw new Error(`Expected HAL to remain awaiting_user; got ${JSON.stringify(halAfterRepeat)}`);
+  }
+
+  // Choose approve deterministically and simulate completion.
+  await vscode.commands.executeCommand('openhands._webviewAction', { action: 'halApprove' });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ObservationEvent',
+    source: 'environment',
+    observation: { content: 'ok', exit_code: 0 },
+    tool_name: 'terminal',
+    tool_call_id: highRiskToolCallId,
+    action_id: 'action_hal'
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'IDLE'
+  });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'idle';
+  }, 15000);
+
   console.log('✓ All ui flow tests passed');
 }


### PR DESCRIPTION
Implements HAL Phase 0 (bundled mode) per docs/hal/elevenlabs_prd.md and Beads oh-tab-iyc.

- Webview HAL overlay replaces confirmation prompt for HIGH-risk actions when openhands.elevenlabs.enabled=true and mode=bundled
- Adds openhands._queryHalState test/debug command and E2E coverage in uiFlows
- Adds teleportAction hook (stub); actual teleport comes in follow-up Beads

Tests:
- npm run typecheck
- npm run lint
- npm test
- npm run e2e