### PR TITLE
oh-tab-ytg: improve terminal ToolResult UX

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -274,6 +274,7 @@ describe('Agent-SDK event rendering', () => {
     } as any;
     postToWindow({ type: 'event', event: actionEvent });
     expect(await screen.findByText(/The agent wants to execute a terminal command/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/ls -la/)).toHaveLength(1);
 
     const observationEvent = {
       kind: 'ObservationEvent',
@@ -288,7 +289,12 @@ describe('Agent-SDK event rendering', () => {
       action_id: 'action_terminal_action',
     } as any;
     postToWindow({ type: 'event', event: observationEvent });
-    expect(await screen.findByText(/finished with code 0/i)).toBeInTheDocument();
+    expect(await screen.findByText(/Done\./i)).toBeInTheDocument();
+    expect(screen.getAllByText(/ls -la/)).toHaveLength(1);
+
+    const toggle = await screen.findByRole('button', { name: /Show tool result/i });
+    fireEvent.click(toggle);
+    expect(await screen.findByText(/README\.md/)).toBeInTheDocument();
   });
 
 

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -282,14 +282,31 @@ function TerminalActionSummary({ action }: { action: JsonRecord | null }): React
   );
 }
 
-function TerminalObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+function TerminalObservationSummary({
+  observation,
+  isExpanded,
+  onToggle,
+}: {
+  observation: JsonRecord;
+  isExpanded: boolean;
+  onToggle: () => void;
+}): React.ReactElement | null {
   const exitCodeNumber = getNumber(observation.exit_code);
   const exitCodeText = exitCodeNumber !== undefined ? exitCodeNumber.toString() : getString(observation.exit_code) ?? 'unknown';
-  const command = getString(observation.command);
+  const summaryText = exitCodeText === '0' ? 'Done.' : `Done (exit code ${exitCodeText}).`;
+  const toggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';
   return (
-    <div className="text-sm leading-relaxed space-y-1">
-      <p>The terminal command finished with code {exitCodeText}.</p>
-      <TerminalCommandPreview command={command} />
+    <div className="text-sm leading-relaxed">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="w-full flex items-center justify-between gap-3 text-left text-xs text-stone-400 hover:text-stone-300 transition-colors bg-black/20 border border-white/[0.04] rounded-lg px-3 py-2 hover:bg-white/[0.04]"
+        aria-label={toggleLabel}
+        title={toggleLabel}
+      >
+        <span className="text-sm text-stone-300">{summaryText}</span>
+        <span className={`codicon codicon-chevron-${isExpanded ? 'up' : 'down'} text-[10px]`} />
+      </button>
     </div>
   );
 }
@@ -527,11 +544,11 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
   const observationSummary = event.tool_name === 'file_editor'
     ? <FileEditorObservationSummary observation={event.observation} />
     : event.tool_name === 'terminal'
-      ? <TerminalObservationSummary observation={event.observation} />
+      ? <TerminalObservationSummary observation={event.observation} isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />
       : null;
   const hasSummary = observationSummary !== null;
   const shouldShowRaw = !hasSummary || isExpanded;
-  const showHeaderToggle = hasSummary;
+  const showHeaderToggle = hasSummary && event.tool_name !== 'terminal';
   const showFooterToggle = !hasSummary && isTruncated;
   const headerToggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';
   const footerToggleLabel = isExpanded ? 'Show less' : 'Show more';


### PR DESCRIPTION
Improves terminal ToolResult UX in the webview:

- Removes duplicated command text from the Tool Result block (Action already shows it).
- Replaces the summary with a compact "Done." button that contains the expand/collapse chevron.
- Keeps raw JSON/details hidden until expanded.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
