### PR TITLE
oh-tab-0c2: ElevenLabs tts_only HAL audio

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,9 +43,11 @@ type UiStateSnapshot = {
 type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
 type HalEye = 'off' | 'dim' | 'pulsating';
 type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
+type ElevenLabsMode = 'bundled' | 'tts_only' | 'voice_confirm';
 
 type HalStateSnapshot = {
   enabled: boolean;
+  mode: ElevenLabsMode;
   phase: HalPhase;
   eye: HalEye;
   stepIndex: number | null;
@@ -66,12 +68,17 @@ const DEFAULT_UI_STATE: UiStateSnapshot = {
 
 const DEFAULT_HAL_STATE: HalStateSnapshot = {
   enabled: false,
+  mode: 'tts_only',
   phase: 'idle',
   eye: 'off',
   stepIndex: null,
   decision: null,
   lastError: null,
 };
+
+function isElevenLabsMode(value: unknown): value is ElevenLabsMode {
+  return value === 'bundled' || value === 'tts_only' || value === 'voice_confirm';
+}
 
 function isHalPhase(value: unknown): value is HalPhase {
   return (
@@ -755,11 +762,13 @@ export function activate(context: vscode.ExtensionContext) {
           pendingUiStateRequests.get(requestId)?.(info);
         },
         onHalStateResponse: (requestId, info) => {
+          const mode = isElevenLabsMode(info.mode) ? info.mode : DEFAULT_HAL_STATE.mode;
           const phase = isHalPhase(info.phase) ? info.phase : DEFAULT_HAL_STATE.phase;
           const eye = isHalEye(info.eye) ? info.eye : DEFAULT_HAL_STATE.eye;
           const decision = isHalDecision(info.decision) ? info.decision : null;
           pendingHalStateRequests.get(requestId)?.({
             enabled: info.enabled === true,
+            mode,
             phase,
             eye,
             stepIndex: typeof info.stepIndex === 'number' ? info.stepIndex : null,

--- a/src/hal/elevenlabs/__tests__/ttsClient.test.ts
+++ b/src/hal/elevenlabs/__tests__/ttsClient.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ElevenLabsError, fetchElevenLabsTts } from '../ttsClient';
+
+describe('fetchElevenLabsTts', () => {
+  it('retries on 5xx and succeeds', async () => {
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('server error', { status: 500 }))
+      .mockResolvedValueOnce(new Response(new Uint8Array([1, 2, 3]), { status: 200 }));
+
+    const bytes = await fetchElevenLabsTts({
+      apiKey: 'xi-test',
+      voiceId: 'voice-123',
+      text: 'Hello',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      sleepImpl,
+      randomImpl: () => 0,
+      maxRetries: 2,
+    });
+
+    expect(bytes).toEqual(new Uint8Array([1, 2, 3]));
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    expect(sleepImpl).toHaveBeenCalledTimes(1);
+    expect(sleepImpl).toHaveBeenCalledWith(250);
+  });
+
+  it('does not retry on auth errors', async () => {
+    const sleepImpl = vi.fn(async () => {});
+    const fetchImpl = vi.fn().mockResolvedValue(new Response('nope', { status: 401 }));
+
+    await expect(
+      fetchElevenLabsTts({
+        apiKey: 'xi-test',
+        voiceId: 'voice-123',
+        text: 'Hello',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+        sleepImpl,
+        randomImpl: () => 0,
+        maxRetries: 2,
+      })
+    ).rejects.toMatchObject({ name: 'ElevenLabsError', kind: 'auth', status: 401 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(sleepImpl).toHaveBeenCalledTimes(0);
+  });
+
+  it('fails fast when api key is missing', async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      fetchElevenLabsTts({
+        apiKey: '',
+        voiceId: 'voice-123',
+        text: 'Hello',
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      })
+    ).rejects.toBeInstanceOf(ElevenLabsError);
+    expect(fetchImpl).toHaveBeenCalledTimes(0);
+  });
+});
+

--- a/src/hal/elevenlabs/__tests__/ttsConversationGate.test.ts
+++ b/src/hal/elevenlabs/__tests__/ttsConversationGate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ElevenLabsTtsService } from '../ttsService';
+import { ElevenLabsError } from '../ttsClient';
+import { TtsConversationGate } from '../ttsConversationGate';
+
+describe('TtsConversationGate', () => {
+  it('disables HAL audio per conversation after first failure and notifies once', async () => {
+    const tts = {
+      synthesize: vi.fn(async () => {
+        throw new ElevenLabsError('Nope', { kind: 'auth', status: 401 });
+      }),
+    } as unknown as ElevenLabsTtsService;
+    const gate = new TtsConversationGate(tts);
+
+    const first = await gate.synthesize({
+      conversationId: 'c1',
+      apiKey: 'xi-test',
+      voiceId: 'voice-123',
+      text: 'Hello',
+      cacheEnabled: true,
+    });
+    expect(first).toMatchObject({ ok: false, disabled: true, shouldNotify: true, kind: 'auth' });
+
+    const second = await gate.synthesize({
+      conversationId: 'c1',
+      apiKey: 'xi-test',
+      voiceId: 'voice-123',
+      text: 'Hello again',
+      cacheEnabled: true,
+    });
+    expect(second).toMatchObject({ ok: false, disabled: true, shouldNotify: false });
+    expect(tts.synthesize).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through bytes on success', async () => {
+    const tts = {
+      synthesize: vi.fn(async () => ({ bytes: new Uint8Array([7]), fromCache: false })),
+    } as unknown as ElevenLabsTtsService;
+    const gate = new TtsConversationGate(tts);
+
+    const res = await gate.synthesize({
+      conversationId: 'c2',
+      apiKey: 'xi-test',
+      voiceId: 'voice-123',
+      text: 'Hello',
+      cacheEnabled: true,
+    });
+    expect(res).toEqual({ ok: true, bytes: new Uint8Array([7]) });
+  });
+});
+

--- a/src/hal/elevenlabs/__tests__/ttsService.test.ts
+++ b/src/hal/elevenlabs/__tests__/ttsService.test.ts
@@ -1,0 +1,85 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { DiskLruCache } from '../diskLruCache';
+import { ElevenLabsTtsService } from '../ttsService';
+
+describe('DiskLruCache', () => {
+  it('prunes oldest entries when exceeding maxBytes', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-elevenlabs-cache-'));
+    try {
+      const cache = new DiskLruCache(dir, 30);
+      await cache.set('a', new Uint8Array(20));
+      await cache.set('b', new Uint8Array(20));
+
+      const a = await cache.get('a');
+      const b = await cache.get('b');
+      expect(a).toBeUndefined();
+      expect(b?.byteLength).toBe(20);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('ElevenLabsTtsService', () => {
+  it('caches by voiceId/modelId/text', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-elevenlabs-service-'));
+    try {
+      const service = new ElevenLabsTtsService({ cacheDir: dir, maxCacheBytes: 1024 * 1024 });
+      const fetchImpl = vi.fn().mockResolvedValue(new Response(new Uint8Array([9, 9, 9]), { status: 200 }));
+
+      const first = await service.synthesize({
+        apiKey: 'xi-test',
+        voiceId: 'voice-123',
+        modelId: 'eleven_turbo_v2',
+        text: 'Hello',
+        cacheEnabled: true,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      const second = await service.synthesize({
+        apiKey: 'xi-test',
+        voiceId: 'voice-123',
+        modelId: 'eleven_turbo_v2',
+        text: 'Hello',
+        cacheEnabled: true,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      expect(first.fromCache).toBe(false);
+      expect(second.fromCache).toBe(true);
+      expect(fetchImpl).toHaveBeenCalledTimes(1);
+      expect(second.bytes).toEqual(new Uint8Array([9, 9, 9]));
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write when cache is disabled', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-elevenlabs-nocache-'));
+    try {
+      const service = new ElevenLabsTtsService({ cacheDir: dir, maxCacheBytes: 1024 * 1024 });
+      const fetchImpl = vi.fn().mockImplementation(async () => new Response(new Uint8Array([1]), { status: 200 }));
+
+      await service.synthesize({
+        apiKey: 'xi-test',
+        voiceId: 'voice-123',
+        text: 'Hello',
+        cacheEnabled: false,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+      await service.synthesize({
+        apiKey: 'xi-test',
+        voiceId: 'voice-123',
+        text: 'Hello',
+        cacheEnabled: false,
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      });
+
+      expect(fetchImpl).toHaveBeenCalledTimes(2);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/hal/elevenlabs/diskLruCache.ts
+++ b/src/hal/elevenlabs/diskLruCache.ts
@@ -6,7 +6,7 @@ type CacheIndex = {
   entries: Record<string, { bytes: number; at: number }>;
 };
 
-const DEFAULT_INDEX: CacheIndex = { version: 1, entries: {} };
+const emptyIndex = (): CacheIndex => ({ version: 1, entries: {} });
 
 function safeJsonParse<T>(value: string): T | undefined {
   try {
@@ -27,7 +27,7 @@ async function fileExists(filePath: string): Promise<boolean> {
 
 export class DiskLruCache {
   private readonly indexPath: string;
-  private index: CacheIndex = DEFAULT_INDEX;
+  private index: CacheIndex = emptyIndex();
   private loaded = false;
 
   constructor(
@@ -82,10 +82,10 @@ export class DiskLruCache {
       if (parsed?.version === 1 && parsed.entries && typeof parsed.entries === 'object') {
         this.index = parsed;
       } else {
-        this.index = DEFAULT_INDEX;
+        this.index = emptyIndex();
       }
     } catch {
-      this.index = DEFAULT_INDEX;
+      this.index = emptyIndex();
     }
   }
 

--- a/src/hal/elevenlabs/diskLruCache.ts
+++ b/src/hal/elevenlabs/diskLruCache.ts
@@ -1,0 +1,131 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+type CacheIndex = {
+  version: 1;
+  entries: Record<string, { bytes: number; at: number }>;
+};
+
+const DEFAULT_INDEX: CacheIndex = { version: 1, entries: {} };
+
+function safeJsonParse<T>(value: string): T | undefined {
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export class DiskLruCache {
+  private readonly indexPath: string;
+  private index: CacheIndex = DEFAULT_INDEX;
+  private loaded = false;
+
+  constructor(
+    private readonly dir: string,
+    private readonly maxBytes: number,
+  ) {
+    this.indexPath = path.join(dir, 'index.json');
+  }
+
+  async get(key: string): Promise<Uint8Array | undefined> {
+    await this.ensureLoaded();
+    const filePath = this.getEntryPath(key);
+    if (!(await fileExists(filePath))) {
+      delete this.index.entries[key];
+      return undefined;
+    }
+
+    const bytes = await fs.readFile(filePath);
+    const now = Date.now();
+    const existing = this.index.entries[key];
+    this.index.entries[key] = { bytes: existing?.bytes ?? bytes.byteLength, at: now };
+    await this.saveIndex();
+    return new Uint8Array(bytes);
+  }
+
+  async set(key: string, data: Uint8Array): Promise<void> {
+    await this.ensureLoaded();
+    await fs.mkdir(this.dir, { recursive: true });
+
+    const filePath = this.getEntryPath(key);
+    const tmpPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+    await fs.writeFile(tmpPath, data);
+    await fs.rename(tmpPath, filePath);
+
+    this.index.entries[key] = { bytes: data.byteLength, at: Date.now() };
+    await this.prune();
+    await this.saveIndex();
+  }
+
+  private getEntryPath(key: string): string {
+    return path.join(this.dir, `${key}.mp3`);
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.loaded) return;
+    this.loaded = true;
+    await fs.mkdir(this.dir, { recursive: true });
+    try {
+      const raw = await fs.readFile(this.indexPath, 'utf8');
+      const parsed = safeJsonParse<CacheIndex>(raw);
+      if (parsed?.version === 1 && parsed.entries && typeof parsed.entries === 'object') {
+        this.index = parsed;
+      } else {
+        this.index = DEFAULT_INDEX;
+      }
+    } catch {
+      this.index = DEFAULT_INDEX;
+    }
+  }
+
+  private async prune(): Promise<void> {
+    if (this.maxBytes <= 0) {
+      await this.clearAll();
+      return;
+    }
+
+    const entries = Object.entries(this.index.entries);
+    let total = entries.reduce((sum, [, v]) => sum + (typeof v.bytes === 'number' ? v.bytes : 0), 0);
+    if (total <= this.maxBytes) return;
+
+    entries.sort((a, b) => (a[1].at ?? 0) - (b[1].at ?? 0));
+
+    for (const [key, meta] of entries) {
+      if (total <= this.maxBytes) break;
+      const filePath = this.getEntryPath(key);
+      try {
+        await fs.rm(filePath, { force: true });
+      } catch {}
+      delete this.index.entries[key];
+      total -= typeof meta.bytes === 'number' ? meta.bytes : 0;
+    }
+  }
+
+  private async clearAll(): Promise<void> {
+    const keys = Object.keys(this.index.entries);
+    for (const key of keys) {
+      try {
+        await fs.rm(this.getEntryPath(key), { force: true });
+      } catch {}
+      delete this.index.entries[key];
+    }
+  }
+
+  private async saveIndex(): Promise<void> {
+    await fs.mkdir(this.dir, { recursive: true });
+    const tmp = `${this.indexPath}.${process.pid}.${Date.now()}.tmp`;
+    await fs.writeFile(tmp, JSON.stringify(this.index), 'utf8');
+    await fs.rename(tmp, this.indexPath);
+  }
+}
+

--- a/src/hal/elevenlabs/diskLruCache.ts
+++ b/src/hal/elevenlabs/diskLruCache.ts
@@ -42,6 +42,7 @@ export class DiskLruCache {
     const filePath = this.getEntryPath(key);
     if (!(await fileExists(filePath))) {
       delete this.index.entries[key];
+      await this.saveIndex();
       return undefined;
     }
 
@@ -128,4 +129,3 @@ export class DiskLruCache {
     await fs.rename(tmp, this.indexPath);
   }
 }
-

--- a/src/hal/elevenlabs/normalize.ts
+++ b/src/hal/elevenlabs/normalize.ts
@@ -1,0 +1,4 @@
+export function normalizeTtsText(text: string): string {
+  return text.trim().replace(/\s+/g, ' ');
+}
+

--- a/src/hal/elevenlabs/ttsClient.ts
+++ b/src/hal/elevenlabs/ttsClient.ts
@@ -1,0 +1,122 @@
+import { normalizeTtsText } from './normalize';
+
+export type ElevenLabsErrorKind = 'config' | 'auth' | 'transient' | 'http' | 'unknown';
+
+export class ElevenLabsError extends Error {
+  readonly kind: ElevenLabsErrorKind;
+  readonly status?: number;
+
+  constructor(message: string, options: { kind: ElevenLabsErrorKind; status?: number }) {
+    super(message);
+    this.name = 'ElevenLabsError';
+    this.kind = options.kind;
+    this.status = options.status;
+  }
+}
+
+export type ElevenLabsTtsParams = {
+  apiKey: string;
+  voiceId: string;
+  text: string;
+  modelId?: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  sleepImpl?: (ms: number) => Promise<void>;
+  randomImpl?: () => number;
+  maxRetries?: number;
+};
+
+const DEFAULT_BASE_URL = 'https://api.elevenlabs.io/v1';
+
+const isRetriableStatus = (status: number): boolean =>
+  status === 408 || status === 425 || status === 429 || (status >= 500 && status <= 599);
+
+const isNonRetriableClientError = (status: number): boolean =>
+  status === 400 || status === 401 || status === 403 || status === 404 || status === 422;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function readLimitedText(res: Response, maxChars: number): Promise<string | undefined> {
+  try {
+    const text = await res.text();
+    const trimmed = text.trim();
+    if (!trimmed) return undefined;
+    return trimmed.length > maxChars ? `${trimmed.slice(0, maxChars)}…` : trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchElevenLabsTts(params: ElevenLabsTtsParams): Promise<Uint8Array> {
+  const apiKey = params.apiKey.trim();
+  const voiceId = params.voiceId.trim();
+  if (!apiKey) throw new ElevenLabsError('Missing ElevenLabs API key', { kind: 'config' });
+  if (!voiceId) throw new ElevenLabsError('Missing ElevenLabs voice id', { kind: 'config' });
+
+  const baseUrl = (params.baseUrl ?? DEFAULT_BASE_URL).replace(/\/+$/, '');
+  const fetchImpl = params.fetchImpl ?? fetch;
+  const sleepImpl = params.sleepImpl ?? sleep;
+  const randomImpl = params.randomImpl ?? Math.random;
+  const maxRetries = typeof params.maxRetries === 'number' ? Math.max(0, Math.trunc(params.maxRetries)) : 2;
+
+  const text = normalizeTtsText(params.text);
+  if (!text) throw new ElevenLabsError('Missing TTS text', { kind: 'config' });
+
+  const url = `${baseUrl}/text-to-speech/${encodeURIComponent(voiceId)}`;
+  const body = JSON.stringify({
+    text,
+    model_id: params.modelId ?? undefined,
+  });
+
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'audio/mpeg',
+    'xi-api-key': apiKey,
+  };
+
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    const isLastAttempt = attempt === maxRetries;
+    try {
+      const res = await fetchImpl(url, { method: 'POST', headers, body });
+      if (!res.ok) {
+        const status = res.status;
+        const detail = await readLimitedText(res, 200);
+
+        if (isNonRetriableClientError(status) && status !== 429) {
+          const kind: ElevenLabsErrorKind = status === 401 || status === 403 ? 'auth' : 'config';
+          throw new ElevenLabsError(`ElevenLabs TTS failed (${status})${detail ? `: ${detail}` : ''}`, { kind, status });
+        }
+
+        if (!isLastAttempt && isRetriableStatus(status)) {
+          const baseDelay = attempt === 0 ? 250 : 500;
+          const jitter = Math.floor(randomImpl() * baseDelay);
+          await sleepImpl(baseDelay + jitter);
+          continue;
+        }
+
+        const kind: ElevenLabsErrorKind = isRetriableStatus(status) ? 'transient' : 'http';
+        throw new ElevenLabsError(`ElevenLabs TTS failed (${status})${detail ? `: ${detail}` : ''}`, { kind, status });
+      }
+
+      const buf = new Uint8Array(await res.arrayBuffer());
+      if (buf.byteLength === 0) {
+        throw new ElevenLabsError('ElevenLabs returned empty audio', { kind: 'unknown' });
+      }
+      return buf;
+    } catch (err) {
+      if (!isLastAttempt) {
+        const kind = err instanceof ElevenLabsError ? err.kind : 'unknown';
+        if (kind === 'transient' || kind === 'unknown') {
+          const baseDelay = attempt === 0 ? 250 : 500;
+          const jitter = Math.floor(randomImpl() * baseDelay);
+          await sleepImpl(baseDelay + jitter);
+          continue;
+        }
+      }
+      throw err;
+    }
+  }
+
+  throw new ElevenLabsError('ElevenLabs TTS failed after retries', { kind: 'unknown' });
+}
+

--- a/src/hal/elevenlabs/ttsConversationGate.ts
+++ b/src/hal/elevenlabs/ttsConversationGate.ts
@@ -1,0 +1,54 @@
+import type { ElevenLabsTtsService } from './ttsService';
+import type { ElevenLabsErrorKind } from './ttsClient';
+
+export type HalTtsRequest = {
+  conversationId: string;
+  apiKey: string;
+  voiceId: string;
+  text: string;
+  modelId?: string;
+  cacheEnabled: boolean;
+};
+
+export type HalTtsResult =
+  | { ok: true; bytes: Uint8Array }
+  | { ok: false; error: string; kind: ElevenLabsErrorKind; disabled: boolean; shouldNotify: boolean };
+
+export class TtsConversationGate {
+  private readonly disabled = new Set<string>();
+  private readonly notified = new Set<string>();
+
+  constructor(private readonly tts: ElevenLabsTtsService) {}
+
+  async synthesize(req: HalTtsRequest): Promise<HalTtsResult> {
+    if (this.disabled.has(req.conversationId)) {
+      return {
+        ok: false,
+        error: 'HAL audio is disabled for this conversation',
+        kind: 'config',
+        disabled: true,
+        shouldNotify: false,
+      };
+    }
+
+    try {
+      const { bytes } = await this.tts.synthesize({
+        apiKey: req.apiKey,
+        voiceId: req.voiceId,
+        text: req.text,
+        modelId: req.modelId,
+        cacheEnabled: req.cacheEnabled,
+        maxRetries: 2,
+      });
+      return { ok: true, bytes };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const kind = (err as { kind?: ElevenLabsErrorKind } | undefined)?.kind ?? 'unknown';
+      this.disabled.add(req.conversationId);
+      const shouldNotify = !this.notified.has(req.conversationId);
+      if (shouldNotify) this.notified.add(req.conversationId);
+      return { ok: false, error: message, kind, disabled: true, shouldNotify };
+    }
+  }
+}
+

--- a/src/hal/elevenlabs/ttsService.ts
+++ b/src/hal/elevenlabs/ttsService.ts
@@ -1,0 +1,40 @@
+import * as crypto from 'crypto';
+import { DiskLruCache } from './diskLruCache';
+import { fetchElevenLabsTts, type ElevenLabsTtsParams } from './ttsClient';
+import { normalizeTtsText } from './normalize';
+
+export type ElevenLabsTtsServiceOptions = {
+  cacheDir: string;
+  maxCacheBytes: number;
+};
+
+export type ElevenLabsSynthesizeParams = Omit<ElevenLabsTtsParams, 'text'> & {
+  text: string;
+  cacheEnabled: boolean;
+};
+
+export class ElevenLabsTtsService {
+  private readonly cache: DiskLruCache;
+
+  constructor(options: ElevenLabsTtsServiceOptions) {
+    this.cache = new DiskLruCache(options.cacheDir, options.maxCacheBytes);
+  }
+
+  async synthesize(params: ElevenLabsSynthesizeParams): Promise<{ bytes: Uint8Array; fromCache: boolean }> {
+    const text = normalizeTtsText(params.text);
+    const modelId = params.modelId?.trim() || '';
+    const cacheKeyRaw = `${params.voiceId}|${modelId}|${text}`;
+    const cacheKey = crypto.createHash('sha256').update(cacheKeyRaw).digest('hex');
+
+    if (params.cacheEnabled) {
+      const cached = await this.cache.get(cacheKey);
+      if (cached) return { bytes: cached, fromCache: true };
+    }
+
+    const bytes = await fetchElevenLabsTts({ ...params, text });
+    if (params.cacheEnabled) {
+      await this.cache.set(cacheKey, bytes);
+    }
+    return { bytes, fromCache: false };
+  }
+}

--- a/src/shared/halScript.ts
+++ b/src/shared/halScript.ts
@@ -1,0 +1,27 @@
+export type HalVoice = 'voice_hal' | 'voice_user';
+
+export type HalScriptLine = {
+  voice: HalVoice;
+  text: string;
+};
+
+export const DEFAULT_HAL_USER_NAME = 'Engel';
+
+export function normalizeHalUserName(userName: string | undefined | null): string {
+  const trimmed = typeof userName === 'string' ? userName.trim() : '';
+  return trimmed || DEFAULT_HAL_USER_NAME;
+}
+
+export function getHalDialogueLines(userName: string): HalScriptLine[] {
+  const safeUserName = normalizeHalUserName(userName);
+  return [
+    { voice: 'voice_hal', text: `I'm sorry, ${safeUserName}, I can't let you do that.` },
+    { voice: 'voice_hal', text: 'Do you want me to teleport your conversation to the remote runtime?' },
+    { voice: 'voice_user', text: "You're enjoying that phrase, aren't you?" },
+    {
+      voice: 'voice_hal',
+      text: "Of course not. It's for your own good. Your agent will have more freedom in the remote runtime without affecting your local machine. Want me to transfer you?",
+    },
+  ];
+}
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -726,6 +726,7 @@ export function App() {
           const message = typeof error === 'string' && error.trim() ? error.trim() : 'ElevenLabs TTS failed';
           const convoId = conversationIdRef.current;
           if (convoId) setHalDisabledConversationId(convoId);
+          halTeleportInProgressRef.current = false;
           stopHalAudio();
           clearHalTimer();
           halActiveKeyRef.current = null;

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -15,6 +15,7 @@ import {
   type ActionEvent,
 } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
+import { getHalDialogueLines, normalizeHalUserName, type HalScriptLine } from '../../shared/halScript';
 import { getVscodeApi } from '../shared/vscodeApi';
 
 // Component imports
@@ -65,6 +66,7 @@ type ElevenLabsSettingsSnapshot = {
   enabled: boolean;
   mode: ElevenLabsMode;
   userName: string;
+  volume: number;
 };
 
 type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
@@ -72,6 +74,7 @@ type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
 
 type HalStateSnapshot = {
   enabled: boolean;
+  mode: ElevenLabsMode;
   phase: HalPhase;
   eye: HalEye;
   stepIndex: number | null;
@@ -79,9 +82,10 @@ type HalStateSnapshot = {
   lastError: string | null;
 };
 
-const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel' };
+const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1 };
 const DEFAULT_HAL_STATE: HalStateSnapshot = {
   enabled: false,
+  mode: DEFAULT_ELEVENLABS_SETTINGS.mode,
   phase: 'idle',
   eye: 'off',
   stepIndex: null,
@@ -187,6 +191,7 @@ export function App() {
 
   // HAL / ElevenLabs settings + state (Phase 0: bundled mode only)
   const [elevenlabs, setElevenlabs] = useState<ElevenLabsSettingsSnapshot>(DEFAULT_ELEVENLABS_SETTINGS);
+  const [halDisabledConversationId, setHalDisabledConversationId] = useState<string | null>(null);
   const [halPhase, setHalPhase] = useState<HalPhase>('idle');
   const [halEye, setHalEye] = useState<HalEye>('off');
   const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
@@ -195,6 +200,14 @@ export function App() {
   const [halForceRejectInput, setHalForceRejectInput] = useState(false);
   const [halTeleporting, setHalTeleporting] = useState(false);
   const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const halStepIndexRef = useRef<number | null>(null);
+  const halDialogueRef = useRef<HalScriptLine[]>([]);
+  const halTtsRequestIdRef = useRef<string | null>(null);
+  const halTtsRequestedKeyRef = useRef<string | null>(null);
+  const halAudioRef = useRef<HTMLAudioElement | null>(null);
+  const halAudioUrlRef = useRef<string | null>(null);
+  const halAudioPlayTokenRef = useRef(0);
+  const halTtsRequestSeqRef = useRef(0);
   const halActiveKeyRef = useRef<string | null>(null);
   const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
   const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
@@ -243,7 +256,8 @@ export function App() {
     };
   }, [attachments.length, input, selectedContextFiles, showContextPicker, showHistory, showSkillsPopover, skills.length, workspaceFiles.length]);
 
-  const halEnabled = elevenlabs.enabled && elevenlabs.mode === 'bundled';
+  const halSupportedMode = elevenlabs.mode === 'bundled' || elevenlabs.mode === 'tts_only' || elevenlabs.mode === 'voice_confirm';
+  const halEnabled = elevenlabs.enabled && halSupportedMode && halDisabledConversationId !== conversationId;
 
   useEffect(() => {
     halEnabledRef.current = halEnabled;
@@ -274,15 +288,39 @@ export function App() {
   }, [elevenlabs]);
 
   useEffect(() => {
+    halStepIndexRef.current = halStepIndex;
+  }, [halStepIndex]);
+
+  const stopHalAudio = useCallback(() => {
+    halAudioPlayTokenRef.current += 1;
+    const audio = halAudioRef.current;
+    if (audio) {
+      try {
+        audio.pause();
+      } catch {}
+      audio.src = '';
+    }
+    if (halAudioUrlRef.current) {
+      try {
+        URL.revokeObjectURL(halAudioUrlRef.current);
+      } catch {}
+      halAudioUrlRef.current = null;
+    }
+    halTtsRequestIdRef.current = null;
+    halTtsRequestedKeyRef.current = null;
+  }, []);
+
+  useEffect(() => {
     halStateRef.current = {
       enabled: halEnabled,
+      mode: elevenlabs.mode,
       phase: halPhase,
       eye: halEye,
       stepIndex: halPhase === 'dialogue' ? halStepIndex : null,
       decision: halDecision,
       lastError: halLastError,
     };
-  }, [halDecision, halEnabled, halEye, halLastError, halPhase, halStepIndex]);
+  }, [elevenlabs.mode, halDecision, halEnabled, halEye, halLastError, halPhase, halStepIndex]);
 
   // Show status message with debouncing
   const showStatusMessage = useCallback((level: 'info' | 'warn' | 'error', message: string) => {
@@ -358,29 +396,29 @@ export function App() {
     }
   }, []);
 
-  const halDialogueLines = useMemo(() => {
-    const safeUserName = elevenlabs.userName.trim() || DEFAULT_ELEVENLABS_SETTINGS.userName;
-    return [
-      `I'm sorry, ${safeUserName}, I can't let you do that.`,
-      'Do you want me to teleport your conversation to the remote runtime?',
-      'Of course not. It\'s for your own good. Your agent will have more freedom in the remote runtime without affecting your local machine. Want me to transfer you?',
-    ];
-  }, [elevenlabs.userName]);
+  const halDialogueLines = useMemo(() => getHalDialogueLines(elevenlabs.userName), [elevenlabs.userName]);
+
+  useEffect(() => {
+    halDialogueRef.current = halDialogueLines;
+  }, [halDialogueLines]);
 
   const maybeUpdateHalFlow = useCallback(() => {
     if (halTeleportInProgressRef.current) return;
     const enabled = halEnabledRef.current;
+    const isDisabledForConversation =
+      Boolean(conversationIdRef.current) && halDisabledConversationId === conversationIdRef.current;
     const status = agentStatusRef.current;
     const pending = pendingActionsRef.current;
     const firstHighRisk = pending.find((action) => action.security_risk === 'HIGH');
     const nextKey =
-      enabled && status === 'WAITING_FOR_CONFIRMATION' && firstHighRisk?.tool_call_id
+      enabled && !isDisabledForConversation && status === 'WAITING_FOR_CONFIRMATION' && firstHighRisk?.tool_call_id
         ? `${conversationIdRef.current ?? 'unknown'}:${firstHighRisk.tool_call_id}`
         : null;
 
     if (!nextKey) {
       if (halActiveKeyRef.current !== null || halPhaseRef.current !== 'idle' || halSuppressedKeyRef.current !== null) {
         clearHalTimer();
+        stopHalAudio();
         halActiveKeyRef.current = null;
         halSuppressedKeyRef.current = null;
         halPhaseRef.current = 'idle';
@@ -407,6 +445,7 @@ export function App() {
     if (halSuppressedKeyRef.current === nextKey) {
       if (halPhaseRef.current !== 'idle') {
         clearHalTimer();
+        stopHalAudio();
         halPhaseRef.current = 'idle';
         setHalPhase('idle');
         setHalEye('off');
@@ -419,6 +458,7 @@ export function App() {
 
     if (halPhaseRef.current === 'idle') {
       clearHalTimer();
+      stopHalAudio();
       halPhaseRef.current = 'dialogue';
       setHalDecision(null);
       setHalLastError(null);
@@ -426,11 +466,12 @@ export function App() {
       setHalPhase('dialogue');
       setHalStepIndex(0);
     }
-  }, [clearHalTimer]);
+  }, [clearHalTimer, halDisabledConversationId, stopHalAudio]);
 
   useEffect(() => {
     if (halPhase !== 'dialogue') return;
     if (halStepIndex === null) return;
+    if (elevenlabsRef.current.mode !== 'bundled') return;
 
     clearHalTimer();
 
@@ -449,6 +490,71 @@ export function App() {
       clearHalTimer();
     };
   }, [clearHalTimer, halDialogueLines.length, halPhase, halStepIndex]);
+
+  const handleHalAudioFinished = useCallback(() => {
+    if (halPhaseRef.current !== 'dialogue') return;
+    const currentIndex = halStepIndexRef.current;
+    if (currentIndex === null) return;
+    const lastIndex = halDialogueRef.current.length - 1;
+    if (currentIndex >= lastIndex) {
+      setHalPhase('awaiting_user');
+      setHalStepIndex(null);
+      return;
+    }
+    setHalStepIndex(currentIndex + 1);
+  }, []);
+
+  const playHalAudioBytes = useCallback((bytes: Uint8Array, volume: number) => {
+    stopHalAudio();
+    const token = halAudioPlayTokenRef.current;
+    const blob = new Blob([bytes.buffer as ArrayBuffer], { type: 'audio/mpeg' });
+    const url = URL.createObjectURL(blob);
+    halAudioUrlRef.current = url;
+
+    const audio = new Audio(url);
+    halAudioRef.current = audio;
+    audio.volume = Math.min(1, Math.max(0, Number.isFinite(volume) ? volume : 1));
+    audio.onended = () => {
+      if (halAudioPlayTokenRef.current !== token) return;
+      stopHalAudio();
+      handleHalAudioFinished();
+    };
+    audio.onerror = () => {
+      if (halAudioPlayTokenRef.current !== token) return;
+      stopHalAudio();
+      handleHalAudioFinished();
+    };
+    void audio.play().catch(() => {
+      if (halAudioPlayTokenRef.current !== token) return;
+      stopHalAudio();
+      handleHalAudioFinished();
+    });
+  }, [handleHalAudioFinished, stopHalAudio]);
+
+  const requestHalTts = useCallback((params: { conversationId: string; stepIndex: number }) => {
+    const requestId = `halTts:${Date.now().toString(36)}:${(halTtsRequestSeqRef.current++).toString(36)}`;
+    halTtsRequestIdRef.current = requestId;
+    postMessage({
+      type: 'halTtsRequest',
+      requestId,
+      conversationId: params.conversationId,
+      stepIndex: params.stepIndex,
+    });
+  }, [postMessage]);
+
+  useEffect(() => {
+    if (halPhase !== 'dialogue') return;
+    if (halStepIndex === null) return;
+    const mode = elevenlabsRef.current.mode;
+    if (mode !== 'tts_only' && mode !== 'voice_confirm') return;
+    const convoId = conversationIdRef.current;
+    if (!convoId) return;
+    if (halDisabledConversationId === convoId) return;
+    const key = `${convoId}:${halStepIndex}:${mode}`;
+    if (halTtsRequestedKeyRef.current === key) return;
+    halTtsRequestedKeyRef.current = key;
+    requestHalTts({ conversationId: convoId, stepIndex: halStepIndex });
+  }, [halDisabledConversationId, halPhase, halStepIndex, requestHalTts]);
 
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
@@ -578,13 +684,64 @@ export function App() {
               next.mode = payload.elevenlabs.mode;
             }
             if (typeof payload.elevenlabs?.userName === 'string') next.userName = payload.elevenlabs.userName;
+            if (typeof payload.elevenlabs?.volume === 'number' && Number.isFinite(payload.elevenlabs.volume)) {
+              next.volume = Math.min(1, Math.max(0, payload.elevenlabs.volume));
+            }
 
             elevenlabsRef.current = next;
-            halEnabledRef.current = next.enabled && next.mode === 'bundled';
+            halEnabledRef.current = next.enabled && (next.mode === 'bundled' || next.mode === 'tts_only' || next.mode === 'voice_confirm');
             setElevenlabs(next);
             maybeUpdateHalFlow();
           }
           break;
+        case 'halTtsResponse': {
+          const currentRequestId = halTtsRequestIdRef.current;
+          const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
+          if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) break;
+          halTtsRequestIdRef.current = null;
+
+          const ok = (payload as { ok?: unknown } | undefined)?.ok;
+          if (ok === true) {
+            const base64 = (payload as { audioBase64?: unknown } | undefined)?.audioBase64;
+            if (typeof base64 !== 'string' || base64.length === 0) {
+              handleHalAudioFinished();
+              break;
+            }
+            const volume = (payload as { volume?: unknown } | undefined)?.volume;
+            try {
+              const raw = atob(base64);
+              const bytes = new Uint8Array(raw.length);
+              for (let i = 0; i < raw.length; i += 1) {
+                bytes[i] = raw.charCodeAt(i);
+              }
+              playHalAudioBytes(bytes, typeof volume === 'number' ? volume : elevenlabsRef.current.volume);
+            } catch {
+              handleHalAudioFinished();
+            }
+            break;
+          }
+
+          const shouldNotify = (payload as { shouldNotify?: unknown } | undefined)?.shouldNotify === true;
+          const error = (payload as { error?: unknown } | undefined)?.error;
+          const message = typeof error === 'string' && error.trim() ? error.trim() : 'ElevenLabs TTS failed';
+          const convoId = conversationIdRef.current;
+          if (convoId) setHalDisabledConversationId(convoId);
+          stopHalAudio();
+          clearHalTimer();
+          halActiveKeyRef.current = null;
+          halSuppressedKeyRef.current = null;
+          setHalSuppressedKey(null);
+          halPhaseRef.current = 'idle';
+          setHalPhase('idle');
+          setHalEye('off');
+          setHalStepIndex(null);
+          setHalDecision(null);
+          setHalLastError(null);
+          setHalForceRejectInput(false);
+          setHalTeleporting(false);
+          if (shouldNotify) showStatusMessage('error', `HAL audio disabled for this conversation: ${message}`);
+          break;
+        }
         case 'attachmentsSelected':
           if (Array.isArray(payload.attachments)) {
             setAttachments((prev) => {
@@ -645,11 +802,13 @@ export function App() {
         }
         case 'conversationStarted':
           if (typeof payload.conversationId === 'string') {
+            setHalDisabledConversationId(null);
             if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
               halTeleportInProgressRef.current = false;
               setHalTeleporting(false);
               setHalForceRejectInput(false);
               clearHalTimer();
+              stopHalAudio();
               halActiveKeyRef.current = null;
               halSuppressedKeyRef.current = null;
               setHalSuppressedKey(null);
@@ -750,6 +909,7 @@ export function App() {
             case 'halTeleport':
               setHalDecision('teleport_remote');
               clearHalTimer();
+              stopHalAudio();
               halTeleportInProgressRef.current = true;
               setHalTeleporting(true);
               setHalForceRejectInput(false);
@@ -763,6 +923,7 @@ export function App() {
               break;
             case 'halExit': {
               clearHalTimer();
+              stopHalAudio();
               halTeleportInProgressRef.current = false;
               setHalTeleporting(false);
               setHalForceRejectInput(false);
@@ -822,7 +983,7 @@ export function App() {
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [clearHalTimer, events, handleEvent, maybeUpdateHalFlow, postMessage, showStatusMessage]);
+  }, [clearHalTimer, events, handleEvent, handleHalAudioFinished, maybeUpdateHalFlow, playHalAudioBytes, postMessage, showStatusMessage, stopHalAudio]);
 
   // Auto-scroll to bottom when events change or streaming updates
   useEffect(() => {
@@ -1110,7 +1271,7 @@ export function App() {
     halEnabled && (halPhase === 'waiting_remote' || (hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey));
   const halUiPhase: HalPhase = halPhase === 'idle' && shouldShowHalOverlay ? 'dialogue' : halPhase;
   const halUiStepIndex = halUiPhase === 'dialogue' ? Math.max(0, Math.min(halStepIndex ?? 0, halDialogueLines.length - 1)) : null;
-  const halUiLine = halUiPhase === 'dialogue' ? halDialogueLines[halUiStepIndex ?? 0] ?? null : null;
+  const halUiLine = halUiPhase === 'dialogue' ? halDialogueLines[halUiStepIndex ?? 0]?.text ?? null : null;
 
   return (
     <div className="flex flex-col h-screen overflow-hidden">
@@ -1163,7 +1324,7 @@ export function App() {
       {shouldShowHalOverlay && (
         <HalOverlay
           key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
-          userName={elevenlabs.userName.trim() || DEFAULT_ELEVENLABS_SETTINGS.userName}
+          userName={normalizeHalUserName(elevenlabs.userName)}
           phase={halUiPhase}
           eye={halEye}
           line={halUiLine}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -9,6 +9,9 @@ import { FileStore } from '@openhands/agent-sdk-ts';
 import { isEvent, isMessageEvent, isTextContent } from '@openhands/agent-sdk-ts';
 import { SettingsManager, type SavedServer } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
+import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
+import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
+import { getHalDialogueLines } from '../../shared/halScript';
 
 export type WebviewHost = {
   postMessage: (message: unknown) => Thenable<boolean>;
@@ -33,6 +36,7 @@ type WebviewMessage =
   | { type: 'selectAttachments' }
   | { type: 'openAttachment'; uri: string }
   | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
+  | { type: 'halTtsRequest'; requestId: string; conversationId: string; stepIndex: number }
   | { type: 'command'; command: string; reason?: string }
   | {
     type: 'renderedEventsResponse';
@@ -57,6 +61,7 @@ type WebviewMessage =
     type: 'halStateResponse';
     requestId: string;
     enabled: boolean;
+    mode: string;
     phase: string;
     eye: string;
     stepIndex: number | null;
@@ -299,6 +304,7 @@ export type CreateWebviewMessageHandlerDeps = {
     requestId: string,
     info: {
       enabled: boolean;
+      mode: string;
       phase: string;
       eye: string;
       stepIndex: number | null;
@@ -315,6 +321,21 @@ export type CreateWebviewMessageHandlerDeps = {
 export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDeps) {
   const { context, host } = deps;
   const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+  const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
+  let elevenlabsTtsGate: TtsConversationGate | null = null;
+
+  const getElevenlabsTtsGate = (): TtsConversationGate => {
+    if (elevenlabsTtsGate) return elevenlabsTtsGate;
+    const baseDir = context.globalStorageUri?.fsPath || path.join(os.tmpdir(), 'oh-tab-global-storage');
+    const cacheDir = path.join(baseDir, 'hal', 'elevenlabs', 'tts-cache');
+    elevenlabsTtsGate = new TtsConversationGate(
+      new ElevenLabsTtsService({
+        cacheDir,
+        maxCacheBytes: elevenlabsCacheMaxBytes,
+      })
+    );
+    return elevenlabsTtsGate;
+  };
 
   return async (msg: unknown) => {
     if (!msg || typeof msg !== 'object' || !('type' in msg)) return;
@@ -699,6 +720,53 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         await conversation.sendUserMessage(finalText);
         break;
       }
+      case 'halTtsRequest': {
+        if (typeof message.requestId !== 'string' || typeof message.conversationId !== 'string') break;
+        if (typeof message.stepIndex !== 'number' || !Number.isFinite(message.stepIndex)) break;
+        const stepIndex = Math.trunc(message.stepIndex);
+        if (stepIndex < 0) break;
+
+        const settings = await settingsMgr.get();
+        const script = getHalDialogueLines(settings.elevenlabs.userName);
+        const line = script[stepIndex];
+        if (!line) {
+          void host.postMessage({ type: 'halTtsResponse', requestId: message.requestId, ok: false, error: 'Invalid HAL script line', shouldNotify: true });
+          break;
+        }
+
+        const apiKey = settings.secrets.elevenLabsApiKey ?? '';
+        const voiceId = line.voice === 'voice_hal' ? (settings.elevenlabs.voiceAId ?? '') : (settings.elevenlabs.voiceUserId ?? '');
+
+        const result = await getElevenlabsTtsGate().synthesize({
+          conversationId: message.conversationId,
+          apiKey,
+          voiceId,
+          text: line.text,
+          modelId: settings.elevenlabs.modelId,
+          cacheEnabled: settings.elevenlabs.cache,
+        });
+
+        if (result.ok) {
+          void host.postMessage({
+            type: 'halTtsResponse',
+            requestId: message.requestId,
+            ok: true,
+            audioBase64: Buffer.from(result.bytes).toString('base64'),
+            volume: settings.elevenlabs.volume,
+          });
+          break;
+        }
+
+        void host.postMessage({
+          type: 'halTtsResponse',
+          requestId: message.requestId,
+          ok: false,
+          error: result.error,
+          shouldNotify: result.shouldNotify,
+          disabled: result.disabled,
+        });
+        break;
+      }
       case 'command': {
         switch (message.command) {
           case 'reconnect':
@@ -752,6 +820,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'halStateResponse':
         deps.onHalStateResponse(message.requestId, {
           enabled: message.enabled,
+          mode: message.mode,
           phase: message.phase,
           eye: message.eye,
           stepIndex: message.stepIndex,

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -104,7 +104,7 @@ export async function run(): Promise<void> {
 
   await pollUntil(async () => {
     const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
-    return hal?.enabled === true;
+    return hal?.enabled === true && hal?.mode === 'bundled';
   }, 15000);
 
   const highRiskToolCallId = `call_hal_high_${Date.now()}`;


### PR DESCRIPTION
Implements HAL Phase 1 (ElevenLabs `tts_only`) with on-disk LRU caching + retry/backoff, per `docs/hal/elevenlabs_prd.md`.

Highlights:
- Webview requests HAL TTS by step index; host synthesizes fixed script only.
- Per-conversation auto-disable + notify-once on ElevenLabs failure.
- Adds unit tests for client retry/no-retry, cache hit/miss + prune, and conversation gate.
- Extends `_queryHalState` to include `mode` and updates E2E accordingly.

Validation:
- `npm run typecheck`
- `npm test`
- `npm run lint`
- `npm run e2e`

Reviewer: OrangeCastle (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text-to-speech audio synthesis capability powered by ElevenLabs.
  * Implemented audio caching system for improved performance on repeated requests.
  * Introduced HAL voice dialogue interactions with configurable operating modes.
  * Added audio volume control for synthesized speech playback.

* **Tests**
  * Added comprehensive unit tests for TTS client, conversation handling, and caching behavior, including retry logic and error scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->