### PR TITLE
oh-tab-4it: document agent-server debug env vars

### DIFF
--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -31,6 +31,9 @@ This document explains how to run automated E2E tests for the OpenHands-Tab VS C
      - `git clone https://github.com/OpenHands/software-agent-sdk.git ~/repos/agent-sdk`
      - `cd ~/repos/agent-sdk && make build`
      - `uv run python -m openhands.agent_server --host 127.0.0.1 --port 3000` (use `0.0.0.0` only if you need remote access)
+   - Debugging tip: start with verbose logs and lightweight startup flags (similar to CI):
+     - `AGENT_SDK_DIR=~/repos/agent-sdk PYTHONUNBUFFERED=1 LOG_LEVEL=DEBUG DEBUG=1 OH_ENABLE_VSCODE=0 OH_ENABLE_VNC=0 OH_PRELOAD_TOOLS=0 npm run agent-server`
+     - Avoid `DEBUG_LLM=1` unless you understand the risks (it prompts and may expose secrets).
 3) Launch the extension in VS Code
    - Open this folder in VS Code
    - Press F5 to run “Extension Development Host”

--- a/docs/vscode_local_setup.md
+++ b/docs/vscode_local_setup.md
@@ -141,6 +141,33 @@ In the Dev Host window, use the commands:
 - OpenHands: Open — reveals the chat sidebar view
 - OpenHands: Start New Conversation — starts a new conversation
 
+## (Optional) Run the Python Agent-Server with Debug Logs
+
+If you want to test **remote mode** against the Python agent-server, start it in a separate terminal. This repo includes a helper script (`npm run agent-server`) that launches `python -m openhands.agent_server` from a local `OpenHands/software-agent-sdk` checkout.
+
+Recommended debugging env vars:
+- `PYTHONUNBUFFERED=1` for unbuffered logs
+- `LOG_LEVEL=DEBUG` (or `INFO`)
+- `DEBUG=1` to force debug logging
+- `OH_ENABLE_VSCODE=0 OH_ENABLE_VNC=0 OH_PRELOAD_TOOLS=0` to keep startup lightweight (similar to CI)
+
+Example (copy/paste):
+```bash
+AGENT_SDK_DIR=~/repos/agent-sdk \
+PYTHONUNBUFFERED=1 \
+LOG_LEVEL=DEBUG \
+DEBUG=1 \
+OH_ENABLE_VSCODE=0 \
+OH_ENABLE_VNC=0 \
+OH_PRELOAD_TOOLS=0 \
+PORT=3000 \
+npm run agent-server
+```
+
+Notes:
+- If you set `SESSION_API_KEY`, you must also set it in VS Code via “OpenHands: Set Session API Key”.
+- Avoid `DEBUG_LLM=1` unless you know what you’re doing: it prompts for confirmation and may expose secrets in logs.
+
 ## Logs and Diagnostics
 - Extension host logs:
   - View → Output → select the OpenHands output channel

--- a/tests/e2e/AGENT_SERVER_QUICKSTART.md
+++ b/tests/e2e/AGENT_SERVER_QUICKSTART.md
@@ -9,6 +9,8 @@ Option A: agent-sdk local (recommended for developers)
   2) `cd ~/repos/agent-sdk && make build` (optional; `uv run` will usually work without it)
   3) Start server from this repo:
      - `AGENT_SDK_DIR=~/repos/agent-sdk PORT=3000 ./scripts/start-agent-server.sh`
+     - Debugging tip (verbose logs + lightweight startup):
+       - `AGENT_SDK_DIR=~/repos/agent-sdk PYTHONUNBUFFERED=1 LOG_LEVEL=DEBUG DEBUG=1 OH_ENABLE_VSCODE=0 OH_ENABLE_VNC=0 OH_PRELOAD_TOOLS=0 PORT=3000 ./scripts/start-agent-server.sh`
      - Or manually (from `~/repos/agent-sdk`): `uv run python -m openhands.agent_server --host 127.0.0.1 --port 3000`
   4) In VS Code (Extension Dev Host), set openhands.serverUrl to <http://localhost:3000>
 


### PR DESCRIPTION
Bead: oh-tab-4it

Docs-only: add copy/paste env var snippets for starting the python agent-server with debug logs + lightweight startup flags.

Updated:
- `docs/vscode_local_setup.md`
- `docs/e2e_testing.md`
- `tests/e2e/AGENT_SERVER_QUICKSTART.md`

Local check: `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added debugging guides for local E2E testing with environment variable presets for verbose logging
  * Added optional debugging section for running agent-server with enhanced logging in setup documentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->