### PR TITLE
[oh-tab-v3u] Policy-driven error classification

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -25,6 +25,7 @@ import { LocalWorkspace } from '../../workspace/LocalWorkspace';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
+import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
 
 export type AgentRunInput = string | Message;
 
@@ -524,7 +525,15 @@ export class Agent extends EventEmitter {
         }
       }
       this.state.setStatus('RUNNING');
-      await this.executeTool(pending.toolCall, pending.actionEvent, pending.args);
+      try {
+        await this.executeTool(pending.toolCall, pending.actionEvent, pending.args);
+      } catch (error) {
+        if (error instanceof ClassifiedToolExecutionError && error.classification === 'conversation') {
+          this.events.push(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
+        }
+        this.state.setStatus('IDLE');
+        throw error;
+      }
       await this.runLoop();
     });
   }
@@ -581,7 +590,8 @@ export class Agent extends EventEmitter {
     try {
       orchestrator = await this.getOrchestrator();
     } catch (error) {
-      this.events.push(this.toConversationErrorEvent(error));
+      const classified = classifyError(error, { stage: 'llm_init' });
+      this.events.push(this.toConversationErrorEvent(error, { code: classified.code }));
       this.state.setStatus('IDLE');
       // Allow a future retry after settings/secrets are updated.
       this.orchestratorPromise = undefined;
@@ -615,7 +625,8 @@ export class Agent extends EventEmitter {
       try {
         response = await orchestrator.runChat(request);
       } catch (error) {
-        this.events.push(this.toConversationErrorEvent(error));
+        const classified = classifyError(error, { stage: 'llm_request' });
+        this.events.push(this.toConversationErrorEvent(error, { code: classified.code }));
         this.state.setStatus('IDLE');
         break;
       }
@@ -689,7 +700,12 @@ export class Agent extends EventEmitter {
 
         try {
           await this.executeTool(toolCall, recordedAction, actionArgs);
-        } catch {
+        } catch (error) {
+          if (error instanceof ClassifiedToolExecutionError && error.classification === 'conversation') {
+            this.events.push(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
+            this.state.setStatus('IDLE');
+            return lastAssistantMessage;
+          }
           toolExecutionFailed = true;
           // Continue processing other tool calls but mark this iteration as failed
         }
@@ -819,9 +835,9 @@ export class Agent extends EventEmitter {
     return factory.createClient();
   }
 
-  private toConversationErrorEvent(error: unknown): Event {
-    const message = stringifyErrorWithCause(error);
-    const code = this.classifyConversationError(message);
+  private toConversationErrorEvent(error: unknown, options?: { code?: string; message?: string }): Event {
+    const message = options?.message ?? stringifyErrorWithCause(error);
+    const code = options?.code ?? classifyConversationErrorCode(message);
     const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
     const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
     const configuredProvider = this.options.settings?.llm?.provider ?? undefined;
@@ -846,13 +862,6 @@ export class Agent extends EventEmitter {
 
     const detail = `${message} (${contextParts.join(', ')})`;
     return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail } as Event;
-  }
-
-  private classifyConversationError(message: string): string | undefined {
-    if (message.includes('Missing API key for LLM provider')) return 'missing_llm_api_key';
-    if (message.includes('LLM model is not configured')) return 'llm_model_not_configured';
-    if (message.startsWith('LLM request failed')) return 'llm_request_failed';
-    return undefined;
   }
 
   private ensureSystemPrompt() {
@@ -914,8 +923,8 @@ export class Agent extends EventEmitter {
       }
       throw new Error('Tool arguments must be a JSON object.');
     } catch (e) {
-      const errText = `Error validating args ${raw} for tool '${toolCall.function.name}': ${e instanceof Error ? e.message : String(e)}`;
-      this.emitToolError(toolCall, errText);
+      const classified = classifyError(e, { stage: 'tool_args', toolName: toolCall.function.name, rawArgs: raw });
+      this.emitToolError(toolCall, classified.message);
       return undefined;
     }
   }
@@ -973,17 +982,18 @@ export class Agent extends EventEmitter {
     if (!tool) {
       const available = Array.from(this.tools.keys());
       const errText = `Tool '${toolCall.function.name}' not found. Available: ${JSON.stringify(available)}`;
-      this.emitToolError(toolCall, errText);
-      throw new Error(errText);
+      const classified = classifyError(errText, { stage: 'tool_lookup', toolName: toolCall.function.name });
+      this.emitToolError(toolCall, classified.message);
+      throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
     }
 
     let validated;
     try {
       validated = tool.validate(args);
     } catch (e) {
-      const errText = `Error validating args ${toolCall.function.arguments} for tool '${tool.name}': ${e instanceof Error ? e.message : String(e)}`;
-      this.emitToolError(toolCall, errText);
-      throw new Error(errText);
+      const classified = classifyError(e, { stage: 'tool_validation', toolName: tool.name, rawArgs: toolCall.function.arguments });
+      this.emitToolError(toolCall, classified.message);
+      throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
     }
 
     try {
@@ -1020,10 +1030,17 @@ export class Agent extends EventEmitter {
       };
       this.events.push(toolMessage);
     } catch (e) {
-      const errText = e instanceof Error ? e.message : String(e);
-      // Treat execution failures as agent-visible errors so the LLM can self-correct
-      this.emitToolError(toolCall, errText);
-      throw e;
+      const classified = classifyError(e, { stage: 'tool_execute', toolName: tool.name });
+      if (classified.classification === 'agent') {
+        // Treat execution failures as agent-visible errors so the LLM can self-correct.
+        this.emitToolError(toolCall, classified.message);
+        throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
+      }
+      throw new ClassifiedToolExecutionError({
+        classification: 'conversation',
+        message: classified.message,
+        ...(classified.code ? { code: classified.code } : {}),
+      });
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -728,7 +728,7 @@ export class Agent extends EventEmitter {
 
   private buildChatRequest() {
     const systemPrompt = this.buildSystemPrompt();
-    const messages = this.events
+    const rawMessages = this.events
       .list()
       .filter(isMessageEvent)
       .map((event) => {
@@ -737,8 +737,69 @@ export class Agent extends EventEmitter {
         }
         return event.llm_message;
       });
+    const messages = this.sanitizeChatMessages(rawMessages);
     const tools = this.getToolDefinitions();
     return { systemPrompt, messages, tools };
+  }
+
+  // OpenAI-compatible providers require that assistant tool_calls are followed by tool messages for each tool_call_id.
+  // If we encounter conversation-level tool execution failures, we intentionally do not emit tool messages; sanitize
+  // orphan tool_calls from the next request to avoid poisoning the conversation history.
+  private sanitizeChatMessages(messages: Message[]): Message[] {
+    const sanitized: Array<Message | null> = [];
+
+    let pendingAssistantIndex: number | null = null;
+    let pendingAssistantMessage: Message | null = null;
+    let pendingToolResponseIds = new Set<string>();
+
+    const hasMeaningfulAssistantContent = (message: Message): boolean => {
+      if (message.responses_reasoning_item) return true;
+      if (typeof message.reasoning_content === 'string' && message.reasoning_content.trim().length > 0) return true;
+      return message.content.some((part) => (part.type === 'text' ? part.text.trim().length > 0 : true));
+    };
+
+    const flushPendingAssistant = () => {
+      if (pendingAssistantIndex === null || !pendingAssistantMessage) return;
+
+      const originalToolCalls = pendingAssistantMessage.tool_calls ?? [];
+      const matchingToolCalls = originalToolCalls.filter((call) => pendingToolResponseIds.has(call.id));
+
+      if (matchingToolCalls.length === 0) {
+        const withoutToolCalls: Message = { ...pendingAssistantMessage, tool_calls: undefined };
+        sanitized[pendingAssistantIndex] = hasMeaningfulAssistantContent(withoutToolCalls) ? withoutToolCalls : null;
+      } else {
+        sanitized[pendingAssistantIndex] = { ...pendingAssistantMessage, tool_calls: matchingToolCalls };
+      }
+
+      pendingAssistantIndex = null;
+      pendingAssistantMessage = null;
+      pendingToolResponseIds = new Set<string>();
+    };
+
+    for (const message of messages) {
+      if (message.role === 'assistant') {
+        flushPendingAssistant();
+
+        if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+          pendingAssistantIndex = sanitized.length;
+          pendingAssistantMessage = message;
+          pendingToolResponseIds = new Set<string>();
+        }
+
+        sanitized.push(message);
+        continue;
+      }
+
+      if (pendingAssistantMessage && message.role === 'tool' && typeof message.tool_call_id === 'string') {
+        pendingToolResponseIds.add(message.tool_call_id);
+      }
+
+      sanitized.push(message);
+    }
+
+    flushPendingAssistant();
+
+    return sanitized.filter((message): message is Message => Boolean(message));
   }
 
   private getToolDefinitions(): LLMToolDefinition[] {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-errors.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-errors.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
 import { isAgentErrorEvent, isConversationErrorEvent, isMessageEvent, type TextContent } from '../../types';
@@ -9,10 +9,12 @@ import type { ToolDefinition } from '../../types/tools';
 import type { OpenHandsSettings } from '../../types/settings';
 
 class MockLLM implements LLMClient {
+  requests: ChatCompletionRequest[] = [];
+
   constructor(private readonly chunks: LLMStreamChunk[]) {}
 
-  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
-    void _request;
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
     for (const chunk of this.chunks) {
       yield chunk;
     }
@@ -27,7 +29,19 @@ const baseSettings: OpenHandsSettings = {
   secrets: {},
 };
 
-const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-errors-'));
+const workspaceRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-tool-errors-'));
+  workspaceRoots.push(root);
+  return root;
+};
 
 describe('Agent tool call error handling', () => {
   it('emits tool messages when parsing tool arguments fails', async () => {
@@ -231,5 +245,39 @@ describe('Agent tool call error handling', () => {
     expect(toolMessages).toHaveLength(0);
 
     expect(agent.state.snapshot.status).toBe('IDLE');
+  });
+
+  it('sanitizes orphan tool_calls from future requests after conversation-level tool failures', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, unknown>, unknown> = {
+      name: 'browser',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => {
+        throw new Error('Global fetch API is unavailable in this runtime');
+      },
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Try browser' },
+      { type: 'tool_call_delta', id: 'call_fetch_missing', name: 'browser', arguments: '{"url":"https://example.com"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, conversation: { maxIterations: 2 } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('browse');
+    await agent.run('retry after failure');
+
+    expect(llm.requests).toHaveLength(2);
+    const secondRequest = llm.requests[1];
+    const hasOrphanedToolCalls = secondRequest.messages.some(
+      (message) => message.role === 'assistant' && message.tool_calls?.some((call) => call.id === 'call_fetch_missing'),
+    );
+    expect(hasOrphanedToolCalls).toBe(false);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-errors.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-errors.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
-import { isAgentErrorEvent, isMessageEvent, type TextContent } from '../../types';
+import { isAgentErrorEvent, isConversationErrorEvent, isMessageEvent, type TextContent } from '../../types';
 import type { ToolDefinition } from '../../types/tools';
 import type { OpenHandsSettings } from '../../types/settings';
 
@@ -193,5 +193,43 @@ describe('Agent tool call error handling', () => {
     const textContent = toolMessages[0].llm_message.content[0] as TextContent;
     // Python SDK sends plain text matching error message
     expect(textContent.text).toContain('execution exploded');
+  });
+
+  it('emits ConversationErrorEvent (and no tool message) for conversation-level tool execution failures', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, unknown>, unknown> = {
+      name: 'browser',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => {
+        throw new Error('Global fetch API is unavailable in this runtime');
+      },
+    };
+    const llm = new MockLLM([
+      { type: 'text', text: 'Try browser' },
+      { type: 'tool_call_delta', id: 'call_fetch_missing', name: 'browser', arguments: '{"url":"https://example.com"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('browse');
+
+    const events = log.list();
+    expect(events.filter(isAgentErrorEvent)).toHaveLength(0);
+
+    const conversationError = events.find(isConversationErrorEvent);
+    expect(conversationError).toBeDefined();
+    expect(conversationError?.code).toBe('missing_fetch_api');
+
+    const toolMessages = events.filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'tool');
+    expect(toolMessages).toHaveLength(0);
+
+    expect(agent.state.snapshot.status).toBe('IDLE');
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/errorPolicy.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/errorPolicy.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { classifyError } from '../errorPolicy';
+
+describe('classifyError', () => {
+  it('classifies LLM init errors as conversation-level with codes', () => {
+    const err = new Error('Missing API key for LLM provider');
+    const result = classifyError(err, { stage: 'llm_init' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('missing_llm_api_key');
+    expect(result.message).toContain('Missing API key');
+  });
+
+  it('formats tool arg parse errors consistently', () => {
+    const err = new Error('Unexpected end of JSON input');
+    const result = classifyError(err, { stage: 'tool_args', toolName: 'task_tracker', rawArgs: '{"a":' });
+    expect(result.classification).toBe('agent');
+    expect(result.message).toContain('Error validating args');
+    expect(result.message).toContain('task_tracker');
+  });
+
+  it('classifies missing fetch as conversation-level tool execution failure', () => {
+    const err = new Error('Global fetch API is unavailable in this runtime');
+    const result = classifyError(err, { stage: 'tool_execute', toolName: 'browser' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('missing_fetch_api');
+  });
+
+  it('classifies missing terminal shell as conversation-level tool execution failure', () => {
+    const err = Object.assign(new Error('spawn /bin/bash ENOENT'), { code: 'ENOENT', path: '/bin/bash' });
+    const result = classifyError(err, { stage: 'tool_execute', toolName: 'terminal' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('terminal_shell_missing');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/errorPolicy.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/errorPolicy.ts
@@ -1,0 +1,81 @@
+export type ErrorClassification = 'agent' | 'conversation';
+
+export type ErrorContext = {
+  stage: 'tool_args' | 'tool_lookup' | 'tool_validation' | 'tool_execute' | 'llm_init' | 'llm_request';
+  toolName?: string;
+  rawArgs?: string;
+};
+
+export type ClassifiedError = {
+  classification: ErrorClassification;
+  message: string;
+  code?: string;
+};
+
+type ErrnoException = Error & { code?: string; syscall?: string; path?: string };
+
+const normalizeMessage = (value: unknown): string => {
+  const raw = value instanceof Error ? value.message : String(value);
+  const trimmed = raw.replace(/\s+/g, ' ').trim();
+  return trimmed || 'Unknown error';
+};
+
+export const classifyConversationErrorCode = (message: string): string | undefined => {
+  if (message.includes('Missing API key for LLM provider')) return 'missing_llm_api_key';
+  if (message.includes('LLM model is not configured')) return 'llm_model_not_configured';
+  if (message.startsWith('LLM request failed')) return 'llm_request_failed';
+  return undefined;
+};
+
+const isErrnoException = (error: unknown): error is ErrnoException => {
+  return Boolean(error && typeof error === 'object' && 'code' in error);
+};
+
+export class ClassifiedToolExecutionError extends Error {
+  readonly classification: ErrorClassification;
+  readonly code?: string;
+
+  constructor(params: { classification: ErrorClassification; message: string; code?: string }) {
+    super(params.message);
+    this.name = 'ClassifiedToolExecutionError';
+    this.classification = params.classification;
+    this.code = params.code;
+  }
+}
+
+export const classifyError = (error: unknown, context: ErrorContext): ClassifiedError => {
+  const baseMessage = normalizeMessage(error);
+  let message = baseMessage;
+
+  if (context.stage === 'llm_init' || context.stage === 'llm_request') {
+    return { classification: 'conversation', message, code: classifyConversationErrorCode(message) };
+  }
+
+  // Default tool behavior: treat as agent-visible so the LLM can self-correct.
+  let classification: ErrorClassification = 'agent';
+  let code: string | undefined;
+
+  if ((context.stage === 'tool_args' || context.stage === 'tool_validation') && context.rawArgs && context.toolName) {
+    message = `Error validating args ${context.rawArgs} for tool '${context.toolName}': ${baseMessage}`;
+  }
+
+  if (context.stage === 'tool_execute') {
+    // Environment/infra failures that are not actionable by the LLM should halt the run.
+    if (message.includes('Global fetch API is unavailable in this runtime')) {
+      classification = 'conversation';
+      code = 'missing_fetch_api';
+    }
+
+    // TerminalSession always spawns a shell (/bin/bash on unix, ComSpec/cmd.exe on windows). If that is missing,
+    // treat it as environment-level (conversation) rather than agent-visible.
+    if (classification === 'agent' && isErrnoException(error) && error.code === 'ENOENT') {
+      const needle = (error.path ?? message).toLowerCase();
+      if (needle.includes('/bin/bash') || needle.includes('cmd.exe')) {
+        classification = 'conversation';
+        code = 'terminal_shell_missing';
+      }
+    }
+  }
+
+  return { classification, message, ...(code ? { code } : {}) };
+};


### PR DESCRIPTION
Implements Beads oh-tab-v3u (GH#153).

- Adds runtime error policy module (classifyError) for tool vs conversation failures.
- Wires Agent to use the policy for tool args/lookup/validation/execute and LLM init/request errors.
- Conversation-level tool execution failures emit ConversationErrorEvent and halt without emitting tool messages.
- Adds unit tests for policy mappings + an integration test for conversation-level tool failures.

Refs: https://github.com/enyst/OpenHands-Tab/issues/153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistent, structured error reporting with classification and optional error codes so failures surface clearly and keep the conversation in idle when needed.
  * Prevented orphaned tool-calls from polluting conversation history after tool failures.

* **Tests**
  * New tests covering error classification, conversation vs agent error behavior, and cleanup across consecutive runs.

* **Chores**
  * Centralized error policy and standardized emission of user-visible error events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->