### PR TITLE
oh-tab-8i5: dedupe HAL shared types

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import * as os from 'os';
 import { SettingsManager, type OpenHandsSettings } from './settings/SettingsManager';
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from './shared/halTeleport';
+import { type HalStateSnapshot, isElevenLabsMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
 import {
   AgentContext,
   Conversation,
@@ -41,21 +42,6 @@ type UiStateSnapshot = {
   attachmentsCount: number;
 };
 
-type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
-type HalEye = 'off' | 'dim' | 'pulsating';
-type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
-type ElevenLabsMode = 'bundled' | 'tts_only' | 'voice_confirm';
-
-type HalStateSnapshot = {
-  enabled: boolean;
-  mode: ElevenLabsMode;
-  phase: HalPhase;
-  eye: HalEye;
-  stepIndex: number | null;
-  decision: HalDecision | null;
-  lastError: string | null;
-};
-
 const DEFAULT_UI_STATE: UiStateSnapshot = {
   input: '',
   showContextPicker: false,
@@ -76,30 +62,6 @@ const DEFAULT_HAL_STATE: HalStateSnapshot = {
   decision: null,
   lastError: null,
 };
-
-function isElevenLabsMode(value: unknown): value is ElevenLabsMode {
-  return value === 'bundled' || value === 'tts_only' || value === 'voice_confirm';
-}
-
-function isHalPhase(value: unknown): value is HalPhase {
-  return (
-    value === 'idle' ||
-    value === 'dialogue' ||
-    value === 'awaiting_user' ||
-    value === 'listening' ||
-    value === 'classifying' ||
-    value === 'waiting_remote' ||
-    value === 'error'
-  );
-}
-
-function isHalEye(value: unknown): value is HalEye {
-  return value === 'off' || value === 'dim' || value === 'pulsating';
-}
-
-function isHalDecision(value: unknown): value is HalDecision {
-  return value === 'approve_local' || value === 'teleport_remote' || value === 'reject';
-}
 
 let chatView: vscode.WebviewView | undefined;
 let conversation: ConversationInstance | undefined;

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,11 +1,10 @@
 import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, ConversationSettings, ConfirmationSettings } from './SettingsAdapter';
+import type { ElevenLabsMode } from '../shared/halTypes';
 
 export interface SavedServer {
   url: string;
   label?: string;
 }
-
-export type ElevenLabsMode = 'bundled' | 'tts_only' | 'voice_confirm';
 
 export type ElevenLabsSettings = {
   enabled: boolean;

--- a/src/shared/halTypes.ts
+++ b/src/shared/halTypes.ts
@@ -1,0 +1,43 @@
+export const HAL_PHASES = [
+  'idle',
+  'dialogue',
+  'awaiting_user',
+  'listening',
+  'classifying',
+  'waiting_remote',
+  'error',
+] as const;
+
+export type HalPhase = (typeof HAL_PHASES)[number];
+
+export const HAL_EYES = ['off', 'dim', 'pulsating'] as const;
+export type HalEye = (typeof HAL_EYES)[number];
+
+export const HAL_DECISIONS = ['approve_local', 'teleport_remote', 'reject'] as const;
+export type HalDecision = (typeof HAL_DECISIONS)[number];
+
+export const ELEVENLABS_MODES = ['bundled', 'tts_only', 'voice_confirm'] as const;
+export type ElevenLabsMode = (typeof ELEVENLABS_MODES)[number];
+
+export type HalStateSnapshot = {
+  enabled: boolean;
+  mode: ElevenLabsMode;
+  phase: HalPhase;
+  eye: HalEye;
+  stepIndex: number | null;
+  decision: HalDecision | null;
+  lastError: string | null;
+};
+
+export const isElevenLabsMode = (value: unknown): value is ElevenLabsMode =>
+  typeof value === 'string' && (ELEVENLABS_MODES as readonly string[]).includes(value);
+
+export const isHalPhase = (value: unknown): value is HalPhase =>
+  typeof value === 'string' && (HAL_PHASES as readonly string[]).includes(value);
+
+export const isHalEye = (value: unknown): value is HalEye =>
+  typeof value === 'string' && (HAL_EYES as readonly string[]).includes(value);
+
+export const isHalDecision = (value: unknown): value is HalDecision =>
+  typeof value === 'string' && (HAL_DECISIONS as readonly string[]).includes(value);
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -24,7 +24,8 @@ import { InputArea, ContextPicker, SkillsPopover } from './InputArea';
 import { ConfirmationPrompt } from './ConfirmationPrompt';
 import { StatusBanner } from './StatusBanner';
 import { HistoryView } from './HistoryView';
-import { HalOverlay, type HalEye } from './HalOverlay';
+import type { ElevenLabsMode, HalDecision, HalEye, HalPhase, HalStateSnapshot } from '../../shared/halTypes';
+import { HalOverlay } from './HalOverlay';
 import {
   SystemPromptEventBlock,
   ActionEventBlock,
@@ -60,26 +61,11 @@ type StatusBannerState = {
   dismissible?: boolean;
 };
 
-type ElevenLabsMode = 'bundled' | 'tts_only' | 'voice_confirm';
-
 type ElevenLabsSettingsSnapshot = {
   enabled: boolean;
   mode: ElevenLabsMode;
   userName: string;
   volume: number;
-};
-
-type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
-type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
-
-type HalStateSnapshot = {
-  enabled: boolean;
-  mode: ElevenLabsMode;
-  phase: HalPhase;
-  eye: HalEye;
-  stepIndex: number | null;
-  decision: HalDecision | null;
-  lastError: string | null;
 };
 
 const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1 };

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -1,9 +1,5 @@
 import { useMemo, useState } from 'react';
-
-export type HalPhase = 'idle' | 'dialogue' | 'awaiting_user' | 'listening' | 'classifying' | 'waiting_remote' | 'error';
-export type HalEye = 'off' | 'dim' | 'pulsating';
-
-type HalDecision = 'approve_local' | 'teleport_remote' | 'reject';
+import type { HalDecision, HalEye, HalPhase } from '../../shared/halTypes';
 
 type HalOverlayProps = {
   userName: string;


### PR DESCRIPTION
Creates a single source of truth for HAL-related types.

- Adds `src/shared/halTypes.ts` exporting `HalPhase`, `HalEye`, `HalDecision`, `ElevenLabsMode`, `HalStateSnapshot` (+ type guards).
- Updates extension + webview to import these shared types (no behavior changes).
- Updates settings to reuse shared `ElevenLabsMode`.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated type definitions for HAL state and ElevenLabs settings into a centralized shared module to ensure consistency across the codebase.
  * Added runtime type guards to validate values at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->