### PR TITLE
oh-tab-klq: cap remote reconnect retries

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -312,4 +312,54 @@ describe('RemoteConversation', () => {
     expect(errors).toHaveLength(1);
     expect(wsInstances).toHaveLength(0);
   });
+
+  it('caps reconnect attempts after disconnect and requires manual reconnect', async () => {
+    vi.useFakeTimers();
+    const randomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
+    try {
+      const fetchMock = vi.fn(async (url: string) => {
+        expect(url).toContain('/events/search');
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      });
+      (globalThis as any).fetch = fetchMock;
+
+      const { RemoteConversation } = await import('../conversation/RemoteConversation');
+      const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+      const errors: unknown[] = [];
+      conversation.on('error', (e) => errors.push(e));
+
+      await conversation.restoreConversation('abc');
+      const ws0 = getEventWS();
+      ws0.open();
+      ws0.close();
+
+      const reconnectDelays = [1000, 2000, 4000, 8000, 15000, 15000];
+      for (const delay of reconnectDelays) {
+        vi.advanceTimersByTime(delay);
+        const ws = wsInstances[wsInstances.length - 1];
+        ws.error(new Error('boom'));
+      }
+
+      const eventSockets = () => wsInstances.filter((ws) => ws.url.includes('/sockets/events'));
+      expect(eventSockets()).toHaveLength(1 + reconnectDelays.length);
+
+      vi.advanceTimersByTime(60_000);
+      expect(eventSockets()).toHaveLength(1 + reconnectDelays.length);
+
+      const errorMessages = errors.map((e) => (e instanceof Error ? e.message : String(e)));
+      expect(errorMessages.some((m) => m.includes('Reconnect retries exhausted'))).toBe(true);
+
+      conversation.reconnect();
+      expect(eventSockets()).toHaveLength(1 + reconnectDelays.length + 1);
+    } finally {
+      randomSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -56,8 +56,10 @@ export class RemoteConversation extends EventEmitter {
   private wsHandshakeTimer?: ReturnType<typeof setTimeout>;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
   private retryCount = 0;
+  private gaveUpReconnect = false;
   private readonly retryBaseMs = 1000;
   private readonly retryMaxMs = 15000;
+  private readonly maxReconnectRetries = 6;
   private readonly workspaceRoot: string;
   private static readonly historyPageLimit = 100;
   private static readonly wsHandshakeTimeoutMs = 10_000;
@@ -353,12 +355,16 @@ export class RemoteConversation extends EventEmitter {
   }
 
   reconnect() {
+    this.clearReconnect();
+    this.retryCount = 0;
+    this.gaveUpReconnect = false;
     if (this.conversationId) {
       this.connect();
     }
   }
 
   private setStatus(s: ConversationStatus) {
+    if (this.status === s) return;
     this.status = s;
     this.emit('status', s);
   }
@@ -379,10 +385,17 @@ export class RemoteConversation extends EventEmitter {
     // If we have never successfully connected, don't spin in a retry loop.
     // In that case, surface the error and let the user manually retry.
     if (!this.hasEverConnected) return;
+    if (this.retryCount >= this.maxReconnectRetries) {
+      if (!this.gaveUpReconnect) {
+        this.gaveUpReconnect = true;
+        this.emit('error', new Error('Disconnected from agent-server. Reconnect retries exhausted.'));
+      }
+      return;
+    }
     const base = Math.min(this.retryMaxMs, Math.floor(this.retryBaseMs * Math.pow(2, this.retryCount)));
     const jitter = Math.floor(base * 0.2 * Math.random());
     const delay = base + jitter;
-    this.retryCount = Math.min(this.retryCount + 1, 10);
+    this.retryCount += 1;
     this.reconnectTimer = setTimeout(() => this.connect(), delay);
   }
 
@@ -439,6 +452,7 @@ export class RemoteConversation extends EventEmitter {
       if (this.ws !== ws) return;
       this.clearWsHandshakeTimer();
       this.retryCount = 0;
+      this.gaveUpReconnect = false;
       this.hasEverConnected = true;
       this.setStatus('online');
     });


### PR DESCRIPTION
Closes Beads: oh-tab-klq\n\n- Cap remote reconnect attempts (default 6) and stop retry loop\n- Dedup identical status emissions to reduce UI churn\n- Reset retry state on manual reconnect\n- Add unit test for retry cap + manual reconnect