### PR TITLE
[oh-tab-gg2] Harden agent-server E2E process cleanup

### DIFF
--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -69,38 +69,57 @@ async function waitForHealthOrExit(proc: ReturnType<typeof spawn>, url: string, 
   throw new Error(`Timed out waiting for agent-server health at ${url}: ${String(lastError)}`);
 }
 
-function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
-  return new Promise((resolve) => {
-    const pid = proc.pid;
-    if (!pid) return resolve();
-    if (proc.exitCode !== null || proc.signalCode !== null) return resolve();
+async function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
+  const pid = proc.pid;
+  if (!pid) return;
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
 
-    const killSignal = 'SIGTERM' as const;
+  const waitForExit = async (timeoutMs: number): Promise<void> => {
+    if (proc.exitCode !== null || proc.signalCode !== null) return;
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs);
+      proc.once('exit', () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  };
+
+  if (process.platform === 'win32') {
     try {
-      if (process.platform !== 'win32') {
-        process.kill(-pid, killSignal);
-      } else {
-        proc.kill(killSignal);
-      }
+      // Best effort: terminate the entire process tree.
+      spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
     } catch {
       // ignore
     }
+    await waitForExit(2000);
+    return;
+  }
 
-    const timeout = setTimeout(() => {
-      try {
-        if (process.platform !== 'win32') process.kill(-pid, 'SIGKILL');
-        else proc.kill('SIGKILL');
-      } catch {
-        // ignore
-      }
-      resolve();
-    }, 5000);
+  try {
+    process.kill(-pid, 'SIGTERM');
+  } catch {
+    try {
+      proc.kill('SIGTERM');
+    } catch {
+      // ignore
+    }
+  }
 
-    proc.once('exit', () => {
-      clearTimeout(timeout);
-      resolve();
-    });
-  });
+  await waitForExit(2000);
+  if (proc.exitCode !== null || proc.signalCode !== null) return;
+
+  try {
+    process.kill(-pid, 'SIGKILL');
+  } catch {
+    try {
+      proc.kill('SIGKILL');
+    } catch {
+      // ignore
+    }
+  }
+
+  await waitForExit(2000);
 }
 
 async function startAgentServerWithRetry(


### PR DESCRIPTION
Improves agent-server E2E cleanup in `tests/e2e/agentServerRemote.test.ts`:

- Uses `taskkill /T /F` on Windows to terminate the whole process tree
- Uses process-group `SIGTERM`/`SIGKILL` on Unix with fallbacks
- Avoids long fixed waits; waits for exit with short timeouts

Local checks: `npm test`, `npm run typecheck`, `npm run lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved process termination handling in end-to-end tests with more robust shutdown sequences and enhanced Windows compatibility, ensuring cleaner test execution and better resource cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->