### PR TITLE
[oh-tab-4zp] Refactor HAL state resets

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -24,7 +24,7 @@ import { InputArea, ContextPicker, SkillsPopover } from './InputArea';
 import { ConfirmationPrompt } from './ConfirmationPrompt';
 import { StatusBanner } from './StatusBanner';
 import { HistoryView } from './HistoryView';
-import type { ElevenLabsMode, HalDecision, HalEye, HalPhase, HalStateSnapshot } from '../../shared/halTypes';
+import { isElevenLabsMode, isHalDecision, type ElevenLabsMode, type HalDecision, type HalEye, type HalPhase, type HalStateSnapshot } from '../../shared/halTypes';
 import { HalOverlay } from './HalOverlay';
 import {
   SystemPromptEventBlock,
@@ -72,6 +72,16 @@ const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false
 const DEFAULT_HAL_STATE: HalStateSnapshot = {
   enabled: false,
   mode: DEFAULT_ELEVENLABS_SETTINGS.mode,
+  phase: 'idle',
+  eye: 'off',
+  stepIndex: null,
+  decision: null,
+  lastError: null,
+};
+
+type HalUiState = Pick<HalStateSnapshot, 'phase' | 'eye' | 'stepIndex' | 'decision' | 'lastError'>;
+
+const DEFAULT_HAL_UI_STATE: HalUiState = {
   phase: 'idle',
   eye: 'off',
   stepIndex: null,
@@ -180,35 +190,35 @@ export function App() {
   const [halDisabledConversationId, setHalDisabledConversationId] = useState<string | null>(null);
   const [halPhase, setHalPhase] = useState<HalPhase>('idle');
   const [halEye, setHalEye] = useState<HalEye>('off');
-    const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
-    const [halDecision, setHalDecision] = useState<HalDecision | null>(null);
-    const [halLastError, setHalLastError] = useState<string | null>(null);
-    const [halForceRejectInput, setHalForceRejectInput] = useState(false);
-    const [halTeleporting, setHalTeleporting] = useState(false);
-    const [halVoiceConfirmFallbackKey, setHalVoiceConfirmFallbackKey] = useState<string | null>(null);
-    const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const halStepIndexRef = useRef<number | null>(null);
-    const halDialogueRef = useRef<HalScriptLine[]>([]);
-    const halTtsRequestIdRef = useRef<string | null>(null);
-    const halTtsRequestedKeyRef = useRef<string | null>(null);
-    const halAudioRef = useRef<HTMLAudioElement | null>(null);
-    const halAudioUrlRef = useRef<string | null>(null);
-    const halAudioPlayTokenRef = useRef(0);
-    const halTtsRequestSeqRef = useRef(0);
-    const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
-    const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
-    const halVoiceConfirmSeqRef = useRef(0);
-    const halVoiceDiscardNextStopRef = useRef(false);
-    const halVoiceStreamRef = useRef<MediaStream | null>(null);
-    const halVoiceRecorderRef = useRef<MediaRecorder | null>(null);
-    const halVoiceChunksRef = useRef<Blob[]>([]);
-    const halActiveKeyRef = useRef<string | null>(null);
-    const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
-    const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
-    const halEnabledRef = useRef<boolean>(false);
-    const halPhaseRef = useRef<HalPhase>('idle');
-    const halSuppressedKeyRef = useRef<string | null>(null);
-    const halTeleportInProgressRef = useRef(false);
+  const [halStepIndex, setHalStepIndex] = useState<number | null>(null);
+  const [halDecision, setHalDecision] = useState<HalDecision | null>(null);
+  const [halLastError, setHalLastError] = useState<string | null>(null);
+  const [halForceRejectInput, setHalForceRejectInput] = useState(false);
+  const [halTeleporting, setHalTeleporting] = useState(false);
+  const [halVoiceConfirmFallbackKey, setHalVoiceConfirmFallbackKey] = useState<string | null>(null);
+  const halTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const halStepIndexRef = useRef<number | null>(null);
+  const halDialogueRef = useRef<HalScriptLine[]>([]);
+  const halTtsRequestIdRef = useRef<string | null>(null);
+  const halTtsRequestedKeyRef = useRef<string | null>(null);
+  const halAudioRef = useRef<HTMLAudioElement | null>(null);
+  const halAudioUrlRef = useRef<string | null>(null);
+  const halAudioPlayTokenRef = useRef(0);
+  const halTtsRequestSeqRef = useRef(0);
+  const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
+  const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
+  const halVoiceConfirmSeqRef = useRef(0);
+  const halVoiceDiscardNextStopRef = useRef(false);
+  const halVoiceStreamRef = useRef<MediaStream | null>(null);
+  const halVoiceRecorderRef = useRef<MediaRecorder | null>(null);
+  const halVoiceChunksRef = useRef<Blob[]>([]);
+  const halActiveKeyRef = useRef<string | null>(null);
+  const [halSuppressedKey, setHalSuppressedKey] = useState<string | null>(null);
+  const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
+  const halEnabledRef = useRef<boolean>(false);
+  const halPhaseRef = useRef<HalPhase>('idle');
+  const halSuppressedKeyRef = useRef<string | null>(null);
+  const halTeleportInProgressRef = useRef(false);
   const pendingActionsRef = useRef<ActionEvent[]>([]);
   const agentStatusRef = useRef<string | undefined>(undefined);
   const conversationIdRef = useRef<string | undefined>(undefined);
@@ -262,13 +272,13 @@ export function App() {
     halPhaseRef.current = halPhase;
   }, [halPhase]);
 
-    useEffect(() => {
-      halSuppressedKeyRef.current = halSuppressedKey;
-    }, [halSuppressedKey]);
+  useEffect(() => {
+    halSuppressedKeyRef.current = halSuppressedKey;
+  }, [halSuppressedKey]);
 
-    useEffect(() => {
-      halVoiceConfirmFallbackKeyRef.current = halVoiceConfirmFallbackKey;
-    }, [halVoiceConfirmFallbackKey]);
+  useEffect(() => {
+    halVoiceConfirmFallbackKeyRef.current = halVoiceConfirmFallbackKey;
+  }, [halVoiceConfirmFallbackKey]);
 
   useEffect(() => {
     pendingActionsRef.current = pendingActions;
@@ -294,46 +304,46 @@ export function App() {
     halStepIndexRef.current = halStepIndex;
   }, [halStepIndex]);
 
-    const stopHalAudio = useCallback(() => {
-      halAudioPlayTokenRef.current += 1;
-      const audio = halAudioRef.current;
-      if (audio) {
-        try {
-          audio.pause();
-        } catch {}
-        audio.src = '';
-      }
-      if (halAudioUrlRef.current) {
-        try {
-          URL.revokeObjectURL(halAudioUrlRef.current);
-        } catch {}
-        halAudioUrlRef.current = null;
-      }
-      halTtsRequestIdRef.current = null;
-      halTtsRequestedKeyRef.current = null;
-    }, []);
+  const stopHalAudio = useCallback(() => {
+    halAudioPlayTokenRef.current += 1;
+    const audio = halAudioRef.current;
+    if (audio) {
+      try {
+        audio.pause();
+      } catch {}
+      audio.src = '';
+    }
+    if (halAudioUrlRef.current) {
+      try {
+        URL.revokeObjectURL(halAudioUrlRef.current);
+      } catch {}
+      halAudioUrlRef.current = null;
+    }
+    halTtsRequestIdRef.current = null;
+    halTtsRequestedKeyRef.current = null;
+  }, []);
 
-    const cleanupHalVoiceConfirm = useCallback(() => {
-      const recorder = halVoiceRecorderRef.current;
-      if (recorder && recorder.state !== 'inactive') {
+  const cleanupHalVoiceConfirm = useCallback(() => {
+    const recorder = halVoiceRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      try {
+        halVoiceDiscardNextStopRef.current = true;
+        recorder.stop();
+      } catch {}
+    }
+    halVoiceRecorderRef.current = null;
+    halVoiceChunksRef.current = [];
+    const stream = halVoiceStreamRef.current;
+    if (stream) {
+      for (const track of stream.getTracks()) {
         try {
-          halVoiceDiscardNextStopRef.current = true;
-          recorder.stop();
+          track.stop();
         } catch {}
       }
-      halVoiceRecorderRef.current = null;
-      halVoiceChunksRef.current = [];
-      const stream = halVoiceStreamRef.current;
-      if (stream) {
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {}
-        }
-      }
-      halVoiceStreamRef.current = null;
-      halVoiceConfirmRequestIdRef.current = null;
-    }, []);
+    }
+    halVoiceStreamRef.current = null;
+    halVoiceConfirmRequestIdRef.current = null;
+  }, []);
 
     const blobToBase64 = (blob: Blob): Promise<string> =>
       new Promise((resolve, reject) => {
@@ -440,44 +450,57 @@ export function App() {
     }
   }, []);
 
+  const setHalSuppressedKeySynced = useCallback((next: string | null) => {
+    halSuppressedKeyRef.current = next;
+    setHalSuppressedKey(next);
+  }, []);
+
+  const resetHalUiState = useCallback((overrides: Partial<HalUiState> = {}) => {
+    const next: HalUiState = { ...DEFAULT_HAL_UI_STATE, ...overrides };
+    halPhaseRef.current = next.phase;
+    setHalPhase(next.phase);
+    setHalEye(next.eye);
+    setHalStepIndex(next.stepIndex);
+    setHalDecision(next.decision);
+    setHalLastError(next.lastError);
+  }, []);
+
+  const cleanupHalFlow = useCallback(() => {
+    clearHalTimer();
+    stopHalAudio();
+    cleanupHalVoiceConfirm();
+  }, [clearHalTimer, cleanupHalVoiceConfirm, stopHalAudio]);
+
   const halDialogueLines = useMemo(
     () => getHalDialogueLinesForMode(elevenlabs.userName, elevenlabs.mode),
     [elevenlabs.mode, elevenlabs.userName]
   );
 
-    useEffect(() => {
-      halDialogueRef.current = halDialogueLines;
-    }, [halDialogueLines]);
+  useEffect(() => {
+    halDialogueRef.current = halDialogueLines;
+  }, [halDialogueLines]);
 
-    const getHalConversationKey = useCallback(() => conversationIdRef.current ?? 'unknown', []);
+  const getHalConversationKey = useCallback(() => conversationIdRef.current ?? 'unknown', []);
 
   const maybeUpdateHalFlow = useCallback(() => {
     if (halTeleportInProgressRef.current) return;
     const enabled = halEnabledRef.current;
-    const isDisabledForConversation =
-      Boolean(conversationIdRef.current) && halDisabledConversationId === conversationIdRef.current;
+    const convoId = conversationIdRef.current;
+    const isDisabledForConversation = Boolean(convoId) && halDisabledConversationId === convoId;
     const status = agentStatusRef.current;
     const pending = pendingActionsRef.current;
     const firstHighRisk = pending.find((action) => action.security_risk === 'HIGH');
     const nextKey =
       enabled && !isDisabledForConversation && status === 'WAITING_FOR_CONFIRMATION' && firstHighRisk?.tool_call_id
-        ? `${conversationIdRef.current ?? 'unknown'}:${firstHighRisk.tool_call_id}`
+        ? `${convoId ?? 'unknown'}:${firstHighRisk.tool_call_id}`
         : null;
 
-      if (!nextKey) {
-        if (halActiveKeyRef.current !== null || halPhaseRef.current !== 'idle' || halSuppressedKeyRef.current !== null) {
-          clearHalTimer();
-          stopHalAudio();
-          cleanupHalVoiceConfirm();
-          halActiveKeyRef.current = null;
-          halSuppressedKeyRef.current = null;
-          halPhaseRef.current = 'idle';
-          setHalSuppressedKey(null);
-          setHalPhase('idle');
-        setHalEye('off');
-        setHalStepIndex(null);
-        setHalDecision(null);
-        setHalLastError(null);
+    if (!nextKey) {
+      if (halActiveKeyRef.current !== null || halPhaseRef.current !== 'idle' || halSuppressedKeyRef.current !== null) {
+        cleanupHalFlow();
+        halActiveKeyRef.current = null;
+        setHalSuppressedKeySynced(null);
+        resetHalUiState();
         setHalForceRejectInput(false);
         setHalTeleporting(false);
       }
@@ -487,22 +510,14 @@ export function App() {
     const isNewSession = halActiveKeyRef.current !== nextKey;
     if (isNewSession) {
       halActiveKeyRef.current = nextKey;
-      halSuppressedKeyRef.current = null;
-      setHalSuppressedKey(null);
+      setHalSuppressedKeySynced(null);
       setHalForceRejectInput(false);
     }
 
-      if (halSuppressedKeyRef.current === nextKey) {
-        if (halPhaseRef.current !== 'idle') {
-          clearHalTimer();
-          stopHalAudio();
-          cleanupHalVoiceConfirm();
-          halPhaseRef.current = 'idle';
-          setHalPhase('idle');
-          setHalEye('off');
-          setHalStepIndex(null);
-        setHalDecision(null);
-        setHalLastError(null);
+    if (halSuppressedKeyRef.current === nextKey) {
+      if (halPhaseRef.current !== 'idle') {
+        cleanupHalFlow();
+        resetHalUiState();
       }
       return;
     }
@@ -510,14 +525,9 @@ export function App() {
     if (halPhaseRef.current === 'idle') {
       clearHalTimer();
       stopHalAudio();
-      halPhaseRef.current = 'dialogue';
-      setHalDecision(null);
-      setHalLastError(null);
-      setHalEye('pulsating');
-      setHalPhase('dialogue');
-      setHalStepIndex(0);
+      resetHalUiState({ phase: 'dialogue', eye: 'pulsating', stepIndex: 0 });
     }
-    }, [clearHalTimer, cleanupHalVoiceConfirm, halDisabledConversationId, stopHalAudio]);
+  }, [clearHalTimer, cleanupHalFlow, halDisabledConversationId, resetHalUiState, setHalSuppressedKeySynced, stopHalAudio]);
 
   useEffect(() => {
     if (halPhase !== 'dialogue') return;
@@ -593,213 +603,204 @@ export function App() {
     });
   }, [postMessage]);
 
-    useEffect(() => {
-      if (halPhase !== 'dialogue') return;
-      if (halStepIndex === null) return;
-      const mode = elevenlabsRef.current.mode;
-      if (mode !== 'tts_only' && mode !== 'voice_confirm') return;
-      const convoId = conversationIdRef.current;
-      if (!convoId) return;
-      if (halDisabledConversationId === convoId) return;
-      const key = `${convoId}:${halStepIndex}:${mode}`;
-      if (halTtsRequestedKeyRef.current === key) return;
-      halTtsRequestedKeyRef.current = key;
-      requestHalTts({ conversationId: convoId, stepIndex: halStepIndex });
-    }, [halDisabledConversationId, halPhase, halStepIndex, requestHalTts]);
+  useEffect(() => {
+    if (halPhase !== 'dialogue') return;
+    if (halStepIndex === null) return;
+    const mode = elevenlabsRef.current.mode;
+    if (mode !== 'tts_only' && mode !== 'voice_confirm') return;
+    const convoId = conversationIdRef.current;
+    if (!convoId) return;
+    if (halDisabledConversationId === convoId) return;
+    const key = `${convoId}:${halStepIndex}:${mode}`;
+    if (halTtsRequestedKeyRef.current === key) return;
+    halTtsRequestedKeyRef.current = key;
+    requestHalTts({ conversationId: convoId, stepIndex: halStepIndex });
+  }, [halDisabledConversationId, halPhase, halStepIndex, requestHalTts]);
 
-    const disableVoiceConfirmForConversation = useCallback((message: string) => {
-      const key = getHalConversationKey();
-      setHalVoiceConfirmFallbackKey(key);
-      halVoiceConfirmFallbackKeyRef.current = key;
+  const disableVoiceConfirmForConversation = useCallback((message: string) => {
+    const key = getHalConversationKey();
+    setHalVoiceConfirmFallbackKey(key);
+    halVoiceConfirmFallbackKeyRef.current = key;
+    cleanupHalVoiceConfirm();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', lastError: message });
+    showStatusMessage('warn', message);
+  }, [cleanupHalVoiceConfirm, getHalConversationKey, resetHalUiState, showStatusMessage]);
+
+  const handleStartVoiceConfirm = useCallback(() => {
+    void (async () => {
+      if (halPhaseRef.current !== 'awaiting_user') return;
+      if (elevenlabsRef.current.mode !== 'voice_confirm') return;
+      if (halVoiceConfirmFallbackKeyRef.current === getHalConversationKey()) return;
+      if (
+        typeof navigator === 'undefined' ||
+        typeof navigator.mediaDevices?.getUserMedia !== 'function' ||
+        typeof MediaRecorder === 'undefined'
+      ) {
+        disableVoiceConfirmForConversation('Microphone is unavailable in this environment. Using buttons instead.');
+        return;
+      }
+
+      const conversationKey = getHalConversationKey();
+      const sessionKey = halActiveKeyRef.current;
+
       cleanupHalVoiceConfirm();
-      setHalLastError(message);
-      halPhaseRef.current = 'awaiting_user';
-      setHalPhase('awaiting_user');
+      halVoiceDiscardNextStopRef.current = false;
+      halVoiceChunksRef.current = [];
+      setHalLastError(null);
+      halPhaseRef.current = 'listening';
+      setHalPhase('listening');
       setHalEye('pulsating');
-      showStatusMessage('warn', message);
-    }, [cleanupHalVoiceConfirm, getHalConversationKey, showStatusMessage]);
 
-    const handleStartVoiceConfirm = useCallback(() => {
-      void (async () => {
-        if (halPhaseRef.current !== 'awaiting_user') return;
-        if (elevenlabsRef.current.mode !== 'voice_confirm') return;
-        if (halVoiceConfirmFallbackKeyRef.current === getHalConversationKey()) return;
-        if (
-          typeof navigator === 'undefined' ||
-          typeof navigator.mediaDevices?.getUserMedia !== 'function' ||
-          typeof MediaRecorder === 'undefined'
-        ) {
-          disableVoiceConfirmForConversation('Microphone is unavailable in this environment. Using buttons instead.');
-          return;
-        }
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        disableVoiceConfirmForConversation(`Microphone permission denied or unavailable: ${reason}`);
+        return;
+      }
 
-        const conversationKey = getHalConversationKey();
-        const sessionKey = halActiveKeyRef.current;
-
-        cleanupHalVoiceConfirm();
-        halVoiceDiscardNextStopRef.current = false;
-        halVoiceChunksRef.current = [];
-        setHalLastError(null);
-        halPhaseRef.current = 'listening';
-        setHalPhase('listening');
-        setHalEye('pulsating');
-
-        let stream: MediaStream;
-        try {
-          stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          disableVoiceConfirmForConversation(`Microphone permission denied or unavailable: ${reason}`);
-          return;
-        }
-
-        if (halPhaseRef.current !== 'listening' || getHalConversationKey() !== conversationKey || halActiveKeyRef.current !== sessionKey) {
-          for (const track of stream.getTracks()) {
-            try {
-              track.stop();
-            } catch {}
-          }
-          return;
-        }
-
-        const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus'];
-        const mimeType = candidates.find((t) => {
+      if (halPhaseRef.current !== 'listening' || getHalConversationKey() !== conversationKey || halActiveKeyRef.current !== sessionKey) {
+        for (const track of stream.getTracks()) {
           try {
-            return MediaRecorder.isTypeSupported(t);
-          } catch {
-            return false;
-          }
-        });
-        let recorder: MediaRecorder;
-        try {
-          recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          for (const track of stream.getTracks()) {
-            try {
-              track.stop();
-            } catch {}
-          }
-          disableVoiceConfirmForConversation(`Microphone recording is not supported: ${reason}`);
-          return;
+            track.stop();
+          } catch {}
         }
+        return;
+      }
 
-        halVoiceStreamRef.current = stream;
-        halVoiceRecorderRef.current = recorder;
-        recorder.ondataavailable = (e) => {
-          if (e.data && e.data.size > 0) {
-            halVoiceChunksRef.current.push(e.data);
-          }
-        };
-        recorder.onstop = () => {
-          void (async () => {
-            const shouldDiscard = halVoiceDiscardNextStopRef.current;
-            halVoiceDiscardNextStopRef.current = false;
+      const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus'];
+      const mimeType = candidates.find((t) => {
+        try {
+          return MediaRecorder.isTypeSupported(t);
+        } catch {
+          return false;
+        }
+      });
+      let recorder: MediaRecorder;
+      try {
+        recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {}
+        }
+        disableVoiceConfirmForConversation(`Microphone recording is not supported: ${reason}`);
+        return;
+      }
 
-            const chunks = halVoiceChunksRef.current;
-            halVoiceChunksRef.current = [];
-            halVoiceRecorderRef.current = null;
-            const activeStream = halVoiceStreamRef.current;
-            halVoiceStreamRef.current = null;
-            if (activeStream) {
-              for (const track of activeStream.getTracks()) {
-                try {
-                  track.stop();
-                } catch {}
-              }
+      halVoiceStreamRef.current = stream;
+      halVoiceRecorderRef.current = recorder;
+      recorder.ondataavailable = (e) => {
+        if (e.data && e.data.size > 0) {
+          halVoiceChunksRef.current.push(e.data);
+        }
+      };
+      recorder.onstop = () => {
+        void (async () => {
+          const shouldDiscard = halVoiceDiscardNextStopRef.current;
+          halVoiceDiscardNextStopRef.current = false;
+
+          const chunks = halVoiceChunksRef.current;
+          halVoiceChunksRef.current = [];
+          halVoiceRecorderRef.current = null;
+          const activeStream = halVoiceStreamRef.current;
+          halVoiceStreamRef.current = null;
+          if (activeStream) {
+            for (const track of activeStream.getTracks()) {
+              try {
+                track.stop();
+              } catch {}
             }
+          }
 
-            if (shouldDiscard) return;
-            if (chunks.length === 0) {
+          if (shouldDiscard) return;
+          if (chunks.length === 0) {
+            disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+            return;
+          }
+
+          try {
+            const blob = new Blob(chunks, { type: recorder.mimeType || mimeType || 'audio/webm' });
+            if (blob.size === 0) {
               disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
               return;
             }
-
-            try {
-              const blob = new Blob(chunks, { type: recorder.mimeType || mimeType || 'audio/webm' });
-              if (blob.size === 0) {
-                disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
-                return;
-              }
-              const audioBase64 = await blobToBase64(blob);
-              if (!audioBase64) {
-                disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
-                return;
-              }
-              const requestId = `halVoiceConfirm:${Date.now().toString(36)}:${(halVoiceConfirmSeqRef.current++).toString(36)}`;
-              halVoiceConfirmRequestIdRef.current = requestId;
-              setHalLastError(null);
-              halPhaseRef.current = 'classifying';
-              setHalPhase('classifying');
-              setHalEye('pulsating');
-              postMessage({
-                type: 'halVoiceConfirmRequest',
-                requestId,
-                mimeType: blob.type || 'audio/webm',
-                audioBase64,
-              });
-            } catch (err) {
-              const reason = err instanceof Error ? err.message : String(err);
-              disableVoiceConfirmForConversation(`Failed to process recorded audio: ${reason}`);
+            const audioBase64 = await blobToBase64(blob);
+            if (!audioBase64) {
+              disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+              return;
             }
-          })();
-        };
-
-        try {
-          recorder.start();
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          for (const track of stream.getTracks()) {
-            try {
-              track.stop();
-            } catch {}
+            const requestId = `halVoiceConfirm:${Date.now().toString(36)}:${(halVoiceConfirmSeqRef.current++).toString(36)}`;
+            halVoiceConfirmRequestIdRef.current = requestId;
+            setHalLastError(null);
+            halPhaseRef.current = 'classifying';
+            setHalPhase('classifying');
+            setHalEye('pulsating');
+            postMessage({
+              type: 'halVoiceConfirmRequest',
+              requestId,
+              mimeType: blob.type || 'audio/webm',
+              audioBase64,
+            });
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            disableVoiceConfirmForConversation(`Failed to process recorded audio: ${reason}`);
           }
-          disableVoiceConfirmForConversation(`Failed to start recording: ${reason}`);
-          return;
-        }
-      })();
-    }, [cleanupHalVoiceConfirm, disableVoiceConfirmForConversation, getHalConversationKey, postMessage]);
+        })();
+      };
 
-    const handleStopVoiceConfirm = useCallback(() => {
-      if (halPhaseRef.current !== 'listening') return;
-      const recorder = halVoiceRecorderRef.current;
-      if (!recorder) return;
-      if (recorder.state === 'inactive') return;
       try {
-        recorder.stop();
+        recorder.start();
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
-        disableVoiceConfirmForConversation(`Failed to stop recording: ${reason}`);
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {}
+        }
+        disableVoiceConfirmForConversation(`Failed to start recording: ${reason}`);
+        return;
       }
-    }, [disableVoiceConfirmForConversation]);
+    })();
+  }, [cleanupHalVoiceConfirm, disableVoiceConfirmForConversation, getHalConversationKey, postMessage]);
 
-    const handleCancelVoiceConfirm = useCallback(() => {
-      if (halPhaseRef.current !== 'listening') return;
-      halVoiceDiscardNextStopRef.current = true;
-      const recorder = halVoiceRecorderRef.current;
-      if (recorder && recorder.state !== 'inactive') {
-        try {
-          recorder.stop();
-        } catch {}
-      }
-      cleanupHalVoiceConfirm();
-      setHalLastError(null);
-      halPhaseRef.current = 'awaiting_user';
-      setHalPhase('awaiting_user');
-      setHalEye('pulsating');
-    }, [cleanupHalVoiceConfirm]);
+  const handleStopVoiceConfirm = useCallback(() => {
+    if (halPhaseRef.current !== 'listening') return;
+    const recorder = halVoiceRecorderRef.current;
+    if (!recorder) return;
+    if (recorder.state === 'inactive') return;
+    try {
+      recorder.stop();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      disableVoiceConfirmForConversation(`Failed to stop recording: ${reason}`);
+    }
+  }, [disableVoiceConfirmForConversation]);
 
-    const handleUseButtonsInstead = useCallback(() => {
-      const key = getHalConversationKey();
-      setHalVoiceConfirmFallbackKey(key);
-      halVoiceConfirmFallbackKeyRef.current = key;
-      cleanupHalVoiceConfirm();
-      setHalLastError(null);
-      halPhaseRef.current = 'awaiting_user';
-      setHalPhase('awaiting_user');
-      setHalEye('pulsating');
-      showStatusMessage('info', 'Switched to button decision for this conversation.');
-    }, [cleanupHalVoiceConfirm, getHalConversationKey, showStatusMessage]);
+  const handleCancelVoiceConfirm = useCallback(() => {
+    if (halPhaseRef.current !== 'listening') return;
+    halVoiceDiscardNextStopRef.current = true;
+    const recorder = halVoiceRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      try {
+        recorder.stop();
+      } catch {}
+    }
+    cleanupHalVoiceConfirm();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating' });
+  }, [cleanupHalVoiceConfirm, resetHalUiState]);
+
+  const handleUseButtonsInstead = useCallback(() => {
+    const key = getHalConversationKey();
+    setHalVoiceConfirmFallbackKey(key);
+    halVoiceConfirmFallbackKeyRef.current = key;
+    cleanupHalVoiceConfirm();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating' });
+    showStatusMessage('info', 'Switched to button decision for this conversation.');
+  }, [cleanupHalVoiceConfirm, getHalConversationKey, resetHalUiState, showStatusMessage]);
 
   const handleApprove = useCallback(() => {
     if (isSubmitting) return;
@@ -830,24 +831,16 @@ export function App() {
   }, [isSubmitting, postMessage, showStatusMessage]);
 
   const handleHalExit = useCallback(() => {
-    clearHalTimer();
-    stopHalAudio();
-    cleanupHalVoiceConfirm();
+    cleanupHalFlow();
     halTeleportInProgressRef.current = false;
     setHalTeleporting(false);
     setHalForceRejectInput(false);
     const key = halActiveKeyRef.current;
     if (key) {
-      halSuppressedKeyRef.current = key;
-      setHalSuppressedKey(key);
+      setHalSuppressedKeySynced(key);
     }
-    halPhaseRef.current = 'idle';
-    setHalPhase('idle');
-    setHalEye('off');
-    setHalStepIndex(null);
-    setHalDecision(null);
-    setHalLastError(null);
-  }, [cleanupHalVoiceConfirm, clearHalTimer, stopHalAudio]);
+    resetHalUiState();
+  }, [cleanupHalFlow, resetHalUiState, setHalSuppressedKeySynced]);
 
   const handleHalApprove = useCallback(() => {
     setHalDecision('approve_local');
@@ -860,21 +853,14 @@ export function App() {
   }, [handleReject]);
 
   const handleHalTeleport = useCallback(() => {
-    setHalDecision('teleport_remote');
-    clearHalTimer();
-    stopHalAudio();
-    cleanupHalVoiceConfirm();
+    cleanupHalFlow();
     halTeleportInProgressRef.current = true;
     setHalTeleporting(true);
     setHalForceRejectInput(false);
-    halPhaseRef.current = 'waiting_remote';
-    setHalPhase('waiting_remote');
-    setHalEye('pulsating');
-    setHalStepIndex(null);
-    setHalLastError(null);
+    resetHalUiState({ phase: 'waiting_remote', eye: 'pulsating', decision: 'teleport_remote' });
     showStatusMessage('info', 'Teleporting to remote runtime…');
     postMessage({ type: 'command', command: 'teleportAction' });
-  }, [cleanupHalVoiceConfirm, clearHalTimer, postMessage, showStatusMessage, stopHalAudio]);
+  }, [cleanupHalFlow, postMessage, resetHalUiState, showStatusMessage]);
 
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
@@ -1020,13 +1006,7 @@ export function App() {
             const prev = elevenlabsRef.current;
             const next: ElevenLabsSettingsSnapshot = { ...prev };
             if (typeof payload.elevenlabs?.enabled === 'boolean') next.enabled = payload.elevenlabs.enabled;
-            if (
-              payload.elevenlabs?.mode === 'bundled' ||
-              payload.elevenlabs?.mode === 'tts_only' ||
-              payload.elevenlabs?.mode === 'voice_confirm'
-            ) {
-              next.mode = payload.elevenlabs.mode;
-            }
+            if (isElevenLabsMode(payload.elevenlabs?.mode)) next.mode = payload.elevenlabs.mode;
             if (typeof payload.elevenlabs?.userName === 'string') next.userName = payload.elevenlabs.userName;
             if (typeof payload.elevenlabs?.volume === 'number' && Number.isFinite(payload.elevenlabs.volume)) {
               next.volume = Math.min(1, Math.max(0, payload.elevenlabs.volume));
@@ -1038,7 +1018,7 @@ export function App() {
             maybeUpdateHalFlow();
           }
           break;
-          case 'halTtsResponse': {
+        case 'halTtsResponse': {
           const currentRequestId = halTtsRequestIdRef.current;
           const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
           if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) break;
@@ -1069,64 +1049,52 @@ export function App() {
           const error = (payload as { error?: unknown } | undefined)?.error;
           const message = typeof error === 'string' && error.trim() ? error.trim() : 'ElevenLabs TTS failed';
           const convoId = conversationIdRef.current;
-            if (convoId) setHalDisabledConversationId(convoId);
-            halTeleportInProgressRef.current = false;
-            stopHalAudio();
-            clearHalTimer();
-            cleanupHalVoiceConfirm();
-            halActiveKeyRef.current = null;
-          halSuppressedKeyRef.current = null;
-          setHalSuppressedKey(null);
-          halPhaseRef.current = 'idle';
-          setHalPhase('idle');
-          setHalEye('off');
-          setHalStepIndex(null);
-          setHalDecision(null);
-          setHalLastError(null);
+          if (convoId) setHalDisabledConversationId(convoId);
+
+          halTeleportInProgressRef.current = false;
+          cleanupHalFlow();
+          halActiveKeyRef.current = null;
+          setHalSuppressedKeySynced(null);
+          resetHalUiState();
           setHalForceRejectInput(false);
           setHalTeleporting(false);
-            if (shouldNotify) showStatusMessage('error', `HAL audio disabled for this conversation: ${message}`);
-            break;
-          }
-          case 'halVoiceConfirmResponse': {
-            const currentRequestId = halVoiceConfirmRequestIdRef.current;
-            const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
-            if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) break;
-            halVoiceConfirmRequestIdRef.current = null;
 
-            const ok = (payload as { ok?: unknown } | undefined)?.ok;
-            if (ok === true) {
-              const decision = (payload as { decision?: unknown } | undefined)?.decision;
-              if (decision === 'teleport_remote') {
-                handleHalTeleport();
-                break;
-              }
-              if (decision === 'approve_local') {
-                halPhaseRef.current = 'awaiting_user';
-                setHalPhase('awaiting_user');
-                setHalEye('pulsating');
-                setHalDecision('approve_local');
-                handleApprove();
-                break;
-              }
-              if (decision === 'reject') {
-                halPhaseRef.current = 'awaiting_user';
-                setHalPhase('awaiting_user');
-                setHalEye('pulsating');
-                setHalDecision('reject');
-                handleReject(undefined);
-                break;
-              }
+          if (shouldNotify) showStatusMessage('error', `HAL audio disabled for this conversation: ${message}`);
+          break;
+        }
+        case 'halVoiceConfirmResponse': {
+          const currentRequestId = halVoiceConfirmRequestIdRef.current;
+          const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
+          if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) break;
+          halVoiceConfirmRequestIdRef.current = null;
 
+          const ok = (payload as { ok?: unknown } | undefined)?.ok;
+          if (ok === true) {
+            const decisionRaw = (payload as { decision?: unknown } | undefined)?.decision;
+            if (!isHalDecision(decisionRaw)) {
               disableVoiceConfirmForConversation('Gemini returned an invalid decision. Using buttons instead.');
               break;
             }
 
-            const error = (payload as { error?: unknown } | undefined)?.error;
-            const message = typeof error === 'string' && error.trim() ? error.trim() : 'Gemini classification failed';
-            disableVoiceConfirmForConversation(message);
+            if (decisionRaw === 'teleport_remote') {
+              handleHalTeleport();
+              break;
+            }
+
+            resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', decision: decisionRaw });
+            if (decisionRaw === 'approve_local') {
+              handleApprove();
+            } else {
+              handleReject(undefined);
+            }
             break;
           }
+
+          const error = (payload as { error?: unknown } | undefined)?.error;
+          const message = typeof error === 'string' && error.trim() ? error.trim() : 'Gemini classification failed';
+          disableVoiceConfirmForConversation(message);
+          break;
+        }
           case 'attachmentsSelected':
             if (Array.isArray(payload.attachments)) {
               setAttachments((prev) => {
@@ -1164,11 +1132,7 @@ export function App() {
           halTeleportInProgressRef.current = false;
           setHalTeleporting(false);
           setHalForceRejectInput(true);
-          setHalDecision(null);
-          setHalLastError(message);
-          halPhaseRef.current = 'awaiting_user';
-          setHalPhase('awaiting_user');
-          setHalEye('pulsating');
+          resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', lastError: message });
           showStatusMessage('error', message);
           break;
         }
@@ -1177,34 +1141,24 @@ export function App() {
           halTeleportInProgressRef.current = false;
           setHalTeleporting(false);
           setHalForceRejectInput(false);
-          setHalDecision(null);
-          setHalLastError(message);
-          halPhaseRef.current = 'error';
-          setHalPhase('error');
-          setHalEye('dim');
+          resetHalUiState({ phase: 'error', eye: 'dim', lastError: message });
           showStatusMessage('error', message);
           break;
         }
-          case 'conversationStarted':
-            if (typeof payload.conversationId === 'string') {
-              setHalDisabledConversationId(null);
-              setHalVoiceConfirmFallbackKey(null);
-              cleanupHalVoiceConfirm();
-              if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
-                halTeleportInProgressRef.current = false;
-                setHalTeleporting(false);
-                setHalForceRejectInput(false);
-                clearHalTimer();
+        case 'conversationStarted':
+          if (typeof payload.conversationId === 'string') {
+            setHalDisabledConversationId(null);
+            setHalVoiceConfirmFallbackKey(null);
+            cleanupHalVoiceConfirm();
+            if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
+              halTeleportInProgressRef.current = false;
+              setHalTeleporting(false);
+              setHalForceRejectInput(false);
+              clearHalTimer();
               stopHalAudio();
               halActiveKeyRef.current = null;
-              halSuppressedKeyRef.current = null;
-              setHalSuppressedKey(null);
-              halPhaseRef.current = 'idle';
-              setHalPhase('idle');
-              setHalEye('off');
-              setHalStepIndex(null);
-              setHalDecision(null);
-              setHalLastError(null);
+              setHalSuppressedKeySynced(null);
+              resetHalUiState();
             }
             conversationIdRef.current = payload.conversationId;
             setConversationId(payload.conversationId);
@@ -1248,7 +1202,7 @@ export function App() {
           const action = (payload as { action: string }).action;
           const rawPayload = (payload as { payload?: unknown }).payload;
 
-            switch (action) {
+          switch (action) {
             case 'openContext':
               setShowSkillsPopover(false);
               setShowContextPicker(true);
@@ -1293,72 +1247,29 @@ export function App() {
               setHalDecision('reject');
               postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
               break;
-              case 'halTeleport':
-                setHalDecision('teleport_remote');
-                clearHalTimer();
-                stopHalAudio();
-                cleanupHalVoiceConfirm();
-                halTeleportInProgressRef.current = true;
-                setHalTeleporting(true);
-                setHalForceRejectInput(false);
-                halPhaseRef.current = 'waiting_remote';
-              setHalPhase('waiting_remote');
-              setHalEye('pulsating');
-              setHalStepIndex(null);
-              setHalLastError(null);
-                showStatusMessage('info', 'Teleporting to remote runtime…');
-                postMessage({ type: 'command', command: 'teleportAction' });
-                break;
-              case 'halVoiceConfirmDecision': {
-                const decision = (rawPayload as { decision?: unknown } | undefined)?.decision;
-                if (decision !== 'approve_local' && decision !== 'teleport_remote' && decision !== 'reject') break;
-                cleanupHalVoiceConfirm();
-                setHalForceRejectInput(false);
-                setHalLastError(null);
-                setHalEye('pulsating');
-                if (decision === 'teleport_remote') {
-                  setHalDecision('teleport_remote');
-                  halTeleportInProgressRef.current = true;
-                  setHalTeleporting(true);
-                  halPhaseRef.current = 'waiting_remote';
-                  setHalPhase('waiting_remote');
-                  setHalStepIndex(null);
-                  showStatusMessage('info', 'Teleporting to remote runtime…');
-                  postMessage({ type: 'command', command: 'teleportAction' });
-                  break;
-                }
-                // approve_local / reject: mimic the non-voice button flow (no mic/network required).
-                halPhaseRef.current = 'awaiting_user';
-                setHalPhase('awaiting_user');
-                setHalStepIndex(null);
-                setHalDecision(decision);
-                if (decision === 'approve_local') {
-                  postMessage({ type: 'command', command: 'approveAction' });
-                } else {
-                  postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
-                }
+            case 'halTeleport':
+              handleHalTeleport();
+              break;
+            case 'halVoiceConfirmDecision': {
+              const decisionRaw = (rawPayload as { decision?: unknown } | undefined)?.decision;
+              if (!isHalDecision(decisionRaw)) break;
+              cleanupHalVoiceConfirm();
+              setHalForceRejectInput(false);
+              if (decisionRaw === 'teleport_remote') {
+                handleHalTeleport();
                 break;
               }
-              case 'halExit': {
-                clearHalTimer();
-                stopHalAudio();
-                cleanupHalVoiceConfirm();
-                halTeleportInProgressRef.current = false;
-                setHalTeleporting(false);
-                setHalForceRejectInput(false);
-              const key = halActiveKeyRef.current;
-              if (key) {
-                halSuppressedKeyRef.current = key;
-                setHalSuppressedKey(key);
+              resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', decision: decisionRaw });
+              if (decisionRaw === 'approve_local') {
+                postMessage({ type: 'command', command: 'approveAction' });
+              } else {
+                postMessage({ type: 'command', command: 'rejectAction', reason: 'E2E reject' });
               }
-              halPhaseRef.current = 'idle';
-              setHalPhase('idle');
-              setHalEye('off');
-              setHalStepIndex(null);
-              setHalDecision(null);
-              setHalLastError(null);
               break;
             }
+            case 'halExit':
+              handleHalExit();
+              break;
           }
           break;
         }
@@ -1403,6 +1314,7 @@ export function App() {
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
   }, [
+    cleanupHalFlow,
     cleanupHalVoiceConfirm,
     clearHalTimer,
     disableVoiceConfirmForConversation,
@@ -1410,11 +1322,14 @@ export function App() {
     handleApprove,
     handleEvent,
     handleHalAudioFinished,
+    handleHalExit,
     handleHalTeleport,
     handleReject,
     maybeUpdateHalFlow,
     playHalAudioBytes,
     postMessage,
+    resetHalUiState,
+    setHalSuppressedKeySynced,
     showStatusMessage,
     stopHalAudio,
   ]);


### PR DESCRIPTION
Consolidates duplicated HAL state-reset logic in `App.tsx`:

- Adds `resetHalUiState(...)` + `cleanupHalFlow()` helpers
- Uses shared runtime guards (`isElevenLabsMode`, `isHalDecision`)
- Removes duplicated HAL reset code paths (including E2E handlers)

Local checks: `npm test`, `npm run typecheck`, `npm run lint`.