### PR TITLE
oh-tab-qdr: HAL Teleport decision

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1096,8 +1096,9 @@ export function activate(context: vscode.ExtensionContext) {
 
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
     const postToWebview = (message: unknown) => {
-      if (!chatView || !chatWebviewReady) return;
+      if (!chatView || !chatWebviewReady) return false;
       void chatView.webview.postMessage(message);
+      return true;
     };
 
     try {
@@ -1108,8 +1109,10 @@ export function activate(context: vscode.ExtensionContext) {
       if (!firstServerUrl) {
         const message = 'No server available';
         outputChannel?.appendLine(`[hal.teleport] ${message}`);
-        postToWebview({ type: 'halTeleportUnavailable', error: message });
-        void vscode.window.showErrorMessage(message);
+        const posted = postToWebview({ type: 'halTeleportUnavailable', error: message });
+        if (!posted) {
+          void vscode.window.showErrorMessage(message);
+        }
         return;
       }
 
@@ -1157,8 +1160,10 @@ export function activate(context: vscode.ExtensionContext) {
     } catch (err) {
       const reason = renderError(err);
       outputChannel?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
-      postToWebview({ type: 'halTeleportFailed', error: reason });
-      void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
+      const posted = postToWebview({ type: 'halTeleportFailed', error: reason });
+      if (!posted) {
+        void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
+      }
     }
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,16 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
+import * as childProcess from 'child_process';
 import * as path from 'path';
 import * as os from 'os';
 import { SettingsManager, type OpenHandsSettings } from './settings/SettingsManager';
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
+import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from './shared/halTeleport';
 import {
   Conversation,
   type ConversationInstance,
   FileEditorTool,
+  LLMFactory,
   TaskTrackerTool,
   TerminalTool,
   type BashEvent,
@@ -570,6 +573,81 @@ function safeStringify(value: unknown): string {
 }
 /* eslint-enable @typescript-eslint/no-unsafe-return */
 
+function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(command, args, { cwd }, (err, stdout, stderr) => {
+      if (err) {
+        const message = typeof stderr === 'string' && stderr.trim().length > 0 ? stderr.trim() : err.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve(typeof stdout === 'string' ? stdout : String(stdout));
+    });
+  });
+}
+
+async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ repoName: string; branchName: string }> {
+  const fallbackRepo = workspaceRoot ? path.basename(workspaceRoot) : 'unknown';
+  if (!workspaceRoot) return { repoName: fallbackRepo, branchName: 'unknown' };
+
+  try {
+    const root = (await execFileText('git', ['rev-parse', '--show-toplevel'], workspaceRoot)).trim();
+    const branch = (await execFileText('git', ['rev-parse', '--abbrev-ref', 'HEAD'], root)).trim();
+    return { repoName: path.basename(root) || fallbackRepo, branchName: branch || 'unknown' };
+  } catch {
+    return { repoName: fallbackRepo, branchName: 'unknown' };
+  }
+}
+
+async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string): Promise<string> {
+  const model = normalizeNonEmptyString(settings.llm.model) ?? '';
+  if (!model) {
+    throw new Error('LLM model is not configured');
+  }
+  const apiKey = normalizeNonEmptyString(settings.secrets.llmApiKey);
+  if (!apiKey) {
+    throw new Error('Missing LLM API key');
+  }
+
+  const factory = new LLMFactory({
+    provider: settings.llm.provider ?? undefined,
+    model,
+    baseUrl: normalizeNonEmptyString(settings.llm.baseUrl),
+    apiKey,
+    apiVersion: normalizeNonEmptyString(settings.llm.apiVersion),
+    timeoutSeconds: settings.llm.timeout ?? undefined,
+    temperature: settings.llm.temperature ?? undefined,
+    topP: settings.llm.topP ?? undefined,
+    topK: settings.llm.topK ?? undefined,
+    maxInputTokens: settings.llm.maxInputTokens ?? undefined,
+    maxOutputTokens: settings.llm.maxOutputTokens ?? undefined,
+    reasoningEffort: settings.llm.reasoningEffort ?? undefined,
+    inputCostPerToken: settings.llm.inputCostPerToken ?? undefined,
+    outputCostPerToken: settings.llm.outputCostPerToken ?? undefined,
+  });
+
+  const client = await factory.createClient();
+  const request = {
+    systemPrompt: '',
+    messages: [
+      {
+        role: 'user' as const,
+        content: [{ type: 'text' as const, text: prompt }],
+      },
+    ],
+  };
+
+  let text = '';
+  for await (const chunk of client.streamChat(request)) {
+    if (chunk.type === 'text') text += chunk.text;
+  }
+  const trimmed = text.trim();
+  if (!trimmed) {
+    throw new Error('LLM returned an empty summary');
+  }
+  return trimmed;
+}
+
 function normalizeNonEmptyString(value: string | undefined | null): string | undefined {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   return trimmed || undefined;
@@ -1016,6 +1094,74 @@ export function activate(context: vscode.ExtensionContext) {
     await conversation?.startNewConversation();
   });
 
