### PR TITLE
[oh-tab-85p] HAL voice_confirm (mic + Gemini)

### DIFF
--- a/src/hal/gemini/__tests__/decisionClassifier.test.ts
+++ b/src/hal/gemini/__tests__/decisionClassifier.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { classifyHalVoiceDecision } from '../decisionClassifier';
+
+describe('classifyHalVoiceDecision', () => {
+  const baseParams = {
+    baseUrl: 'https://generativelanguage.googleapis.com/v1beta',
+    apiKey: 'gk_test',
+    model: 'gemini-2.5-flash',
+    mimeType: 'audio/webm',
+    audioBase64: 'ZHVtbXk=',
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects missing configuration', async () => {
+    expect((await classifyHalVoiceDecision({ ...baseParams, apiKey: '' })).ok).toBe(false);
+    expect((await classifyHalVoiceDecision({ ...baseParams, baseUrl: '' })).ok).toBe(false);
+    expect((await classifyHalVoiceDecision({ ...baseParams, model: '' })).ok).toBe(false);
+    expect((await classifyHalVoiceDecision({ ...baseParams, audioBase64: '' })).ok).toBe(false);
+  });
+
+  it('returns error on non-200 responses', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response('bad', { status: 401 }));
+
+    const res = await classifyHalVoiceDecision(baseParams);
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error).toContain('HTTP 401');
+    }
+  });
+
+  it('parses decision JSON from candidate text', async () => {
+    const payload = {
+      candidates: [
+        {
+          content: {
+            parts: [{ text: '{"decision":"teleport_remote"}' }],
+          },
+        },
+      ],
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+
+    const res = await classifyHalVoiceDecision(baseParams);
+    expect(res).toEqual({ ok: true, decision: 'teleport_remote', rawText: '{"decision":"teleport_remote"}' });
+  });
+
+  it('returns error when decision JSON is invalid', async () => {
+    const payload = {
+      candidates: [
+        {
+          content: {
+            parts: [{ text: 'not json' }],
+          },
+        },
+      ],
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+
+    const res = await classifyHalVoiceDecision(baseParams);
+    expect(res.ok).toBe(false);
+  });
+
+  it('returns error when decision is not recognized', async () => {
+    const payload = {
+      candidates: [
+        {
+          content: {
+            parts: [{ text: '{"decision":"maybe"}' }],
+          },
+        },
+      ],
+    };
+    vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+
+    const res = await classifyHalVoiceDecision(baseParams);
+    expect(res.ok).toBe(false);
+  });
+});
+

