### PR TITLE
oh-tab-rre: route GPT-5 via OpenAI Responses

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -181,6 +181,12 @@ describe('LLMFactory integration', () => {
     expect(client).toBeInstanceOf(OpenAIResponsesClient);
   });
 
+  it('does not route GPT-5 models through Responses API when baseUrl is custom', async () => {
+    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', baseUrl: 'http://localhost:4000', apiKey: 'sk-inline' });
+    const client = await factory.createClient();
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
   const maybeIt = process.env.OPENAI_API_KEY ? it : it.skip;
 
   maybeIt('streams from OpenAI with real credentials', async () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { AgentOrchestrator } from '../runtime';
-import { OpenAICompatibleClient, LLMFactory, LLMCredentialProvider } from '../llm';
+import { OpenAICompatibleClient, OpenAIResponsesClient, LLMFactory, LLMCredentialProvider } from '../llm';
 import type { ChatCompletionRequest, LLMConfiguration } from '../llm';
 import { ConversationState, EventLog } from '../runtime';
 
@@ -109,6 +109,61 @@ describe('OpenAICompatibleClient streaming', () => {
   });
 });
 
+describe('OpenAIResponsesClient (non-stream)', () => {
+  const baseConfig: LLMConfiguration = { model: 'gpt-5-mini', provider: 'openai' };
+
+  const buildRequest = (): ChatCompletionRequest => ({
+    systemPrompt: 'you are a test harness',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+    tools: [{ type: 'function', function: { name: 'ping' } }],
+  });
+
+  it('parses output text, tool calls, and reasoning item', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'reasoning',
+          id: 'rs_1',
+          summary: [{ type: 'summary_text', text: 'short summary' }],
+          encrypted_content: 'encrypted',
+          status: 'completed',
+        },
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+        {
+          type: 'function_call',
+          id: 'fc_call_1',
+          call_id: 'fc_call_1',
+          name: 'ping',
+          arguments: '{"ok":true}',
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2, input_tokens_details: { cached_tokens: 1 } },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient(baseConfig, 'test-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    const response = await orchestrator.runChat(buildRequest());
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0] ?? '')).toContain('/responses');
+
+    expect(response.message.content[0]).toEqual({ type: 'text', text: 'Hello' });
+    expect(response.message.tool_calls?.[0]).toEqual({
+      id: 'fc_call_1',
+      type: 'function',
+      function: { name: 'ping', arguments: '{"ok":true}' },
+    });
+    expect(response.usage).toEqual({ inputTokens: 5, outputTokens: 2, cacheReadTokens: 1, cacheWriteTokens: undefined });
+    expect(response.message.responses_reasoning_item).toMatchObject({ id: 'rs_1', summary: ['short summary'], encrypted_content: 'encrypted' });
+  });
+});
+
 describe('LLMFactory integration', () => {
   it('uses inline apiKey without registry lookup', async () => {
     const spy = vi.spyOn(LLMCredentialProvider.prototype, 'getApiKey');
@@ -118,6 +173,12 @@ describe('LLMFactory integration', () => {
 
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('routes GPT-5 models through Responses API', async () => {
+    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline' });
+    const client = await factory.createClient();
+    expect(client).toBeInstanceOf(OpenAIResponsesClient);
   });
 
   const maybeIt = process.env.OPENAI_API_KEY ? it : it.skip;

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -1,6 +1,7 @@
 import { LLMCredentialProvider } from './credentials';
 import { AnthropicClient } from './anthropic';
 import { OpenAICompatibleClient } from './openai-compatible';
+import { OpenAIResponsesClient } from './openai-responses';
 import type { ChatCompletionRequest, LLMClient, LLMConfiguration } from './types';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMRegistry, TrackedLLMClient } from './registry';
@@ -42,7 +43,13 @@ export class LLMFactory {
     }
 
     const provider = this.config.provider ?? detectProviderFromBaseUrl(this.config.baseUrl);
-    const base = provider === 'anthropic' ? new AnthropicClient(this.config, apiKey) : new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
+    const normalizedModel = this.config.model.toLowerCase();
+    const useResponses = provider !== 'anthropic' && normalizedModel.startsWith('gpt-5');
+    const base = provider === 'anthropic'
+      ? new AnthropicClient(this.config, apiKey)
+      : useResponses
+        ? new OpenAIResponsesClient({ ...this.config, provider }, apiKey)
+        : new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
 
     if (this.config.usageId) {
       const metrics = new Metrics(this.config.model);

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -6,7 +6,7 @@ import type { ChatCompletionRequest, LLMClient, LLMConfiguration } from './types
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMRegistry, TrackedLLMClient } from './registry';
 import { Metrics } from './metrics';
-import { detectProviderFromBaseUrl } from './provider';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl } from './provider';
 
 export interface LLMFactoryOptions {
   secrets?: SecretRegistry;
@@ -44,7 +44,15 @@ export class LLMFactory {
 
     const provider = this.config.provider ?? detectProviderFromBaseUrl(this.config.baseUrl);
     const normalizedModel = this.config.model.toLowerCase();
-    const useResponses = provider !== 'anthropic' && normalizedModel.startsWith('gpt-5');
+    const normalizeUrl = (value: string | null | undefined): string | undefined => {
+      const trimmed = typeof value === 'string' ? value.trim() : '';
+      if (!trimmed) return undefined;
+      return trimmed.replace(/\/+$/, '');
+    };
+    const normalizedBaseUrl = normalizeUrl(this.config.baseUrl);
+    const normalizedDefaultOpenAIBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS.openai);
+    const baseUrlSupportsResponses = !normalizedBaseUrl || normalizedBaseUrl === normalizedDefaultOpenAIBaseUrl;
+    const useResponses = provider === 'openai' && normalizedModel.startsWith('gpt-5') && baseUrlSupportsResponses;
     const base = provider === 'anthropic'
       ? new AnthropicClient(this.config, apiKey)
       : useResponses

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -1,6 +1,7 @@
 export * from './types';
 export * from './credentials';
 export * from './openai-compatible';
+export * from './openai-responses';
 export * from './anthropic';
 export * from './factory';
 export * from './provider';

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -112,8 +112,8 @@ const toResponsesTool = (tool: LLMToolDefinition): ResponsesToolParam => ({
 
 const toResponsesReasoningInputItem = (reasoning: ResponsesReasoningItem): ResponsesReasoningInputItem | undefined => {
   if (!reasoning.id) return undefined;
-  const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text', text }));
-  const content = reasoning.content?.length ? reasoning.content.map((text) => ({ type: 'reasoning_text', text })) : undefined;
+  const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text' as const, text }));
+  const content = reasoning.content?.length ? reasoning.content.map((text) => ({ type: 'reasoning_text' as const, text })) : undefined;
   return {
     type: 'reasoning',
     id: reasoning.id,

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -1,0 +1,418 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import type { Message, ResponsesReasoningItem, ToolCall } from '../types';
+import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
+import { DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions } from './types';
+
+const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
+  ...(base ?? {}),
+  ...(overrides ?? {}),
+});
+
+const defaultBaseUrls: Record<string, string> = {
+  openai: DEFAULT_PROVIDER_BASE_URLS.openai,
+  openrouter: DEFAULT_PROVIDER_BASE_URLS.openrouter,
+  litellm_proxy: DEFAULT_PROVIDER_BASE_URLS.litellm_proxy,
+};
+
+type ResponsesInputText = { type: 'input_text'; text: string };
+type ResponsesOutputText = { type: 'output_text'; text: string };
+type ResponsesInputImage = { type: 'input_image'; image_url: string; detail?: string };
+
+type ResponsesMessageInputItem = {
+  type: 'message';
+  role: 'user' | 'assistant';
+  content: Array<ResponsesInputText | ResponsesOutputText | ResponsesInputImage>;
+};
+
+type ResponsesFunctionCallInputItem = {
+  type: 'function_call';
+  id: string;
+  call_id: string;
+  name: string;
+  arguments: string;
+};
+
+type ResponsesFunctionCallOutputInputItem = {
+  type: 'function_call_output';
+  call_id: string;
+  output: string;
+};
+
+type ResponsesReasoningInputItem = {
+  type: 'reasoning';
+  id: string;
+  summary: Array<{ type: 'summary_text'; text: string }>;
+  content?: Array<{ type: 'reasoning_text'; text: string }>;
+  encrypted_content?: string;
+  status?: string;
+};
+
+type ResponsesInputItem =
+  | ResponsesMessageInputItem
+  | ResponsesFunctionCallInputItem
+  | ResponsesFunctionCallOutputInputItem
+  | ResponsesReasoningInputItem;
+
+type ResponsesToolParam = {
+  type: 'function';
+  name: string;
+  description?: string;
+  parameters?: unknown;
+  strict: boolean;
+};
+
+type OpenAIResponsesUsage = {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+  input_tokens?: number;
+  output_tokens?: number;
+  input_tokens_details?: { cached_tokens?: number };
+};
+
+type OpenAIResponsesOutputItem =
+  | {
+    type: 'message';
+    role?: string;
+    content?: Array<{ type?: string; text?: string }>;
+  }
+  | {
+    type: 'function_call';
+    id?: string;
+    call_id?: string;
+    name?: string;
+    arguments?: unknown;
+  }
+  | {
+    type: 'reasoning';
+    id?: string;
+    summary?: Array<{ type?: string; text?: string }>;
+    content?: Array<{ type?: string; text?: string }>;
+    encrypted_content?: string;
+    status?: string;
+  }
+  | Record<string, unknown>;
+
+type OpenAIResponsesResponse = {
+  output?: OpenAIResponsesOutputItem[];
+  usage?: OpenAIResponsesUsage;
+};
+
+const isRecord = (candidate: unknown): candidate is Record<string, unknown> => typeof candidate === 'object' && candidate !== null;
+
+const normalizeToolCallId = (id: string): string => (id.startsWith('fc') ? id : `fc_${id}`);
+
+const toResponsesTool = (tool: LLMToolDefinition): ResponsesToolParam => ({
+  type: 'function',
+  name: tool.function.name,
+  description: tool.function.description,
+  parameters: tool.function.parameters,
+  strict: false,
+});
+
+const toResponsesReasoningInputItem = (reasoning: ResponsesReasoningItem): ResponsesReasoningInputItem | undefined => {
+  if (!reasoning.id) return undefined;
+  const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text', text }));
+  const content = reasoning.content?.length ? reasoning.content.map((text) => ({ type: 'reasoning_text', text })) : undefined;
+  return {
+    type: 'reasoning',
+    id: reasoning.id,
+    summary,
+    ...(content ? { content } : {}),
+    ...(reasoning.encrypted_content ? { encrypted_content: reasoning.encrypted_content } : {}),
+    ...(reasoning.status ? { status: reasoning.status } : {}),
+  };
+};
+
+const toResponsesInputItems = (messages: Message[]): ResponsesInputItem[] => {
+  const items: ResponsesInputItem[] = [];
+
+  for (const message of messages) {
+    if (message.role === 'system') continue;
+
+    if (message.role === 'user') {
+      const content: ResponsesMessageInputItem['content'] = [];
+      for (const part of message.content) {
+        if (part.type === 'text') {
+          content.push({ type: 'input_text', text: part.text });
+        } else if (part.type === 'image' && Array.isArray(part.image_urls)) {
+          for (const imageUrl of part.image_urls) {
+            content.push({ type: 'input_image', image_url: imageUrl, detail: 'auto' });
+          }
+        }
+      }
+
+      items.push({
+        type: 'message',
+        role: 'user',
+        content: content.length ? content : [{ type: 'input_text', text: '' }],
+      });
+      continue;
+    }
+
+    if (message.role === 'assistant') {
+      if (message.responses_reasoning_item) {
+        const reasoningItem = toResponsesReasoningInputItem(message.responses_reasoning_item);
+        if (reasoningItem) items.push(reasoningItem);
+      }
+
+      const content: ResponsesMessageInputItem['content'] = [];
+      for (const part of message.content) {
+        if (part.type === 'text' && part.text) {
+          content.push({ type: 'output_text', text: part.text });
+        }
+      }
+      if (content.length) {
+        items.push({
+          type: 'message',
+          role: 'assistant',
+          content,
+        });
+      }
+
+      if (Array.isArray(message.tool_calls)) {
+        for (const toolCall of message.tool_calls) {
+          const callId = normalizeToolCallId(toolCall.id);
+          items.push({
+            type: 'function_call',
+            id: callId,
+            call_id: callId,
+            name: toolCall.function.name,
+            arguments: toolCall.function.arguments,
+          });
+        }
+      }
+      continue;
+    }
+
+    if (message.role === 'tool') {
+      if (!message.tool_call_id) continue;
+      const callId = normalizeToolCallId(message.tool_call_id);
+      for (const part of message.content) {
+        if (part.type === 'text') {
+          items.push({
+            type: 'function_call_output',
+            call_id: callId,
+            output: part.text,
+          });
+        }
+      }
+    }
+  }
+
+  return items;
+};
+
+const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest) => ({
+  model: config.model,
+  instructions: request.systemPrompt,
+  input: toResponsesInputItems(request.messages),
+  tools: request.tools?.length ? request.tools.map(toResponsesTool) : undefined,
+  tool_choice: request.tools?.length ? 'auto' : undefined,
+  store: false,
+  temperature: 1.0,
+  max_output_tokens: config.maxOutputTokens ?? undefined,
+  reasoning: config.reasoningEffort && config.reasoningEffort !== 'none' ? { effort: config.reasoningEffort } : undefined,
+});
+
+const parseResponsesOutput = (output: unknown): { text?: string; toolCalls: ToolCall[]; responsesReasoningItem?: ResponsesReasoningItem } => {
+  const assistantTextParts: string[] = [];
+  const toolCalls: ToolCall[] = [];
+  let responsesReasoningItem: ResponsesReasoningItem | undefined;
+
+  if (!Array.isArray(output)) {
+    return { toolCalls };
+  }
+
+  for (const item of output) {
+    if (!isRecord(item)) continue;
+    const type = item.type;
+    if (type === 'message') {
+      const content = item.content;
+      if (!Array.isArray(content)) continue;
+      for (const part of content) {
+        if (!isRecord(part)) continue;
+        if (part.type === 'output_text' && typeof part.text === 'string') {
+          assistantTextParts.push(part.text);
+        }
+      }
+      continue;
+    }
+
+    if (type === 'function_call') {
+      const id = typeof item.call_id === 'string' && item.call_id ? item.call_id : (typeof item.id === 'string' ? item.id : '');
+      const name = typeof item.name === 'string' ? item.name : '';
+      const argumentsStr = typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments ?? '');
+      if (!id) {
+        throw new Error(`Responses function_call missing call_id/id: ${JSON.stringify(item)}`);
+      }
+      if (!name) {
+        throw new Error(`Responses function_call missing name: ${JSON.stringify(item)}`);
+      }
+      toolCalls.push({
+        id: String(id),
+        type: 'function',
+        function: {
+          name: String(name),
+          arguments: argumentsStr,
+        },
+      });
+      continue;
+    }
+
+    if (type === 'reasoning') {
+      const id = typeof item.id === 'string' ? item.id : '';
+      if (!id) continue;
+      const summary: string[] = [];
+      if (Array.isArray(item.summary)) {
+        for (const s of item.summary) {
+          if (isRecord(s) && typeof s.text === 'string') summary.push(s.text);
+        }
+      }
+      const content: string[] = [];
+      if (Array.isArray(item.content)) {
+        for (const c of item.content) {
+          if (isRecord(c) && typeof c.text === 'string') content.push(c.text);
+        }
+      }
+      responsesReasoningItem = {
+        id,
+        summary,
+        content: content.length ? content : null,
+        encrypted_content: typeof item.encrypted_content === 'string' ? item.encrypted_content : undefined,
+        status: typeof item.status === 'string' ? item.status : undefined,
+      };
+    }
+  }
+
+  const text = assistantTextParts.join('\n').trim();
+  return {
+    ...(text ? { text } : {}),
+    toolCalls,
+    ...(responsesReasoningItem ? { responsesReasoningItem } : {}),
+  };
+};
+
+const parseUsage = (usage: unknown): { inputTokens?: number; outputTokens?: number; cacheReadTokens?: number } => {
+  if (!isRecord(usage)) return {};
+
+  const inputTokens = typeof usage.input_tokens === 'number'
+    ? usage.input_tokens
+    : (typeof usage.prompt_tokens === 'number' ? usage.prompt_tokens : undefined);
+  const outputTokens = typeof usage.output_tokens === 'number'
+    ? usage.output_tokens
+    : (typeof usage.completion_tokens === 'number' ? usage.completion_tokens : undefined);
+
+  const inputDetails = isRecord(usage.input_tokens_details) ? usage.input_tokens_details : undefined;
+  const promptDetails = isRecord(usage.prompt_tokens_details) ? usage.prompt_tokens_details : undefined;
+  const cacheReadTokens = typeof inputDetails?.cached_tokens === 'number'
+    ? inputDetails.cached_tokens
+    : (typeof promptDetails?.cached_tokens === 'number' ? promptDetails.cached_tokens : undefined);
+
+  return { inputTokens, outputTokens, cacheReadTokens };
+};
+
+export class OpenAIResponsesClient implements LLMClient {
+  private readonly config: LLMConfiguration;
+  private readonly apiKey: string;
+  private readonly retry: RetryOptions;
+
+  constructor(config: LLMConfiguration, apiKey: string, retry: RetryOptions = DEFAULT_RETRY_OPTIONS) {
+    this.config = config;
+    this.apiKey = apiKey;
+    this.retry = retry;
+  }
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    const response = await this.fetchWithRetry(request);
+    const { text, toolCalls, responsesReasoningItem } = parseResponsesOutput(response.output);
+    const usage = parseUsage(response.usage);
+
+    if (responsesReasoningItem) {
+      yield { type: 'responses_reasoning_item', item: responsesReasoningItem };
+    }
+
+    if (text) {
+      yield { type: 'text', text };
+    }
+
+    for (const toolCall of toolCalls) {
+      yield { type: 'tool_call_delta', id: toolCall.id, name: toolCall.function.name, arguments: toolCall.function.arguments };
+    }
+
+    if (usage.inputTokens || usage.outputTokens || usage.cacheReadTokens) {
+      yield { type: 'usage', inputTokens: usage.inputTokens, outputTokens: usage.outputTokens, cacheReadTokens: usage.cacheReadTokens };
+    }
+
+    yield { type: 'finish' };
+  }
+
+  private async fetchWithRetry(request: ChatCompletionRequest): Promise<OpenAIResponsesResponse> {
+    let attempt = 0;
+    let delayMs = this.retry.baseDelayMs;
+    let lastError: Error | undefined;
+
+    while (attempt <= this.retry.maxRetries) {
+      try {
+        const controller = new AbortController();
+        const effectiveSeconds = (typeof this.config.timeoutSeconds === 'number' && this.config.timeoutSeconds > 0)
+          ? this.config.timeoutSeconds
+          : (DEFAULT_TIMEOUT_MS / 1000);
+        const timeout = setTimeout(() => controller.abort(), effectiveSeconds * 1000);
+        const response = await fetch(this.requestUrl(), {
+          method: 'POST',
+          headers: this.requestHeaders(),
+          body: JSON.stringify(toRequestBody(this.config, request)),
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+
+        if (!response.ok) {
+          if (this.retry.retryOn(response.status) && attempt < this.retry.maxRetries) {
+            await delay(delayMs);
+            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
+            attempt += 1;
+            continue;
+          }
+          const message = await response.text();
+          throw new Error(`LLM request failed (${response.status}): ${message}`);
+        }
+
+        const json = await response.json() as unknown;
+        if (!isRecord(json)) {
+          throw new Error(`Responses API returned non-object payload: ${JSON.stringify(json)}`);
+        }
+        return json as OpenAIResponsesResponse;
+      } catch (error) {
+        lastError = error as Error;
+        if (attempt >= this.retry.maxRetries) break;
+        await delay(delayMs);
+        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
+        attempt += 1;
+      }
+    }
+
+    throw lastError ?? new Error('LLM request failed after retries');
+  }
+
+  private requestUrl(): string {
+    const providerBase = this.config.baseUrl || defaultBaseUrls[this.config.provider ?? 'openai'] || defaultBaseUrls.openai;
+    const normalized = providerBase.endsWith('/') ? providerBase.slice(0, -1) : providerBase;
+    const apiVersionSegment = this.config.apiVersion ? `?api-version=${encodeURIComponent(this.config.apiVersion)}` : '';
+    return `${normalized}/responses${apiVersionSegment}`;
+  }
+
+  private requestHeaders(): Record<string, string> {
+    const baseHeaders: Record<string, string> = {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+
+    if (this.config.provider === 'openrouter') {
+      baseHeaders['HTTP-Referer'] = 'https://openhands.io';
+      baseHeaders['X-Title'] = 'OpenHands';
+    }
+
+    return mergeHeaders(baseHeaders, this.config.headers);
+  }
+}

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -210,7 +210,7 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
   tools: request.tools?.length ? request.tools.map(toResponsesTool) : undefined,
   tool_choice: request.tools?.length ? 'auto' : undefined,
   store: false,
-  temperature: 1.0,
+  temperature: config.temperature ?? undefined,
   max_output_tokens: config.maxOutputTokens ?? undefined,
   reasoning: config.reasoningEffort && config.reasoningEffort !== 'none' ? { effort: config.reasoningEffort } : undefined,
 });

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -1,4 +1,4 @@
-import type { Message, ToolCall } from '../types';
+import type { Message, ResponsesReasoningItem, ToolCall } from '../types';
 
 export type LLMProvider = 'openai' | 'litellm_proxy' | 'openrouter' | 'anthropic';
 
@@ -41,6 +41,7 @@ export interface ChatCompletionRequest {
 export type LLMStreamChunk =
   | { type: 'text'; text: string }
   | { type: 'reasoning'; reasoning: string }
+  | { type: 'responses_reasoning_item'; item: ResponsesReasoningItem }
   | { type: 'tool_call_delta'; id: string; name?: string; arguments?: string }
   | { type: 'usage'; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number }
   | { type: 'finish'; finishReason?: string };

--- a/packages/agent-sdk-ts/src/sdk/runtime/AgentOrchestrator.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/AgentOrchestrator.ts
@@ -39,6 +39,9 @@ export class AgentOrchestrator {
         case 'reasoning':
           message.reasoning_content = (message.reasoning_content ?? '') + chunk.reasoning;
           break;
+        case 'responses_reasoning_item':
+          message.responses_reasoning_item = chunk.item;
+          break;
         case 'tool_call_delta': {
           const current = toolCalls[chunk.id] ?? { id: chunk.id, type: 'function', function: { name: chunk.name ?? '', arguments: '' } };
           current.function = {

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -18,6 +18,14 @@ export interface ToolCall {
   };
 }
 
+export interface ResponsesReasoningItem {
+  id: string;
+  summary?: string[];
+  content?: string[] | null;
+  encrypted_content?: string;
+  status?: string;
+}
+
 export interface Message {
   role: Role;
   content: Content[];
@@ -27,6 +35,7 @@ export interface Message {
   tool_call_id?: string;
   name?: string;
   reasoning_content?: string;
+  responses_reasoning_item?: ResponsesReasoningItem | null;
 }
 
 export interface EventBase {


### PR DESCRIPTION
Implements OpenAI `/responses` support in `@openhands/agent-sdk-ts` and routes `gpt-5*` models to use it by default.

- Adds `OpenAIResponsesClient` (non-stream) that maps OpenHands chat history to Responses `instructions` + `input[]` (incl tool calls + tool outputs) and parses Responses output back into text/tool_calls (+ reasoning item passthrough).
- Updates `LLMFactory` to use Responses for `gpt-5*` models.
- Adds unit tests for the new client + routing.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GPT-5 models with specialized API integration for enhanced response handling
  * Enabled streaming of reasoning items alongside text content and tool calls in real-time chat responses
  * Extended message structure to capture and preserve reasoning content from supported providers

* **Tests**
  * Added comprehensive test coverage for GPT-5 model routing and API response payload parsing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->