### PR TITLE
oh-tab-3qq: delete conversations from HistoryView

### DIFF
--- a/src/webview-src/__tests__/HistoryView.test.tsx
+++ b/src/webview-src/__tests__/HistoryView.test.tsx
@@ -16,6 +16,7 @@ describe('HistoryView', () => {
   it('filters conversations by search query', () => {
     const onClose = vi.fn();
     const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
 
     render(
       <HistoryView
@@ -27,6 +28,7 @@ describe('HistoryView', () => {
         ]}
         currentConversationId="def456"
         onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
       />
     );
 
@@ -46,16 +48,18 @@ describe('HistoryView', () => {
   it('shows no-results state and clears search', () => {
     const onClose = vi.fn();
     const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
 
     render(
       <HistoryView
         isOpen
         onClose={onClose}
         conversations={[
-          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 },
-          { id: 'def456', firstMessage: 'Refactor prompt', timestamp: 2000 },
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 2000 },
+          { id: 'def456', firstMessage: 'Refactor prompt', timestamp: 1000 },
         ]}
         onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
       />
     );
 
@@ -74,6 +78,7 @@ describe('HistoryView', () => {
   it('clears search on Escape without closing', () => {
     const onClose = vi.fn();
     const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
 
     render(
       <HistoryView
@@ -81,6 +86,7 @@ describe('HistoryView', () => {
         onClose={onClose}
         conversations={[{ id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 }]}
         onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
       />
     );
 
@@ -97,6 +103,7 @@ describe('HistoryView', () => {
   it('closes on Escape when search is empty', () => {
     const onClose = vi.fn();
     const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
 
     render(
       <HistoryView
@@ -104,6 +111,7 @@ describe('HistoryView', () => {
         onClose={onClose}
         conversations={[{ id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 }]}
         onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
       />
     );
 
@@ -116,6 +124,7 @@ describe('HistoryView', () => {
   it('paginates conversations with Load more', () => {
     const onClose = vi.fn();
     const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
 
     const conversations = Array.from({ length: 31 }, (_, idx) => {
       const n = idx + 1;
@@ -128,6 +137,7 @@ describe('HistoryView', () => {
         onClose={onClose}
         conversations={conversations}
         onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
       />
     );
 
@@ -141,5 +151,32 @@ describe('HistoryView', () => {
     expect(screen.getByText('Conversation 1')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Load more conversations' })).not.toBeInTheDocument();
     expect(screen.getByText('31 conversations')).toBeInTheDocument();
+  });
+
+  it('calls onDeleteConversation when trash icon is clicked', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 2000 },
+          { id: 'def456', firstMessage: 'Refactor prompt', timestamp: 1000 },
+        ]}
+        onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    const deletes = screen.getAllByRole('button', { name: 'Delete conversation' });
+    fireEvent.click(deletes[0]!);
+
+    expect(onDeleteConversation).toHaveBeenCalledTimes(1);
+    expect(onDeleteConversation).toHaveBeenCalledWith('abc123');
   });
 });

--- a/src/webview-src/__tests__/HistoryView.test.tsx
+++ b/src/webview-src/__tests__/HistoryView.test.tsx
@@ -179,4 +179,29 @@ describe('HistoryView', () => {
     expect(onDeleteConversation).toHaveBeenCalledTimes(1);
     expect(onDeleteConversation).toHaveBeenCalledWith('abc123');
   });
+
+  it('disables delete for the active conversation', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000 },
+          { id: 'def456', firstMessage: 'Refactor prompt', timestamp: 2000 },
+        ]}
+        currentConversationId="def456"
+        onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    const deletes = screen.getAllByRole('button', { name: 'Delete conversation' });
+    expect(deletes[0]).toBeDisabled();
+  });
 });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1252,6 +1252,11 @@ export function App() {
     postMessage({ type: 'restoreConversation', id });
   }, [postMessage]);
 
+  const handleDeleteConversation = useCallback((id: string) => {
+    setHistory((prev) => prev.filter((conversation) => conversation.id !== id));
+    postMessage({ type: 'deleteConversation', id });
+  }, [postMessage]);
+
   // Server selection handlers
   const handleSelectServer = useCallback((url: string) => {
     postMessage({ type: 'selectServer', url });
@@ -1424,6 +1429,7 @@ export function App() {
         conversations={history}
         currentConversationId={conversationId}
         onSelectConversation={handleSelectConversation}
+        onDeleteConversation={handleDeleteConversation}
       />
     </div>
   );

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1253,9 +1253,10 @@ export function App() {
   }, [postMessage]);
 
   const handleDeleteConversation = useCallback((id: string) => {
+    if (id === conversationId) return;
     setHistory((prev) => prev.filter((conversation) => conversation.id !== id));
     postMessage({ type: 'deleteConversation', id });
-  }, [postMessage]);
+  }, [conversationId, postMessage]);
 
   // Server selection handlers
   const handleSelectServer = useCallback((url: string) => {

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -22,6 +22,7 @@ interface HistoryViewProps {
   conversations: Conversation[];
   currentConversationId?: string;
   onSelectConversation: (id: string) => void;
+  onDeleteConversation: (id: string) => void;
 }
 
 interface ConversationItemProps {
@@ -29,6 +30,7 @@ interface ConversationItemProps {
   isActive: boolean;
   animationDelay: number;
   onSelect: () => void;
+  onDelete: () => void;
 }
 
 // --- Utility Functions ---
@@ -89,58 +91,72 @@ function ConversationItem({
   isActive,
   animationDelay,
   onSelect,
+  onDelete,
 }: ConversationItemProps) {
   const displayTitle = getDisplayTitle(conversation);
   const promptPreview = getPromptPreview(conversation.firstMessage);
   const timeAgo = formatTimeAgo(conversation.timestamp);
 
   return (
-    <button
-      onClick={onSelect}
-      className={`
-        w-full text-left p-4 rounded-xl
-        transition-all duration-200
-        border
-        hover:bg-white/[0.04]
-        focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
-        ${isActive
-          ? 'bg-brand-500/10 border-brand-500/25 hover:bg-brand-500/15'
-          : 'bg-white/[0.02] border-white/[0.04] hover:border-white/[0.08]'}
-        animate-slide-up
-      `}
+    <div
+      className="relative animate-slide-up"
       style={{ animationDelay: `${animationDelay}ms` }}
     >
-      {/* Title Row */}
-      <div className="flex items-start justify-between gap-3 mb-1">
-        <div className={`font-medium text-sm line-clamp-2 flex-1 ${isActive ? 'text-brand-200' : 'text-stone-200'}`}>
-          {displayTitle}
+      <button
+        onClick={onSelect}
+        className={`
+          w-full text-left p-4 pr-12 rounded-xl
+          transition-all duration-200
+          border
+          hover:bg-white/[0.04]
+          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+          ${isActive
+            ? 'bg-brand-500/10 border-brand-500/25 hover:bg-brand-500/15'
+            : 'bg-white/[0.02] border-white/[0.04] hover:border-white/[0.08]'}
+        `}
+      >
+        {/* Title Row */}
+        <div className="flex items-start justify-between gap-3 mb-1">
+          <div className={`font-medium text-sm line-clamp-2 flex-1 ${isActive ? 'text-brand-200' : 'text-stone-200'}`}>
+            {displayTitle}
+          </div>
+          {isActive && (
+            <span className="flex-shrink-0 w-2 h-2 rounded-full bg-brand-400 mt-1 animate-pulse" />
+          )}
         </div>
-        {isActive && (
-          <span className="flex-shrink-0 w-2 h-2 rounded-full bg-brand-400 mt-1 animate-pulse" />
+
+        {/* Prompt Preview */}
+        {promptPreview && (
+          <div className="text-xs text-stone-500 line-clamp-2 mb-2">
+            {promptPreview}
+          </div>
         )}
-      </div>
 
-      {/* Prompt Preview */}
-      {promptPreview && (
-        <div className="text-xs text-stone-500 line-clamp-2 mb-2">
-          {promptPreview}
-        </div>
-      )}
-
-      {/* Metadata Row */}
-      <div className="flex items-center gap-3 text-xs text-stone-500">
-        <span className="flex items-center gap-1">
-          <span className="codicon codicon-clock" />
-          {timeAgo}
-        </span>
-        {conversation.messageCount !== undefined && (
+        {/* Metadata Row */}
+        <div className="flex items-center gap-3 text-xs text-stone-500">
           <span className="flex items-center gap-1">
-            <span className="codicon codicon-comment" />
-            {conversation.messageCount}
+            <span className="codicon codicon-clock" />
+            {timeAgo}
           </span>
-        )}
-      </div>
-    </button>
+          {conversation.messageCount !== undefined && (
+            <span className="flex items-center gap-1">
+              <span className="codicon codicon-comment" />
+              {conversation.messageCount}
+            </span>
+          )}
+        </div>
+      </button>
+
+      <button
+        type="button"
+        onClick={onDelete}
+        className="absolute right-3 top-3 h-7 w-7 rounded-md text-stone-500 hover:text-stone-200 hover:bg-white/[0.06] flex items-center justify-center transition-all"
+        aria-label="Delete conversation"
+        title="Delete conversation"
+      >
+        <span className="codicon codicon-trash text-sm" />
+      </button>
+    </div>
   );
 }
 
@@ -192,6 +208,7 @@ export function HistoryView({
   conversations,
   currentConversationId,
   onSelectConversation,
+  onDeleteConversation,
 }: HistoryViewProps) {
   const panelRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState('');
@@ -338,6 +355,7 @@ export function HistoryView({
                     onSelectConversation(conversation.id);
                     onClose();
                   }}
+                  onDelete={() => onDeleteConversation(conversation.id)}
                 />
               ))}
 

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -150,9 +150,12 @@ function ConversationItem({
       <button
         type="button"
         onClick={onDelete}
-        className="absolute right-3 top-3 h-7 w-7 rounded-md text-stone-500 hover:text-stone-200 hover:bg-white/[0.06] flex items-center justify-center transition-all"
+        disabled={isActive}
+        className={`absolute right-3 top-3 h-7 w-7 rounded-md text-stone-500 flex items-center justify-center transition-all ${isActive
+          ? 'opacity-40 cursor-not-allowed'
+          : 'hover:text-stone-200 hover:bg-white/[0.06]'}`}
         aria-label="Delete conversation"
-        title="Delete conversation"
+        title={isActive ? 'Cannot delete active conversation' : 'Delete conversation'}
       >
         <span className="codicon codicon-trash text-sm" />
       </button>

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -543,6 +543,11 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'deleteConversation': {
         const id = message.id;
         if (!id) break;
+        const activeConversationId = conversation?.getConversationId?.();
+        if (activeConversationId && activeConversationId === id) {
+          void vscode.window.showWarningMessage('Cannot delete the active conversation.');
+          break;
+        }
         try {
           if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
             throw new Error('Invalid conversation id');

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -28,6 +28,7 @@ type WebviewMessage =
   | { type: 'openWorkspaceDiff'; path: string; oldContent: string; newContent: string }
   | { type: 'requestHistory' }
   | { type: 'restoreConversation'; id: string }
+  | { type: 'deleteConversation'; id: string }
   | { type: 'getConfig' }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }
@@ -344,6 +345,61 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
     const outputChannel = deps.getOutputChannel();
     const conversation = deps.getConversation();
 
+    const sendHistoryList = async (): Promise<void> => {
+      try {
+        const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
+        let ids: string[] = [];
+        try {
+          ids = FileStore.listConversations(convRoot);
+        } catch {
+          ids = [];
+        }
+        const conversations = await Promise.all(
+          ids.map(async (id) => {
+            try {
+              const statePath = path.join(convRoot, id, 'state.json');
+              const eventsPath = path.join(convRoot, id, 'events.jsonl');
+              const stat = await fs.stat(statePath).catch(async () => fs.stat(eventsPath));
+              const timestamp = stat?.mtimeMs ?? Date.now();
+              let firstMessage: string | undefined;
+              try {
+                const line = await findFirstMessageEventLine(eventsPath);
+                if (line) {
+                  try {
+                    const parsed: unknown = JSON.parse(line);
+                    if (isEvent(parsed) && isMessageEvent(parsed)) {
+                      const msg = parsed.llm_message;
+                      if (msg.role === 'user') {
+                        const textPart = msg.content.find(isTextContent);
+                        if (textPart) firstMessage = textPart.text;
+                      }
+                    }
+                  } catch (err) {
+                    const reason = err instanceof Error ? err.message : String(err);
+                    outputChannel?.appendLine(`[history] Failed to parse MessageEvent for ${id}: ${reason}`);
+                  }
+                }
+              } catch (err) {
+                const code = (err as NodeJS.ErrnoException).code;
+                if (code !== 'ENOENT') {
+                  const reason = err instanceof Error ? err.message : String(err);
+                  outputChannel?.appendLine(`[history] Failed to scan events for ${id}: ${reason}`);
+                }
+              }
+              return { id, timestamp: Math.floor(timestamp), firstMessage };
+            } catch {
+              return { id, timestamp: Date.now() };
+            }
+          })
+        );
+        void host.postMessage({ type: 'historyList', conversations });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        outputChannel?.appendLine(`[history] ${reason}`);
+        void host.postMessage({ type: 'historyList', conversations: [] });
+      }
+    };
+
     switch (message.type) {
       case 'webviewReady': {
         deps.setWebviewReadyState(message.conversationId, message.lastSeenSeq);
@@ -481,58 +537,30 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'requestHistory': {
+        await sendHistoryList();
+        break;
+      }
+      case 'deleteConversation': {
+        const id = message.id;
+        if (!id) break;
         try {
-          const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
-          let ids: string[] = [];
-          try {
-            ids = FileStore.listConversations(convRoot);
-          } catch {
-            ids = [];
+          if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+            throw new Error('Invalid conversation id');
           }
-          const conversations = await Promise.all(
-            ids.map(async (id) => {
-              try {
-                const statePath = path.join(convRoot, id, 'state.json');
-                const eventsPath = path.join(convRoot, id, 'events.jsonl');
-                const stat = await fs.stat(statePath).catch(async () => fs.stat(eventsPath));
-                const timestamp = stat?.mtimeMs ?? Date.now();
-                let firstMessage: string | undefined;
-                try {
-                  const line = await findFirstMessageEventLine(eventsPath);
-                  if (line) {
-                    try {
-                      const parsed: unknown = JSON.parse(line);
-                      if (isEvent(parsed) && isMessageEvent(parsed)) {
-                        const msg = parsed.llm_message;
-                        if (msg.role === 'user') {
-                          const textPart = msg.content.find(isTextContent);
-                          if (textPart) firstMessage = textPart.text;
-                        }
-                      }
-                    } catch (err) {
-                      const reason = err instanceof Error ? err.message : String(err);
-                      outputChannel?.appendLine(`[history] Failed to parse MessageEvent for ${id}: ${reason}`);
-                    }
-                  }
-                } catch (err) {
-                  const code = (err as NodeJS.ErrnoException).code;
-                  if (code !== 'ENOENT') {
-                    const reason = err instanceof Error ? err.message : String(err);
-                    outputChannel?.appendLine(`[history] Failed to scan events for ${id}: ${reason}`);
-                  }
-                }
-                return { id, timestamp: Math.floor(timestamp), firstMessage };
-              } catch {
-                return { id, timestamp: Date.now() };
-              }
-            })
-          );
-          void host.postMessage({ type: 'historyList', conversations });
+          const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
+          const resolvedRoot = path.resolve(convRoot);
+          const targetDir = path.resolve(convRoot, id);
+          const relative = path.relative(resolvedRoot, targetDir);
+          if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+            throw new Error('Invalid conversation id');
+          }
+          await fs.rm(targetDir, { recursive: true, force: true });
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine(`[history] ${reason}`);
-          void host.postMessage({ type: 'historyList', conversations: [] });
+          outputChannel?.appendLine(`[history] Failed to delete ${id}: ${reason}`);
+          void vscode.window.showErrorMessage(`Failed to delete conversation: ${reason}`);
         }
+        await sendHistoryList();
         break;
       }
       case 'restoreConversation': {


### PR DESCRIPTION
Adds a trash icon to each HistoryView row to delete a conversation.

- Webview: calls `onDeleteConversation(id)` and optimistically removes the row.
- Host: handles `deleteConversation` by removing the conversation directory under the store root and refreshes `historyList`.

Tests:
- `src/webview-src/__tests__/HistoryView.test.tsx`
