### PR TITLE
[oh-tab-7bt] Unify security risk badge styling

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -835,6 +835,7 @@ describe('App - Advanced Test Coverage', () => {
         const badge = screen.getByText('high');
         expect(badge).toBeInTheDocument();
         expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed high risk for this action.');
+        expect(badge.className).toContain('bg-red-500/15');
       });
     });
 
@@ -852,6 +853,7 @@ describe('App - Advanced Test Coverage', () => {
         const badge = screen.getByText('medium');
         expect(badge).toBeInTheDocument();
         expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed medium risk for this action.');
+        expect(badge.className).toContain('bg-amber-500/15');
       });
     });
 
@@ -869,6 +871,7 @@ describe('App - Advanced Test Coverage', () => {
         const badge = screen.getByText('low');
         expect(badge).toBeInTheDocument();
         expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed low risk for this action.');
+        expect(badge.className).toContain('bg-stone-500/15');
       });
     });
 

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -63,6 +63,7 @@ describe('App - Confirmation Flow', () => {
     const riskBadge = scope.getByText(/high risk/);
     expect(riskBadge).toBeInTheDocument();
     expect(riskBadge.closest('[title]')).toHaveAttribute('title', 'The model assessed high risk for this action.');
+    expect(riskBadge.className).toContain('bg-red-500/15');
     expect(scope.getByText(/Reasoning/)).toBeInTheDocument();
   });
 

--- a/src/webview-src/components/ConfirmationPrompt.tsx
+++ b/src/webview-src/components/ConfirmationPrompt.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { ActionEvent } from '@openhands/agent-sdk-ts';
+import { SecurityRiskBadge } from './SecurityRiskBadge';
 
 interface ConfirmationPromptProps {
   pendingActions: ActionEvent[];
@@ -110,19 +111,7 @@ export function ConfirmationPrompt({
                       <span className="font-mono text-sm text-teal-300">{action.tool_name}</span>
                     </div>
                     {action.security_risk && action.security_risk !== 'UNKNOWN' && (
-                      <span
-                        title={`The model assessed ${action.security_risk.toLowerCase()} risk for this action.`}
-                        className={`
-                          inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border
-                          ${action.security_risk === 'HIGH' ? 'bg-red-500/15 text-red-300 border-red-400/30' :
-                            action.security_risk === 'MEDIUM' ? 'bg-amber-500/15 text-amber-300 border-amber-400/30' :
-                            'bg-teal-500/15 text-teal-300 border-teal-400/30'
-                          }
-                        `}
-                      >
-                        <span className={`codicon codicon-${action.security_risk === 'HIGH' ? 'shield' : 'warning'} text-[10px]`} />
-                        {action.security_risk.toLowerCase()} risk
-                      </span>
+                      <SecurityRiskBadge risk={action.security_risk} labelSuffix=" risk" />
                     )}
                   </div>
 

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -27,6 +27,7 @@ import {
   isTextContent,
 } from '@openhands/agent-sdk-ts';
 import { getVscodeApi } from '../shared/vscodeApi';
+import { SecurityRiskBadge } from './SecurityRiskBadge';
 
 // ============================================================================
 // Type Definitions
@@ -335,35 +336,6 @@ const OBSERVATION_ACCENT_COLOR = AGENT_ACCENT_COLOR;
 const withAlpha = (color: string, percent: number) =>
   `color-mix(in srgb, ${color} ${percent}%, transparent)`;
 
-// Security risk badge component with refined styling
-function SecurityBadge({ risk }: { risk: 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN' }) {
-  const styles = {
-    HIGH: 'bg-red-500/15 text-red-300 border-red-400/30 shadow-[0_0_8px_rgba(248,113,113,0.15)]',
-    MEDIUM: 'bg-amber-500/15 text-amber-300 border-amber-400/30',
-    LOW: 'bg-stone-500/15 text-stone-400 border-stone-400/20',
-    UNKNOWN: 'bg-stone-500/15 text-stone-400 border-stone-400/20',
-  };
-
-  const icons = {
-    HIGH: 'shield',
-    MEDIUM: 'warning',
-    LOW: 'info',
-    UNKNOWN: 'question',
-  };
-
-  const tooltip = `The model assessed ${risk.toLowerCase()} risk for this action.`;
-
-  return (
-    <span
-      title={tooltip}
-      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border ${styles[risk]}`}
-    >
-      <span className={`codicon codicon-${icons[risk]} text-[10px]`} />
-      {risk.toLowerCase()}
-    </span>
-  );
-}
-
 /**
  * Base event container with accent bar and refined styling.
  * Uses warm gradients and subtle shadows for depth.
@@ -489,7 +461,7 @@ export function ActionEventBlock({ event, index }: { event: ActionEvent; index?:
           <div className="font-semibold text-sm text-stone-200">Agent Action</div>
         </div>
         {event.security_risk && event.security_risk !== 'UNKNOWN' && (
-          <SecurityBadge risk={event.security_risk} />
+          <SecurityRiskBadge risk={event.security_risk} />
         )}
       </div>
 

--- a/src/webview-src/components/SecurityRiskBadge.tsx
+++ b/src/webview-src/components/SecurityRiskBadge.tsx
@@ -1,0 +1,31 @@
+export type SecurityRiskLevel = 'HIGH' | 'MEDIUM' | 'LOW' | 'UNKNOWN';
+
+const RISK_STYLES: Record<SecurityRiskLevel, string> = {
+  HIGH: 'bg-red-500/15 text-red-300 border-red-400/30 shadow-[0_0_8px_rgba(248,113,113,0.15)]',
+  MEDIUM: 'bg-amber-500/15 text-amber-300 border-amber-400/30',
+  LOW: 'bg-stone-500/15 text-stone-400 border-stone-400/20',
+  UNKNOWN: 'bg-stone-500/15 text-stone-400 border-stone-400/20',
+};
+
+const RISK_ICONS: Record<SecurityRiskLevel, string> = {
+  HIGH: 'shield',
+  MEDIUM: 'warning',
+  LOW: 'info',
+  UNKNOWN: 'question',
+};
+
+export function SecurityRiskBadge({ risk, labelSuffix = '' }: { risk: SecurityRiskLevel; labelSuffix?: string }) {
+  const tooltip = `The model assessed ${risk.toLowerCase()} risk for this action.`;
+  const label = `${risk.toLowerCase()}${labelSuffix}`;
+
+  return (
+    <span
+      title={tooltip}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border ${RISK_STYLES[risk]}`}
+    >
+      <span className={`codicon codicon-${RISK_ICONS[risk]} text-[10px]`} />
+      {label}
+    </span>
+  );
+}
+


### PR DESCRIPTION
Unifies the security risk badge styling between EventBlock and ConfirmationPrompt.

- Extracted shared `SecurityRiskBadge` component.
- ConfirmationPrompt now uses the same colors/icons/tooltip as EventBlock.
- Tests assert consistent risk badge classes.

Ran: `npm run lint`, `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified security risk badge component with consistent styling and visual indicators across the application.

* **Tests**
  * Updated test assertions to verify risk badges display with appropriate opacity background colors for HIGH, MEDIUM, and LOW risk levels.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->