### PR TITLE
oh-tab-hln: Responses reasoning summary setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
             ],
             "default": "none",
             "order": 8,
-            "markdownDescription": "For OpenAI GPT-5 models using the Responses API, request a reasoning summary. `none` omits the summary."
+            "markdownDescription": "For OpenAI GPT-5 models using the Responses API, request a reasoning summary (only when `openhands.llm.reasoningEffort` is not `none`). `none` omits the summary."
           },
           "openhands.llm.apiVersion": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,18 @@
             "order": 7,
             "markdownDescription": "For OpenAI GPT-5 models in local mode, choose which API to use. `auto` uses Responses when supported (otherwise Chat Completions)."
           },
+          "openhands.llm.reasoningSummary": {
+            "type": "string",
+            "enum": [
+              "none",
+              "auto",
+              "concise",
+              "detailed"
+            ],
+            "default": "none",
+            "order": 8,
+            "markdownDescription": "For OpenAI GPT-5 models using the Responses API, request a reasoning summary. `none` omits the summary."
+          },
           "openhands.llm.apiVersion": {
             "type": "string",
             "order": 10,

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -162,6 +162,29 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     expect(response.usage).toEqual({ inputTokens: 5, outputTokens: 2, cacheReadTokens: 1, cacheWriteTokens: undefined });
     expect(response.message.responses_reasoning_item).toMatchObject({ id: 'rs_1', summary: ['short summary'], encrypted_content: 'encrypted' });
   });
+
+  it('includes reasoning summary in Responses request body when configured', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient({ ...baseConfig, reasoningEffort: 'medium', reasoningSummary: 'detailed' }, 'test-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    await orchestrator.runChat(buildRequest());
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    expect(body?.reasoning).toEqual({ effort: 'medium', summary: 'detailed' });
+  });
 });
 
 describe('LLMFactory integration', () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -185,6 +185,29 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
     expect(body?.reasoning).toEqual({ effort: 'medium', summary: 'detailed' });
   });
