### PR TITLE
[oh-tab-p4m] Workspace-safe reads for FileEditorTool

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,6 +1,5 @@
 import fs from 'fs/promises';
 import path from 'path';
-import type { Dirent } from 'node:fs';
 import { z } from 'zod';
 import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
@@ -195,10 +194,10 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       case 'view': {
         const stat = await fs.stat(resolved);
         if (stat.isDirectory()) {
-          const { text } = await this.viewDirectory(resolved, ws.root);
+          const { text } = await this.viewDirectory(resolved, ws);
           return { command: 'view', path: resolved, prev_exist: true, old_content: null, new_content: text };
         }
-        const buffer = await this.readValidatedFile(resolved, extension);
+        const buffer = await this.readValidatedFile(resolved, extension, ws);
         if (IMAGE_EXTENSIONS.has(extension)) {
           return this.viewImage(resolved, extension, buffer);
         }
@@ -233,7 +232,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         if (IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION) {
           throw new Error(`str_replace failed: refusing to edit binary file type: ${extension}`);
         }
-        const buffer = await this.readValidatedFile(resolved, extension);
+        const buffer = await this.readValidatedFile(resolved, extension, ws);
         const prev = buffer.toString('utf8');
         const oldStr = args.old_str ?? '';
         if (oldStr.length === 0) {
@@ -260,7 +259,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         if (IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION) {
           throw new Error(`insert failed: refusing to edit binary file type: ${extension}`);
         }
-        const buffer = await this.readValidatedFile(resolved, extension);
+        const buffer = await this.readValidatedFile(resolved, extension, ws);
         const prev = buffer.toString('utf8');
         const lines = prev.split(/\r?\n/);
         const insertion = args.new_str ?? '';
@@ -276,7 +275,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {
-        const current = await this.readOptionalFile(resolved);
+        const current = await this.readOptionalFile(resolved, ws);
 
         const stack = this.undoHistory.get(resolved);
         if (!stack || stack.length === 0) {
@@ -309,17 +308,8 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     }
   }
 
-  private async readValidatedFile(absPath: string, extension: string): Promise<Buffer> {
-    const stat = await fs.stat(absPath);
-    if (!stat.isFile()) {
-      throw new Error(`Path is not a file: ${absPath}`);
-    }
-    if (stat.size > MAX_FILE_SIZE_BYTES) {
-      const mb = stat.size / 1024 / 1024;
-      throw new Error(`File is too large (${mb.toFixed(1)}MB). Maximum allowed size is 10MB.`);
-    }
-
-    const buffer = await fs.readFile(absPath);
+  private async readValidatedFile(absPath: string, extension: string, workspace: ToolContext['workspace']): Promise<Buffer> {
+    const buffer = await workspace.readFileBytes(absPath, { maxBytes: MAX_FILE_SIZE_BYTES });
     const binaryAllowed = IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION;
     if (!binaryAllowed && isProbablyBinary(buffer)) {
       throw new Error('File appears to be binary and this file type cannot be read or edited by this tool.');
@@ -327,7 +317,8 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     return buffer;
   }
 
-  private async viewDirectory(absPath: string, workspaceRoot: string): Promise<{ text: string }> {
+  private async viewDirectory(absPath: string, workspace: ToolContext['workspace']): Promise<{ text: string }> {
+    const workspaceRoot = workspace.root;
     const toDisplayPath = (absolutePath: string): string => {
       const relative = path.relative(workspaceRoot, absolutePath);
       if (!relative || relative === '') return '.';
@@ -335,12 +326,12 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       return relative;
     };
 
-    const topEntries = await fs.readdir(absPath, { withFileTypes: true });
+    const topEntries = await workspace.list(absPath);
     const hiddenCount = topEntries.filter((entry) => entry.name.startsWith('.')).length;
 
     const visibleTop = topEntries
       .filter((entry) => !entry.name.startsWith('.'))
-      .map((entry) => ({ name: entry.name, abs: path.join(absPath, entry.name), isDir: entry.isDirectory() }))
+      .map((entry) => ({ name: entry.name, abs: entry.path, isDir: entry.isDirectory }))
       .sort((a, b) => a.name.localeCompare(b.name));
 
     const displayRoot = toDisplayPath(absPath);
@@ -351,16 +342,16 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       lines.push(`${entry.isDir ? 'd' : 'f'} ${displayEntry}`);
       if (!entry.isDir) continue;
 
-      let childEntries: Dirent[];
+      let childEntries: Awaited<ReturnType<ToolContext['workspace']['list']>>;
       try {
-        childEntries = await fs.readdir(entry.abs, { withFileTypes: true });
+        childEntries = await workspace.list(entry.abs);
       } catch {
         lines.push(`skipped unreadable: ${displayEntry}`);
         continue;
       }
       const visibleChildren = childEntries
         .filter((child) => !child.name.startsWith('.'))
-        .map((child) => ({ name: child.name, abs: path.join(entry.abs, child.name), isDir: child.isDirectory() }))
+        .map((child) => ({ name: child.name, abs: child.path, isDir: child.isDirectory }))
         .sort((a, b) => a.name.localeCompare(b.name));
       for (const child of visibleChildren) {
         const displayChild = toDisplayPath(child.abs);
@@ -474,9 +465,9 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     return true;
   }
 
-  private async readOptionalFile(absPath: string): Promise<string | null> {
+  private async readOptionalFile(absPath: string, workspace: ToolContext['workspace']): Promise<string | null> {
     try {
-      return await fs.readFile(absPath, 'utf8');
+      return await workspace.readFile(absPath, 'utf8');
     } catch {
       return null;
     }

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it, afterEach } from 'vitest';
+import { describe, expect, it, afterEach, vi } from 'vitest';
 import { BrowserTool, FileEditorTool, OUTPUT_CLIP_MARKER, TaskTrackerTool, TerminalTool } from '..';
 import { LocalWorkspace } from '../../workspace';
 
@@ -176,6 +176,47 @@ describe('FileEditorTool', () => {
       expect(listing).toContain('skipped unreadable: unreadable');
     } finally {
       await fs.promises.chmod(path.join(dir, 'unreadable'), 0o755);
+    }
+  });
+
+  it('rejects view when the parent becomes a symlink mid-read', async () => {
+    if (process.platform === 'win32') return;
+
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new FileEditorTool();
+
+    await tool.execute(tool.validate({ command: 'create', path: 'parent/inside.txt', file_text: 'hello' }), { workspace });
+
+    const canonicalParentDir = workspace.resolvePath('parent');
+    const redirectDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-tools-redirect-view-'));
+    created.push(redirectDir);
+    await fs.promises.writeFile(path.join(redirectDir, 'inside.txt'), 'secret', 'utf8');
+
+    let swapped = false;
+    const swapParent = async () => {
+      if (swapped) return;
+      swapped = true;
+      const backupDir = `${canonicalParentDir}-bak`;
+      await fs.promises.rename(canonicalParentDir, backupDir);
+      await fs.promises.symlink(redirectDir, canonicalParentDir, 'dir');
+    };
+
+    const originalRealpath = fs.promises.realpath;
+    const realpathSpy = vi.spyOn(fs.promises, 'realpath').mockImplementation(async (targetPath, ...args) => {
+      const targetString = targetPath instanceof Buffer ? targetPath.toString() : String(targetPath);
+      const result = await originalRealpath.call(fs.promises, targetPath as never, ...(args as never[]));
+      if (!swapped && targetString === canonicalParentDir) {
+        await swapParent();
+      }
+      return result;
+    });
+
+    try {
+      await expect(tool.execute(tool.validate({ command: 'view', path: 'parent/inside.txt' }), { workspace }))
+        .rejects.toThrowError(/symlink|escapes|parent/i);
+    } finally {
+      realpathSpy.mockRestore();
     }
   });
 

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -475,6 +475,79 @@ export class LocalWorkspace {
     return readFileAsync(safeTargetPath, encoding);
   }
 
+  async readFileBytes(targetPath: string, options: { maxBytes?: number } = {}): Promise<Buffer> {
+    const resolved = this.resolvePath(targetPath);
+    const parentDir = path.dirname(resolved);
+    const root = this.getContainingDirRoot(parentDir) ?? undefined;
+
+    let canonicalParentDir: string;
+    try {
+      canonicalParentDir = await fs.promises.realpath(parentDir);
+    } catch (error) {
+      if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'ENOENT') {
+        throw new Error(`readFileBytes failed: parent directory does not exist: ${parentDir}`);
+      }
+      throw error;
+    }
+
+    const stableParentDir = await this.revalidateDirectory(
+      'readFileBytes',
+      'read',
+      'parent directory',
+      parentDir,
+      resolved,
+      canonicalParentDir,
+      root,
+      { requireDirectory: true, throwIfMissing: true, notDirectorySubject: 'parent' },
+    );
+
+    const constants = fs.constants as Record<string, number>;
+    const noFollow =
+      os.platform() === 'win32'
+        ? 0
+        : typeof constants.O_NOFOLLOW === 'number'
+          ? constants.O_NOFOLLOW
+          : 0;
+
+    const safeTargetPath = path.join(stableParentDir, path.basename(resolved));
+    const maxBytes = options.maxBytes;
+
+    const formatTooLargeError = (sizeBytes: number): Error => {
+      const mb = sizeBytes / 1024 / 1024;
+      const maxMb = typeof maxBytes === 'number' ? maxBytes / 1024 / 1024 : 0;
+      const maxLabel = Number.isInteger(maxMb) ? String(maxMb) : maxMb.toFixed(1);
+      return new Error(`File is too large (${mb.toFixed(1)}MB). Maximum allowed size is ${maxLabel}MB.`);
+    };
+
+    if (noFollow) {
+      const handle = await fs.promises.open(safeTargetPath, constants.O_RDONLY | noFollow);
+      try {
+        const stat = await handle.stat();
+        if (!stat.isFile()) {
+          throw new Error(`readFileBytes failed: path is not a file: ${safeTargetPath}`);
+        }
+        if (typeof maxBytes === 'number' && stat.size > maxBytes) {
+          throw formatTooLargeError(stat.size);
+        }
+        return await handle.readFile();
+      } finally {
+        await handle.close();
+      }
+    }
+
+    const stat = await fs.promises.lstat(safeTargetPath);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`readFileBytes failed: refusing to read symlink path: ${safeTargetPath}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`readFileBytes failed: path is not a file: ${safeTargetPath}`);
+    }
+    if (typeof maxBytes === 'number' && stat.size > maxBytes) {
+      throw formatTooLargeError(stat.size);
+    }
+    return readFileAsync(safeTargetPath);
+  }
+
   async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
     const resolved = this.resolvePath(targetPath);
     const parentDir = path.dirname(resolved);

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -26,6 +26,21 @@ describe('LocalWorkspace', () => {
       expect(content).toBe('hello');
     });
 
+    it('reads file bytes inside the sandbox', async () => {
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      const payload = Buffer.from([0, 1, 2, 3, 255]);
+      await workspace.writeFile('bytes.bin', payload);
+      const read = await workspace.readFileBytes('bytes.bin');
+      expect(read).toEqual(payload);
+    });
+
+    it('enforces maxBytes in readFileBytes', async () => {
+      const { workspace } = await makeWorkspace((dir) => created.push(dir));
+      const payload = Buffer.alloc(2 * 1024 * 1024, 1);
+      await workspace.writeFile('big.bin', payload);
+      await expect(workspace.readFileBytes('big.bin', { maxBytes: 1024 * 1024 })).rejects.toThrowError(/too large/i);
+    });
+
     it('blocks path traversal attacks', async () => {
       const { workspace } = await makeWorkspace((dir) => created.push(dir));
       const vectors = [


### PR DESCRIPTION
Closes a remaining workspace parity gap by routing FileEditorTool reads/listing through LocalWorkspace (so TOCTOU/symlink protections apply), and adds a binary-safe read helper.

Changes:
- Add `LocalWorkspace.readFileBytes()` with optional `maxBytes` guard.
- Update `FileEditorTool` view/read paths to use `workspace.readFileBytes()` and `workspace.list()`.
- Add regression tests for `readFileBytes()` and for rejecting a symlink-swap mid-view.

Checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new file reading capabilities with configurable byte-size limits, enabling more granular and controlled access to file content with improved resource management.

* **Tests**
  * Significantly expanded test coverage for symlink protection scenarios and parent directory integrity validation, ensuring robust handling of edge cases and concurrent file access operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->