### PR TITLE
[oh-tab-bho] Gemini settings + API key

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "onCommand:openhands.setSessionApiKey",
     "onCommand:openhands.setGithubToken",
     "onCommand:openhands.setElevenLabsApiKey",
+    "onCommand:openhands.setGeminiApiKey",
     "onCommand:openhands.setCustomSecret1",
     "onCommand:openhands.setCustomSecret2",
     "onCommand:openhands.setCustomSecret3",
@@ -65,6 +66,10 @@
       {
         "command": "openhands.setElevenLabsApiKey",
         "title": "OpenHands: Set ElevenLabs API Key"
+      },
+      {
+        "command": "openhands.setGeminiApiKey",
+        "title": "OpenHands: Set Gemini API Key"
       },
       {
         "command": "openhands.setCustomSecret1",
@@ -312,6 +317,16 @@
           "default": true,
           "markdownDescription": "Enable caching for generated ElevenLabs audio."
         },
+        "openhands.gemini.model": {
+          "type": "string",
+          "default": "gemini-2.5-flash",
+          "markdownDescription": "Gemini model used for `voice_confirm` classification."
+        },
+        "openhands.gemini.baseUrl": {
+          "type": "string",
+          "default": "https://generativelanguage.googleapis.com/v1beta",
+          "markdownDescription": "Gemini API base URL (default is Google AI Studio; allow proxies)."
+        },
         "openhands.secrets.githubToken": {
           "type": "string",
           "default": "",
@@ -323,6 +338,12 @@
           "default": "",
           "editPresentation": "singlelineText",
           "markdownDescription": "**To set your ElevenLabs API key securely:**\n\n[🔑 Configure ElevenLabs API Key](command:openhands.setElevenLabsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
+        },
+        "openhands.secrets.geminiApiKey": {
+          "type": "string",
+          "default": "",
+          "editPresentation": "singlelineText",
+          "markdownDescription": "**To set your Gemini API key securely:**\n\n[🔑 Configure Gemini API Key](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
         },
         "openhands.secrets.customSecret1": {
           "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1136,6 +1136,15 @@ export function activate(context: vscode.ExtensionContext) {
     errorPrefix: 'Failed to save ElevenLabs API key',
   });
 
