### PR TITLE
oh-tab-9bi: risk badge hover tooltip

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -832,7 +832,9 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'event', event: action });
 
       await waitFor(() => {
-        expect(screen.getByText('high')).toBeInTheDocument();
+        const badge = screen.getByText('high');
+        expect(badge).toBeInTheDocument();
+        expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed high risk for this action.');
       });
     });
 
@@ -847,7 +849,9 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'event', event: action });
 
       await waitFor(() => {
-        expect(screen.getByText('medium')).toBeInTheDocument();
+        const badge = screen.getByText('medium');
+        expect(badge).toBeInTheDocument();
+        expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed medium risk for this action.');
       });
     });
 
@@ -862,7 +866,9 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'event', event: action });
 
       await waitFor(() => {
-        expect(screen.getByText('low')).toBeInTheDocument();
+        const badge = screen.getByText('low');
+        expect(badge).toBeInTheDocument();
+        expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed low risk for this action.');
       });
     });
 

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -60,7 +60,9 @@ describe('App - Confirmation Flow', () => {
     const scope = within(dialog);
     // Tool name is shown in the action details
     expect(scope.getAllByText(/terminal/i).length).toBeGreaterThanOrEqual(1);
-    expect(scope.getByText(/high risk/)).toBeInTheDocument();
+    const riskBadge = scope.getByText(/high risk/);
+    expect(riskBadge).toBeInTheDocument();
+    expect(riskBadge.closest('[title]')).toHaveAttribute('title', 'The model assessed high risk for this action.');
     expect(scope.getByText(/Reasoning/)).toBeInTheDocument();
   });
 

--- a/src/webview-src/components/ConfirmationPrompt.tsx
+++ b/src/webview-src/components/ConfirmationPrompt.tsx
@@ -111,6 +111,7 @@ export function ConfirmationPrompt({
                     </div>
                     {action.security_risk && action.security_risk !== 'UNKNOWN' && (
                       <span
+                        title={`The model assessed ${action.security_risk.toLowerCase()} risk for this action.`}
                         className={`
                           inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border
                           ${action.security_risk === 'HIGH' ? 'bg-red-500/15 text-red-300 border-red-400/30' :

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -334,8 +334,13 @@ function SecurityBadge({ risk }: { risk: 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN' }
     UNKNOWN: 'question',
   };
 
+  const tooltip = `The model assessed ${risk.toLowerCase()} risk for this action.`;
+
   return (
-    <span className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border ${styles[risk]}`}>
+    <span
+      title={tooltip}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border ${styles[risk]}`}
+    >
       <span className={`codicon codicon-${icons[risk]} text-[10px]`} />
       {risk.toLowerCase()}
     </span>


### PR DESCRIPTION
Closes Beads: oh-tab-9bi\n\n- Add hover tooltip on risk badges to clarify it’s model-assessed risk\n- Add unit coverage for tooltip text