### PR TITLE
[oh-tab-30k] RemoteConversation pass-through tools/workspace

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { OpenHandsSettings } from '../types/settings';
+import type { RemoteConversationTool, RemoteConversationWorkspace } from './RemoteConversation';
+import { RemoteConversation } from './RemoteConversation';
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: {},
+  confirmation: {},
+  secrets: {},
+};
+
+describe('RemoteConversation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('passes provided tools and workspace through to POST /api/conversations', async () => {
+    const connectSpy = vi
+      .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')
+      .mockImplementation(() => {});
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      void _url;
+      void init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'conv-1' }),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const tools: RemoteConversationTool[] = [
+      { name: 'glob', params: { pattern: '**/*.ts' } },
+      { name: 'terminal' },
+    ];
+    const workspace: RemoteConversationWorkspace = { kind: 'RemoteWorkspace', base_url: 'http://example.com' };
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      tools,
+      workspace,
+    });
+
+    await conversation.startNewConversation();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe('http://localhost:3000/api/conversations');
+    expect(init?.method).toBe('POST');
+    expect(typeof init?.body).toBe('string');
+    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
+    expect(parsed.agent.tools).toEqual(tools);
+    expect(parsed.workspace).toEqual(workspace);
+  });
+
+  it('uses defaults when tools/workspace are not provided', async () => {
+    vi.spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect').mockImplementation(() => {});
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      void _url;
+      void init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'conv-2' }),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const workspaceRoot = '/tmp/example-workspace';
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000/',
+      settings: baseSettings,
+      workspaceRoot,
+    });
+
+    await conversation.startNewConversation();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    expect(url).toBe('http://localhost:3000/api/conversations');
+    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
+    expect(parsed.agent.tools).toEqual([
+      { name: 'terminal' },
+      { name: 'file_editor' },
+      { name: 'task_tracker' },
+    ]);
+    expect(parsed.workspace).toEqual({ kind: 'LocalWorkspace', working_dir: workspaceRoot });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -13,6 +13,16 @@ interface ConversationHistoryPage {
 
 type StaticSecret = { kind: 'StaticSecret'; value: string };
 
+export type RemoteConversationTool = {
+  name: string;
+  params?: Record<string, unknown>;
+};
+
+export type RemoteConversationWorkspace = {
+  kind: string;
+  [key: string]: unknown;
+};
+
 const toStaticSecret = (value: unknown): StaticSecret | undefined => {
   if (typeof value !== 'string') return undefined;
   const trimmed = value.trim();
@@ -35,6 +45,8 @@ export interface RemoteConversationOptions {
   serverUrl: string;
   settings: OpenHandsSettings;
   workspaceRoot?: string;
+  tools?: RemoteConversationTool[];
+  workspace?: RemoteConversationWorkspace;
   conversationId?: string;
 }
 
@@ -61,6 +73,8 @@ export class RemoteConversation extends EventEmitter {
   private readonly retryMaxMs = 15000;
   private readonly maxReconnectRetries = 6;
   private readonly workspaceRoot: string;
+  private readonly tools?: RemoteConversationTool[];
+  private readonly workspace?: RemoteConversationWorkspace;
   private static readonly historyPageLimit = 100;
   private static readonly wsHandshakeTimeoutMs = 10_000;
   private static readonly httpTimeoutMs = 15_000;
@@ -71,6 +85,8 @@ export class RemoteConversation extends EventEmitter {
     this.serverUrl = normalizeRemoteServerUrl(options.serverUrl);
     this.settings = options.settings;
     this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
+    this.tools = options.tools;
+    this.workspace = options.workspace;
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
@@ -177,17 +193,20 @@ export class RemoteConversation extends EventEmitter {
         return Math.min(500, Math.max(1, n));
       })();
       const headers = this.getAuthHeaders();
-        const req = {
+      const defaultTools: RemoteConversationTool[] = [
+        { name: 'terminal' },
+        { name: 'file_editor' },
+        { name: 'task_tracker' },
+      ];
+      const workspace = this.workspace ?? { kind: 'LocalWorkspace', working_dir: this.workspaceRoot };
+      const tools = this.tools ?? defaultTools;
+      const req = {
           agent: {
             llm,
-            tools: [
-            { name: 'terminal' },
-            { name: 'file_editor' },
-            { name: 'task_tracker' }
-          ],
+            tools,
           security_analyzer: s?.agent.enableSecurityAnalyzer ? { kind: 'LLMSecurityAnalyzer' } : undefined,
         },
-        workspace: { kind: 'LocalWorkspace', working_dir: this.workspaceRoot },
+        workspace,
         secrets: typedSecrets,
         confirmation_policy,
         max_iterations: clampedMaxIterations,


### PR DESCRIPTION
Implements Beads oh-tab-30k.

- RemoteConversationOptions now accepts optional tools/workspace and passes them through to POST /api/conversations.
- Defaults remain unchanged when options are omitted.
- Adds unit tests for payload construction.

Tests:
- npm test -w @openhands/agent-sdk-ts
- npm run lint -w @openhands/agent-sdk-ts
- npm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable configuration of custom tools and workspace when starting conversations.
  * Automatically apply default tools (terminal, file editor, task tracker) and workspace when custom settings are not provided.

* **Tests**
  * Added comprehensive test coverage for conversation initialization with both custom and default configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->