+  const setGeminiApiKey = registerSecretCommand('openhands.setGeminiApiKey', {
+    title: 'Gemini API Key',
+    secretKey: 'geminiApiKey',
+    prompt: 'Enter your Gemini API key. It will be stored securely in VS Code SecretStorage.',
+    successMessage: 'Gemini API key saved securely.',
+    clearedMessage: 'Gemini API key cleared.',
+    errorPrefix: 'Failed to save Gemini API key',
+  });
+
   const setCustomSecret1 = registerSecretCommand('openhands.setCustomSecret1', {
     title: 'Custom Secret 1',
     secretKey: 'customSecret1',
@@ -1244,6 +1253,7 @@ export function activate(context: vscode.ExtensionContext) {
     setSessionApiKey,
     setGithubToken,
     setElevenLabsApiKey,
+    setGeminiApiKey,
     setCustomSecret1,
     setCustomSecret2,
     setCustomSecret3,

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -18,12 +18,18 @@ export type ElevenLabsSettings = {
   cache: boolean;
 };
 
+export type GeminiSettings = {
+  model: string;
+  baseUrl: string;
+};
+
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
   elevenlabs: ElevenLabsSettings;
+  gemini: GeminiSettings;
   servers: SavedServer[];
   secrets: {
     sessionApiKey?: string;
@@ -32,6 +38,7 @@ export type OpenHandsSettings = ServerSettings & {
     awsSecretAccessKey?: string;
     githubToken?: string;
     elevenLabsApiKey?: string;
+    geminiApiKey?: string;
     customSecret1?: string;
     customSecret2?: string;
     customSecret3?: string;
@@ -46,6 +53,7 @@ const DEFAULTS: OpenHandsSettings = {
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
   elevenlabs: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },
+  gemini: { model: 'gemini-2.5-flash', baseUrl: 'https://generativelanguage.googleapis.com/v1beta' },
   secrets: {}
 };
 
@@ -166,6 +174,14 @@ export class SettingsManager {
       ),
       cache: this.adapter.get<boolean>('openhands.elevenlabs.cache', DEFAULTS.elevenlabs.cache) ?? DEFAULTS.elevenlabs.cache,
     };
+    const gemini: GeminiSettings = {
+      model: normalizeNonEmptyString(
+        this.adapter.get<string | null>('openhands.gemini.model', DEFAULTS.gemini.model) ?? DEFAULTS.gemini.model
+      ) ?? DEFAULTS.gemini.model,
+      baseUrl: normalizeNonEmptyString(
+        this.adapter.get<string | null>('openhands.gemini.baseUrl', DEFAULTS.gemini.baseUrl) ?? DEFAULTS.gemini.baseUrl
+      ) ?? DEFAULTS.gemini.baseUrl,
+    };
     const secrets = {
       sessionApiKey: await this.adapter.getSecret('openhands.sessionApiKey'),
       llmApiKey: await this.adapter.getSecret('openhands.llmApiKey'),
@@ -173,11 +189,12 @@ export class SettingsManager {
       awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
       githubToken: await this.adapter.getSecret('openhands.githubToken'),
       elevenLabsApiKey: await this.adapter.getSecret('openhands.elevenLabsApiKey'),
+      geminiApiKey: await this.adapter.getSecret('openhands.geminiApiKey'),
       customSecret1: await this.adapter.getSecret('openhands.customSecret1'),
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
       customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
     };
-    return { serverUrl, servers, llm, agent, conversation, confirmation, elevenlabs, secrets };
+    return { serverUrl, servers, llm, agent, conversation, confirmation, elevenlabs, gemini, secrets };
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
@@ -262,6 +279,15 @@ export class SettingsManager {
       }
     }
 
+    if (partial.gemini) {
+      if (partial.gemini.model !== undefined) {
+        ops.push(this.adapter.update('openhands.gemini.model', partial.gemini.model, target));
+      }
+      if (partial.gemini.baseUrl !== undefined) {
+        ops.push(this.adapter.update('openhands.gemini.baseUrl', partial.gemini.baseUrl, target));
+      }
+    }
+
     if (partial.secrets) {
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'sessionApiKey')) {
         ops.push(this.adapter.storeSecret('openhands.sessionApiKey', partial.secrets.sessionApiKey));
@@ -280,6 +306,9 @@ export class SettingsManager {
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'elevenLabsApiKey')) {
         ops.push(this.adapter.storeSecret('openhands.elevenLabsApiKey', partial.secrets.elevenLabsApiKey));
+      }
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'geminiApiKey')) {
+        ops.push(this.adapter.storeSecret('openhands.geminiApiKey', partial.secrets.geminiApiKey));
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret1')) {
         ops.push(this.adapter.storeSecret('openhands.customSecret1', partial.secrets.customSecret1));

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -40,6 +40,8 @@ describe('SettingsManager', () => {
     expect(s.elevenlabs.modelId).toBeUndefined();
     expect(s.elevenlabs.volume).toBe(1);
     expect(s.elevenlabs.cache).toBe(true);
+    expect(s.gemini.model).toBe('gemini-2.5-flash');
+    expect(s.gemini.baseUrl).toBe('https://generativelanguage.googleapis.com/v1beta');
   });
 
   it('includes a default model in remote mode', async () => {
@@ -74,7 +76,11 @@ describe('SettingsManager', () => {
         volume: 0.25,
         cache: false,
       },
-      secrets: { sessionApiKey: 'sess', llmApiKey: 'key' }
+      gemini: {
+        model: 'gemini-2.5-pro',
+        baseUrl: 'https://proxy.example.com/v1beta',
+      },
+      secrets: { sessionApiKey: 'sess', llmApiKey: 'key', geminiApiKey: 'gemini-key' }
     });
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
@@ -98,8 +104,11 @@ describe('SettingsManager', () => {
     expect(s.elevenlabs.modelId).toBe('eleven_turbo_v2');
     expect(s.elevenlabs.volume).toBe(0.25);
     expect(s.elevenlabs.cache).toBe(false);
+    expect(s.gemini.model).toBe('gemini-2.5-pro');
+    expect(s.gemini.baseUrl).toBe('https://proxy.example.com/v1beta');
     expect(s.secrets.sessionApiKey).toBe('sess');
     expect(s.secrets.llmApiKey).toBe('key');
+    expect(s.secrets.geminiApiKey).toBe('gemini-key');
   });
 
   it('sanitizes invalid ElevenLabs mode and clamps volume', async () => {
@@ -124,13 +133,15 @@ describe('SettingsManager', () => {
     expect(s2.elevenlabs.volume).toBe(0);
   });
 
-  it('clears secret when undefined is provided', async () => {
-    await mgr.update({ secrets: { llmApiKey: 'abc' } });
+  it('clears secrets when undefined is provided', async () => {
+    await mgr.update({ secrets: { llmApiKey: 'abc', geminiApiKey: 'g1' } });
     let s = await mgr.get();
     expect(s.secrets.llmApiKey).toBe('abc');
-    await mgr.update({ secrets: { llmApiKey: undefined } });
+    expect(s.secrets.geminiApiKey).toBe('g1');
+    await mgr.update({ secrets: { llmApiKey: undefined, geminiApiKey: undefined } });
     s = await mgr.get();
     expect(s.secrets.llmApiKey).toBeUndefined();
+    expect(s.secrets.geminiApiKey).toBeUndefined();
   });
 
   it('updates AWS credentials', async () => {


### PR DESCRIPTION
Closes Beads `oh-tab-bho`.

- Add `openhands.gemini.model` and `openhands.gemini.baseUrl` settings
- Add secure secret `openhands.geminiApiKey` with `OpenHands: Set Gemini API Key`
- Wire secret through `SettingsManager` + tests

Tests:
- `npm test`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini API integration with secure API key management
  * Introduced HAL (Hyper-Attention Layer) dialogue overlay for managing high-risk actions with visual feedback and decision controls

* **Configuration**
  * Added Gemini settings: model selection and API base URL configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->