### PR TITLE
oh-tab-0i4: avoid duplicate teleport errors

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -338,6 +338,27 @@ describe('Command handlers', () => {
     expect(conversationInstance.rejectAction).toHaveBeenCalledWith('nope');
   });
 
+  it('does not show a duplicate error popup for teleportAction failures', async () => {
+    const handler = chatView._messageHandler;
+    expect(handler).toBeTypeOf('function');
+
+    const exec = vscode.commands.executeCommand as unknown as Mock;
+    const orig = exec.getMockImplementation();
+    try {
+      exec.mockImplementation(async (name: string, ...args: any[]) => {
+        if (name === 'openhands._teleportToRemoteRuntime') {
+          throw new Error('boom');
+        }
+        return orig?.(name, ...args);
+      });
+
+      await handler({ type: 'command', command: 'teleportAction' });
+      expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+    } finally {
+      exec.mockImplementation(orig);
+    }
+  });
+
   it('opens a diff view for openWorkspaceDiff messages', async () => {
     const handler = chatView._messageHandler;
     expect(handler).toBeTypeOf('function');

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -789,7 +789,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
               await vscode.commands.executeCommand('openhands._teleportToRemoteRuntime');
             } catch (err) {
               const reason = err instanceof Error ? err.message : String(err);
-              void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
+              outputChannel?.appendLine(`[teleportAction] ${reason}`);
             }
             break;
           default:


### PR DESCRIPTION
Fixes oh-tab-0i4.

- Removes vscode.window.showErrorMessage() from the webview handler for teleportAction failures.
- Logs failures to the output channel instead; the teleport command owns UX notifications.
- Adds a unit test asserting no duplicate error popup is shown.
