### PR TITLE
[oh-tab-nxs] Lowercase risk badges

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -832,7 +832,7 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'event', event: action });
 
       await waitFor(() => {
-        expect(screen.getByText('HIGH')).toBeInTheDocument();
+        expect(screen.getByText('high')).toBeInTheDocument();
       });
     });
 
@@ -847,7 +847,7 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'event', event: action });
 
       await waitFor(() => {
-        expect(screen.getByText('MEDIUM')).toBeInTheDocument();
+        expect(screen.getByText('medium')).toBeInTheDocument();
       });
     });
 
@@ -862,7 +862,7 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'event', event: action });
 
       await waitFor(() => {
-        expect(screen.getByText('LOW')).toBeInTheDocument();
+        expect(screen.getByText('low')).toBeInTheDocument();
       });
     });
 

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -60,7 +60,7 @@ describe('App - Confirmation Flow', () => {
     const scope = within(dialog);
     // Tool name is shown in the action details
     expect(scope.getAllByText(/terminal/i).length).toBeGreaterThanOrEqual(1);
-    expect(scope.getByText(/HIGH RISK/)).toBeInTheDocument();
+    expect(scope.getByText(/high risk/)).toBeInTheDocument();
     expect(scope.getByText(/Reasoning/)).toBeInTheDocument();
   });
 

--- a/src/webview-src/components/ConfirmationPrompt.tsx
+++ b/src/webview-src/components/ConfirmationPrompt.tsx
@@ -120,7 +120,7 @@ export function ConfirmationPrompt({
                         `}
                       >
                         <span className={`codicon codicon-${action.security_risk === 'HIGH' ? 'shield' : 'warning'} text-[10px]`} />
-                        {action.security_risk} RISK
+                        {action.security_risk.toLowerCase()} risk
                       </span>
                     )}
                   </div>

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -337,7 +337,7 @@ function SecurityBadge({ risk }: { risk: 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN' }
   return (
     <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border ${styles[risk]}`}>
       <span className={`codicon codicon-${icons[risk]} text-[10px]`} />
-      {risk}
+      {risk.toLowerCase()}
     </span>
   );
 }


### PR DESCRIPTION
Closes Beads `oh-tab-nxs`.

- Render `HIGH/MEDIUM/LOW` risk badges as lowercase in event blocks
- Render confirmation badge as `high risk` (etc.)
- Update webview tests accordingly

Tests:
- `npm test`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for security risk badge display to assert lowercase text formatting (high, medium, low instead of HIGH, MEDIUM, LOW).

* **Style**
  * Reformatted security risk label rendering from uppercase to lowercase in confirmation dialogs and event block components for consistent text presentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->