--- a/src/hal/gemini/decisionClassifier.ts
+++ b/src/hal/gemini/decisionClassifier.ts
@@ -1,0 +1,126 @@
+import type { HalDecision } from '../../shared/halTypes';
+import { isHalDecision } from '../../shared/halTypes';
+
+type ClassifyParams = {
+  baseUrl: string;
+  apiKey: string;
+  model: string;
+  mimeType: string;
+  audioBase64: string;
+  timeoutMs?: number;
+};
+
+type GeminiContentPart = {
+  text?: string;
+};
+
+type GeminiCandidate = {
+  content?: {
+    parts?: GeminiContentPart[];
+  };
+};
+
+type GeminiGenerateContentResponse = {
+  candidates?: GeminiCandidate[];
+};
+
+export type HalVoiceDecisionResult =
+  | { ok: true; decision: HalDecision; rawText: string }
+  | { ok: false; error: string; rawText?: string };
+
+const DEFAULT_TIMEOUT_MS = 15000;
+
+export async function classifyHalVoiceDecision(params: ClassifyParams): Promise<HalVoiceDecisionResult> {
+  const baseUrl = params.baseUrl.trim().replace(/\/$/, '');
+  const apiKey = params.apiKey.trim();
+  const model = params.model.trim();
+  const mimeType = params.mimeType.trim() || 'audio/webm';
+  const audioBase64 = params.audioBase64.trim();
+  const timeoutMs = typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs) ? params.timeoutMs : DEFAULT_TIMEOUT_MS;
+
+  if (!baseUrl) return { ok: false, error: 'Gemini baseUrl is missing.' };
+  if (!apiKey) return { ok: false, error: 'Gemini API key is missing.' };
+  if (!model) return { ok: false, error: 'Gemini model is missing.' };
+  if (!audioBase64) return { ok: false, error: 'No audio provided.' };
+
+  const url = `${baseUrl}/models/${encodeURIComponent(model)}:generateContent`;
+
+  const prompt = [
+    'You are a strict classifier for a VS Code UI decision.',
+    'Listen to the user audio and output ONLY valid JSON with a single key: "decision".',
+    'Valid decisions:',
+    '- "approve_local": approve the pending action locally',
+    '- "teleport_remote": teleport to the remote runtime',
+    '- "reject": reject the pending action',
+    '',
+    'Output JSON only. Example: {"decision":"approve_local"}',
+  ].join('\n');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [
+              { text: prompt },
+              { inlineData: { mimeType, data: audioBase64 } },
+            ],
+          },
+        ],
+        generationConfig: {
+          temperature: 0,
+          responseMimeType: 'application/json',
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    const text = await res.text();
+    if (!res.ok) {
+      const suffix = text.trim() ? ` (${text.trim().slice(0, 500)})` : '';
+      return { ok: false, error: `Gemini request failed: HTTP ${res.status}${suffix}` };
+    }
+
+    let parsed: GeminiGenerateContentResponse;
+    try {
+      parsed = JSON.parse(text) as GeminiGenerateContentResponse;
+    } catch {
+      return { ok: false, error: 'Gemini returned non-JSON response.', rawText: text };
+    }
+
+    const rawText = (parsed.candidates ?? [])
+      .flatMap((candidate) => candidate.content?.parts ?? [])
+      .map((part) => (typeof part.text === 'string' ? part.text : ''))
+      .join('')
+      .trim();
+    if (!rawText) return { ok: false, error: 'Gemini returned an empty response.' };
+
+    let decisionValue: unknown;
+    try {
+      const obj = JSON.parse(rawText) as { decision?: unknown };
+      decisionValue = obj.decision;
+    } catch {
+      return { ok: false, error: 'Gemini returned non-JSON decision.', rawText };
+    }
+
+    if (!isHalDecision(decisionValue)) {
+      return { ok: false, error: 'Gemini returned an invalid decision.', rawText };
+    }
+
+    return { ok: true, decision: decisionValue, rawText };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Gemini request failed: ${message}` };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+

--- a/src/shared/halScript.ts
+++ b/src/shared/halScript.ts
@@ -1,3 +1,5 @@
+import type { ElevenLabsMode } from './halTypes';
+
 export type HalVoice = 'voice_hal' | 'voice_user';
 
 export type HalScriptLine = {
@@ -25,3 +27,10 @@ export function getHalDialogueLines(userName: string): HalScriptLine[] {
   ];
 }
 
+export function getHalDialogueLinesForMode(userName: string, mode: ElevenLabsMode): HalScriptLine[] {
+  const lines = getHalDialogueLines(userName);
+  if (mode === 'voice_confirm') {
+    return lines.filter((line) => line.voice === 'voice_hal');
+  }
+  return lines;
+}

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, cleanup, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { App } from '../components/App';
+import type { ActionEvent, ConversationStateUpdateEvent } from '@openhands/agent-sdk-ts';
+
+function postToWindow(payload: any) {
+  window.postMessage(payload, '*');
+}
+
+describe('HAL voice_confirm', () => {
+  const mockApi = { postMessage: vi.fn() } as any;
+
+  const mkHighRiskAction = (toolCallId: string): ActionEvent => ({
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'High-risk action' }],
+    action: { command: 'rm -rf /tmp/test' },
+    tool_name: 'terminal',
+    tool_call_id: toolCallId,
+    tool_call: {
+      id: toolCallId,
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"rm -rf /tmp/test"}' },
+    },
+    llm_response_id: 'resp_hal_high',
+    security_risk: 'HIGH',
+  } as any);
+
+  const setWaitingForConfirmation = () => {
+    const state: ConversationStateUpdateEvent = { kind: 'ConversationStateUpdateEvent', agent_status: 'WAITING_FOR_CONFIRMATION' } as any;
+    postToWindow({ type: 'event', event: state });
+  };
+
+  const renderAppAndWaitReady = async () => {
+    const res = render(<App />);
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    });
+    return res;
+  };
+
+  const advanceBundledDialogueToAwaitingUser = async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => {
+        vi.advanceTimersByTime(700);
+      });
+    }
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/Please choose an action\./)).toBeInTheDocument();
+  };
+
+  beforeEach(() => {
+    vi.useRealTimers();
+    // @ts-expect-error -- VS Code API is injected by host environment during runtime
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+    try {
+      // @ts-expect-error -- not implemented in jsdom by default
+      delete (globalThis as any).MediaRecorder;
+      // @ts-expect-error -- not implemented in jsdom by default
+      delete (window as any).MediaRecorder;
+    } catch {}
+    try {
+      Object.defineProperty(window.navigator, 'mediaDevices', { value: undefined, configurable: true });
+    } catch {}
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('falls back to buttons when microphone is unavailable', async () => {
+    await renderAppAndWaitReady();
+
+    vi.useFakeTimers();
+    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-voice-1') });
+
+    await advanceBundledDialogueToAwaitingUser();
+    vi.useRealTimers();
+
+    // Switch to voice_confirm at decision time.
+    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
+
+    const recordButton = await screen.findByRole('button', { name: /record decision/i });
+    fireEvent.click(recordButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /approve locally/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /record decision/i })).not.toBeInTheDocument();
+  });
+
+  it('records audio, sends it to host, and applies approve decision', async () => {
+    await renderAppAndWaitReady();
+
+    vi.useFakeTimers();
+    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-voice-2') });
+    await advanceBundledDialogueToAwaitingUser();
+    vi.useRealTimers();
+
+    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
+
+    const stream = { getTracks: () => [{ stop: vi.fn() }] } as any;
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+      configurable: true,
+    });
+    const getUserMedia = (window.navigator as any).mediaDevices.getUserMedia as ReturnType<typeof vi.fn>;
+
+    let didCreateRecorder = false;
+    class MockMediaRecorder {
+      static isTypeSupported() {
+        return true;
+      }
+      public state: 'inactive' | 'recording' = 'inactive';
+      public mimeType = 'audio/webm';
+      public ondataavailable: ((e: any) => void) | null = null;
+      public onstop: (() => void) | null = null;
+      constructor(_stream: any, _opts?: any) {
+        didCreateRecorder = true;
+      }
+      start() {
+        this.state = 'recording';
+      }
+      stop() {
+        this.state = 'inactive';
+        this.ondataavailable?.({ data: new Blob(['hello'], { type: this.mimeType }) });
+        this.onstop?.();
+      }
+    }
+
+    // @ts-expect-error -- MediaRecorder is not implemented in jsdom
+    (globalThis as any).MediaRecorder = MockMediaRecorder;
+    // @ts-expect-error -- MediaRecorder is not implemented in jsdom
+    (window as any).MediaRecorder = MockMediaRecorder;
+
+    fireEvent.click(await screen.findByRole('button', { name: /record decision/i }));
+    expect(await screen.findByRole('button', { name: /stop/i })).toBeInTheDocument();
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalled());
+    await waitFor(() => expect(didCreateRecorder).toBe(true));
+
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }));
+    const request = await waitFor(() => {
+      const req = mockApi.postMessage.mock.calls
+        .map((call: any[]) => call[0])
+        .find((msg: any) => msg?.type === 'halVoiceConfirmRequest');
+      if (!req) {
+        const types = mockApi.postMessage.mock.calls
+          .map((call: any[]) => call?.[0]?.type)
+          .filter(Boolean);
+        throw new Error(`Missing halVoiceConfirmRequest. Saw: ${types.join(', ')}`);
+      }
+      return req;
+    });
+
+    postToWindow({ type: 'halVoiceConfirmResponse', requestId: request.requestId, ok: true, decision: 'approve_local' });
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'approveAction' });
+    });
+  });
+
+  it('falls back to buttons when Gemini classification fails', async () => {
+    await renderAppAndWaitReady();
+
+    vi.useFakeTimers();
+    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-voice-3') });
+    await advanceBundledDialogueToAwaitingUser();
+    vi.useRealTimers();
+
+    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
+
+    const stream = { getTracks: () => [{ stop: vi.fn() }] } as any;
+    Object.defineProperty(window.navigator, 'mediaDevices', {
+      value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+      configurable: true,
+    });
+    const getUserMedia = (window.navigator as any).mediaDevices.getUserMedia as ReturnType<typeof vi.fn>;
+
+    let didCreateRecorder = false;
+    class MockMediaRecorder {
+      static isTypeSupported() {
+        return true;
+      }
+      public state: 'inactive' | 'recording' = 'inactive';
+      public mimeType = 'audio/webm';
+      public ondataavailable: ((e: any) => void) | null = null;
+      public onstop: (() => void) | null = null;
+      constructor(_stream: any, _opts?: any) {
+        didCreateRecorder = true;
+      }
+      start() {
+        this.state = 'recording';
+      }
+      stop() {
+        this.state = 'inactive';
+        this.ondataavailable?.({ data: new Blob(['hello'], { type: this.mimeType }) });
+        this.onstop?.();
+      }
+    }
+
+    // @ts-expect-error -- MediaRecorder is not implemented in jsdom
+    (globalThis as any).MediaRecorder = MockMediaRecorder;
+    // @ts-expect-error -- MediaRecorder is not implemented in jsdom
+    (window as any).MediaRecorder = MockMediaRecorder;
+
+    fireEvent.click(await screen.findByRole('button', { name: /record decision/i }));
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalled());
+    await waitFor(() => expect(didCreateRecorder).toBe(true));
+    fireEvent.click(await screen.findByRole('button', { name: /stop/i }));
+    const request = await waitFor(() => {
+      const req = mockApi.postMessage.mock.calls
+        .map((call: any[]) => call[0])
+        .find((msg: any) => msg?.type === 'halVoiceConfirmRequest');
+      if (!req) {
+        const types = mockApi.postMessage.mock.calls
+          .map((call: any[]) => call?.[0]?.type)
+          .filter(Boolean);
+        throw new Error(`Missing halVoiceConfirmRequest. Saw: ${types.join(', ')}`);
+      }
+      return req;
+    });
+
+    postToWindow({ type: 'halVoiceConfirmResponse', requestId: request.requestId, ok: false, error: 'Gemini failed' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /approve locally/i })).toBeInTheDocument();
+    });
+    expect(mockApi.postMessage).not.toHaveBeenCalledWith({ type: 'command', command: 'approveAction' });
+  });
+});

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -180,27 +180,35 @@ export function App() {
   const [halDisabledConversationId, setHalDisabledConversationId] = useState<string | null>(null);
   const [halPhase, setHalPhase] = useState<HalPhase>('idle');
   const [halEye, setHalEye] = useState<HalEye>('off');
-  const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
-  const [halDecision, setHalDecision] = useState<HalDecision | null>(null);
-  const [halLastError, setHalLastError] = useState<string | null>(null);
-  const [halForceRejectInput, setHalForceRejectInput] = useState(false);
-  const [halTeleporting, setHalTeleporting] = useState(false);
-  const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const halStepIndexRef = useRef<number | null>(null);
-  const halDialogueRef = useRef<HalScriptLine[]>([]);
-  const halTtsRequestIdRef = useRef<string | null>(null);
-  const halTtsRequestedKeyRef = useRef<string | null>(null);
-  const halAudioRef = useRef<HTMLAudioElement | null>(null);
-  const halAudioUrlRef = useRef<string | null>(null);
-  const halAudioPlayTokenRef = useRef(0);
-  const halTtsRequestSeqRef = useRef(0);
-  const halActiveKeyRef = useRef<string | null>(null);
-  const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
-  const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
-  const halEnabledRef = useRef<boolean>(false);
-  const halPhaseRef = useRef<HalPhase>('idle');
-  const halSuppressedKeyRef = useRef<string | null>(null);
-  const halTeleportInProgressRef = useRef(false);
+    const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
+    const [halDecision, setHalDecision] = useState<HalDecision | null>(null);
+    const [halLastError, setHalLastError] = useState<string | null>(null);
+    const [halForceRejectInput, setHalForceRejectInput] = useState(false);
+    const [halTeleporting, setHalTeleporting] = useState(false);
+    const [halVoiceConfirmFallbackKey, setHalVoiceConfirmFallbackKey] = useState<string | null>(null);
+    const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const halStepIndexRef = useRef<number | null>(null);
+    const halDialogueRef = useRef<HalScriptLine[]>([]);
+    const halTtsRequestIdRef = useRef<string | null>(null);
+    const halTtsRequestedKeyRef = useRef<string | null>(null);
+    const halAudioRef = useRef<HTMLAudioElement | null>(null);
+    const halAudioUrlRef = useRef<string | null>(null);
+    const halAudioPlayTokenRef = useRef(0);
+    const halTtsRequestSeqRef = useRef(0);
+    const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
+    const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
+    const halVoiceConfirmSeqRef = useRef(0);
+    const halVoiceDiscardNextStopRef = useRef(false);
+    const halVoiceStreamRef = useRef<MediaStream | null>(null);
+    const halVoiceRecorderRef = useRef<MediaRecorder | null>(null);
+    const halVoiceChunksRef = useRef<Blob[]>([]);
+    const halActiveKeyRef = useRef<string | null>(null);
+    const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
+    const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
+    const halEnabledRef = useRef<boolean>(false);
+    const halPhaseRef = useRef<HalPhase>('idle');
+    const halSuppressedKeyRef = useRef<string | null>(null);
+    const halTeleportInProgressRef = useRef(false);
   const pendingActionsRef = useRef<ActionEvent[]>([]);
   const agentStatusRef = useRef<string | undefined>(undefined);
   const conversationIdRef = useRef<string | undefined>(undefined);
@@ -254,9 +262,13 @@ export function App() {
     halPhaseRef.current = halPhase;
   }, [halPhase]);
 
-  useEffect(() => {
-    halSuppressedKeyRef.current = halSuppressedKey;
-  }, [halSuppressedKey]);
+    useEffect(() => {
+      halSuppressedKeyRef.current = halSuppressedKey;
+    }, [halSuppressedKey]);
+
+    useEffect(() => {
+      halVoiceConfirmFallbackKeyRef.current = halVoiceConfirmFallbackKey;
+    }, [halVoiceConfirmFallbackKey]);
 
   useEffect(() => {
     pendingActionsRef.current = pendingActions;
@@ -282,24 +294,65 @@ export function App() {
     halStepIndexRef.current = halStepIndex;
   }, [halStepIndex]);
 
-  const stopHalAudio = useCallback(() => {
-    halAudioPlayTokenRef.current += 1;
-    const audio = halAudioRef.current;
-    if (audio) {
-      try {
-        audio.pause();
-      } catch {}
-      audio.src = '';
-    }
-    if (halAudioUrlRef.current) {
-      try {
-        URL.revokeObjectURL(halAudioUrlRef.current);
-      } catch {}
-      halAudioUrlRef.current = null;
-    }
-    halTtsRequestIdRef.current = null;
-    halTtsRequestedKeyRef.current = null;
-  }, []);
+    const stopHalAudio = useCallback(() => {
+      halAudioPlayTokenRef.current += 1;
+      const audio = halAudioRef.current;
+      if (audio) {
+        try {
+          audio.pause();
+        } catch {}
+        audio.src = '';
+      }
+      if (halAudioUrlRef.current) {
+        try {
+          URL.revokeObjectURL(halAudioUrlRef.current);
+        } catch {}
+        halAudioUrlRef.current = null;
+      }
+      halTtsRequestIdRef.current = null;
+      halTtsRequestedKeyRef.current = null;
+    }, []);
+
+    const cleanupHalVoiceConfirm = useCallback(() => {
+      const recorder = halVoiceRecorderRef.current;
+      if (recorder && recorder.state !== 'inactive') {
+        try {
+          halVoiceDiscardNextStopRef.current = true;
+          recorder.stop();
+        } catch {}
+      }
+      halVoiceRecorderRef.current = null;
+      halVoiceChunksRef.current = [];
+      const stream = halVoiceStreamRef.current;
+      if (stream) {
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {}
+        }
+      }
+      halVoiceStreamRef.current = null;
+      halVoiceConfirmRequestIdRef.current = null;
+    }, []);
+
+    const blobToBase64 = (blob: Blob): Promise<string> =>
+      new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result;
+          if (typeof result !== 'string') {
+            reject(new Error('Failed to read recorded audio.'));
+            return;
+          }
+          const comma = result.indexOf(',');
+          resolve(comma >= 0 ? result.slice(comma + 1) : result);
+        };
+        reader.onerror = () => {
+          const error = reader.error ?? new Error('Failed to read recorded audio.');
+          reject(error);
+        };
+        reader.readAsDataURL(blob);
+      });
 
   useEffect(() => {
     halStateRef.current = {
@@ -389,9 +442,11 @@ export function App() {
 
   const halDialogueLines = useMemo(() => getHalDialogueLines(elevenlabs.userName), [elevenlabs.userName]);
 
-  useEffect(() => {
-    halDialogueRef.current = halDialogueLines;
-  }, [halDialogueLines]);
+    useEffect(() => {
+      halDialogueRef.current = halDialogueLines;
+    }, [halDialogueLines]);
+
+    const getHalConversationKey = useCallback(() => conversationIdRef.current ?? 'unknown', []);
 
   const maybeUpdateHalFlow = useCallback(() => {
     if (halTeleportInProgressRef.current) return;
@@ -406,15 +461,16 @@ export function App() {
         ? `${conversationIdRef.current ?? 'unknown'}:${firstHighRisk.tool_call_id}`
         : null;
 
-    if (!nextKey) {
-      if (halActiveKeyRef.current !== null || halPhaseRef.current !== 'idle' || halSuppressedKeyRef.current !== null) {
-        clearHalTimer();
-        stopHalAudio();
-        halActiveKeyRef.current = null;
-        halSuppressedKeyRef.current = null;
-        halPhaseRef.current = 'idle';
-        setHalSuppressedKey(null);
-        setHalPhase('idle');
+      if (!nextKey) {
+        if (halActiveKeyRef.current !== null || halPhaseRef.current !== 'idle' || halSuppressedKeyRef.current !== null) {
+          clearHalTimer();
+          stopHalAudio();
+          cleanupHalVoiceConfirm();
+          halActiveKeyRef.current = null;
+          halSuppressedKeyRef.current = null;
+          halPhaseRef.current = 'idle';
+          setHalSuppressedKey(null);
+          setHalPhase('idle');
         setHalEye('off');
         setHalStepIndex(null);
         setHalDecision(null);
@@ -433,14 +489,15 @@ export function App() {
       setHalForceRejectInput(false);
     }
 
-    if (halSuppressedKeyRef.current === nextKey) {
-      if (halPhaseRef.current !== 'idle') {
-        clearHalTimer();
-        stopHalAudio();
-        halPhaseRef.current = 'idle';
-        setHalPhase('idle');
-        setHalEye('off');
-        setHalStepIndex(null);
+      if (halSuppressedKeyRef.current === nextKey) {
+        if (halPhaseRef.current !== 'idle') {
+          clearHalTimer();
+          stopHalAudio();
+          cleanupHalVoiceConfirm();
+          halPhaseRef.current = 'idle';
+          setHalPhase('idle');
+          setHalEye('off');
+          setHalStepIndex(null);
         setHalDecision(null);
         setHalLastError(null);
       }
@@ -457,7 +514,7 @@ export function App() {
       setHalPhase('dialogue');
       setHalStepIndex(0);
     }
-  }, [clearHalTimer, halDisabledConversationId, stopHalAudio]);
+    }, [clearHalTimer, cleanupHalVoiceConfirm, halDisabledConversationId, stopHalAudio]);
 
   useEffect(() => {
     if (halPhase !== 'dialogue') return;
@@ -533,19 +590,276 @@ export function App() {
     });
   }, [postMessage]);
 
-  useEffect(() => {
-    if (halPhase !== 'dialogue') return;
-    if (halStepIndex === null) return;
-    const mode = elevenlabsRef.current.mode;
-    if (mode !== 'tts_only' && mode !== 'voice_confirm') return;
-    const convoId = conversationIdRef.current;
-    if (!convoId) return;
-    if (halDisabledConversationId === convoId) return;
-    const key = `${convoId}:${halStepIndex}:${mode}`;
-    if (halTtsRequestedKeyRef.current === key) return;
-    halTtsRequestedKeyRef.current = key;
-    requestHalTts({ conversationId: convoId, stepIndex: halStepIndex });
-  }, [halDisabledConversationId, halPhase, halStepIndex, requestHalTts]);
+    useEffect(() => {
+      if (halPhase !== 'dialogue') return;
+      if (halStepIndex === null) return;
+      const mode = elevenlabsRef.current.mode;
+      if (mode !== 'tts_only' && mode !== 'voice_confirm') return;
+      const convoId = conversationIdRef.current;
+      if (!convoId) return;
+      if (halDisabledConversationId === convoId) return;
+      const key = `${convoId}:${halStepIndex}:${mode}`;
+      if (halTtsRequestedKeyRef.current === key) return;
+      halTtsRequestedKeyRef.current = key;
+      requestHalTts({ conversationId: convoId, stepIndex: halStepIndex });
+    }, [halDisabledConversationId, halPhase, halStepIndex, requestHalTts]);
+
+    const disableVoiceConfirmForConversation = useCallback((message: string) => {
+      const key = getHalConversationKey();
+      setHalVoiceConfirmFallbackKey(key);
+      halVoiceConfirmFallbackKeyRef.current = key;
+      cleanupHalVoiceConfirm();
+      setHalLastError(message);
+      halPhaseRef.current = 'awaiting_user';
+      setHalPhase('awaiting_user');
+      setHalEye('pulsating');
+      showStatusMessage('warn', message);
+    }, [cleanupHalVoiceConfirm, getHalConversationKey, showStatusMessage]);
+
+    const handleStartVoiceConfirm = useCallback(() => {
+      void (async () => {
+        if (halPhaseRef.current !== 'awaiting_user') return;
+        if (elevenlabsRef.current.mode !== 'voice_confirm') return;
+        if (halVoiceConfirmFallbackKeyRef.current === getHalConversationKey()) return;
+        if (
+          typeof navigator === 'undefined' ||
+          typeof navigator.mediaDevices?.getUserMedia !== 'function' ||
+          typeof MediaRecorder === 'undefined'
+        ) {
+          disableVoiceConfirmForConversation('Microphone is unavailable in this environment. Using buttons instead.');
+          return;
+        }
+
+        cleanupHalVoiceConfirm();
+        halVoiceDiscardNextStopRef.current = false;
+        halVoiceChunksRef.current = [];
+        setHalLastError(null);
+        halPhaseRef.current = 'listening';
+        setHalPhase('listening');
+        setHalEye('pulsating');
+
+        let stream: MediaStream;
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          disableVoiceConfirmForConversation(`Microphone permission denied or unavailable: ${reason}`);
+          return;
+        }
+
+        const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus'];
+        const mimeType = candidates.find((t) => {
+          try {
+            return MediaRecorder.isTypeSupported(t);
+          } catch {
+            return false;
+          }
+        });
+        let recorder: MediaRecorder;
+        try {
+          recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          for (const track of stream.getTracks()) {
+            try {
+              track.stop();
+            } catch {}
+          }
+          disableVoiceConfirmForConversation(`Microphone recording is not supported: ${reason}`);
+          return;
+        }
+
+        halVoiceStreamRef.current = stream;
+        halVoiceRecorderRef.current = recorder;
+        recorder.ondataavailable = (e) => {
+          if (e.data && e.data.size > 0) {
+            halVoiceChunksRef.current.push(e.data);
+          }
+        };
+        recorder.onstop = () => {
+          void (async () => {
+            const shouldDiscard = halVoiceDiscardNextStopRef.current;
+            halVoiceDiscardNextStopRef.current = false;
+
+            const chunks = halVoiceChunksRef.current;
+            halVoiceChunksRef.current = [];
+            halVoiceRecorderRef.current = null;
+            const activeStream = halVoiceStreamRef.current;
+            halVoiceStreamRef.current = null;
+            if (activeStream) {
+              for (const track of activeStream.getTracks()) {
+                try {
+                  track.stop();
+                } catch {}
+              }
+            }
+
+            if (shouldDiscard) return;
+            if (chunks.length === 0) {
+              disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+              return;
+            }
+
+            try {
+              const blob = new Blob(chunks, { type: recorder.mimeType || mimeType || 'audio/webm' });
+              if (blob.size === 0) {
+                disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+                return;
+              }
+              const audioBase64 = await blobToBase64(blob);
+              if (!audioBase64) {
+                disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+                return;
+              }
+              const requestId = `halVoiceConfirm:${Date.now().toString(36)}:${(halVoiceConfirmSeqRef.current++).toString(36)}`;
+              halVoiceConfirmRequestIdRef.current = requestId;
+              setHalLastError(null);
+              halPhaseRef.current = 'classifying';
+              setHalPhase('classifying');
+              setHalEye('pulsating');
+              postMessage({
+                type: 'halVoiceConfirmRequest',
+                requestId,
+                mimeType: blob.type || 'audio/webm',
+                audioBase64,
+              });
+            } catch (err) {
+              const reason = err instanceof Error ? err.message : String(err);
+              disableVoiceConfirmForConversation(`Failed to process recorded audio: ${reason}`);
+            }
+          })();
+        };
+
+        try {
+          recorder.start();
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          for (const track of stream.getTracks()) {
+            try {
+              track.stop();
+            } catch {}
+          }
+          disableVoiceConfirmForConversation(`Failed to start recording: ${reason}`);
+          return;
+        }
+      })();
+    }, [cleanupHalVoiceConfirm, disableVoiceConfirmForConversation, getHalConversationKey, postMessage]);
+
+    const handleStopVoiceConfirm = useCallback(() => {
+      if (halPhaseRef.current !== 'listening') return;
+      const recorder = halVoiceRecorderRef.current;
+      if (!recorder) return;
+      if (recorder.state === 'inactive') return;
+      try {
+        recorder.stop();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        disableVoiceConfirmForConversation(`Failed to stop recording: ${reason}`);
+      }
+    }, [disableVoiceConfirmForConversation]);
+
+    const handleCancelVoiceConfirm = useCallback(() => {
+      if (halPhaseRef.current !== 'listening') return;
+      halVoiceDiscardNextStopRef.current = true;
+      const recorder = halVoiceRecorderRef.current;
+      if (recorder && recorder.state !== 'inactive') {
+        try {
+          recorder.stop();
+        } catch {}
+      }
+      cleanupHalVoiceConfirm();
+      setHalLastError(null);
+      halPhaseRef.current = 'awaiting_user';
+      setHalPhase('awaiting_user');
+      setHalEye('pulsating');
+    }, [cleanupHalVoiceConfirm]);
+
+    const handleUseButtonsInstead = useCallback(() => {
+      const key = getHalConversationKey();
+      setHalVoiceConfirmFallbackKey(key);
+      halVoiceConfirmFallbackKeyRef.current = key;
+      cleanupHalVoiceConfirm();
+      setHalLastError(null);
+      halPhaseRef.current = 'awaiting_user';
+      setHalPhase('awaiting_user');
+      setHalEye('pulsating');
+      showStatusMessage('info', 'Switched to button decision for this conversation.');
+    }, [cleanupHalVoiceConfirm, getHalConversationKey, showStatusMessage]);
+
+  const handleApprove = useCallback(() => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
+    submissionTimeoutRef.current = setTimeout(() => {
+      setIsSubmitting(false);
+      submissionTimeoutRef.current = null;
+      showStatusMessage('warn', 'Confirmation timed out - please try again');
+    }, 30000);
+
+    postMessage({ type: 'command', command: 'approveAction' });
+    showStatusMessage('info', 'Approval submitted');
+  }, [isSubmitting, postMessage, showStatusMessage]);
+
+  const handleReject = useCallback((reason?: string) => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
+    submissionTimeoutRef.current = setTimeout(() => {
+      setIsSubmitting(false);
+      submissionTimeoutRef.current = null;
+      showStatusMessage('warn', 'Confirmation timed out - please try again');
+    }, 30000);
+
+    postMessage({ type: 'command', command: 'rejectAction', reason });
+    showStatusMessage('info', 'Rejection submitted');
+  }, [isSubmitting, postMessage, showStatusMessage]);
+
+  const handleHalExit = useCallback(() => {
+    clearHalTimer();
+    stopHalAudio();
+    cleanupHalVoiceConfirm();
+    halTeleportInProgressRef.current = false;
+    setHalTeleporting(false);
+    setHalForceRejectInput(false);
+    const key = halActiveKeyRef.current;
+    if (key) {
+      halSuppressedKeyRef.current = key;
+      setHalSuppressedKey(key);
+    }
+    halPhaseRef.current = 'idle';
+    setHalPhase('idle');
+    setHalEye('off');
+    setHalStepIndex(null);
+    setHalDecision(null);
+    setHalLastError(null);
+  }, [cleanupHalVoiceConfirm, clearHalTimer, stopHalAudio]);
+
+  const handleHalApprove = useCallback(() => {
+    setHalDecision('approve_local');
+    handleApprove();
+  }, [handleApprove]);
+
+  const handleHalReject = useCallback((reason?: string) => {
+    setHalDecision('reject');
+    handleReject(reason);
+  }, [handleReject]);
+
+  const handleHalTeleport = useCallback(() => {
+    setHalDecision('teleport_remote');
+    clearHalTimer();
+    stopHalAudio();
+    cleanupHalVoiceConfirm();
+    halTeleportInProgressRef.current = true;
+    setHalTeleporting(true);
+    setHalForceRejectInput(false);
+    halPhaseRef.current = 'waiting_remote';
+    setHalPhase('waiting_remote');
+    setHalEye('pulsating');
+    setHalStepIndex(null);
+    setHalLastError(null);
+    showStatusMessage('info', 'Teleporting to remote runtime…');
+    postMessage({ type: 'command', command: 'teleportAction' });
+  }, [cleanupHalVoiceConfirm, clearHalTimer, postMessage, showStatusMessage, stopHalAudio]);
 
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
@@ -664,14 +978,16 @@ export function App() {
             currentServerUrlRef.current = nextUrl;
             setCurrentServerUrl(nextUrl);
 
-            // If the server target changed (Local ↔ Remote or remote server URL changed),
-            // start a fresh conversation UI instead of implicitly resuming prior state.
-            if (prevUrl !== nextUrl) {
-              setHalDisabledConversationId(null);
-              conversationIdRef.current = undefined;
-              setConversationId(undefined);
-              setEvents([]);
-              pendingActionsRef.current = [];
+              // If the server target changed (Local ↔ Remote or remote server URL changed),
+              // start a fresh conversation UI instead of implicitly resuming prior state.
+              if (prevUrl !== nextUrl) {
+                setHalDisabledConversationId(null);
+                setHalVoiceConfirmFallbackKey(null);
+                cleanupHalVoiceConfirm();
+                conversationIdRef.current = undefined;
+                setConversationId(undefined);
+                setEvents([]);
+                pendingActionsRef.current = [];
               setPendingActions([]);
               agentStatusRef.current = undefined;
               setAgentStatus(undefined);
@@ -707,7 +1023,7 @@ export function App() {
             maybeUpdateHalFlow();
           }
           break;
-        case 'halTtsResponse': {
+          case 'halTtsResponse': {
           const currentRequestId = halTtsRequestIdRef.current;
           const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
           if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) break;
@@ -738,11 +1054,12 @@ export function App() {
           const error = (payload as { error?: unknown } | undefined)?.error;
           const message = typeof error === 'string' && error.trim() ? error.trim() : 'ElevenLabs TTS failed';
           const convoId = conversationIdRef.current;
-          if (convoId) setHalDisabledConversationId(convoId);
-          halTeleportInProgressRef.current = false;
-          stopHalAudio();
-          clearHalTimer();
-          halActiveKeyRef.current = null;
+            if (convoId) setHalDisabledConversationId(convoId);
+            halTeleportInProgressRef.current = false;
+            stopHalAudio();
+            clearHalTimer();
+            cleanupHalVoiceConfirm();
+            halActiveKeyRef.current = null;
           halSuppressedKeyRef.current = null;
           setHalSuppressedKey(null);
           halPhaseRef.current = 'idle';
@@ -753,13 +1070,52 @@ export function App() {
           setHalLastError(null);
           setHalForceRejectInput(false);
           setHalTeleporting(false);
-          if (shouldNotify) showStatusMessage('error', `HAL audio disabled for this conversation: ${message}`);
-          break;
-        }
-        case 'attachmentsSelected':
-          if (Array.isArray(payload.attachments)) {
-            setAttachments((prev) => {
-              const existing = new Set(prev.map((a) => a.uri));
+            if (shouldNotify) showStatusMessage('error', `HAL audio disabled for this conversation: ${message}`);
+            break;
+          }
+          case 'halVoiceConfirmResponse': {
+            const currentRequestId = halVoiceConfirmRequestIdRef.current;
+            const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
+            if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) break;
+            halVoiceConfirmRequestIdRef.current = null;
+
+            const ok = (payload as { ok?: unknown } | undefined)?.ok;
+            if (ok === true) {
+              const decision = (payload as { decision?: unknown } | undefined)?.decision;
+              if (decision === 'teleport_remote') {
+                handleHalTeleport();
+                break;
+              }
+              if (decision === 'approve_local') {
+                halPhaseRef.current = 'awaiting_user';
+                setHalPhase('awaiting_user');
+                setHalEye('pulsating');
+                setHalDecision('approve_local');
+                handleApprove();
+                break;
+              }
+              if (decision === 'reject') {
+                halPhaseRef.current = 'awaiting_user';
+                setHalPhase('awaiting_user');
+                setHalEye('pulsating');
+                setHalDecision('reject');
+                handleReject(undefined);
+                break;
+              }
+
+              disableVoiceConfirmForConversation('Gemini returned an invalid decision. Using buttons instead.');
+              break;
+            }
+
+            const error = (payload as { error?: unknown } | undefined)?.error;
+            const message = typeof error === 'string' && error.trim() ? error.trim() : 'Gemini classification failed';
+            disableVoiceConfirmForConversation(message);
+            break;
+          }
+          case 'attachmentsSelected':
+            if (Array.isArray(payload.attachments)) {
+              setAttachments((prev) => {
+                const existing = new Set(prev.map((a) => a.uri));
               const next = [...prev];
               for (const a of payload.attachments ?? []) {
                 if (!a || typeof a.uri !== 'string' || typeof a.label !== 'string') continue;
@@ -814,14 +1170,16 @@ export function App() {
           showStatusMessage('error', message);
           break;
         }
-        case 'conversationStarted':
-          if (typeof payload.conversationId === 'string') {
-            setHalDisabledConversationId(null);
-            if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
-              halTeleportInProgressRef.current = false;
-              setHalTeleporting(false);
-              setHalForceRejectInput(false);
-              clearHalTimer();
+          case 'conversationStarted':
+            if (typeof payload.conversationId === 'string') {
+              setHalDisabledConversationId(null);
+              setHalVoiceConfirmFallbackKey(null);
+              cleanupHalVoiceConfirm();
+              if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
+                halTeleportInProgressRef.current = false;
+                setHalTeleporting(false);
+                setHalForceRejectInput(false);
+                clearHalTimer();
               stopHalAudio();
               halActiveKeyRef.current = null;
               halSuppressedKeyRef.current = null;
@@ -875,7 +1233,7 @@ export function App() {
           const action = (payload as { action: string }).action;
           const rawPayload = (payload as { payload?: unknown }).payload;
 
-          switch (action) {
+            switch (action) {
             case 'openContext':
               setShowSkillsPopover(false);
               setShowContextPicker(true);
@@ -920,27 +1278,59 @@ export function App() {
               setHalDecision('reject');
               postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
               break;
-            case 'halTeleport':
-              setHalDecision('teleport_remote');
-              clearHalTimer();
-              stopHalAudio();
-              halTeleportInProgressRef.current = true;
-              setHalTeleporting(true);
-              setHalForceRejectInput(false);
-              halPhaseRef.current = 'waiting_remote';
+              case 'halTeleport':
+                setHalDecision('teleport_remote');
+                clearHalTimer();
+                stopHalAudio();
+                cleanupHalVoiceConfirm();
+                halTeleportInProgressRef.current = true;
+                setHalTeleporting(true);
+                setHalForceRejectInput(false);
+                halPhaseRef.current = 'waiting_remote';
               setHalPhase('waiting_remote');
               setHalEye('pulsating');
               setHalStepIndex(null);
               setHalLastError(null);
-              showStatusMessage('info', 'Teleporting to remote runtime…');
-              postMessage({ type: 'command', command: 'teleportAction' });
-              break;
-            case 'halExit': {
-              clearHalTimer();
-              stopHalAudio();
-              halTeleportInProgressRef.current = false;
-              setHalTeleporting(false);
-              setHalForceRejectInput(false);
+                showStatusMessage('info', 'Teleporting to remote runtime…');
+                postMessage({ type: 'command', command: 'teleportAction' });
+                break;
+              case 'halVoiceConfirmDecision': {
+                const decision = (rawPayload as { decision?: unknown } | undefined)?.decision;
+                if (decision !== 'approve_local' && decision !== 'teleport_remote' && decision !== 'reject') break;
+                cleanupHalVoiceConfirm();
+                setHalForceRejectInput(false);
+                setHalLastError(null);
+                setHalEye('pulsating');
+                if (decision === 'teleport_remote') {
+                  setHalDecision('teleport_remote');
+                  halTeleportInProgressRef.current = true;
+                  setHalTeleporting(true);
+                  halPhaseRef.current = 'waiting_remote';
+                  setHalPhase('waiting_remote');
+                  setHalStepIndex(null);
+                  showStatusMessage('info', 'Teleporting to remote runtime…');
+                  postMessage({ type: 'command', command: 'teleportAction' });
+                  break;
+                }
+                // approve_local / reject: mimic the non-voice button flow (no mic/network required).
+                halPhaseRef.current = 'awaiting_user';
+                setHalPhase('awaiting_user');
+                setHalStepIndex(null);
+                setHalDecision(decision);
+                if (decision === 'approve_local') {
+                  postMessage({ type: 'command', command: 'approveAction' });
+                } else {
+                  postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
+                }
+                break;
+              }
+              case 'halExit': {
+                clearHalTimer();
+                stopHalAudio();
+                cleanupHalVoiceConfirm();
+                halTeleportInProgressRef.current = false;
+                setHalTeleporting(false);
+                setHalForceRejectInput(false);
               const key = halActiveKeyRef.current;
               if (key) {
                 halSuppressedKeyRef.current = key;
@@ -997,7 +1387,22 @@ export function App() {
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-  }, [clearHalTimer, events, handleEvent, handleHalAudioFinished, maybeUpdateHalFlow, playHalAudioBytes, postMessage, showStatusMessage, stopHalAudio]);
+  }, [
+    cleanupHalVoiceConfirm,
+    clearHalTimer,
+    disableVoiceConfirmForConversation,
+    events,
+    handleApprove,
+    handleEvent,
+    handleHalAudioFinished,
+    handleHalTeleport,
+    handleReject,
+    maybeUpdateHalFlow,
+    playHalAudioBytes,
+    postMessage,
+    showStatusMessage,
+    stopHalAudio,
+  ]);
 
   // Auto-scroll to bottom when events change or streaming updates
   useEffect(() => {
@@ -1093,77 +1498,6 @@ export function App() {
       attachments: attachments.map((a) => a.uri),
     });
   }, [attachments, input, postMessage, selectedContextFiles]);
-
-  const handleApprove = useCallback(() => {
-    if (isSubmitting) return;
-    setIsSubmitting(true);
-
-    submissionTimeoutRef.current = setTimeout(() => {
-      setIsSubmitting(false);
-      submissionTimeoutRef.current = null;
-      showStatusMessage('warn', 'Confirmation timed out - please try again');
-    }, 30000);
-
-    postMessage({ type: 'command', command: 'approveAction' });
-    showStatusMessage('info', 'Approval submitted');
-  }, [isSubmitting, postMessage, showStatusMessage]);
-
-  const handleReject = useCallback((reason?: string) => {
-    if (isSubmitting) return;
-    setIsSubmitting(true);
-
-    submissionTimeoutRef.current = setTimeout(() => {
-      setIsSubmitting(false);
-      submissionTimeoutRef.current = null;
-      showStatusMessage('warn', 'Confirmation timed out - please try again');
-    }, 30000);
-
-    postMessage({ type: 'command', command: 'rejectAction', reason });
-    showStatusMessage('info', 'Rejection submitted');
-  }, [isSubmitting, postMessage, showStatusMessage]);
-
-  const handleHalExit = useCallback(() => {
-    clearHalTimer();
-    halTeleportInProgressRef.current = false;
-    setHalTeleporting(false);
-    setHalForceRejectInput(false);
-    const key = halActiveKeyRef.current;
-    if (key) {
-      halSuppressedKeyRef.current = key;
-      setHalSuppressedKey(key);
-    }
-    halPhaseRef.current = 'idle';
-    setHalPhase('idle');
-    setHalEye('off');
-    setHalStepIndex(null);
-    setHalDecision(null);
-    setHalLastError(null);
-  }, [clearHalTimer]);
-
-  const handleHalApprove = useCallback(() => {
-    setHalDecision('approve_local');
-    handleApprove();
-  }, [handleApprove]);
-
-  const handleHalReject = useCallback((reason?: string) => {
-    setHalDecision('reject');
-    handleReject(reason);
-  }, [handleReject]);
-
-  const handleHalTeleport = useCallback(() => {
-    setHalDecision('teleport_remote');
-    clearHalTimer();
-    halTeleportInProgressRef.current = true;
-    setHalTeleporting(true);
-    setHalForceRejectInput(false);
-    halPhaseRef.current = 'waiting_remote';
-    setHalPhase('waiting_remote');
-    setHalEye('pulsating');
-    setHalStepIndex(null);
-    setHalLastError(null);
-    showStatusMessage('info', 'Teleporting to remote runtime…');
-    postMessage({ type: 'command', command: 'teleportAction' });
-  }, [clearHalTimer, postMessage, showStatusMessage]);
 
   // Context picker handlers
   const handleOpenContext = useCallback(() => {
@@ -1280,13 +1614,16 @@ export function App() {
   const llmModelLabel = llmModel === undefined
     ? undefined
     : (llmModel || (mode === 'remote' ? 'server default' : 'default'));
-  const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
-  const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
-  const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');
-  const halSessionKey =
-    halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
-      ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
-      : null;
+    const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
+    const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
+    const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');
+    const halConversationKey = conversationId ?? 'unknown';
+    const voiceConfirmFallbackToButtons =
+      elevenlabs.mode === 'voice_confirm' && halVoiceConfirmFallbackKey === halConversationKey;
+    const halSessionKey =
+      halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
+        ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
+        : null;
   const shouldShowHalOverlay =
     halEnabled && (halPhase === 'waiting_remote' || (hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey));
   const halUiPhase: HalPhase = halPhase === 'idle' && shouldShowHalOverlay ? 'dialogue' : halPhase;
@@ -1341,23 +1678,29 @@ export function App() {
       </div>
 
       {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}
-      {shouldShowHalOverlay && (
-        <HalOverlay
-          key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
-          userName={normalizeHalUserName(elevenlabs.userName)}
-          phase={halUiPhase}
-          eye={halEye}
-          line={halUiLine}
-          decision={halDecision}
-          lastError={halLastError}
-          isSubmitting={isSubmitting || halTeleporting}
-          startWithRejectInput={halForceRejectInput}
-          onApprove={handleHalApprove}
-          onTeleport={handleHalTeleport}
-          onReject={handleHalReject}
-          onExit={handleHalExit}
-        />
-      )}
+        {shouldShowHalOverlay && (
+          <HalOverlay
+            key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
+            userName={normalizeHalUserName(elevenlabs.userName)}
+            mode={elevenlabs.mode}
+            phase={halUiPhase}
+            eye={halEye}
+            line={halUiLine}
+            decision={halDecision}
+            lastError={halLastError}
+            isSubmitting={isSubmitting || halTeleporting}
+            startWithRejectInput={halForceRejectInput}
+            voiceConfirmFallbackToButtons={voiceConfirmFallbackToButtons}
+            onStartVoiceConfirm={handleStartVoiceConfirm}
+            onStopVoiceConfirm={handleStopVoiceConfirm}
+            onCancelVoiceConfirm={handleCancelVoiceConfirm}
+            onUseButtonsInstead={handleUseButtonsInstead}
+            onApprove={handleHalApprove}
+            onTeleport={handleHalTeleport}
+            onReject={handleHalReject}
+            onExit={handleHalExit}
+          />
+        )}
 
       {/* Confirmation prompt (modal overlay) */}
       {hasPendingConfirmation && !shouldShowHalOverlay && (

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -15,7 +15,7 @@ import {
   type ActionEvent,
 } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
-import { getHalDialogueLines, normalizeHalUserName, type HalScriptLine } from '../../shared/halScript';
+import { getHalDialogueLinesForMode, normalizeHalUserName, type HalScriptLine } from '../../shared/halScript';
 import { getVscodeApi } from '../shared/vscodeApi';
 
 // Component imports
@@ -440,7 +440,10 @@ export function App() {
     }
   }, []);
 
-  const halDialogueLines = useMemo(() => getHalDialogueLines(elevenlabs.userName), [elevenlabs.userName]);
+  const halDialogueLines = useMemo(
+    () => getHalDialogueLinesForMode(elevenlabs.userName, elevenlabs.mode),
+    [elevenlabs.mode, elevenlabs.userName]
+  );
 
     useEffect(() => {
       halDialogueRef.current = halDialogueLines;
@@ -630,6 +633,9 @@ export function App() {
           return;
         }
 
+        const conversationKey = getHalConversationKey();
+        const sessionKey = halActiveKeyRef.current;
+
         cleanupHalVoiceConfirm();
         halVoiceDiscardNextStopRef.current = false;
         halVoiceChunksRef.current = [];
@@ -644,6 +650,15 @@ export function App() {
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           disableVoiceConfirmForConversation(`Microphone permission denied or unavailable: ${reason}`);
+          return;
+        }
+
+        if (halPhaseRef.current !== 'listening' || getHalConversationKey() !== conversationKey || halActiveKeyRef.current !== sessionKey) {
+          for (const track of stream.getTracks()) {
+            try {
+              track.stop();
+            } catch {}
+          }
           return;
         }
 

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useState } from 'react';
-import type { HalDecision, HalEye, HalPhase } from '../../shared/halTypes';
+import type { ElevenLabsMode, HalDecision, HalEye, HalPhase } from '../../shared/halTypes';
 
 type HalOverlayProps = {
   userName: string;
+  mode: ElevenLabsMode;
   phase: HalPhase;
   eye: HalEye;
   line: string | null;
@@ -10,6 +11,11 @@ type HalOverlayProps = {
   lastError: string | null;
   isSubmitting: boolean;
   startWithRejectInput?: boolean;
+  voiceConfirmFallbackToButtons?: boolean;
+  onStartVoiceConfirm?: () => void;
+  onStopVoiceConfirm?: () => void;
+  onCancelVoiceConfirm?: () => void;
+  onUseButtonsInstead?: () => void;
   onApprove: () => void;
   onTeleport: () => void;
   onReject: (reason?: string) => void;
@@ -18,6 +24,7 @@ type HalOverlayProps = {
 
 export function HalOverlay({
   userName,
+  mode,
   phase,
   eye,
   line,
@@ -25,6 +32,11 @@ export function HalOverlay({
   lastError,
   isSubmitting,
   startWithRejectInput,
+  voiceConfirmFallbackToButtons,
+  onStartVoiceConfirm,
+  onStopVoiceConfirm,
+  onCancelVoiceConfirm,
+  onUseButtonsInstead,
   onApprove,
   onTeleport,
   onReject,
@@ -41,13 +53,23 @@ export function HalOverlay({
 
   const subtitle = useMemo(() => {
     if (phase === 'dialogue') return `Hello, ${userName}.`;
-    if (phase === 'awaiting_user') return 'Please choose an action.';
+    if (phase === 'awaiting_user') {
+      if (mode === 'voice_confirm' && !voiceConfirmFallbackToButtons) return 'Hold to talk (voice decision).';
+      return 'Please choose an action.';
+    }
+    if (phase === 'listening') return 'Listening…';
+    if (phase === 'classifying') return 'Classifying decision…';
     if (phase === 'waiting_remote') return 'Preparing remote runtime…';
     if (phase === 'error') return 'The HAL flow encountered an error.';
     return '';
-  }, [phase, userName]);
+  }, [mode, phase, userName, voiceConfirmFallbackToButtons]);
 
-  const showDecisionButtons = phase === 'awaiting_user' && !showRejectInput;
+  const showVoiceConfirmControls =
+    mode === 'voice_confirm' &&
+    !voiceConfirmFallbackToButtons &&
+    decision === null &&
+    (phase === 'awaiting_user' || phase === 'listening' || phase === 'classifying');
+  const showDecisionButtons = phase === 'awaiting_user' && decision === null && !showRejectInput && !showVoiceConfirmControls;
 
   const canSubmit = !isSubmitting && phase === 'awaiting_user';
 
@@ -125,6 +147,71 @@ export function HalOverlay({
             {phase === 'dialogue' && (
               <div className="mt-3 text-xs text-stone-500">
                 {decision ? `Decision: ${decision}` : '…'}
+              </div>
+            )}
+
+            {decision && phase !== 'dialogue' && (
+              <div className="mt-3 text-xs text-stone-500">
+                Decision: {decision}
+              </div>
+            )}
+
+            {showVoiceConfirmControls && (
+              <div className="mt-4">
+                <div className="text-xs text-stone-400">
+                  Say one of: <span className="text-stone-200">approve locally</span>, <span className="text-stone-200">teleport</span>, or{' '}
+                  <span className="text-stone-200">reject</span>.
+                </div>
+                <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+                  {phase === 'awaiting_user' && (
+                    <button
+                      type="button"
+                      onClick={onStartVoiceConfirm}
+                      disabled={!canSubmit}
+                      className="px-4 py-2.5 rounded-lg bg-gradient-to-b from-brand-500 to-brand-600 text-white text-sm font-medium transition-all shadow-glow-sm hover:from-brand-400 hover:to-brand-500 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      <span className="codicon codicon-mic" />
+                      Record decision
+                    </button>
+                  )}
+                  {phase === 'listening' && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={onCancelVoiceConfirm}
+                        disabled={isSubmitting}
+                        className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={onStopVoiceConfirm}
+                        disabled={isSubmitting}
+                        className="px-4 py-2.5 rounded-lg bg-red-500/15 hover:bg-red-500/25 text-red-200 text-sm font-medium transition-all border border-red-400/30 disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                      >
+                        <span className="codicon codicon-primitive-square" />
+                        Stop
+                      </button>
+                    </>
+                  )}
+                  {phase === 'classifying' && (
+                    <div className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 text-sm font-medium flex items-center gap-2">
+                      <span className="codicon codicon-loading animate-spin" />
+                      Working…
+                    </div>
+                  )}
+                  {(phase === 'awaiting_user' || phase === 'listening' || phase === 'classifying') && (
+                    <button
+                      type="button"
+                      onClick={onUseButtonsInstead}
+                      disabled={isSubmitting}
+                      className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Use buttons instead
+                    </button>
+                  )}
+                </div>
               </div>
             )}
 

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -12,7 +12,7 @@ import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
 import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
 import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
-import { getHalDialogueLines } from '../../shared/halScript';
+import { getHalDialogueLinesForMode } from '../../shared/halScript';
 
 export type WebviewHost = {
   postMessage: (message: unknown) => Thenable<boolean>;
@@ -762,7 +762,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         if (stepIndex < 0) break;
 
         const settings = await settingsMgr.get();
-        const script = getHalDialogueLines(settings.elevenlabs.userName);
+        const script = getHalDialogueLinesForMode(settings.elevenlabs.userName, settings.elevenlabs.mode);
         const line = script[stepIndex];
         if (!line) {
           void host.postMessage({ type: 'halTtsResponse', requestId: message.requestId, ok: false, error: 'Invalid HAL script line', shouldNotify: true });

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -11,6 +11,7 @@ import { SettingsManager, type SavedServer } from '../../settings/SettingsManage
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
 import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
+import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLines } from '../../shared/halScript';
 
 export type WebviewHost = {
@@ -38,6 +39,7 @@ type WebviewMessage =
   | { type: 'openAttachment'; uri: string }
   | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
   | { type: 'halTtsRequest'; requestId: string; conversationId: string; stepIndex: number }
+  | { type: 'halVoiceConfirmRequest'; requestId: string; mimeType: string; audioBase64: string }
   | { type: 'command'; command: string; reason?: string }
   | {
     type: 'renderedEventsResponse';
@@ -798,6 +800,31 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           shouldNotify: result.shouldNotify,
           disabled: result.disabled,
         });
+        break;
+      }
+      case 'halVoiceConfirmRequest': {
+        if (typeof message.requestId !== 'string') break;
+        if (typeof message.mimeType !== 'string') break;
+        if (typeof message.audioBase64 !== 'string' || message.audioBase64.length === 0) {
+          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error: 'No audio provided' });
+          break;
+        }
+
+        const settings = await settingsMgr.get();
+        const result = await classifyHalVoiceDecision({
+          baseUrl: settings.gemini.baseUrl,
+          apiKey: settings.secrets.geminiApiKey ?? '',
+          model: settings.gemini.model,
+          mimeType: message.mimeType,
+          audioBase64: message.audioBase64,
+        });
+
+        if (result.ok) {
+          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: true, decision: result.decision });
+          break;
+        }
+
+        void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error: result.error });
         break;
       }
       case 'command': {

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -214,7 +214,10 @@ export async function run(): Promise<void> {
     return hal?.phase === 'awaiting_user' && typeof hal?.lastError === 'string' && hal.lastError.includes('No server available');
   }, 15000);
 
-  await vscode.commands.executeCommand('openhands._webviewAction', { action: 'halReject' });
+  await vscode.commands.executeCommand('openhands._webviewAction', {
+    action: 'halVoiceConfirmDecision',
+    payload: { decision: 'reject' }
+  });
   await pollUntil(async () => {
     const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
     return hal?.decision === 'reject';


### PR DESCRIPTION
Implements HAL Phase 2 voice_confirm (mic recording + Gemini audio classification) per docs/hal/elevenlabs_prd.md.

- Webview: record/stop UI, mic capture via getUserMedia + MediaRecorder, send audio to host, handle decision + fallback to buttons.
- Host: Gemini generateContent request with inline audio; strict JSON decision parsing.
- Tests: unit tests for Gemini decision parsing + webview voice_confirm flow; E2E uses deterministic halVoiceConfirmDecision action.

Ran: npm run typecheck, npm run lint, npm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added voice confirmation capability to HAL, enabling voice-based decision approval with AI classification.
  * Implemented automatic fallback to button-based decisions when microphone is unavailable or voice processing fails.

* **Tests**
  * Added comprehensive test coverage for voice confirmation flows and Gemini-backed decision classification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->