### PR TITLE
[oh-tab-7q5] Agent-server E2E SESSION_API_KEY passthrough

### DIFF
--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -93,7 +93,8 @@ describe('OpenHands-Tab E2E', function() {
 **Agent-Server Dependency:**
 - For fully integrated tests (send message and read streamed events), ensure the server is reachable
 - In CI, you can launch a local agent-server or point to a remote test instance
-- Inject `SESSION_API_KEY` environment variable if required
+- By default, the agent-server E2E test runs with auth disabled (`SESSION_API_KEY=''`)
+- To run an authenticated agent-server E2E, set `SESSION_API_KEY` in your environment (the test runner forwards it to both the spawned server and the VS Code extension host)
 
 **Test Stability:**
 - Start with smoke tests (activation + command execution + webview created)

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -99,30 +99,30 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
     const port = await getFreePort();
     const serverUrl = `http://127.0.0.1:${port}`;
 
-	    const output: string[] = [];
-	    const env: Record<string, string | undefined> = {
-	      ...process.env,
-	      PYTHONUNBUFFERED: '1',
-	      // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
-	      OH_ENABLE_VSCODE: '0',
-	      OH_ENABLE_VNC: '0',
-	      OH_PRELOAD_TOOLS: '0',
-	    };
-	    if (env.SESSION_API_KEY === undefined) {
-	      // Default to no auth for CI, but allow authenticated runs by setting
-	      // SESSION_API_KEY in the environment.
-	      env.SESSION_API_KEY = '';
-	    }
-	    const child = spawn(
-	      'uv',
-	      ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
-	      {
-	        cwd: agentSdkDir,
-	        env,
-	        stdio: ['ignore', 'pipe', 'pipe'],
-	        detached: process.platform !== 'win32',
-	      }
-	    );
+    const output: string[] = [];
+    const env: Record<string, string | undefined> = {
+      ...process.env,
+      PYTHONUNBUFFERED: '1',
+      // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
+      OH_ENABLE_VSCODE: '0',
+      OH_ENABLE_VNC: '0',
+      OH_PRELOAD_TOOLS: '0',
+    };
+    if (env.SESSION_API_KEY === undefined) {
+      // Default to no auth for CI, but allow authenticated runs by setting
+      // SESSION_API_KEY in the environment.
+      env.SESSION_API_KEY = '';
+    }
+    const child = spawn(
+      'uv',
+      ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
+      {
+        cwd: agentSdkDir,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: process.platform !== 'win32',
+      }
+    );
 
     const append = (buf: Buffer) => {
       output.push(buf.toString('utf8'));

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -99,25 +99,30 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
     const port = await getFreePort();
     const serverUrl = `http://127.0.0.1:${port}`;
 
-    const output: string[] = [];
-    const child = spawn(
-      'uv',
-      ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
-      {
-        cwd: agentSdkDir,
-        env: {
-          ...process.env,
-          PYTHONUNBUFFERED: '1',
-          SESSION_API_KEY: '',
-          // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
-          OH_ENABLE_VSCODE: '0',
-          OH_ENABLE_VNC: '0',
-          OH_PRELOAD_TOOLS: '0',
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: process.platform !== 'win32',
-      }
-    );
+	    const output: string[] = [];
+	    const env: Record<string, string | undefined> = {
+	      ...process.env,
+	      PYTHONUNBUFFERED: '1',
+	      // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
+	      OH_ENABLE_VSCODE: '0',
+	      OH_ENABLE_VNC: '0',
+	      OH_PRELOAD_TOOLS: '0',
+	    };
+	    if (env.SESSION_API_KEY === undefined) {
+	      // Default to no auth for CI, but allow authenticated runs by setting
+	      // SESSION_API_KEY in the environment.
+	      env.SESSION_API_KEY = '';
+	    }
+	    const child = spawn(
+	      'uv',
+	      ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
+	      {
+	        cwd: agentSdkDir,
+	        env,
+	        stdio: ['ignore', 'pipe', 'pipe'],
+	        detached: process.platform !== 'win32',
+	      }
+	    );
 
     const append = (buf: Buffer) => {
       output.push(buf.toString('utf8'));


### PR DESCRIPTION
Fixes agent-server E2E launcher to not clobber SESSION_API_KEY when it is set (keeps CI default auth-off).

Docs: clarifies how to run authenticated E2E via SESSION_API_KEY.

Bead: oh-tab-7q5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated End-to-End testing documentation to provide comprehensive guidance on authentication configuration, including clear instructions for environment variable setup and expected behavior for both authenticated and unauthenticated test runs.

* **Tests**
  * Refined E2E test environment configuration with enhanced credential handling and improved defaults, supporting both CI scenarios without authentication and authenticated test execution via environment variable overrides.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->