### PR TITLE
[oh-tab-fkw] AgentContext system suffix parity (REPO_CONTEXT + CUSTOM_SECRETS)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
@@ -138,7 +138,18 @@ describe('AgentContext', () => {
       const context = new AgentContext({ skills: [repoSkill] });
       const suffix = context.getSystemMessageSuffix();
 
-      expect(suffix).toBe('## coding-standards\n\nUse TypeScript strict mode.');
+      expect(suffix).toBe(
+        [
+          '<REPO_CONTEXT>',
+          "The following information has been included based on several files defined in user's repository.",
+          'Please follow them while working.',
+          '',
+          '[BEGIN context from [coding-standards]]',
+          'Use TypeScript strict mode.',
+          '[END Context]',
+          '</REPO_CONTEXT>',
+        ].join('\n'),
+      );
     });
 
     it('combines multiple repo skills', () => {
@@ -148,8 +159,21 @@ describe('AgentContext', () => {
       const context = new AgentContext({ skills: [skill1, skill2] });
       const suffix = context.getSystemMessageSuffix();
 
-      expect(suffix).toContain('## style\n\nStyle guide');
-      expect(suffix).toContain('## security\n\nSecurity rules');
+      expect(suffix).toBe(
+        [
+          '<REPO_CONTEXT>',
+          "The following information has been included based on several files defined in user's repository.",
+          'Please follow them while working.',
+          '',
+          '[BEGIN context from [style]]',
+          'Style guide',
+          '[END Context]',
+          '[BEGIN context from [security]]',
+          'Security rules',
+          '[END Context]',
+          '</REPO_CONTEXT>',
+        ].join('\n'),
+      );
     });
 
     it('excludes knowledge skills from system suffix', () => {
@@ -163,8 +187,10 @@ describe('AgentContext', () => {
       const context = new AgentContext({ skills: [repoSkill, knowledgeSkill] });
       const suffix = context.getSystemMessageSuffix();
 
-      expect(suffix).toContain('repo');
-      expect(suffix).not.toContain('knowledge');
+      expect(suffix).toContain('[BEGIN context from [repo]]');
+      expect(suffix).toContain('Repo');
+      expect(suffix).not.toContain('[BEGIN context from [knowledge]]');
+      expect(suffix).not.toContain('Knowledge');
     });
 
     it('appends custom system message suffix', () => {
@@ -176,7 +202,9 @@ describe('AgentContext', () => {
       });
       const suffix = context.getSystemMessageSuffix();
 
-      expect(suffix).toContain('## repo\n\nRepo');
+      expect(suffix).toContain('<REPO_CONTEXT>');
+      expect(suffix).toContain('[BEGIN context from [repo]]');
+      expect(suffix).toContain('Repo');
       expect(suffix).toContain('Current date: 2025-01-15');
     });
 
@@ -194,6 +222,39 @@ describe('AgentContext', () => {
       });
 
       expect(context.getSystemMessageSuffix()).toBe('Trimmed');
+    });
+
+    it('renders custom secrets section when provided', () => {
+      const context = new AgentContext();
+      const suffix = context.getSystemMessageSuffix({ secretNames: ['GITHUB_TOKEN', 'API_KEY'] });
+
+      expect(suffix).toContain('<CUSTOM_SECRETS>');
+      expect(suffix).toContain('### Credential Access');
+      expect(suffix).toContain('Automatic secret injection');
+      expect(suffix).toContain('**$GITHUB_TOKEN**');
+      expect(suffix).toContain('**$API_KEY**');
+      expect(suffix).toContain('</CUSTOM_SECRETS>');
+    });
+
+    it('renders repo context and custom secrets when both apply', () => {
+      const repoSkill = new Skill({ name: 'security_rules', content: 'Always validate user input.', trigger: null });
+      const context = new AgentContext({ skills: [repoSkill] });
+      const suffix = context.getSystemMessageSuffix({ secretNames: ['GITHUB_TOKEN'] });
+
+      expect(suffix).toContain('<REPO_CONTEXT>');
+      expect(suffix).toContain('[BEGIN context from [security_rules]]');
+      expect(suffix).toContain('Always validate user input.');
+      expect(suffix).toContain('<CUSTOM_SECRETS>');
+      expect(suffix).toContain('**$GITHUB_TOKEN**');
+    });
+
+    it('renders custom suffix and custom secrets when both apply', () => {
+      const context = new AgentContext({ systemMessageSuffix: 'Additional custom instructions.' });
+      const suffix = context.getSystemMessageSuffix({ secretNames: ['API_KEY'] });
+
+      expect(suffix).toContain('Additional custom instructions.');
+      expect(suffix).toContain('<CUSTOM_SECRETS>');
+      expect(suffix).toContain('**$API_KEY**');
     });
   });
 

