### PR TITLE
fix(agent-sdk-ts): skip unreadable directory test when running as root

### DIFF
--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -155,6 +155,8 @@ describe('FileEditorTool', () => {
 
   it('directory view skips unreadable child directories', async () => {
     if (process.platform === 'win32') return;
+    // Root can read any directory regardless of permissions, so skip this test
+    if (process.getuid?.() === 0) return;
 
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);


### PR DESCRIPTION
## Summary

This PR fixes a test that fails when running as root user. The test `FileEditorTool > directory view skips unreadable child directories` was failing because root can read any directory regardless of permissions.

## Changes

- Added a check to skip the test when running as root (`process.getuid?.() === 0`)
- This is consistent with the existing Windows platform check in the same test

## Why this is needed

When running tests in environments where the user is root (e.g., Docker containers, CI environments), the `chmod 0o000` command doesn't actually prevent access to the directory. Root bypasses file permission checks on Unix systems.

## Testing

- All 261 agent-sdk-ts tests pass
- All 188 main package tests pass

Closes #91

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c67a10442c124520aa67af2cf526de77)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for directory access scenarios when running as the root user.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->