### PR TITLE
oh-tab-ssi: wire skills into local LLM calls

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
@@ -5,6 +5,7 @@ import { LocalConversation } from './LocalConversation';
 import type { Event, MessageEvent } from '../types';
 import { isActionEvent, isAgentErrorEvent, isConversationErrorEvent, isMessageEvent, isObservationEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
+import { AgentContext, Skill } from '../context';
 
 class FakeLLM implements LLMClient {
   private readonly responses: LLMStreamChunk[][];
@@ -19,6 +20,16 @@ class FakeLLM implements LLMClient {
     for (const chunk of next) {
       yield chunk;
     }
+  }
+}
+
+class RecordingLLM implements LLMClient {
+  requests: ChatCompletionRequest[] = [];
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
+    yield { type: 'finish' };
   }
 }
 
@@ -184,6 +195,40 @@ describe('LocalConversation', () => {
           process.env[key] = value;
         }
       }
+    }
+  });
+
+  it('includes skill extended_content in LLM requests when agentContext is configured', async () => {
+    const llm = new RecordingLLM();
+    const agentContext = new AgentContext({
+      skills: [
+        new Skill({
+          name: 'e2e-skill',
+          content: 'Hello from skill.',
+          trigger: { type: 'keyword', keywords: ['banana'] },
+        }),
+      ],
+    });
+
+    const conversation = new LocalConversation({
+      settings: baseSettings,
+      llmClient: llm,
+      tools: createDefaultTools(),
+      agentContext,
+    });
+
+    await conversation.sendUserMessage('banana');
+
+    expect(llm.requests).toHaveLength(1);
+    const req = llm.requests[0];
+    const userMessages = req.messages.filter((m) => m.role === 'user');
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0].content.map((c) => c.type)).toEqual(['text', 'text']);
+    const extra = userMessages[0].content[1];
+    expect(extra).toEqual(expect.objectContaining({ type: 'text' }));
+    if (extra.type === 'text') {
+      expect(extra.text).toContain('Hello from skill.');
+      expect(extra.text).toContain('<EXTRA_INFO>');
     }
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -1,5 +1,6 @@
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
+import type { AgentContext } from '../context';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
 
@@ -14,6 +15,7 @@ export interface ConversationFactoryOptions {
   conversationId?: string;
   tools?: ToolDefinition<unknown, unknown>[];
   persistenceDir?: string;
+  agentContext?: AgentContext;
 }
 
 export function Conversation(options: ConversationFactoryOptions): ConversationInstance {
@@ -31,6 +33,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     workspaceRoot: options.workspaceRoot,
     tools: options.tools,
     persistenceDir: options.persistenceDir,
+    agentContext: options.agentContext,
   }) as ConversationInstance;
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -705,7 +705,12 @@ export class Agent extends EventEmitter {
     const messages = this.events
       .list()
       .filter(isMessageEvent)
-      .map((event) => event.llm_message);
+      .map((event) => {
+        if (event.source === 'user' && event.extended_content?.length) {
+          return { ...event.llm_message, content: [...event.llm_message.content, ...event.extended_content] };
+        }
+        return event.llm_message;
+      });
     const tools = this.getToolDefinitions();
     return { systemPrompt, messages, tools };
   }

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -60,6 +60,10 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     }
   }
 
+  class AgentContext {
+    constructor(_params?: unknown) {}
+  }
+
   const Conversation = vi.fn((options: any) => {
     const emitter = new EventEmitter() as any;
     emitter.mode = options?.serverUrl ? 'remote' : 'local';
@@ -99,6 +103,7 @@ vi.mock('@openhands/agent-sdk-ts', () => {
   }
 
   return {
+    AgentContext,
     Conversation,
     isBashCommand: vi.fn((event: any) => event?.type === 'BashCommand'),
     isBashOutput: vi.fn((event: any) => event?.type === 'BashOutput'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { SettingsManager, type OpenHandsSettings } from './settings/SettingsMana
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from './shared/halTeleport';
 import {
+  AgentContext,
   Conversation,
   type ConversationInstance,
   FileEditorTool,
@@ -907,12 +908,18 @@ export function activate(context: vscode.ExtensionContext) {
           : undefined;
       conversationStoreRoot = persistenceDir;
 
+      const agentContext =
+        desiredMode === 'local'
+          ? new AgentContext({ loadUserSkills: true })
+          : undefined;
+
       const conversationOptions = {
         serverUrl: settings.serverUrl ?? undefined,
         settings,
         workspaceRoot,
         tools: settings.serverUrl ? undefined : createDefaultLocalTools(),
         persistenceDir,
+        agentContext,
       };
 
       try {


### PR DESCRIPTION
Closes Beads: oh-tab-ssi

- Create AgentContext(loadUserSkills=true) for local conversations
- Include skill extended content in LLM request messages (without polluting UI text)
- Add unit coverage for request augmentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AgentContext support enabling skill loading and integration in local conversation mode
  * Skills are now automatically included in LLM requests when configured

* **Tests**
  * Added test coverage verifying skill information is properly propagated to LLM requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->