### PR TITLE
[oh-tab-8cp] TerminalTool secret injection + masked BashEvents

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -228,6 +228,16 @@ export class Agent extends EventEmitter {
     this.confirmation.riskyThreshold = settings?.confirmation?.riskyThreshold ?? 'MEDIUM';
     this.confirmation.confirmUnknown = settings?.confirmation?.confirmUnknown ?? true;
     this.debug = settings?.agent?.debug ?? false;
+    this.syncToolSecrets(settings);
+  }
+
+  private syncToolSecrets(settings: OpenHandsSettings): void {
+    const s = settings?.secrets;
+    this.secrets.set('GITHUB_TOKEN', s?.githubToken);
+    this.secrets.set('CUSTOM_SECRET_1', s?.customSecret1);
+    this.secrets.set('CUSTOM_SECRET_2', s?.customSecret2);
+    this.secrets.set('CUSTOM_SECRET_3', s?.customSecret3);
+    this.secrets.set('ELEVENLABS_API_KEY', s?.elevenLabsApiKey);
   }
 
   private getSecretValuesForMasking(): string[] {
@@ -1022,6 +1032,9 @@ export class Agent extends EventEmitter {
     const payload = result as { command?: string; stdout?: string; stderr?: string; exitCode?: number };
     const commandId = toolCall.id;
     const timestamp = new Date().toISOString();
+    const command = this.maskSecretsInText(payload.command ?? toolCall.function.arguments);
+    const stdout = payload.stdout ? this.maskSecretsInText(payload.stdout) : null;
+    const stderr = payload.stderr ? this.maskSecretsInText(payload.stderr) : null;
     const events: BashEvent[] = [
       {
         id: randomUUID(),
@@ -1029,7 +1042,7 @@ export class Agent extends EventEmitter {
         timestamp,
         command_id: commandId,
         order: 0,
-        command: payload.command ?? toolCall.function.arguments,
+        command,
       },
       {
         id: randomUUID(),
@@ -1038,8 +1051,8 @@ export class Agent extends EventEmitter {
         command_id: commandId,
         order: 1,
         exit_code: payload.exitCode ?? 0,
-        stdout: payload.stdout ?? null,
-        stderr: payload.stderr ?? null,
+        stdout,
+        stderr,
       },
     ];
     events.forEach((evt) => this.options.onTerminalEvent?.(evt));

--- a/packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts
@@ -23,6 +23,15 @@ export class SecretRegistry {
     this.secrets.set(name, value);
   }
 
+  set(name: string, value: string | undefined): void {
+    const trimmed = typeof value === 'string' ? value.trim() : '';
+    if (!trimmed) {
+      this.secrets.delete(name);
+      return;
+    }
+    this.secrets.set(name, trimmed);
+  }
+
   async get(name: string): Promise<string | undefined> {
     if (this.secrets.has(name)) {
       return this.secrets.get(name);
@@ -48,5 +57,9 @@ export class SecretRegistry {
 
   getRegisteredValues(): string[] {
     return Array.from(this.secrets.values());
+  }
+
+  getRegisteredNames(): string[] {
+    return Array.from(this.secrets.keys());
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
-import { isMessageEvent, type TextContent } from '../../types';
+import { isBashCommand, isBashOutput, isMessageEvent, type BashEvent, type TextContent } from '../../types';
 import type { ToolDefinition } from '../../types/tools';
 import type { OpenHandsSettings } from '../../types/settings';
 import { SecretRegistry } from '../SecretRegistry';
@@ -91,6 +91,60 @@ describe('Agent tool message formatting', () => {
     const observation = observations[0] as unknown as { observation?: Record<string, unknown> };
     expect(JSON.stringify(observation.observation)).not.toContain(secretValue);
     expect(JSON.stringify(observation.observation)).toContain('***');
+  });
+
+  it('masks secrets in BashEvents emitted from the terminal tool', async () => {
+    const secretValue = 'ghp_BASHEVENTSECRET1234567890';
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: { githubToken: secretValue },
+    };
+    const log = new EventLog();
+    const terminalEvents: BashEvent[] = [];
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: `echo ${secretValue}`,
+        exitCode: 0,
+        stdout: `hello ${secretValue}`,
+        stderr: '',
+        timeout: false,
+      }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Running terminal' },
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: JSON.stringify({ command: `echo ${secretValue}` }) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+      onTerminalEvent: (event) => terminalEvents.push(event),
+    });
+
+    await agent.run('run terminal');
+
+    const bashCommand = terminalEvents.find(isBashCommand);
+    expect(bashCommand).toBeDefined();
+    expect(bashCommand?.command).not.toContain(secretValue);
+    expect(bashCommand?.command).toContain('***');
+
+    const bashOutput = terminalEvents.find(isBashOutput);
+    expect(bashOutput).toBeDefined();
+    const combined = `${bashOutput?.stdout ?? ''}${bashOutput?.stderr ?? ''}`;
+    expect(combined).toContain('hello');
+    expect(combined).not.toContain(secretValue);
+    expect(combined).toContain('***');
   });
 
   it('serializes non-plain tool results in ObservationEvent payloads', async () => {

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -78,6 +78,32 @@ class TerminalSession {
     );
   }
 
+  async injectSecretsFromCommand(
+    command: string,
+    secrets: { getRegisteredNames: () => string[]; get: (name: string) => Promise<string | undefined> },
+  ): Promise<void> {
+    const trimmed = command.trim();
+    if (!trimmed) return;
+    const names = secrets.getRegisteredNames();
+    if (!names.length) return;
+
+    const lower = trimmed.toLowerCase();
+    const updates: Record<string, string> = {};
+
+    for (const name of names) {
+      const candidate = typeof name === 'string' ? name.trim() : '';
+      if (!candidate) continue;
+      if (!lower.includes(candidate.toLowerCase())) continue;
+      const value = await secrets.get(candidate);
+      if (!value) continue;
+      updates[candidate] = value;
+    }
+
+    for (const [key, value] of Object.entries(updates)) {
+      this.env[key] = value;
+    }
+  }
+
   private async killRunning(signal: SupportedSignal): Promise<void> {
     const running = this.running;
     if (!running) return;
@@ -503,21 +529,27 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
         this.session = new TerminalSession(context.workspace.root);
       }
 
+      const isInput = args.is_input ?? false;
+      const command = args.command ?? '';
+      if (!isInput && context.secrets) {
+        await this.session.injectSecretsFromCommand(command, context.secrets);
+      }
+
       const timeoutSeconds =
         typeof args.timeout === 'number' && Number.isFinite(args.timeout)
           ? args.timeout
           : DEFAULT_NO_CHANGE_TIMEOUT_SECONDS;
 
       const result = await this.session.execute({
-        command: args.command ?? '',
-        is_input: args.is_input ?? false,
+        command,
+        is_input: isInput,
         timeoutSeconds,
       });
 
       const exitCode = result.exitCode;
-      const command = result.command ?? args.command ?? '';
+      const resolvedCommand = result.command ?? command;
       return {
-        command,
+        command: resolvedCommand,
         stdout: result.stdout,
         stderr: result.stderr,
         exit_code: exitCode,

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { TerminalTool } from '../TerminalTool';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import { SecretRegistry } from '../../sdk/runtime/SecretRegistry';
 
 const makeWorkspace = async () => {
   const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'terminal-tool-session-'));
@@ -18,6 +19,24 @@ afterEach(async () => {
 });
 
 describe('TerminalTool session behavior', () => {
+  it('injects registered secrets into the command environment when referenced', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+    const secrets = new SecretRegistry();
+    secrets.register('GITHUB_TOKEN', 'ghp_example123');
+
+    const result = await tool.execute(
+      tool.validate({ command: 'node -e "process.stdout.write(process.env.GITHUB_TOKEN||\'\')"', timeout: 0.2 }),
+      { workspace, secrets },
+    );
+
+    expect(result.exit_code).toBe(0);
+    expect((result.stdout ?? '').trim()).toBe('ghp_example123');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace, secrets });
+  });
+
   it('persists working directory across commands', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);


### PR DESCRIPTION
Implements Beads oh-tab-8cp.

- Registers non-LLM secrets into SecretRegistry (GITHUB_TOKEN, CUSTOM_SECRET_1/2/3, ELEVENLABS_API_KEY) from settings.
- TerminalTool injects registered secrets into the terminal env when their names appear in a non-input command.
- Agent masks secrets in emitted BashEvents (command/stdout/stderr) to avoid leaking into the VS Code pseudoterminal.

Tests:
- npm test -w @openhands/agent-sdk-ts
- npm run lint -w @openhands/agent-sdk-ts
- npm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal event logs now automatically mask sensitive information to prevent exposure of secrets in command output and error streams.
  * Secrets are automatically injected into terminal sessions based on registered credentials.
  * Enhanced secret configuration handling with improved synchronization.

* **Tests**
  * Added comprehensive test coverage for secret masking in terminal events.
  * Added test coverage for automatic secret injection functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->