### PR TITLE
oh-tab-bt7: normalize server labels

### DIFF
--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -100,6 +100,22 @@ const clampUnitInterval = (value: number | null | undefined, defaultValue: numbe
   return Math.min(1, Math.max(0, value));
 };
 
+const normalizeSavedServer = (value: unknown): SavedServer | null => {
+  if (!value || typeof value !== 'object') return null;
+  const candidate = value as Partial<Record<keyof SavedServer, unknown>>;
+  const url = normalizeNonEmptyString(typeof candidate.url === 'string' ? candidate.url : undefined);
+  if (!url) return null;
+  const label = normalizeNonEmptyString(typeof candidate.label === 'string' ? candidate.label : undefined);
+  return label ? { url, label } : { url };
+};
+
+const normalizeSavedServers = (value: unknown, defaultValue: SavedServer[]): SavedServer[] => {
+  if (!Array.isArray(value)) return defaultValue;
+  return value
+    .map(normalizeSavedServer)
+    .filter((server): server is SavedServer => server !== null);
+};
+
 export class SettingsManager {
   constructor(private adapter: SettingsAdapter) {}
 
@@ -108,7 +124,10 @@ export class SettingsManager {
       this.adapter.get<string | null>('openhands.serverUrl', DEFAULTS.serverUrl) ?? DEFAULTS.serverUrl
     );
     const isRemote = !!serverUrl;
-    const servers = this.adapter.get<SavedServer[]>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers;
+    const servers = normalizeSavedServers(
+      this.adapter.get<unknown>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers,
+      DEFAULTS.servers
+    );
     const explicitBaseUrl = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.baseUrl'));
     const explicitProvider = normalizeLlmProvider(this.adapter.getExplicit<string>('openhands.llm.provider'));
     const provider = isRemote ? explicitProvider : explicitProvider ?? (explicitBaseUrl ? undefined : DEFAULTS.llm.provider);

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -52,6 +52,20 @@ describe('SettingsManager', () => {
     expect(s.llm.model).toBe(defaults.llm.model);
   });
 
+  it('normalizes saved servers', async () => {
+    a.cfg.set('openhands.servers', [
+      { url: ' http://localhost:3000 ', label: '   ' },
+      { url: '   ' },
+      { url: 'https://example.com:1234', label: ' My Server ' },
+    ]);
+
+    const s = await mgr.get();
+    expect(s.servers).toEqual([
+      { url: 'http://localhost:3000' },
+      { url: 'https://example.com:1234', label: 'My Server' },
+    ]);
+  });
+
   it('updates and persists config and secrets', async () => {
     await mgr.update({
       serverUrl: 'http://example:1234',

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -21,7 +21,8 @@ interface ServerSelectorProps {
 
 // Helper to extract display name from server - exported for reuse in Header
 export function getServerDisplayLabel(server: SavedServer): string {
-  if (server.label) return server.label;
+  const trimmedLabel = server.label?.trim();
+  if (trimmedLabel) return trimmedLabel;
   try {
     const url = new URL(server.url);
     return url.hostname + (url.port ? ':' + url.port : '');
@@ -147,6 +148,7 @@ export function ServerSelector({
             {servers.map((server) => {
               const selected = isServerSelected(server.url);
               const displayLabel = getServerDisplayLabel(server);
+              const hasCustomLabel = Boolean(server.label?.trim());
               return (
                 <div
                   key={server.url}
@@ -170,7 +172,7 @@ export function ServerSelector({
                     <span className="codicon codicon-cloud" />
                     <div className="flex-1 min-w-0">
                       <div className="truncate">{displayLabel}</div>
-                      {server.label && (
+                      {hasCustomLabel && (
                         <div className="text-xs opacity-50 truncate">{server.url}</div>
                       )}
                     </div>


### PR DESCRIPTION
Fixes oh-tab-bt7.

- Trims/sanitizes saved server URLs/labels in SettingsManager (prevents whitespace-only labels/urls causing blank entries).
- Makes webview ServerSelector treat whitespace-only labels as missing.
- Adds unit coverage in SettingsManager tests.
