### PR TITLE
oh-tab-pqc: OpenAI GPT-5 API mode toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,17 @@
             "order": 6,
             "markdownDescription": "Reasoning effort for supported models."
           },
+          "openhands.llm.openaiApiMode": {
+            "type": "string",
+            "enum": [
+              "auto",
+              "chat_completions",
+              "responses"
+            ],
+            "default": "auto",
+            "order": 7,
+            "markdownDescription": "For OpenAI GPT-5 models in local mode, choose which API to use. `auto` uses Responses when supported (otherwise Chat Completions)."
+          },
           "openhands.llm.apiVersion": {
             "type": "string",
             "order": 10,

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -181,6 +181,24 @@ describe('LLMFactory integration', () => {
     expect(client).toBeInstanceOf(OpenAIResponsesClient);
   });
 
+  it('honors openaiApiMode=chat_completions for GPT-5 models', async () => {
+    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', openaiApiMode: 'chat_completions', apiKey: 'sk-inline' });
+    const client = await factory.createClient();
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+  });
+
+  it('honors openaiApiMode=responses even when baseUrl is custom', async () => {
+    const factory = new LLMFactory({
+      model: 'gpt-5-mini',
+      provider: 'openai',
+      baseUrl: 'http://localhost:4000',
+      openaiApiMode: 'responses',
+      apiKey: 'sk-inline',
+    });
+    const client = await factory.createClient();
+    expect(client).toBeInstanceOf(OpenAIResponsesClient);
+  });
+
   it('does not route GPT-5 models through Responses API when baseUrl is custom', async () => {
     const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', baseUrl: 'http://localhost:4000', apiKey: 'sk-inline' });
     const client = await factory.createClient();

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -44,6 +44,7 @@ export class LLMFactory {
 
     const provider = this.config.provider ?? detectProviderFromBaseUrl(this.config.baseUrl);
     const normalizedModel = this.config.model.toLowerCase();
+    const openaiApiMode = provider === 'openai' ? this.config.openaiApiMode ?? undefined : undefined;
     const normalizeUrl = (value: string | null | undefined): string | undefined => {
       const trimmed = typeof value === 'string' ? value.trim() : '';
       if (!trimmed) return undefined;
@@ -52,7 +53,10 @@ export class LLMFactory {
     const normalizedBaseUrl = normalizeUrl(this.config.baseUrl);
     const normalizedDefaultOpenAIBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS.openai);
     const baseUrlSupportsResponses = !normalizedBaseUrl || normalizedBaseUrl === normalizedDefaultOpenAIBaseUrl;
-    const useResponses = provider === 'openai' && normalizedModel.startsWith('gpt-5') && baseUrlSupportsResponses;
+    const isGpt5 = normalizedModel.startsWith('gpt-5');
+    const useResponses = provider === 'openai'
+      && isGpt5
+      && (openaiApiMode === 'responses' || (openaiApiMode !== 'chat_completions' && baseUrlSupportsResponses));
     const base = provider === 'anthropic'
       ? new AnthropicClient(this.config, apiKey)
       : useResponses

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -2,6 +2,8 @@ import type { Message, ResponsesReasoningItem, ToolCall } from '../types';
 
 export type LLMProvider = 'openai' | 'litellm_proxy' | 'openrouter' | 'anthropic';
 
+export type OpenAIChatApi = 'chat_completions' | 'responses';
+
 export interface LLMToolDefinition {
   type: 'function';
   function: {
@@ -15,6 +17,8 @@ export interface LLMConfiguration {
   provider?: LLMProvider;
   model: string;
   usageId?: string | null;
+  /** Only applies to OpenAI provider. */
+  openaiApiMode?: OpenAIChatApi | null;
   baseUrl?: string | null;
   apiKey?: string;
   apiVersion?: string | null;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -778,6 +778,7 @@ export class Agent extends EventEmitter {
     const config = {
       provider: s.llm.provider ?? undefined,
       model: s.llm.model ?? '',
+      openaiApiMode: s.llm.openaiApiMode ?? undefined,
       usageId: s.llm.usageId ?? undefined,
       baseUrl: s.llm.baseUrl ?? undefined,
       apiKey: s.secrets?.llmApiKey ?? undefined,

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -1,9 +1,11 @@
-import type { LLMProvider } from '../llm/types';
+import type { LLMProvider, OpenAIChatApi } from '../llm/types';
 
 export type LLMSettings = {
   usageId?: string | null;
   provider?: LLMProvider | null;
   model?: string | null;
+  /** OpenAI-specific API selection (local-mode only). */
+  openaiApiMode?: OpenAIChatApi | null;
   baseUrl?: string | null;
   apiVersion?: string | null;
   timeout?: number | null;

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -82,6 +82,19 @@ const normalizeLlmProvider = (value: unknown): LLMSettings['provider'] | undefin
   }
 };
 
+const normalizeOpenaiApiMode = (value: unknown): LLMSettings['openaiApiMode'] | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return undefined;
+  if (trimmed === 'auto') return undefined;
+  switch (trimmed) {
+    case 'chat_completions':
+    case 'responses':
+      return trimmed;
+    default:
+      return undefined;
+  }
+};
+
 const normalizeElevenLabsMode = (value: unknown, defaultValue: ElevenLabsMode): ElevenLabsMode => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   switch (trimmed) {
@@ -146,6 +159,11 @@ export class SettingsManager {
       usageId,
       provider,
       model,
+      openaiApiMode: normalizeOpenaiApiMode(
+        isRemote
+          ? this.adapter.getExplicit<string>('openhands.llm.openaiApiMode')
+          : (this.adapter.get<string | null>('openhands.llm.openaiApiMode', 'auto') ?? 'auto')
+      ),
       baseUrl: normalizeNonEmptyString(
         isRemote
           ? this.adapter.getExplicit<string>('openhands.llm.baseUrl')
@@ -230,6 +248,9 @@ export class SettingsManager {
       if (partial.llm.usageId !== undefined) ops.push(this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target));
       if (partial.llm.provider !== undefined) ops.push(this.adapter.update('openhands.llm.provider', partial.llm.provider, target));
       if (partial.llm.model !== undefined) ops.push(this.adapter.update('openhands.llm.model', partial.llm.model, target));
+      if (partial.llm.openaiApiMode !== undefined) {
+        ops.push(this.adapter.update('openhands.llm.openaiApiMode', partial.llm.openaiApiMode ?? 'auto', target));
+      }
       if (partial.llm.baseUrl !== undefined) ops.push(this.adapter.update('openhands.llm.baseUrl', partial.llm.baseUrl, target));
       if (partial.llm.apiVersion !== undefined) ops.push(this.adapter.update('openhands.llm.apiVersion', partial.llm.apiVersion, target));
       if (partial.llm.timeout !== undefined) ops.push(this.adapter.update('openhands.llm.timeout', partial.llm.timeout, target));

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -28,6 +28,7 @@ describe('SettingsManager', () => {
     expect(s.serverUrl).toBeUndefined();
     expect(s.llm.usageId).toBe('default-llm');
     expect(s.llm.provider).toBe('anthropic');
+    expect(s.llm.openaiApiMode).toBeUndefined();
     // Local mode requires a default model for the local Agent to run.
     expect(s.llm.model).toBe('claude-sonnet-4-20250514');
     expect(s.agent.enableSecurityAnalyzer).toBe(false);
@@ -258,6 +259,7 @@ describe('SettingsManager', () => {
         temperature: 0.7,
         topP: 0.9,
         topK: 50,
+        openaiApiMode: 'chat_completions',
         maxInputTokens: 4096,
         maxOutputTokens: 2048,
         reasoningEffort: 'high',
@@ -272,11 +274,24 @@ describe('SettingsManager', () => {
     expect(s.llm.temperature).toBe(0.7);
     expect(s.llm.topP).toBe(0.9);
     expect(s.llm.topK).toBe(50);
+    expect(s.llm.openaiApiMode).toBe('chat_completions');
     expect(s.llm.maxInputTokens).toBe(4096);
     expect(s.llm.maxOutputTokens).toBe(2048);
     expect(s.llm.reasoningEffort).toBe('high');
     expect(s.llm.inputCostPerToken).toBe(0.000001);
     expect(s.llm.outputCostPerToken).toBe(0.000002);
+  });
+
+  it('normalizes openaiApiMode and persists auto', async () => {
+    await mgr.update({ llm: { openaiApiMode: 'responses' } });
+    expect(a.cfg.get('openhands.llm.openaiApiMode')).toBe('responses');
+    let s = await mgr.get();
+    expect(s.llm.openaiApiMode).toBe('responses');
+
+    await mgr.update({ llm: { openaiApiMode: null } });
+    expect(a.cfg.get('openhands.llm.openaiApiMode')).toBe('auto');
+    s = await mgr.get();
+    expect(s.llm.openaiApiMode).toBeUndefined();
   });
 
   it('handles sanitizePositiveInteger with invalid inputs', async () => {


### PR DESCRIPTION
Adds VS Code setting `openhands.llm.openaiApiMode` (`auto`/`chat_completions`/`responses`) and wires it through local Agent -> LLMFactory so GPT-5 can be forced onto Chat Completions or Responses.

Tests:
- `src/settings/__tests__/SettingsManager.test.ts`
- `packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to specify OpenAI API mode for local GPT-5 models. Users can now choose between "auto" (default), "chat_completions," and "responses" variants to optimize compatibility and performance with their local OpenAI setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->