### PR TITLE
oh-tab-ky6: derive stable LLM usage ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,9 +223,8 @@
           },
           "openhands.llm.usageId": {
             "type": "string",
-            "default": "default-llm",
             "order": 30,
-            "markdownDescription": "Optional usage_id for local-mode LLM metrics tracking. In remote mode, only applies if explicitly set."
+            "markdownDescription": "Optional usage_id for LLM metrics tracking. If unset in local mode, the SDK derives a stable id per provider/model/config so switching models preserves per-client metrics."
           }
         }
       },

--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -64,6 +64,18 @@ describe('LLMRegistry and TrackedLLMClient', () => {
     expect(events).toEqual(['default-llm:gpt-5-mini', 'default-llm:gpt-4o-mini']);
   });
 
+  it('registers tracked clients under provider/model registry keys', async () => {
+    const registry = new LLMRegistry();
+    const factory = new LLMFactory(
+      { model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline', usageId: 'default-llm' },
+      { registry },
+    );
+    const client = await factory.createClient();
+    expect(
+      registry.getByConfig({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline', usageId: 'default-llm' }),
+    ).toBe(client);
+  });
+
   it('notifies subscriber and ConversationStats can register', () => {
     const registry = new LLMRegistry();
     const events: string[] = [];

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -19,6 +19,7 @@ export interface LocalConversationOptions {
   workspaceRoot?: string;
   llmClient?: LLMClient;
   tools?: ToolDefinition<unknown, unknown>[];
+  secrets?: SecretRegistry;
   persistenceDir?: string;
   persistence?: ConversationPersistence;
   agentContext?: AgentContext;
@@ -53,7 +54,7 @@ export class LocalConversation extends EventEmitter {
     this.state = new ConversationState({ eventLog: this.events, persistence: this.persistence });
     this.customLlmClient = options.llmClient;
     this.tools = options.tools ?? [];
-    this.secrets = new SecretRegistry();
+    this.secrets = options.secrets ?? new SecretRegistry();
     this.agentContext = options.agentContext;
     this.llmRegistry = new LLMRegistry();
     this.stats = new ConversationStats();

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -1,6 +1,7 @@
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import type { AgentContext } from '../context';
+import type { SecretRegistry } from '../runtime';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
 
@@ -14,6 +15,7 @@ export interface ConversationFactoryOptions {
   workspaceRoot?: string;
   conversationId?: string;
   tools?: ToolDefinition<unknown, unknown>[];
+  secrets?: SecretRegistry;
   persistenceDir?: string;
   agentContext?: AgentContext;
 }
@@ -32,6 +34,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     conversationId: options.conversationId,
     workspaceRoot: options.workspaceRoot,
     tools: options.tools,
+    secrets: options.secrets,
     persistenceDir: options.persistenceDir,
     agentContext: options.agentContext,
   }) as ConversationInstance;

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -1,10 +1,11 @@
+import { createHash } from 'crypto';
 import { LLMCredentialProvider } from './credentials';
 import { AnthropicClient } from './anthropic';
 import { OpenAICompatibleClient } from './openai-compatible';
 import { OpenAIResponsesClient } from './openai-responses';
 import type { ChatCompletionRequest, LLMClient, LLMConfiguration } from './types';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
-import { LLMRegistry, TrackedLLMClient } from './registry';
+import { LLMRegistry, TrackedLLMClient, llmRegistryKeyToString, toLLMRegistryKey } from './registry';
 import { Metrics } from './metrics';
 import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl } from './provider';
 
@@ -29,6 +30,17 @@ export class LLMFactory {
   }
 
   async createClient(): Promise<LLMClient> {
+    const normalizeOptionalString = (value: unknown): string | undefined => {
+      const trimmed = typeof value === 'string' ? value.trim() : '';
+      return trimmed.length ? trimmed : undefined;
+    };
+    const hashString = (input: string): string => createHash('sha256').update(input).digest('hex');
+    const stableStringifyHeaders = (headers: Record<string, string> | undefined): string | undefined => {
+      if (!headers) return undefined;
+      const entries = Object.entries(headers).sort(([a], [b]) => a.localeCompare(b));
+      return JSON.stringify(Object.fromEntries(entries));
+    };
+
     const inlineApiKey =
       typeof this.config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(this.config.apiKey)
         ? this.config.apiKey
@@ -57,16 +69,53 @@ export class LLMFactory {
     const useResponses = provider === 'openai'
       && isGpt5
       && (openaiApiMode === 'responses' || (openaiApiMode !== 'chat_completions' && baseUrlSupportsResponses));
+    const effectiveOpenaiApiMode = provider === 'openai' ? (useResponses ? 'responses' : 'chat_completions') : undefined;
+    const registryKey = toLLMRegistryKey({ ...this.config, provider, openaiApiMode: effectiveOpenaiApiMode });
+
+    const explicitUsageId = normalizeOptionalString(this.config.usageId);
+    const derivedUsageId = (() => {
+      if (explicitUsageId) return explicitUsageId;
+      if (!this.registry) return undefined;
+      const fingerprint = {
+        key: llmRegistryKeyToString(registryKey),
+        timeoutSeconds: this.config.timeoutSeconds ?? null,
+        temperature: this.config.temperature ?? null,
+        topP: this.config.topP ?? null,
+        topK: this.config.topK ?? null,
+        maxInputTokens: this.config.maxInputTokens ?? null,
+        maxOutputTokens: this.config.maxOutputTokens ?? null,
+        reasoningEffort: this.config.reasoningEffort ?? null,
+        reasoningSummary: this.config.reasoningSummary ?? null,
+        headers: stableStringifyHeaders(this.config.headers),
+        inputCostPerToken: this.config.inputCostPerToken ?? null,
+        outputCostPerToken: this.config.outputCostPerToken ?? null,
+        apiKeyHash: hashString(apiKey).slice(0, 16),
+      };
+      const digest = hashString(JSON.stringify(fingerprint)).slice(0, 12);
+      return `${registryKey.provider}:${registryKey.model}:${digest}`;
+    })();
+
+    if (derivedUsageId && !explicitUsageId && this.registry) {
+      try {
+        const cached = this.registry.get(derivedUsageId);
+        cached.setOnMetricsUpdate(this.onMetricsUpdate);
+        // Re-announce selection so stats/UI have a consistent "current llm" signal.
+        this.registry.switchLlm(cached, registryKey);
+        return cached;
+      } catch {
+        // Cache miss; create a fresh client.
+      }
+    }
     const base = provider === 'anthropic'
       ? new AnthropicClient(this.config, apiKey)
       : useResponses
         ? new OpenAIResponsesClient({ ...this.config, provider }, apiKey)
         : new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
 
-    if (this.config.usageId) {
+    if (derivedUsageId) {
       const metrics = new Metrics(this.config.model);
-      const tracked = new TrackedLLMClient({ inner: base, usageId: this.config.usageId, modelName: this.config.model, metrics, onMetricsUpdate: this.onMetricsUpdate });
-      this.registry?.switchLlm(tracked);
+      const tracked = new TrackedLLMClient({ inner: base, usageId: derivedUsageId, modelName: this.config.model, metrics, onMetricsUpdate: this.onMetricsUpdate });
+      this.registry?.switchLlm(tracked, registryKey);
       return tracked;
     }
 

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -1,11 +1,56 @@
 import type { LLMClient } from './types';
+import type { LLMConfiguration, LLMProvider, OpenAIChatApi } from './types';
 import type { Metrics } from './metrics';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl } from './provider';
 
 export type RegistryEvent = { llm: TrackedLLMClient };
+
+export type LLMRegistryKey = {
+  provider: LLMProvider;
+  model: string;
+  baseUrl?: string;
+  openaiApiMode?: OpenAIChatApi;
+  apiVersion?: string;
+};
+
+const normalizeUrl = (value: string | null | undefined): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) return undefined;
+  return trimmed.replace(/\/+$/, '');
+};
+
+export const toLLMRegistryKey = (config: LLMConfiguration): LLMRegistryKey => {
+  const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
+  const effectiveBaseUrl = normalizeUrl(config.baseUrl) ?? normalizeUrl(DEFAULT_PROVIDER_BASE_URLS[provider]);
+  const normalizedModel = config.model.toLowerCase();
+  const configuredOpenaiApiMode = provider === 'openai' ? (config.openaiApiMode ?? undefined) : undefined;
+  const normalizedConfiguredBaseUrl = normalizeUrl(config.baseUrl);
+  const normalizedDefaultOpenAIBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS.openai);
+  const baseUrlSupportsResponses = !normalizedConfiguredBaseUrl || normalizedConfiguredBaseUrl === normalizedDefaultOpenAIBaseUrl;
+  const useResponses = provider === 'openai'
+    && normalizedModel.startsWith('gpt-5')
+    && (configuredOpenaiApiMode === 'responses' || (configuredOpenaiApiMode !== 'chat_completions' && baseUrlSupportsResponses));
+  const effectiveOpenaiApiMode = provider === 'openai' ? (useResponses ? 'responses' : 'chat_completions') : undefined;
+  return {
+    provider,
+    model: config.model,
+    baseUrl: effectiveBaseUrl,
+    openaiApiMode: effectiveOpenaiApiMode,
+    apiVersion: normalizeUrl(config.apiVersion),
+  };
+};
+
+export const llmRegistryKeyToString = (key: LLMRegistryKey): string => {
+  const baseUrl = key.baseUrl ?? '';
+  const apiVersion = key.apiVersion ?? '';
+  const openaiApiMode = key.provider === 'openai' ? (key.openaiApiMode ?? '') : '';
+  return `${key.provider}|${key.model}|${baseUrl}|${openaiApiMode}|${apiVersion}`;
+};
 
 export class LLMRegistry {
   readonly registryId: string;
   private usageToLLM = new Map<string, TrackedLLMClient>();
+  private keyToLLM = new Map<string, TrackedLLMClient>();
   private subscriber?: (event: RegistryEvent) => void;
 
   constructor() {
@@ -26,9 +71,12 @@ export class LLMRegistry {
     this.switchLlm(llm);
   }
 
-  switchLlm(llm: TrackedLLMClient): void {
+  switchLlm(llm: TrackedLLMClient, key?: LLMRegistryKey): void {
     const id = llm.usageId;
     this.usageToLLM.set(id, llm);
+    if (key) {
+      this.keyToLLM.set(llmRegistryKeyToString(key), llm);
+    }
     this.notify({ llm });
   }
 
@@ -36,6 +84,17 @@ export class LLMRegistry {
     const llm = this.usageToLLM.get(usageId);
     if (!llm) throw new Error(`Usage ID '${usageId}' not found in registry`);
     return llm;
+  }
+
+  getByKey(key: LLMRegistryKey): TrackedLLMClient {
+    const encoded = llmRegistryKeyToString(key);
+    const llm = this.keyToLLM.get(encoded);
+    if (!llm) throw new Error(`LLM key '${encoded}' not found in registry`);
+    return llm;
+  }
+
+  getByConfig(config: LLMConfiguration): TrackedLLMClient {
+    return this.getByKey(toLLMRegistryKey(config));
   }
 
   listUsageIds(): string[] { return Array.from(this.usageToLLM.keys()); }
@@ -46,7 +105,7 @@ export class TrackedLLMClient implements LLMClient {
   readonly usageId: string;
   readonly modelName: string;
   readonly metrics: Metrics;
-  private readonly onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
+  private onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 
   constructor(params: { inner: LLMClient; usageId: string; modelName: string; metrics: Metrics; onMetricsUpdate?: (usageId: string, metrics: Metrics) => void }) {
     this.inner = params.inner;
@@ -54,6 +113,10 @@ export class TrackedLLMClient implements LLMClient {
     this.modelName = params.modelName;
     this.metrics = params.metrics;
     this.onMetricsUpdate = params.onMetricsUpdate;
+  }
+
+  setOnMetricsUpdate(cb?: (usageId: string, metrics: Metrics) => void): void {
+    this.onMetricsUpdate = cb;
   }
 
   async *streamChat(request: import('./types').ChatCompletionRequest): AsyncGenerator<import('./types').LLMStreamChunk> {

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -47,7 +47,7 @@ export type OpenHandsSettings = ServerSettings & {
 const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
   servers: [],
-  llm: { usageId: 'default-llm', provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
+  llm: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
   agent: { enableSecurityAnalyzer: false, debug: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
@@ -168,18 +168,14 @@ export class SettingsManager {
     const explicitBaseUrl = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.baseUrl'));
     const explicitProvider = normalizeLlmProvider(this.adapter.getExplicit<string>('openhands.llm.provider'));
     const provider = isRemote ? explicitProvider : explicitProvider ?? (explicitBaseUrl ? undefined : DEFAULTS.llm.provider);
-    const usageId = normalizeNonEmptyString(
-      isRemote
-        ? this.adapter.getExplicit<string>('openhands.llm.usageId')
-        : (this.adapter.get<string | null>('openhands.llm.usageId', DEFAULTS.llm.usageId) ?? DEFAULTS.llm.usageId)
-    );
+    const usageId = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.usageId'));
     const explicitModel = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.model'));
     // Always provide a model name, even in remote mode: the python agent-server requires it in StartConversationRequest.
     const model = explicitModel ?? normalizeNonEmptyString(
       this.adapter.get<string | null>('openhands.llm.model', DEFAULTS.llm.model) ?? DEFAULTS.llm.model
     );
     const llm: LLMSettings = {
-      // In remote mode, omit usageId unless explicitly configured.
+      // Omit usageId unless explicitly configured (local-mode SDK can derive a stable id per config).
       // Always provide a model so LocalConversation and RemoteConversation can start reliably.
       usageId,
       provider,

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -26,7 +26,7 @@ describe('SettingsManager', () => {
   it('returns defaults when unset', async () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBeUndefined();
-    expect(s.llm.usageId).toBe('default-llm');
+    expect(s.llm.usageId).toBeUndefined();
     expect(s.llm.provider).toBe('anthropic');
     expect(s.llm.openaiApiMode).toBeUndefined();
     expect(s.llm.reasoningSummary).toBeUndefined();


### PR DESCRIPTION
Bead: oh-tab-ky6 (GH#113)

- Make `openhands.llm.usageId` truly optional (no default); local mode derives a stable id per provider/model/baseUrl/apiMode/etc so switching model/provider no longer collides on `default-llm`.
- Add per-config client reuse: `LLMFactory` reuses an existing tracked client when settings match, and re-announces selection via `LLMRegistry`.
- Allow passing a `SecretRegistry` into `Conversation(...)` / `LocalConversation` (plumbing for non-extension consumers; VS Code already materializes secrets into settings).

Verified locally: `npm test`, `npm run typecheck`, `npm run lint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM usageId setting now auto-derives a stable per-client ID based on provider/model/config when unset, improving metrics tracking across model switches.
  * Enhanced LLM client registry with key-based lookup and caching capabilities.

* **Tests**
  * Added test coverage for registry-based client retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->