### PR TITLE
oh-tab-6or: order settings categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,6 +140,8 @@
           "openhands.llm.temperature": {
             "type": "number",
             "default": 0,
+            "minimum": 0,
+            "maximum": 2,
             "order": 5,
             "markdownDescription": "Sampling temperature (0-2)."
           },

--- a/package.json
+++ b/package.json
@@ -100,271 +100,352 @@
         "title": "OpenHands: Diagnostics (Internal)"
       }
     ],
-    "configuration": {
-      "type": "object",
-      "title": "OpenHands Tab",
-      "properties": {
-        "openhands.devBridge.enabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable webview→extension debug logging bridge (Output channel + file in extension log path)."
-        },
-        "openhands.serverUrl": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "OpenHands agent-server base URL. Leave blank to run in local mode."
-        },
-        "openhands.servers": {
-          "type": "array",
-          "default": [],
-          "items": {
-            "type": "object",
-            "properties": {
-              "url": {
-                "type": "string"
-              },
-              "label": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "url"
-            ]
+    "configuration": [
+      {
+        "type": "object",
+        "title": "OpenHands: LLM",
+        "order": 1,
+        "properties": {
+          "openhands.llm.model": {
+            "type": "string",
+            "default": "claude-sonnet-4-20250514",
+            "order": 1,
+            "markdownDescription": "Default model name for LLM requests."
           },
-          "markdownDescription": "List of saved OpenHands server URLs with optional labels."
-        },
-        "openhands.secrets.sessionApiKey": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your Session API Key securely:**\n\n[🔑 Configure Session API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json. Used to authenticate to agent-server.)_"
-        },
-        "openhands.conversation.maxIterations": {
-          "type": "number",
-          "default": 50,
-          "markdownDescription": "Default max iterations for new conversations (server default is 500)."
-        },
-        "openhands.conversation.storeRoot": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Optional directory for local-mode conversation history/events. Leave empty to use `~/.openhands/conversations-vscode/`."
-        },
-        "openhands.terminal.renderProgress": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Coalesce carriage-return (\\r) progress updates in the OpenHands terminal log (keeps only the last update per line)."
-        },
-        "openhands.confirmation.policy": {
-          "type": "string",
-          "enum": [
-            "never",
-            "always",
-            "risky"
-          ],
-          "default": "never",
-          "markdownDescription": "Action confirmation policy: never ask, always ask, or ask for risky actions."
-        },
-        "openhands.confirmation.risky.threshold": {
-          "type": "string",
-          "enum": [
-            "LOW",
-            "MEDIUM",
-            "HIGH"
-          ],
-          "default": "MEDIUM",
-          "markdownDescription": "Risk threshold for ConfirmRisky policy. Actions at or above this require confirmation."
-        },
-        "openhands.confirmation.risky.confirmUnknown": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Whether actions with UNKNOWN risk require confirmation in risky mode."
-        },
-        "openhands.agent.enableSecurityAnalyzer": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
-        },
-        "openhands.agent.debug": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable local-mode debug events (e.g., llm_request/tool_call_raw)."
-        },
-        "openhands.llm.model": {
-          "type": "string",
-          "default": "claude-sonnet-4-20250514",
-          "markdownDescription": "Default model name for LLM requests."
-        },
-        "openhands.llm.provider": {
-          "type": "string",
-          "enum": [
-            "auto",
-            "anthropic",
-            "openai",
-            "openrouter",
-            "litellm_proxy"
-          ],
-          "default": "auto",
-          "markdownDescription": "LLM provider selection. Use `auto` to infer from `openhands.llm.baseUrl` when set; otherwise local mode defaults to Anthropic."
-        },
-        "openhands.llm.baseUrl": {
-          "type": "string",
-          "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
-        },
-        "openhands.llm.apiVersion": {
-          "type": "string",
-          "markdownDescription": "Optional LLM API version (e.g., Azure). Leave empty if not applicable."
-        },
-        "openhands.llm.apiKey": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.llm.timeout": {
-          "type": "number",
-          "markdownDescription": "HTTP timeout in seconds. Leave empty to use default."
-        },
-        "openhands.llm.temperature": {
-          "type": "number",
-          "default": 0,
-          "markdownDescription": "Sampling temperature (0-2)."
-        },
-        "openhands.llm.topP": {
-          "type": "number",
-          "default": 1,
-          "markdownDescription": "Top-p nucleus sampling."
-        },
-        "openhands.llm.topK": {
-          "type": "number",
-          "markdownDescription": "Top-k sampling. Leave empty to use default."
-        },
-        "openhands.llm.maxInputTokens": {
-          "type": "number",
-          "markdownDescription": "Max input tokens. Leave empty to use default."
-        },
-        "openhands.llm.maxOutputTokens": {
-          "type": "number",
-          "markdownDescription": "Max output tokens. Leave empty to use default."
-        },
-        "openhands.llm.reasoningEffort": {
-          "type": "string",
-          "enum": [
-            "low",
-            "medium",
-            "high",
-            "none"
-          ],
-          "default": "none",
-          "markdownDescription": "Reasoning effort for supported models."
-        },
-        "openhands.llm.inputCostPerToken": {
-          "type": "number",
-          "markdownDescription": "Optional cost per input token (USD) for usage stats."
-        },
-        "openhands.llm.outputCostPerToken": {
-          "type": "number",
-          "markdownDescription": "Optional cost per output token (USD) for usage stats."
-        },
-        "openhands.llm.usageId": {
-          "type": "string",
-          "default": "default-llm",
-          "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
-        },
-        "openhands.elevenlabs.enabled": {
-          "type": "boolean",
-          "default": false,
-          "markdownDescription": "Enable the HAL high-risk confirmation flow."
-        },
-        "openhands.elevenlabs.mode": {
-          "type": "string",
-          "enum": [
-            "bundled",
-            "tts_only",
-            "voice_confirm"
-          ],
-          "default": "tts_only",
-          "markdownDescription": "HAL mode when enabled: `bundled` (E2E/CI), `tts_only` (TTS + buttons), `voice_confirm` (TTS + mic + Gemini)."
-        },
-        "openhands.elevenlabs.userName": {
-          "type": "string",
-          "default": "Engel",
-          "markdownDescription": "User name used only in templated HAL script lines."
-        },
-        "openhands.elevenlabs.voiceAId": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "ElevenLabs voice ID for HAL (voice A)."
-        },
-        "openhands.elevenlabs.voiceUserId": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "ElevenLabs voice ID for the user (voice B, used in `tts_only` mode)."
-        },
-        "openhands.elevenlabs.modelId": {
-          "type": "string",
-          "default": "",
-          "markdownDescription": "Optional ElevenLabs model id (e.g., `eleven_turbo_v2`)."
-        },
-        "openhands.elevenlabs.volume": {
-          "type": "number",
-          "default": 1,
-          "minimum": 0,
-          "maximum": 1,
-          "markdownDescription": "Playback volume (0.0–1.0)."
-        },
-        "openhands.elevenlabs.cache": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "Enable caching for generated ElevenLabs audio."
-        },
-        "openhands.gemini.model": {
-          "type": "string",
-          "default": "gemini-2.5-flash",
-          "markdownDescription": "Gemini model used for `voice_confirm` classification."
-        },
-        "openhands.gemini.baseUrl": {
-          "type": "string",
-          "default": "https://generativelanguage.googleapis.com/v1beta",
-          "markdownDescription": "Gemini API base URL (default is Google AI Studio; allow proxies)."
-        },
-        "openhands.secrets.githubToken": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.elevenLabsApiKey": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your ElevenLabs API key securely:**\n\n[🔑 Configure ElevenLabs API Key](command:openhands.setElevenLabsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.geminiApiKey": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your Gemini API key securely:**\n\n[🔑 Configure Gemini API Key](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.customSecret1": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.customSecret2": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
-        },
-        "openhands.secrets.customSecret3": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "singlelineText",
-          "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+          "openhands.llm.apiKey": {
+            "type": "string",
+            "default": "",
+            "order": 2,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your LLM API Key securely:**\n\n[🔑 Configure API Key](command:openhands.setApiKey)\n\n_(API keys are stored in secure system keychain, not in settings.json)_"
+          },
+          "openhands.llm.baseUrl": {
+            "type": "string",
+            "order": 3,
+            "markdownDescription": "Optional LLM base URL override. Leave empty to use provider default."
+          },
+          "openhands.llm.provider": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "anthropic",
+              "openai",
+              "openrouter",
+              "litellm_proxy"
+            ],
+            "default": "auto",
+            "order": 4,
+            "markdownDescription": "LLM provider selection. Use `auto` to infer from `openhands.llm.baseUrl` when set; otherwise local mode defaults to Anthropic."
+          },
+          "openhands.llm.temperature": {
+            "type": "number",
+            "default": 0,
+            "order": 5,
+            "markdownDescription": "Sampling temperature (0-2)."
+          },
+          "openhands.llm.reasoningEffort": {
+            "type": "string",
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "none"
+            ],
+            "default": "none",
+            "order": 6,
+            "markdownDescription": "Reasoning effort for supported models."
+          },
+          "openhands.llm.apiVersion": {
+            "type": "string",
+            "order": 10,
+            "markdownDescription": "Optional LLM API version (e.g., Azure). Leave empty if not applicable."
+          },
+          "openhands.llm.timeout": {
+            "type": "number",
+            "order": 11,
+            "markdownDescription": "HTTP timeout in seconds. Leave empty to use default."
+          },
+          "openhands.llm.topP": {
+            "type": "number",
+            "default": 1,
+            "order": 12,
+            "markdownDescription": "Top-p nucleus sampling."
+          },
+          "openhands.llm.topK": {
+            "type": "number",
+            "order": 13,
+            "markdownDescription": "Top-k sampling. Leave empty to use default."
+          },
+          "openhands.llm.maxInputTokens": {
+            "type": "number",
+            "order": 14,
+            "markdownDescription": "Max input tokens. Leave empty to use default."
+          },
+          "openhands.llm.maxOutputTokens": {
+            "type": "number",
+            "order": 15,
+            "markdownDescription": "Max output tokens. Leave empty to use default."
+          },
+          "openhands.llm.inputCostPerToken": {
+            "type": "number",
+            "order": 20,
+            "markdownDescription": "Optional cost per input token (USD) for usage stats."
+          },
+          "openhands.llm.outputCostPerToken": {
+            "type": "number",
+            "order": 21,
+            "markdownDescription": "Optional cost per output token (USD) for usage stats."
+          },
+          "openhands.llm.usageId": {
+            "type": "string",
+            "default": "default-llm",
+            "order": 30,
+            "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
+          },
+          "openhands.gemini.model": {
+            "type": "string",
+            "default": "gemini-2.5-flash",
+            "order": 40,
+            "markdownDescription": "Gemini model used for `voice_confirm` classification."
+          },
+          "openhands.gemini.baseUrl": {
+            "type": "string",
+            "default": "https://generativelanguage.googleapis.com/v1beta",
+            "order": 41,
+            "markdownDescription": "Gemini API base URL (default is Google AI Studio; allow proxies)."
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "OpenHands: Agent",
+        "order": 2,
+        "properties": {
+          "openhands.agent.enableSecurityAnalyzer": {
+            "type": "boolean",
+            "default": false,
+            "order": 1,
+            "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
+          },
+          "openhands.agent.debug": {
+            "type": "boolean",
+            "default": false,
+            "order": 2,
+            "markdownDescription": "Enable local-mode debug events (e.g., llm_request/tool_call_raw)."
+          },
+          "openhands.devBridge.enabled": {
+            "type": "boolean",
+            "default": false,
+            "order": 3,
+            "markdownDescription": "Enable webview→extension debug logging bridge (Output channel + file in extension log path)."
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "OpenHands: Confirmation",
+        "order": 3,
+        "properties": {
+          "openhands.confirmation.policy": {
+            "type": "string",
+            "enum": [
+              "never",
+              "always",
+              "risky"
+            ],
+            "default": "never",
+            "order": 1,
+            "markdownDescription": "Action confirmation policy: never ask, always ask, or ask for risky actions."
+          },
+          "openhands.confirmation.risky.threshold": {
+            "type": "string",
+            "enum": [
+              "LOW",
+              "MEDIUM",
+              "HIGH"
+            ],
+            "default": "MEDIUM",
+            "order": 2,
+            "markdownDescription": "Risk threshold for ConfirmRisky policy. Actions at or above this require confirmation."
+          },
+          "openhands.confirmation.risky.confirmUnknown": {
+            "type": "boolean",
+            "default": true,
+            "order": 3,
+            "markdownDescription": "Whether actions with UNKNOWN risk require confirmation in risky mode."
+          },
+          "openhands.elevenlabs.enabled": {
+            "type": "boolean",
+            "default": false,
+            "order": 10,
+            "markdownDescription": "Enable the HAL high-risk confirmation flow."
+          },
+          "openhands.elevenlabs.mode": {
+            "type": "string",
+            "enum": [
+              "bundled",
+              "tts_only",
+              "voice_confirm"
+            ],
+            "default": "tts_only",
+            "order": 11,
+            "markdownDescription": "HAL mode when enabled: `bundled` (E2E/CI), `tts_only` (TTS + buttons), `voice_confirm` (TTS + mic + Gemini)."
+          },
+          "openhands.elevenlabs.userName": {
+            "type": "string",
+            "default": "Engel",
+            "order": 12,
+            "markdownDescription": "User name used only in templated HAL script lines."
+          },
+          "openhands.elevenlabs.voiceAId": {
+            "type": "string",
+            "default": "",
+            "order": 13,
+            "markdownDescription": "ElevenLabs voice ID for HAL (voice A)."
+          },
+          "openhands.elevenlabs.voiceUserId": {
+            "type": "string",
+            "default": "",
+            "order": 14,
+            "markdownDescription": "ElevenLabs voice ID for the user (voice B, used in `tts_only` mode)."
+          },
+          "openhands.elevenlabs.modelId": {
+            "type": "string",
+            "default": "",
+            "order": 15,
+            "markdownDescription": "Optional ElevenLabs model id (e.g., `eleven_turbo_v2`)."
+          },
+          "openhands.elevenlabs.volume": {
+            "type": "number",
+            "default": 1,
+            "order": 16,
+            "minimum": 0,
+            "maximum": 1,
+            "markdownDescription": "Playback volume (0.0–1.0)."
+          },
+          "openhands.elevenlabs.cache": {
+            "type": "boolean",
+            "default": true,
+            "order": 17,
+            "markdownDescription": "Enable caching for generated ElevenLabs audio."
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "OpenHands: Servers",
+        "order": 4,
+        "properties": {
+          "openhands.serverUrl": {
+            "type": "string",
+            "default": "",
+            "order": 1,
+            "markdownDescription": "OpenHands agent-server base URL. Leave blank to run in local mode."
+          },
+          "openhands.servers": {
+            "type": "array",
+            "default": [],
+            "order": 2,
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url"
+              ]
+            },
+            "markdownDescription": "List of saved OpenHands server URLs with optional labels."
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "OpenHands: Conversation",
+        "order": 5,
+        "properties": {
+          "openhands.conversation.maxIterations": {
+            "type": "number",
+            "default": 50,
+            "order": 1,
+            "markdownDescription": "Default max iterations for new conversations (server default is 500)."
+          },
+          "openhands.conversation.storeRoot": {
+            "type": "string",
+            "default": "",
+            "order": 2,
+            "markdownDescription": "Optional directory for local-mode conversation history/events. Leave empty to use `~/.openhands/conversations-vscode/`."
+          },
+          "openhands.terminal.renderProgress": {
+            "type": "boolean",
+            "default": true,
+            "order": 3,
+            "markdownDescription": "Coalesce carriage-return (\\r) progress updates in the OpenHands terminal log (keeps only the last update per line)."
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "OpenHands: Secrets",
+        "order": 6,
+        "properties": {
+          "openhands.secrets.sessionApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 1,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your Session API Key securely:**\n\n[🔑 Configure Session API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json. Used to authenticate to agent-server.)_"
+          },
+          "openhands.secrets.githubToken": {
+            "type": "string",
+            "default": "",
+            "order": 2,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
+          },
+          "openhands.secrets.geminiApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 3,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your Gemini API key securely:**\n\n[🔑 Configure Gemini API Key](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
+          },
+          "openhands.secrets.elevenLabsApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 4,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your ElevenLabs API key securely:**\n\n[🔑 Configure ElevenLabs API Key](command:openhands.setElevenLabsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
+          },
+          "openhands.secrets.customSecret1": {
+            "type": "string",
+            "default": "",
+            "order": 10,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your custom secret 1 securely:**\n\n[🔑 Configure Custom Secret 1](command:openhands.setCustomSecret1)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+          },
+          "openhands.secrets.customSecret2": {
+            "type": "string",
+            "default": "",
+            "order": 11,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your custom secret 2 securely:**\n\n[🔑 Configure Custom Secret 2](command:openhands.setCustomSecret2)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+          },
+          "openhands.secrets.customSecret3": {
+            "type": "string",
+            "default": "",
+            "order": 12,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your custom secret 3 securely:**\n\n[🔑 Configure Custom Secret 3](command:openhands.setCustomSecret3)\n\n_(Secrets are stored in secure system keychain, not in settings.json)_"
+          }
         }
       }
-    },
+    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/package.json
+++ b/package.json
@@ -201,18 +201,6 @@
             "default": "default-llm",
             "order": 30,
             "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
-          },
-          "openhands.gemini.model": {
-            "type": "string",
-            "default": "gemini-2.5-flash",
-            "order": 40,
-            "markdownDescription": "Gemini model used for `voice_confirm` classification."
-          },
-          "openhands.gemini.baseUrl": {
-            "type": "string",
-            "default": "https://generativelanguage.googleapis.com/v1beta",
-            "order": 41,
-            "markdownDescription": "Gemini API base URL (default is Google AI Studio; allow proxies)."
           }
         }
       },