+
+  it('ignores reasoningSummary when reasoningEffort is none', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient({ ...baseConfig, reasoningEffort: 'none', reasoningSummary: 'detailed' }, 'test-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    await orchestrator.runChat(buildRequest());
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    expect(body).not.toHaveProperty('reasoning');
+  });
 });
 
 describe('LLMFactory integration', () => {

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -212,7 +212,12 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
   store: false,
   temperature: config.temperature ?? undefined,
   max_output_tokens: config.maxOutputTokens ?? undefined,
-  reasoning: config.reasoningEffort && config.reasoningEffort !== 'none' ? { effort: config.reasoningEffort } : undefined,
+  reasoning: config.reasoningEffort && config.reasoningEffort !== 'none'
+    ? {
+      effort: config.reasoningEffort,
+      ...(config.reasoningSummary ? { summary: config.reasoningSummary } : {}),
+    }
+    : undefined,
 });
 
 const parseResponsesOutput = (output: unknown): { text?: string; toolCalls: ToolCall[]; responsesReasoningItem?: ResponsesReasoningItem } => {

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -4,6 +4,8 @@ export type LLMProvider = 'openai' | 'litellm_proxy' | 'openrouter' | 'anthropic
 
 export type OpenAIChatApi = 'chat_completions' | 'responses';
 
+export type ReasoningSummary = 'auto' | 'concise' | 'detailed';
+
 export interface LLMToolDefinition {
   type: 'function';
   function: {
@@ -29,6 +31,8 @@ export interface LLMConfiguration {
   maxInputTokens?: number | null;
   maxOutputTokens?: number | null;
   reasoningEffort?: 'low' | 'medium' | 'high' | 'none' | null;
+  /** Responses-only; ignored by Chat Completions. */
+  reasoningSummary?: ReasoningSummary | null;
   headers?: Record<string, string>;
   /** Cost per input token in USD (or base currency). */
   inputCostPerToken?: number | null;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -790,6 +790,7 @@ export class Agent extends EventEmitter {
       maxInputTokens: s.llm.maxInputTokens ?? undefined,
       maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
       reasoningEffort: s.llm.reasoningEffort ?? undefined,
+      reasoningSummary: s.llm.reasoningSummary ?? undefined,
       inputCostPerToken: s.llm.inputCostPerToken ?? undefined,
       outputCostPerToken: s.llm.outputCostPerToken ?? undefined,
     };

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -1,4 +1,4 @@
-import type { LLMProvider, OpenAIChatApi } from '../llm/types';
+import type { LLMProvider, OpenAIChatApi, ReasoningSummary } from '../llm/types';
 
 export type LLMSettings = {
   usageId?: string | null;
@@ -15,6 +15,8 @@ export type LLMSettings = {
   maxInputTokens?: number | null;
   maxOutputTokens?: number | null;
   reasoningEffort?: 'low' | 'medium' | 'high' | 'none' | null;
+  /** OpenAI Responses-only; ignored by Chat Completions. */
+  reasoningSummary?: ReasoningSummary | null;
   inputCostPerToken?: number | null;
   outputCostPerToken?: number | null;
 };

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -95,6 +95,20 @@ const normalizeOpenaiApiMode = (value: unknown): LLMSettings['openaiApiMode'] | 
   }
 };
 
+const normalizeReasoningSummary = (value: unknown): LLMSettings['reasoningSummary'] | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return undefined;
+  if (trimmed === 'none') return undefined;
+  switch (trimmed) {
+    case 'auto':
+    case 'concise':
+    case 'detailed':
+      return trimmed;
+    default:
+      return undefined;
+  }
+};
+
 const normalizeElevenLabsMode = (value: unknown, defaultValue: ElevenLabsMode): ElevenLabsMode => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   switch (trimmed) {
@@ -177,6 +191,11 @@ export class SettingsManager {
       maxInputTokens: sanitizePositiveInteger(this.adapter.get<number | null>('openhands.llm.maxInputTokens', null) ?? undefined),
       maxOutputTokens: sanitizePositiveInteger(this.adapter.get<number | null>('openhands.llm.maxOutputTokens', null) ?? undefined),
       reasoningEffort: this.adapter.get<'low' | 'medium' | 'high' | 'none' | null>('openhands.llm.reasoningEffort', DEFAULTS.llm.reasoningEffort) ?? DEFAULTS.llm.reasoningEffort,
+      reasoningSummary: normalizeReasoningSummary(
+        isRemote
+          ? this.adapter.getExplicit<string>('openhands.llm.reasoningSummary')
+          : (this.adapter.get<string | null>('openhands.llm.reasoningSummary', 'none') ?? 'none')
+      ),
       inputCostPerToken: this.adapter.get<number | null>('openhands.llm.inputCostPerToken', DEFAULTS.llm.inputCostPerToken) ?? DEFAULTS.llm.inputCostPerToken,
       outputCostPerToken: this.adapter.get<number | null>('openhands.llm.outputCostPerToken', DEFAULTS.llm.outputCostPerToken) ?? DEFAULTS.llm.outputCostPerToken,
     };
@@ -260,6 +279,9 @@ export class SettingsManager {
       if (partial.llm.maxInputTokens !== undefined) ops.push(this.adapter.update('openhands.llm.maxInputTokens', partial.llm.maxInputTokens, target));
       if (partial.llm.maxOutputTokens !== undefined) ops.push(this.adapter.update('openhands.llm.maxOutputTokens', partial.llm.maxOutputTokens, target));
       if (partial.llm.reasoningEffort !== undefined) ops.push(this.adapter.update('openhands.llm.reasoningEffort', partial.llm.reasoningEffort, target));
+      if (partial.llm.reasoningSummary !== undefined) {
+        ops.push(this.adapter.update('openhands.llm.reasoningSummary', partial.llm.reasoningSummary ?? 'none', target));
+      }
       if (partial.llm.inputCostPerToken !== undefined) ops.push(this.adapter.update('openhands.llm.inputCostPerToken', partial.llm.inputCostPerToken, target));
       if (partial.llm.outputCostPerToken !== undefined) ops.push(this.adapter.update('openhands.llm.outputCostPerToken', partial.llm.outputCostPerToken, target));
     }

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -297,6 +297,22 @@ describe('SettingsManager', () => {
     expect(s.llm.openaiApiMode).toBeUndefined();
   });
 
+  it('normalizes reasoningSummary and persists none', async () => {
+    await mgr.update({ llm: { reasoningSummary: 'detailed' } });
+    expect(a.cfg.get('openhands.llm.reasoningSummary')).toBe('detailed');
+    let s = await mgr.get();
+    expect(s.llm.reasoningSummary).toBe('detailed');
+
+    a.cfg.set('openhands.llm.reasoningSummary', 'wat');
+    s = await mgr.get();
+    expect(s.llm.reasoningSummary).toBeUndefined();
+
+    await mgr.update({ llm: { reasoningSummary: null } });
+    expect(a.cfg.get('openhands.llm.reasoningSummary')).toBe('none');
+    s = await mgr.get();
+    expect(s.llm.reasoningSummary).toBeUndefined();
+  });
+
   it('handles sanitizePositiveInteger with invalid inputs', async () => {
     // Test with invalid maxInputTokens and maxOutputTokens
     await mgr.update({

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -29,6 +29,7 @@ describe('SettingsManager', () => {
     expect(s.llm.usageId).toBe('default-llm');
     expect(s.llm.provider).toBe('anthropic');
     expect(s.llm.openaiApiMode).toBeUndefined();
+    expect(s.llm.reasoningSummary).toBeUndefined();
     // Local mode requires a default model for the local Agent to run.
     expect(s.llm.model).toBe('claude-sonnet-4-20250514');
     expect(s.agent.enableSecurityAnalyzer).toBe(false);
@@ -263,6 +264,7 @@ describe('SettingsManager', () => {
         maxInputTokens: 4096,
         maxOutputTokens: 2048,
         reasoningEffort: 'high',
+        reasoningSummary: 'detailed',
         inputCostPerToken: 0.000001,
         outputCostPerToken: 0.000002,
       }
@@ -278,6 +280,7 @@ describe('SettingsManager', () => {
     expect(s.llm.maxInputTokens).toBe(4096);
     expect(s.llm.maxOutputTokens).toBe(2048);
     expect(s.llm.reasoningEffort).toBe('high');
+    expect(s.llm.reasoningSummary).toBe('detailed');
     expect(s.llm.inputCostPerToken).toBe(0.000001);
     expect(s.llm.outputCostPerToken).toBe(0.000002);
   });


### PR DESCRIPTION
Adds `openhands.llm.reasoningSummary` (none/auto/concise/detailed) and threads it into OpenAI Responses requests as `reasoning.summary` (only when `reasoningEffort` is set).

Tests:
- `src/settings/__tests__/SettingsManager.test.ts`
- `packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reasoning summary configuration for OpenAI GPT-5 models using the Responses API. New setting allows selecting summary detail level: `none`, `auto`, `concise`, or `detailed` (defaults to `none`).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->