### PR TITLE
oh-tab-0qp: start fresh conversation on mode switch

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -284,6 +284,42 @@ describe('Chat view behavior', () => {
 
     expect(conv.setSettings).toHaveBeenCalledWith(mockSettings);
   });
+
+  it('starts a fresh conversation on serverUrl changes (no auto-restore)', async () => {
+    await resolveChatView(mockContext);
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const initial = __getLastConversation();
+    expect(initial).toBeTruthy();
+
+    // Even if a saved conversation id exists for the next mode, serverUrl changes should not restore it.
+    (mockContext.workspaceState.get as Mock).mockImplementation((key: string) => {
+      if (key === 'openhands.conversationId.local') return 'local-saved';
+      if (key === 'openhands.conversationId.remote') return 'remote-saved';
+      return undefined;
+    });
+
+    // Switch from remote → local by clearing serverUrl.
+    mockSettings = { ...mockSettings, serverUrl: '' as any };
+    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', '');
+    (vscode as any).__triggerConfigChange({
+      affectsConfiguration: (key: string) => key === 'openhands.serverUrl',
+    });
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const current = __getLastConversation();
+      if (current && current !== initial) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    const next = __getLastConversation();
+    expect(next).toBeTruthy();
+    expect(next).not.toBe(initial);
+    expect(next.restoreConversation).not.toHaveBeenCalled();
+
+    // Mode switches clear the saved id for the target scope so no implicit restore can occur later.
+    expect(mockContext.workspaceState.update).toHaveBeenCalledWith('openhands.conversationId.local', undefined);
+  });
 });
 
 describe('Command handlers', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -871,7 +871,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
   };
 