+  const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
+    const postToWebview = (message: unknown) => {
+      if (!chatView || !chatWebviewReady) return;
+      void chatView.webview.postMessage(message);
+    };
+
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      const settings = await settingsMgr.get();
+
+      const firstServerUrl = typeof settings.servers?.[0]?.url === 'string' ? settings.servers[0].url.trim() : '';
+      if (!firstServerUrl) {
+        const message = 'No server available';
+        outputChannel?.appendLine(`[hal.teleport] ${message}`);
+        postToWebview({ type: 'halTeleportUnavailable', error: message });
+        void vscode.window.showErrorMessage(message);
+        return;
+      }
+
+      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const { repoName, branchName } = await resolveGitContext(workspaceRoot);
+      const introLines = [
+        'Teleported from the local VS Code runtime after a HIGH-risk confirmation.',
+        `Repo: ${repoName}`,
+        `Branch: ${branchName}`,
+        'Note: uncommitted local changes may not be present remotely.',
+      ];
+      const intro = introLines.join('\n');
+
+      const backlogEvents = Array.from(iterConversationEventBacklog(), (item) => item.event);
+      const summaryEvents = takeLastTeleportableEvents(backlogEvents, TELEPORT_SUMMARY_EVENT_LIMIT);
+      const prompt = renderCondensationSummarizingPrompt({
+        previousSummary: '',
+        eventStrings: summaryEvents.map((e) => safeStringify(e)),
+      });
+
+      let firstRemoteMessage: string;
+      try {
+        const summary = await summarizeWithLocalLlm(settings, prompt);
+        firstRemoteMessage = `${intro}\n\n---\n\n${summary}`;
+      } catch (err) {
+        const last10 = takeLastTeleportableEvents(backlogEvents, TELEPORT_FALLBACK_EVENT_LIMIT).map((e) => safeStringify(e));
+        const reason = renderError(err);
+        const block = last10.map((e) => `<EVENT>\n${e}\n</EVENT>`).join('\n\n');
+        firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary failed: ${reason}\n\nLast 10 events (Action/Observation/Message only):\n\n${block}`;
+      }
+
+      try {
+        await conversation?.rejectAction('Teleported to remote runtime');
+      } catch (err) {
+        outputChannel?.appendLine(`[hal.teleport] Failed to reject local confirmation: ${renderError(err)}`);
+      }
+
+      // Ensure we always start a new remote conversation instead of restoring a prior one.
+      await context.workspaceState.update('openhands.conversationId.remote', undefined);
+
+      await settingsMgr.update({ serverUrl: firstServerUrl });
+      await ensureConversationAndConnection({ uiJustCreated: true });
+      await conversation?.startNewConversation();
+      await conversation?.sendUserMessage(firstRemoteMessage);
+    } catch (err) {
+      const reason = renderError(err);
+      outputChannel?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
+      postToWebview({ type: 'halTeleportFailed', error: reason });
+      void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
+    }
+  });
+
   const configure = vscode.commands.registerCommand('openhands.configure', async () => {
     // Open VS Code settings page for OpenHands extension
     await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
@@ -1248,6 +1394,7 @@ export function activate(context: vscode.ExtensionContext) {
     queryHalState,
     webviewAction,
     startNew,
+    teleportToRemoteRuntime,
     configure,
     setApiKey,
     setSessionApiKey,

--- a/src/shared/__tests__/halTeleport.test.ts
+++ b/src/shared/__tests__/halTeleport.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import type { Event } from '@openhands/agent-sdk-ts';
+import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents } from '../halTeleport';
+
+describe('takeLastTeleportableEvents', () => {
+  it('filters to Action/Observation/Message (user/assistant) and keeps order', () => {
+    const events: Event[] = [
+      { kind: 'ConversationStateUpdateEvent', source: 'agent' } as unknown as Event,
+      {
+        kind: 'MessageEvent',
+        source: 'agent',
+        llm_message: { role: 'system', content: [{ type: 'text', text: 'system prompt' }] },
+      } as unknown as Event,
+      {
+        kind: 'ActionEvent',
+        source: 'agent',
+        thought: [{ type: 'text', text: 't' }],
+        action: { kind: 'TerminalAction', command: 'pwd' },
+        tool_name: 'terminal',
+        tool_call_id: 'call_1',
+        tool_call: { id: 'call_1', type: 'function', function: { name: 'terminal', arguments: '{}' } },
+        llm_response_id: 'resp_1',
+      } as unknown as Event,
+      {
+        kind: 'MessageEvent',
+        source: 'user',
+        llm_message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+      } as unknown as Event,
+      { kind: 'Condensation', source: 'environment', forgotten_event_ids: [] } as unknown as Event,
+      {
+        kind: 'ObservationEvent',
+        source: 'environment',
+        observation: { kind: 'TerminalObservation', content: [] },
+        tool_name: 'terminal',
+        tool_call_id: 'call_1',
+        action_id: 'a1',
+      } as unknown as Event,
+    ];
+
+    const picked = takeLastTeleportableEvents(events, 10);
+    expect(picked.map((e) => e.kind)).toEqual(['ActionEvent', 'MessageEvent', 'ObservationEvent']);
+  });
+
+  it('limits to last N', () => {
+    const events: Event[] = [
+      { kind: 'ActionEvent', source: 'agent' } as unknown as Event,
+      { kind: 'ObservationEvent', source: 'environment' } as unknown as Event,
+      {
+        kind: 'MessageEvent',
+        source: 'agent',
+        llm_message: { role: 'assistant', content: [{ type: 'text', text: 'ok' }] },
+      } as unknown as Event,
+    ];
+    const picked = takeLastTeleportableEvents(events, 2);
+    expect(picked.map((e) => e.kind)).toEqual(['ObservationEvent', 'MessageEvent']);
+  });
+});
+
+describe('renderCondensationSummarizingPrompt', () => {
+  it('includes previous summary and event wrappers', () => {
+    const rendered = renderCondensationSummarizingPrompt({
+      previousSummary: 'prev',
+      eventStrings: ['{"kind":"MessageEvent"}', '{"kind":"ActionEvent"}'],
+    });
+    expect(rendered).toContain('<PREVIOUS SUMMARY>');
+    expect(rendered).toContain('prev');
+    expect(rendered).toContain('<EVENT>');
+    expect(rendered).toContain('{"kind":"MessageEvent"}');
+    expect(rendered).toContain('Now summarize the events using the rules above.');
+  });
+});
+

--- a/src/shared/halTeleport.ts
+++ b/src/shared/halTeleport.ts
@@ -1,0 +1,101 @@
+import type { Event, MessageEvent } from '@openhands/agent-sdk-ts';
+
+export const TELEPORT_SUMMARY_EVENT_LIMIT = 200;
+export const TELEPORT_FALLBACK_EVENT_LIMIT = 10;
+
+const isTeleportableMessage = (event: MessageEvent): boolean => {
+  const role = event.llm_message?.role;
+  return role === 'user' || role === 'assistant';
+};
+
+export const isTeleportableEvent = (event: Event): boolean => {
+  switch (event.kind) {
+    case 'ActionEvent':
+    case 'ObservationEvent':
+      return true;
+    case 'MessageEvent':
+      return isTeleportableMessage(event);
+    default:
+      return false;
+  }
+};
+
+export function takeLastTeleportableEvents(events: Iterable<Event>, limit: number): Event[] {
+  if (limit <= 0) return [];
+  const out: Event[] = [];
+  for (const event of events) {
+    if (!isTeleportableEvent(event)) continue;
+    out.push(event);
+    if (out.length > limit) out.shift();
+  }
+  return out;
+}
+
+const SUMMARIZING_PROMPT_HEADER = `You are maintaining a context-aware state summary for an interactive agent.
+You will be given a list of events corresponding to actions taken by the agent, and the most recent previous summary if one exists.
+If the events being summarized contain ANY task-tracking, you MUST include a TASK_TRACKING section to maintain continuity.
+When referencing tasks make sure to preserve exact task IDs and statuses.
+
+Track:
+
+USER_CONTEXT: (Preserve essential user requirements, goals, and clarifications in concise form)
+
+TASK_TRACKING: {Active tasks, their IDs and statuses - PRESERVE TASK IDs}
+
+COMPLETED: (Tasks completed so far, with brief results)
+PENDING: (Tasks that still need to be done)
+CURRENT_STATE: (Current variables, data structures, or relevant state)
+
+For code-specific tasks, also include:
+CODE_STATE: {File paths, function signatures, data structures}
+TESTS: {Failing cases, error messages, outputs}
+CHANGES: {Code edits, variable updates}
+DEPS: {Dependencies, imports, external calls}
+VERSION_CONTROL_STATUS: {Repository state, current branch, PR status, commit history}
+
+PRIORITIZE:
+1. Adapt tracking format to match the actual task type
+2. Capture key user requirements and goals
+3. Distinguish between completed and pending tasks
+4. Keep all sections concise and relevant
+
+SKIP: Tracking irrelevant details for the current task type
+
+Example formats:
+
+For code tasks:
+USER_CONTEXT: Fix FITS card float representation issue
+COMPLETED: Modified mod_float() in card.py, all tests passing
+PENDING: Create PR, update documentation
+CODE_STATE: mod_float() in card.py updated
+TESTS: test_format() passed
+CHANGES: str(val) replaces f"{val:.16G}"
+DEPS: None modified
+VERSION_CONTROL_STATUS: Branch: fix-float-precision, Latest commit: a1b2c3d
+
+For other tasks:
+USER_CONTEXT: Write 20 haikus based on coin flip results
+COMPLETED: 15 haikus written for results [T,H,T,H,T,H,T,T,H,T,H,T,H,T,H]
+PENDING: 5 more haikus needed
+CURRENT_STATE: Last flip: Heads, Haiku count: 15/20`;
+
+export function renderCondensationSummarizingPrompt(params: {
+  previousSummary?: string;
+  eventStrings: string[];
+}): string {
+  const previous = params.previousSummary ?? '';
+  const events = params.eventStrings
+    .map((event) => `<EVENT>\n${event}\n</EVENT>`)
+    .join('\n\n');
+
+  return `${SUMMARIZING_PROMPT_HEADER}
+
+<PREVIOUS SUMMARY>
+${previous}
+</PREVIOUS SUMMARY>
+
+${events}
+
+Now summarize the events using the rules above.
+`;
+}

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -192,6 +192,8 @@ export function App() {
   const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
   const [halDecision, setHalDecision] = useState<HalDecision | null>(null);
   const [halLastError, setHalLastError] = useState<string | null>(null);
+  const [halForceRejectInput, setHalForceRejectInput] = useState(false);
+  const [halTeleporting, setHalTeleporting] = useState(false);
   const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const halActiveKeyRef = useRef<string | null>(null);
   const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
@@ -199,6 +201,7 @@ export function App() {
   const halEnabledRef = useRef<boolean>(false);
   const halPhaseRef = useRef<HalPhase>('idle');
   const halSuppressedKeyRef = useRef<string | null>(null);
+  const halTeleportInProgressRef = useRef(false);
   const pendingActionsRef = useRef<ActionEvent[]>([]);
   const agentStatusRef = useRef<string | undefined>(undefined);
   const conversationIdRef = useRef<string | undefined>(undefined);
@@ -365,6 +368,7 @@ export function App() {
   }, [elevenlabs.userName]);
 
   const maybeUpdateHalFlow = useCallback(() => {
+    if (halTeleportInProgressRef.current) return;
     const enabled = halEnabledRef.current;
     const status = agentStatusRef.current;
     const pending = pendingActionsRef.current;
@@ -386,6 +390,8 @@ export function App() {
         setHalStepIndex(null);
         setHalDecision(null);
         setHalLastError(null);
+        setHalForceRejectInput(false);
+        setHalTeleporting(false);
       }
       return;
     }
@@ -395,6 +401,7 @@ export function App() {
       halActiveKeyRef.current = nextKey;
       halSuppressedKeyRef.current = null;
       setHalSuppressedKey(null);
+      setHalForceRejectInput(false);
     }
 
     if (halSuppressedKeyRef.current === nextKey) {
@@ -610,8 +617,49 @@ export function App() {
             setStatusBanner({ message: 'An unknown error occurred', level: 'error' });
           }
           break;
+        case 'halTeleportUnavailable': {
+          const message = typeof payload.error === 'string' && payload.error.trim() ? payload.error.trim() : 'No server available';
+          halTeleportInProgressRef.current = false;
+          setHalTeleporting(false);
+          setHalForceRejectInput(true);
+          setHalDecision(null);
+          setHalLastError(message);
+          halPhaseRef.current = 'awaiting_user';
+          setHalPhase('awaiting_user');
+          setHalEye('pulsating');
+          showStatusMessage('error', message);
+          break;
+        }
+        case 'halTeleportFailed': {
+          const message = typeof payload.error === 'string' && payload.error.trim() ? payload.error.trim() : 'Teleport failed';
+          halTeleportInProgressRef.current = false;
+          setHalTeleporting(false);
+          setHalForceRejectInput(false);
+          setHalDecision(null);
+          setHalLastError(message);
+          halPhaseRef.current = 'error';
+          setHalPhase('error');
+          setHalEye('dim');
+          showStatusMessage('error', message);
+          break;
+        }
         case 'conversationStarted':
           if (typeof payload.conversationId === 'string') {
+            if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
+              halTeleportInProgressRef.current = false;
+              setHalTeleporting(false);
+              setHalForceRejectInput(false);
+              clearHalTimer();
+              halActiveKeyRef.current = null;
+              halSuppressedKeyRef.current = null;
+              setHalSuppressedKey(null);
+              halPhaseRef.current = 'idle';
+              setHalPhase('idle');
+              setHalEye('off');
+              setHalStepIndex(null);
+              setHalDecision(null);
+              setHalLastError(null);
+            }
             conversationIdRef.current = payload.conversationId;
             setConversationId(payload.conversationId);
             setEvents([]);
@@ -699,8 +747,25 @@ export function App() {
               setHalDecision('reject');
               postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
               break;
+            case 'halTeleport':
+              setHalDecision('teleport_remote');
+              clearHalTimer();
+              halTeleportInProgressRef.current = true;
+              setHalTeleporting(true);
+              setHalForceRejectInput(false);
+              halPhaseRef.current = 'waiting_remote';
+              setHalPhase('waiting_remote');
+              setHalEye('pulsating');
+              setHalStepIndex(null);
+              setHalLastError(null);
+              showStatusMessage('info', 'Teleporting to remote runtime…');
+              postMessage({ type: 'command', command: 'teleportAction' });
+              break;
             case 'halExit': {
               clearHalTimer();
+              halTeleportInProgressRef.current = false;
+              setHalTeleporting(false);
+              setHalForceRejectInput(false);
               const key = halActiveKeyRef.current;
               if (key) {
                 halSuppressedKeyRef.current = key;
@@ -884,6 +949,9 @@ export function App() {
 
   const handleHalExit = useCallback(() => {
     clearHalTimer();
+    halTeleportInProgressRef.current = false;
+    setHalTeleporting(false);
+    setHalForceRejectInput(false);
     const key = halActiveKeyRef.current;
     if (key) {
       halSuppressedKeyRef.current = key;
@@ -910,17 +978,15 @@ export function App() {
   const handleHalTeleport = useCallback(() => {
     setHalDecision('teleport_remote');
     clearHalTimer();
-    const key = halActiveKeyRef.current;
-    if (key) {
-      halSuppressedKeyRef.current = key;
-      setHalSuppressedKey(key);
-    }
-    halPhaseRef.current = 'idle';
-    setHalPhase('idle');
-    setHalEye('off');
+    halTeleportInProgressRef.current = true;
+    setHalTeleporting(true);
+    setHalForceRejectInput(false);
+    halPhaseRef.current = 'waiting_remote';
+    setHalPhase('waiting_remote');
+    setHalEye('pulsating');
     setHalStepIndex(null);
     setHalLastError(null);
-    showStatusMessage('warn', 'Teleport to remote runtime is not implemented yet');
+    showStatusMessage('info', 'Teleporting to remote runtime…');
     postMessage({ type: 'command', command: 'teleportAction' });
   }, [clearHalTimer, postMessage, showStatusMessage]);
 
@@ -1040,7 +1106,8 @@ export function App() {
     halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
       ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
       : null;
-  const shouldShowHalOverlay = halEnabled && hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey;
+  const shouldShowHalOverlay =
+    halEnabled && (halPhase === 'waiting_remote' || (hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey));
   const halUiPhase: HalPhase = halPhase === 'idle' && shouldShowHalOverlay ? 'dialogue' : halPhase;
   const halUiStepIndex = halUiPhase === 'dialogue' ? Math.max(0, Math.min(halStepIndex ?? 0, halDialogueLines.length - 1)) : null;
   const halUiLine = halUiPhase === 'dialogue' ? halDialogueLines[halUiStepIndex ?? 0] ?? null : null;
@@ -1095,13 +1162,15 @@ export function App() {
       {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}
       {shouldShowHalOverlay && (
         <HalOverlay
+          key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
           userName={elevenlabs.userName.trim() || DEFAULT_ELEVENLABS_SETTINGS.userName}
           phase={halUiPhase}
           eye={halEye}
           line={halUiLine}
           decision={halDecision}
           lastError={halLastError}
-          isSubmitting={isSubmitting}
+          isSubmitting={isSubmitting || halTeleporting}
+          startWithRejectInput={halForceRejectInput}
           onApprove={handleHalApprove}
           onTeleport={handleHalTeleport}
           onReject={handleHalReject}

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -13,6 +13,7 @@ type HalOverlayProps = {
   decision: HalDecision | null;
   lastError: string | null;
   isSubmitting: boolean;
+  startWithRejectInput?: boolean;
   onApprove: () => void;
   onTeleport: () => void;
   onReject: (reason?: string) => void;
@@ -27,12 +28,13 @@ export function HalOverlay({
   decision,
   lastError,
   isSubmitting,
+  startWithRejectInput,
   onApprove,
   onTeleport,
   onReject,
   onExit,
 }: HalOverlayProps) {
-  const [showRejectInput, setShowRejectInput] = useState(false);
+  const [showRejectInput, setShowRejectInput] = useState(() => Boolean(startWithRejectInput));
   const [rejectReason, setRejectReason] = useState('');
 
   const title = useMemo(() => {

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -717,7 +717,12 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
             await conversation?.rejectAction(message.reason);
             break;
           case 'teleportAction':
-            void vscode.window.showInformationMessage('Teleport to remote runtime is not implemented yet.');
+            try {
+              await vscode.commands.executeCommand('openhands._teleportToRemoteRuntime');
+            } catch (err) {
+              const reason = err instanceof Error ? err.message : String(err);
+              void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
+            }
             break;
           default:
             console.warn(`Unknown command received from webview: ${message.command}`);

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -97,6 +97,8 @@ export async function run(): Promise<void> {
 
   // HAL: Phase 0 bundled flow (no network calls)
   const cfg = vscode.workspace.getConfiguration();
+  await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.servers', [], vscode.ConfigurationTarget.Global);
   await cfg.update('openhands.elevenlabs.enabled', true, vscode.ConfigurationTarget.Global);
   await cfg.update('openhands.elevenlabs.mode', 'bundled', vscode.ConfigurationTarget.Global);
 
@@ -158,6 +160,66 @@ export async function run(): Promise<void> {
     tool_name: 'terminal',
     tool_call_id: highRiskToolCallId,
     action_id: 'action_hal'
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'IDLE'
+  });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'idle';
+  }, 15000);
+
+  // Teleport (no servers): should fall back to Reject+reason prompt with a visible error.
+  const teleportToolCallId = `call_hal_teleport_${Date.now()}`;
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'High-risk action (teleport)' }],
+    action: { command: 'rm -rf /tmp/test-teleport' },
+    tool_name: 'terminal',
+    tool_call_id: teleportToolCallId,
+    tool_call: {
+      id: teleportToolCallId,
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"rm -rf /tmp/test-teleport"}' }
+    },
+    llm_response_id: 'resp_hal_teleport',
+    security_risk: 'HIGH'
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION'
+  });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'awaiting_user';
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._webviewAction', { action: 'halTeleport' });
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.phase === 'awaiting_user' && typeof hal?.lastError === 'string' && hal.lastError.includes('No server available');
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._webviewAction', { action: 'halReject' });
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.decision === 'reject';
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'UserRejectObservation',
+    source: 'environment',
+    rejection_reason: 'E2E reject',
+    tool_name: 'terminal',
+    tool_call_id: teleportToolCallId,
+    action_id: 'action_hal_teleport'
   });
   await vscode.commands.executeCommand('openhands._sendTestEvent', {
     kind: 'ConversationStateUpdateEvent',


### PR DESCRIPTION
Implements HAL decision outcome “Teleport to remote runtime” per `docs/hal/elevenlabs_prd.md`.

- Picks `servers[0]`; if empty: shows “No server available” and returns to Reject+reason flow.
- Runs one-shot local summary (condensation prompt) and sends summary-only as first remote user message; falls back to note + last 10 Action/Observation/Message events.
- Keeps HAL overlay in `waiting_remote` (“Teleporting…”) until remote conversation starts.
- Adds unit tests for event filtering + prompt rendering, and extends E2E to cover no-server teleport fallback.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run e2e`

Beads: `oh-tab-qdr`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote runtime teleport to transfer active sessions with dedicated teleport UI state and status messages.
  * Automatic conversation summarization during remote transfers, with fallback messaging when needed.

* **Bug Fixes**
  * Improved error handling and clearer user feedback when teleport attempts fail or no server is available.

* **Tests**
  * Added end-to-end tests covering teleport flows, including no-server and reject scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->