### PR TITLE
[oh-tab-94f] LocalWorkspace TOCTOU hardening

### DIFF
--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -267,7 +267,7 @@ export class LocalWorkspace {
     absPath: string,
     expectedCanonicalDir: string,
     containingRoot: string | undefined,
-    options: { requireDirectory: boolean; throwIfMissing: boolean },
+    options: { requireDirectory: boolean; throwIfMissing: boolean; notDirectorySubject?: string },
   ): Promise<string> {
     let parentStat: fs.Stats;
     try {
@@ -283,7 +283,7 @@ export class LocalWorkspace {
       throw new Error(`${operation} failed: refusing to ${verb} through symlink ${subject}: ${directoryPath}`);
     }
     if (options.requireDirectory && !parentStat.isDirectory()) {
-      const notDirectorySubject = subject.endsWith(' directory') ? subject.slice(0, -' directory'.length) : subject;
+      const notDirectorySubject = options.notDirectorySubject ?? subject;
       throw new Error(`${operation} failed: ${notDirectorySubject} is not a directory: ${directoryPath}`);
     }
 
@@ -426,7 +426,7 @@ export class LocalWorkspace {
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
     const parentDir = path.dirname(resolved);
-    const root = this.getContainingDirRoot(parentDir);
+    const root = this.getContainingDirRoot(parentDir) ?? undefined;
 
     let canonicalParentDir: string;
     try {
@@ -445,8 +445,8 @@ export class LocalWorkspace {
       parentDir,
       resolved,
       canonicalParentDir,
-      root ?? undefined,
-      { requireDirectory: true, throwIfMissing: true },
+      root,
+      { requireDirectory: true, throwIfMissing: true, notDirectorySubject: 'parent' },
     );
 
     const constants = fs.constants as Record<string, number>;
@@ -506,7 +506,7 @@ export class LocalWorkspace {
   async remove(targetPath: string): Promise<void> {
     const resolved = this.resolvePath(targetPath);
     const parentDir = path.dirname(resolved);
-    const root = this.getContainingDirRoot(parentDir);
+    const root = this.getContainingDirRoot(parentDir) ?? undefined;
     if (!root) {
       const kind = this.allowedRoots.get(resolved);
       if (kind !== 'file') {
@@ -531,8 +531,8 @@ export class LocalWorkspace {
       parentDir,
       resolved,
       canonicalParentDir,
-      root ?? undefined,
-      { requireDirectory: true, throwIfMissing: false },
+      root,
+      { requireDirectory: true, throwIfMissing: false, notDirectorySubject: 'parent' },
     );
 
     const safeTargetPath = path.join(stableParentDir, path.basename(resolved));
@@ -555,7 +555,7 @@ export class LocalWorkspace {
       resolved,
       canonicalDir,
       root,
-      { requireDirectory: true, throwIfMissing: true },
+      { requireDirectory: true, throwIfMissing: true, notDirectorySubject: 'path' },
     );
 
     const entries = await readdir(stableDir, { withFileTypes: true });

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -259,8 +259,11 @@ export class LocalWorkspace {
     }
   }
 
-  private async revalidateWriteFileParentDir(
-    requestedDir: string,
+  private async revalidateDirectory(
+    operation: string,
+    verb: string,
+    subject: string,
+    directoryPath: string,
     absPath: string,
     expectedCanonicalDir: string,
     containingRoot: string | undefined,
@@ -268,22 +271,23 @@ export class LocalWorkspace {
   ): Promise<string> {
     let parentStat: fs.Stats;
     try {
-      parentStat = await fs.promises.lstat(requestedDir);
+      parentStat = await fs.promises.lstat(directoryPath);
     } catch (error) {
       if (options.throwIfMissing) {
-        throw new Error(`writeFile failed: parent directory does not exist: ${requestedDir}`);
+        throw new Error(`${operation} failed: ${subject} does not exist: ${directoryPath}`);
       }
       throw error;
     }
 
     if (parentStat.isSymbolicLink()) {
-      throw new Error(`writeFile failed: refusing to write through symlink parent directory: ${requestedDir}`);
+      throw new Error(`${operation} failed: refusing to ${verb} through symlink ${subject}: ${directoryPath}`);
     }
     if (options.requireDirectory && !parentStat.isDirectory()) {
-      throw new Error(`writeFile failed: parent is not a directory: ${requestedDir}`);
+      const notDirectorySubject = subject.endsWith(' directory') ? subject.slice(0, -' directory'.length) : subject;
+      throw new Error(`${operation} failed: ${notDirectorySubject} is not a directory: ${directoryPath}`);
     }
 
-    const canonicalDir = await fs.promises.realpath(requestedDir);
+    const canonicalDir = await fs.promises.realpath(directoryPath);
     if (containingRoot) {
       const rel = path.relative(containingRoot, canonicalDir);
       if (rel.startsWith(`..${path.sep}`) || rel === '..' || path.isAbsolute(rel)) {
@@ -291,7 +295,7 @@ export class LocalWorkspace {
       }
     }
     if (canonicalDir !== expectedCanonicalDir) {
-      throw new Error(`writeFile failed: parent directory changed during write: ${requestedDir}`);
+      throw new Error(`${operation} failed: ${subject} changed during ${verb}: ${directoryPath}`);
     }
 
     return canonicalDir;
@@ -352,7 +356,10 @@ export class LocalWorkspace {
     if (noFollow) {
       // `O_NOFOLLOW` only protects the final path component; re-validate the parent directory
       // immediately before opening so a late parent symlink swap can't redirect the write.
-      const canonicalDirBeforeOpen = await this.revalidateWriteFileParentDir(
+      const canonicalDirBeforeOpen = await this.revalidateDirectory(
+        'writeFile',
+        'write',
+        'parent directory',
         requestedDir,
         absPath,
         canonicalDir,
@@ -386,7 +393,7 @@ export class LocalWorkspace {
         handle = undefined;
 
         // Re-check parent just before renaming to avoid late symlink swaps.
-        await this.revalidateWriteFileParentDir(requestedDir, absPath, canonicalDir, containingRoot, {
+        await this.revalidateDirectory('writeFile', 'write', 'parent directory', requestedDir, absPath, canonicalDir, containingRoot, {
           requireDirectory: false,
           throwIfMissing: false,
         });
@@ -418,7 +425,54 @@ export class LocalWorkspace {
 
   async readFile(targetPath: string, encoding: WorkspaceEncoding = 'utf8'): Promise<string> {
     const resolved = this.resolvePath(targetPath);
-    return readFileAsync(resolved, encoding);
+    const parentDir = path.dirname(resolved);
+    const root = this.getContainingDirRoot(parentDir);
+
+    let canonicalParentDir: string;
+    try {
+      canonicalParentDir = await fs.promises.realpath(parentDir);
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+        throw new Error(`readFile failed: parent directory does not exist: ${parentDir}`);
+      }
+      throw error;
+    }
+
+    const stableParentDir = await this.revalidateDirectory(
+      'readFile',
+      'read',
+      'parent directory',
+      parentDir,
+      resolved,
+      canonicalParentDir,
+      root ?? undefined,
+      { requireDirectory: true, throwIfMissing: true },
+    );
+
+    const constants = fs.constants as Record<string, number>;
+    const noFollow =
+      os.platform() === 'win32'
+        ? 0
+        : typeof constants.O_NOFOLLOW === 'number'
+          ? constants.O_NOFOLLOW
+          : 0;
+
+    const safeTargetPath = path.join(stableParentDir, path.basename(resolved));
+    if (noFollow) {
+      const handle = await fs.promises.open(safeTargetPath, constants.O_RDONLY | noFollow);
+      try {
+        const buf = await handle.readFile();
+        return buf.toString(encoding);
+      } finally {
+        await handle.close();
+      }
+    }
+
+    const stat = await fs.promises.lstat(safeTargetPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`readFile failed: refusing to read symlink path: ${safeTargetPath}`);
+    }
+    return readFileAsync(safeTargetPath, encoding);
   }
 
   async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
@@ -451,12 +505,60 @@ export class LocalWorkspace {
 
   async remove(targetPath: string): Promise<void> {
     const resolved = this.resolvePath(targetPath);
-    await rm(resolved, { force: true, recursive: true });
+    const parentDir = path.dirname(resolved);
+    const root = this.getContainingDirRoot(parentDir);
+    if (!root) {
+      const kind = this.allowedRoots.get(resolved);
+      if (kind !== 'file') {
+        throw new Error(`remove failed: path is not contained in an allowlisted workspace root: ${targetPath}`);
+      }
+    }
+
+    let canonicalParentDir: string;
+    try {
+      canonicalParentDir = await fs.promises.realpath(parentDir);
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    }
+
+    const stableParentDir = await this.revalidateDirectory(
+      'remove',
+      'remove',
+      'parent directory',
+      parentDir,
+      resolved,
+      canonicalParentDir,
+      root ?? undefined,
+      { requireDirectory: true, throwIfMissing: false },
+    );
+
+    const safeTargetPath = path.join(stableParentDir, path.basename(resolved));
+    await rm(safeTargetPath, { force: true, recursive: true });
   }
 
   async list(targetPath = '.'): Promise<DirectoryEntry[]> {
     const resolved = this.resolvePath(targetPath);
-    const entries = await readdir(resolved, { withFileTypes: true });
+    const root = this.getContainingDirRoot(resolved);
+    if (!root) {
+      throw new Error(`list failed: path is not contained in an allowlisted workspace root: ${targetPath}`);
+    }
+
+    const canonicalDir = await fs.promises.realpath(resolved);
+    const stableDir = await this.revalidateDirectory(
+      'list',
+      'list',
+      'directory',
+      resolved,
+      resolved,
+      canonicalDir,
+      root,
+      { requireDirectory: true, throwIfMissing: true },
+    );
+
+    const entries = await readdir(stableDir, { withFileTypes: true });
     return entries.map((entry) => ({
       name: entry.name,
       path: path.join(targetPath, entry.name),

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -277,6 +277,120 @@ describe('LocalWorkspace', () => {
         lstatSpy.mockRestore();
       }
     });
+
+    it('rejects reads when the parent becomes a symlink mid-read', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      await workspace.ensureDirectory('parent');
+      await workspace.writeFile('parent/inside.txt', 'hello');
+
+      const canonicalParentDir = workspace.resolvePath('parent');
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-read-'));
+      created.push(redirectDir);
+      await fs.promises.writeFile(path.join(redirectDir, 'inside.txt'), 'secret', 'utf8');
+
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
+
+      const originalRealpath = fs.promises.realpath;
+      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+        if (!swapped && targetString === canonicalParentDir) {
+          await swapParent();
+        }
+        return result;
+      });
+
+      try {
+        await expect(workspace.readFile('parent/inside.txt')).rejects.toThrowError(/symlink|escapes|parent/i);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
+
+    it('rejects listing when the directory becomes a symlink mid-list', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      await workspace.ensureDirectory('dir');
+      await workspace.writeFile('dir/file.txt', 'hello');
+
+      const canonicalDir = workspace.resolvePath('dir');
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-list-'));
+      created.push(redirectDir);
+
+      let swapped = false;
+      const swapDir = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalDir}-bak`;
+        await fs.promises.rename(canonicalDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalDir, 'dir');
+      };
+
+      const originalRealpath = fs.promises.realpath;
+      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+        if (!swapped && targetString === canonicalDir) {
+          await swapDir();
+        }
+        return result;
+      });
+
+      try {
+        await expect(workspace.list('dir')).rejects.toThrowError(/symlink|escapes|directory/i);
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
+
+    it('rejects remove when the parent becomes a symlink mid-remove', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      await workspace.ensureDirectory('parent');
+      await workspace.writeFile('parent/inside.txt', 'hello');
+
+      const canonicalParentDir = workspace.resolvePath('parent');
+      const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-redirect-remove-'));
+      created.push(redirectDir);
+      await fs.promises.writeFile(path.join(redirectDir, 'inside.txt'), 'secret', 'utf8');
+
+      let swapped = false;
+      const swapParent = async () => {
+        if (swapped) return;
+        swapped = true;
+        const backupDir = `${canonicalParentDir}-bak`;
+        await fs.promises.rename(canonicalParentDir, backupDir);
+        await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+      };
+
+      const originalRealpath = fs.promises.realpath;
+      const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+        const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+        const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+        if (!swapped && targetString === canonicalParentDir) {
+          await swapParent();
+        }
+        return result;
+      });
+
+      try {
+        await expect(workspace.remove('parent/inside.txt')).rejects.toThrowError(/symlink|escapes|parent/i);
+        await expect(fs.promises.readFile(path.join(redirectDir, 'inside.txt'), 'utf8')).resolves.toBe('secret');
+      } finally {
+        realpathSpy.mockRestore();
+      }
+    });
   });
 
   describe('commands', () => {


### PR DESCRIPTION
Implements defense-in-depth checks for LocalWorkspace file ops to reduce symlink-swap TOCTOU windows, plus unit tests.

- Revalidates parent directories (lstat+realpath) for read/remove/list and write paths.
- Hardens ensureDirectory creation loop against parent swaps.
- Adds Vitest cases simulating mid-operation symlink swaps (non-Windows).

Validation:
- npm test
- npm run typecheck
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced directory validation logic with improved error messages that now include operation context and actual file paths for clearer debugging.
  * Strengthened symlink safety checks to prevent unintended directory operations outside workspace boundaries.
  * Added safeguards for missing directory detection with clearer error reporting.

* **Tests**
  * Expanded test coverage for symlink escape scenarios and mid-operation directory changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->