-  async function ensureConversationAndConnection(options?: { uiJustCreated?: boolean }) {
+  async function ensureConversationAndConnection(options?: { uiJustCreated?: boolean; modeSwitched?: boolean }) {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
     lastKnownLlmModel = settings.llm.model ?? null;
@@ -884,7 +884,15 @@ export function activate(context: vscode.ExtensionContext) {
 
     const desiredMode: 'local' | 'remote' = settings.serverUrl ? 'remote' : 'local';
     const savedIdKey = desiredMode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
-    let savedId = options?.uiJustCreated ? undefined : context.workspaceState.get<string>(savedIdKey);
+    if (options?.modeSwitched) {
+      // Switching modes should always start a fresh conversation, never restore prior state.
+      resetConversationEventBacklog(undefined);
+      await context.workspaceState.update(savedIdKey, undefined);
+    }
+
+    let savedId = (options?.uiJustCreated || options?.modeSwitched)
+      ? undefined
+      : context.workspaceState.get<string>(savedIdKey);
 
     if (savedId) {
       const looksLocal = savedId.startsWith('local-');
@@ -1366,7 +1374,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   // Listen for runtime configuration changes
   const onConfigurationChangeBase = createConfigurationChangeHandler({
-    ensureConversationAndConnection: () => ensureConversationAndConnection(),
+    ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
     getConversation: () => conversation,
     setConversation: (next) => {
       conversation = next;

--- a/src/settings/host/createConfigurationChangeHandler.ts
+++ b/src/settings/host/createConfigurationChangeHandler.ts
@@ -3,8 +3,13 @@ import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 
 type TerminalLogPtyLike = { ensureNewline?: () => void };
 
+type EnsureConversationOptions = {
+  uiJustCreated?: boolean;
+  modeSwitched?: boolean;
+};
+
 export type CreateConfigurationChangeHandlerDeps = {
-  ensureConversationAndConnection: () => Promise<void>;
+  ensureConversationAndConnection: (options?: EnsureConversationOptions) => Promise<void>;
 
   getConversation: () => ConversationInstance | undefined;
   setConversation: (conversation: ConversationInstance | undefined) => void;
@@ -38,7 +43,7 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
         deps.setTerminalLogPty(undefined);
       }
       deps.setConversation(undefined);
-      await deps.ensureConversationAndConnection();
+      await deps.ensureConversationAndConnection({ modeSwitched: true });
       return;
     }
 
@@ -80,4 +85,3 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
     }
   };
 }
-

--- a/src/webview-src/__tests__/App.render.test.tsx
+++ b/src/webview-src/__tests__/App.render.test.tsx
@@ -22,6 +22,48 @@ describe('App render', () => {
     expect(screen.getByLabelText('Add context')).toBeInTheDocument();
   });
 
+  it('clears conversation UI when server selection changes', async () => {
+    render(<App />);
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'MessageEvent',
+              source: 'user',
+              llm_message: {
+                role: 'user',
+                content: [{ type: 'text', text: 'hello-server-switch' }],
+              },
+            },
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText('hello-server-switch').length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'serverListUpdated',
+            servers: [],
+            serverUrl: 'http://localhost:3000',
+          },
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('hello-server-switch')).not.toBeInTheDocument();
+    });
+  });
+
   it('displays streaming content incrementally', async () => {
     render(<App />);
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -218,6 +218,7 @@ export function App() {
   const pendingActionsRef = useRef<ActionEvent[]>([]);
   const agentStatusRef = useRef<string | undefined>(undefined);
   const conversationIdRef = useRef<string | undefined>(undefined);
+  const currentServerUrlRef = useRef<string | undefined>(undefined);
   const elevenlabsRef = useRef<ElevenLabsSettingsSnapshot>(DEFAULT_ELEVENLABS_SETTINGS);
 
   // Refs
@@ -282,6 +283,10 @@ export function App() {
   useEffect(() => {
     conversationIdRef.current = conversationId;
   }, [conversationId]);
+
+  useEffect(() => {
+    currentServerUrlRef.current = currentServerUrl;
+  }, [currentServerUrl]);
 
   useEffect(() => {
     elevenlabsRef.current = elevenlabs;
@@ -663,14 +668,36 @@ export function App() {
             setMode('remote');
           }
           break;
-        case 'serverListUpdated':
+        case 'serverListUpdated': {
           if (Array.isArray(payload.servers)) {
             setServers(payload.servers);
           }
           if (typeof payload.serverUrl === 'string') {
-            setCurrentServerUrl(payload.serverUrl || undefined);
+            const nextUrl = payload.serverUrl || undefined;
+            const prevUrl = currentServerUrlRef.current;
+            currentServerUrlRef.current = nextUrl;
+            setCurrentServerUrl(nextUrl);
+
+            // If the server target changed (Local ↔ Remote or remote server URL changed),
+            // start a fresh conversation UI instead of implicitly resuming prior state.
+            if (prevUrl !== nextUrl) {
+              setHalDisabledConversationId(null);
+              conversationIdRef.current = undefined;
+              setConversationId(undefined);
+              setEvents([]);
+              pendingActionsRef.current = [];
+              setPendingActions([]);
+              agentStatusRef.current = undefined;
+              setAgentStatus(undefined);
+              setStreamingContent(null);
+              eventId.current = 1;
+              const api = getVscodeApi();
+              api.setState?.({});
+              maybeUpdateHalFlow();
+            }
           }
           break;
+        }
         case 'elevenlabsSettings':
           if (payload.elevenlabs && typeof payload.elevenlabs === 'object') {
             const prev = elevenlabsRef.current;


### PR DESCRIPTION
Fixes oh-tab-0qp.

- openhands.serverUrl changes no longer auto-restore a saved conversation id; we clear the target mode key and reset backlog.
- Webview clears conversation UI when the selected server URL changes (Local ↔ Remote), so switching modes shows a fresh conversation.
- Adds unit coverage in extension + webview tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation UI now clears automatically when switching servers, ensuring a fresh conversation starts rather than restoring previous conversations.

* **Tests**
  * Added test coverage for server URL changes and conversation state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->