### PR TITLE
[oh-tab-6l9] Deduplicate E2E pollUntil + host binding docs

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -1502,7 +1502,7 @@ For VS Code usage without an external server, run agent-server on localhost:
 ```typescript
 import { Conversation, isMessageEvent } from '@openhands/agent-sdk-ts';
 
-// Run agent-server locally: uv run agent-server --host 0.0.0.0 --port 3000
+// Run agent-server locally: uv run agent-server --host 127.0.0.1 --port 3000 (use 0.0.0.0 only if you need remote access)
 const conversation = Conversation({
   serverUrl: 'http://localhost:3000', // connects to local agent-server
   settings: {

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -30,7 +30,7 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
    - Or clone it:
      - `git clone https://github.com/OpenHands/software-agent-sdk.git ~/repos/agent-sdk`
      - `cd ~/repos/agent-sdk && make build`
-     - `uv run python -m openhands.agent_server --host 0.0.0.0 --port 3000`
+     - `uv run python -m openhands.agent_server --host 127.0.0.1 --port 3000` (use `0.0.0.0` only if you need remote access)
 3) Launch the extension in VS Code
    - Open this folder in VS Code
    - Press F5 to run “Extension Development Host”

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
 
 type DiagnosticsInfo = {
   chat?: { hasView?: boolean; webviewReady?: boolean };
@@ -27,19 +28,6 @@ type RenderedEventSnapshot = {
 const sleep = async (ms: number): Promise<void> => {
   await new Promise((r) => setTimeout(r, ms));
 };
-
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await sleep(intervalMs);
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
 
 function containsSubsequence(haystack: unknown[], needle: unknown[]): boolean {
   if (needle.length === 0) return true;

--- a/tests/e2e/suite/confirmation.ts
+++ b/tests/e2e/suite/confirmation.ts
@@ -1,18 +1,5 @@
 import * as vscode from 'vscode';
-
-// Helper to poll until condition is met
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
+import { pollUntil } from './pollUntil';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created

--- a/tests/e2e/suite/errorHandling.ts
+++ b/tests/e2e/suite/errorHandling.ts
@@ -1,18 +1,5 @@
 import * as vscode from 'vscode';
-
-// Helper to poll until condition is met
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
+import { pollUntil } from './pollUntil';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created

--- a/tests/e2e/suite/history.ts
+++ b/tests/e2e/suite/history.ts
@@ -1,18 +1,5 @@
 import * as vscode from 'vscode';
-
-// Helper to poll until condition is met
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
+import { pollUntil } from './pollUntil';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created

--- a/tests/e2e/suite/messaging.ts
+++ b/tests/e2e/suite/messaging.ts
@@ -1,18 +1,5 @@
 import * as vscode from 'vscode';
-
-// Helper to poll until condition is met
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
+import { pollUntil } from './pollUntil';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created

--- a/tests/e2e/suite/pollUntil.ts
+++ b/tests/e2e/suite/pollUntil.ts
@@ -1,0 +1,13 @@
+export async function pollUntil(
+  condition: () => Promise<boolean>,
+  timeoutMs: number = 10000,
+  intervalMs: number = 200
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await condition()) return;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
+}
+

--- a/tests/e2e/suite/serverSelection.ts
+++ b/tests/e2e/suite/serverSelection.ts
@@ -1,18 +1,5 @@
 import * as vscode from 'vscode';
-
-// Helper to poll until condition is met
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
+import { pollUntil } from './pollUntil';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -2,19 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-
-async function pollUntil(
-  condition: () => Promise<boolean>,
-  timeoutMs: number = 10000,
-  intervalMs: number = 200
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (await condition()) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-  throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-}
+import { pollUntil } from './pollUntil';
 
 export async function run(): Promise<void> {
   // Skills: create a temp skill file *before* opening the webview so the initial


### PR DESCRIPTION
- Adds shared `tests/e2e/suite/pollUntil.ts` and removes duplicate `pollUntil` implementations across suite tests.
- Updates docs to recommend `--host 127.0.0.1` for local agent-server (use `0.0.0.0` only when remote access is needed).

Local checks: `npm test`, `npm run lint`.