--- a/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
@@ -86,17 +86,57 @@ export class AgentContext {
    * - Conversation instructions (e.g., user preferences, task details)
    * - Repository-specific instructions (collected from repo skills)
    */
-  getSystemMessageSuffix(): string | null {
+  getSystemMessageSuffix(options?: { secretNames?: string[] }): string | null {
     const repoSkills = this.skills.filter((s) => s.trigger === null);
 
-    const repoSkillContent = repoSkills
-      .map((skill) => `## ${skill.name}\n\n${skill.content}`)
-      .join('\n\n');
+    const parts: string[] = [];
 
-    const suffix = [repoSkillContent, this.systemMessageSuffix?.trim()]
-      .filter(Boolean)
-      .join('\n\n');
+    if (repoSkills.length) {
+      const repoSkillContent = repoSkills
+        .map((skill) => `[BEGIN context from [${skill.name}]]\n${skill.content}\n[END Context]`)
+        .join('\n');
+      parts.push(
+        [
+          '<REPO_CONTEXT>',
+          "The following information has been included based on several files defined in user's repository.",
+          'Please follow them while working.',
+          '',
+          repoSkillContent,
+          '</REPO_CONTEXT>',
+        ].join('\n'),
+      );
+    }
 
+    const customSuffix = this.systemMessageSuffix?.trim();
+    if (customSuffix) {
+      parts.push(customSuffix);
+    }
+
+    const secretNames = (options?.secretNames ?? [])
+      .map((name) => (typeof name === 'string' ? name.trim() : ''))
+      .filter(Boolean);
+    if (secretNames.length) {
+      const normalizedSecretNames = Array.from(new Set(secretNames)).sort();
+      const listedSecrets = normalizedSecretNames.map((name) => `* **$${name}**`).join('\n');
+      parts.push(
+        [
+          '<CUSTOM_SECRETS>',
+          '### Credential Access',
+          '* Automatic secret injection: When you reference a registered secret key in your bash command, the secret value will be automatically exported as an environment variable before your command executes.',
+          '* How to use secrets: Simply reference the secret key in your command (e.g., `echo ${GITHUB_TOKEN:0:8}` or `curl -H "Authorization: Bearer $API_KEY" https://api.example.com`). The system will detect the key name in your command text and export it as environment variable before it executes your command.',
+          '* Secret detection: The system performs case-insensitive matching to find secret keys in your command text. If a registered secret key appears anywhere in your command, its value will be made available as an environment variable.',
+          '* Security: Secret values are automatically masked in command output to prevent accidental exposure. You will see `***` instead of the actual secret value in the output.',
+          '* Refreshing expired secrets: Some secrets (like GITHUB_TOKEN) may be updated periodically or expire over time. If a secret stops working (e.g., authentication failures), try using it again in a new command - the system should automatically use the refreshed value. For example, if GITHUB_TOKEN was used in a git remote URL and later expired, you can update the remote URL with the current token: `git remote set-url origin https://${GITHUB_TOKEN}@github.com/username/repo.git` to pick up the refreshed token value.',
+          '* If it still fails, report it to the user.',
+          '',
+          'You have access to the following environment variables',
+          listedSecrets,
+          '</CUSTOM_SECRETS>',
+        ].join('\n'),
+      );
+    }
+
+    const suffix = parts.join('\n\n');
     return suffix || null;
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -748,7 +748,7 @@ export class Agent extends EventEmitter {
   private buildSystemPrompt(): string {
     let systemPrompt = SYSTEM_PROMPT;
     if (this.agentContext) {
-      const suffix = this.agentContext.getSystemMessageSuffix();
+      const suffix = this.agentContext.getSystemMessageSuffix({ secretNames: this.secrets.getRegisteredNames() });
       if (suffix) {
         systemPrompt += '\n\n' + suffix;
       }


### PR DESCRIPTION
Implements Beads oh-tab-fkw.

- AgentContext.getSystemMessageSuffix now renders repo skills using <REPO_CONTEXT> with [BEGIN context from [...]] blocks (matching python template semantics).
- Adds optional <CUSTOM_SECRETS> section when secretNames are provided, listing available env var names and describing injection/masking behavior.
- Agent.buildSystemPrompt passes registered secret names from SecretRegistry into AgentContext.
- Updates unit tests for the new formatting.

Refs: ~/repos/agent-sdk/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System message suffix now features organized blocks for repository context, custom directives, and secrets
  * Repository information is clearly structured with explicit markers for better organization
  * Registered secret names are automatically collected and formatted in a dedicated block within the system prompt

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->