@@ -328,6 +316,18 @@
             "default": true,
             "order": 17,
             "markdownDescription": "Enable caching for generated ElevenLabs audio."
+          },
+          "openhands.gemini.model": {
+            "type": "string",
+            "default": "gemini-2.5-flash",
+            "order": 18,
+            "markdownDescription": "Gemini model used for `voice_confirm` classification."
+          },
+          "openhands.gemini.baseUrl": {
+            "type": "string",
+            "default": "https://generativelanguage.googleapis.com/v1beta",
+            "order": 19,
+            "markdownDescription": "Gemini API base URL (default is Google AI Studio; allow proxies)."
           }
         }
       },


### PR DESCRIPTION
Reorders the Settings UI by splitting `contributes.configuration` into ordered categories and using `order` fields (per VS Code docs) so settings are grouped as:

1) LLM
2) Agent
3) Confirmation
4) Servers
5) Conversation
6) Secrets

LLM fields are ordered with model, API key, base URL, provider, temperature, reasoning effort first.

Validation:
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

Reviewer: OrangeCastle (required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Extension settings reorganized into six distinct sections (LLM, Agent, Confirmation, Servers, Conversation, Secrets) with explicit ordering and grouped keys. Settings now include expanded LLM options, agent toggles, richer confirmation and voice options, consolidated server configuration, conversation controls, and dedicated secret entries, improving discoverability and configuration clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->