### PR TITLE
E2E: cover LLM switching via mock server

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -131,7 +131,10 @@ export class AnthropicClient implements LLMClient {
     while (attempt <= this.retry.maxRetries) {
       try {
         const controller = new AbortController();
-        const timeout = setTimeout(() => controller.abort(), (this.config.timeoutSeconds ?? (DEFAULT_TIMEOUT_MS / 1000)) * 1000);
+        const effectiveSeconds = (typeof this.config.timeoutSeconds === 'number' && this.config.timeoutSeconds > 0)
+          ? this.config.timeoutSeconds
+          : (DEFAULT_TIMEOUT_MS / 1000);
+        const timeout = setTimeout(() => controller.abort(), effectiveSeconds * 1000);
         const response = await fetch(this.requestUrl(), {
           method: 'POST',
           headers: this.requestHeaders(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -991,6 +991,59 @@ export function activate(context: vscode.ExtensionContext) {
     };
   });
 
+  // Internal: return the last error event from the buffered backlog (for E2E + debugging).
+  const queryLastError = vscode.commands.registerCommand('openhands._queryLastError', () => {
+    let last: { seq: number; event: Event } | undefined;
+    for (const item of iterConversationEventBacklog()) {
+      if (item.event.kind === 'ConversationErrorEvent' || item.event.kind === 'AgentErrorEvent') {
+        last = { seq: item.seq, event: item.event };
+      }
+    }
+    if (!last) return null;
+
+    const e = last.event as unknown as Record<string, unknown>;
+    const payload: Record<string, unknown> = {
+      seq: last.seq,
+      kind: e.kind,
+      source: e.source,
+    };
+    if (typeof e.code === 'string') payload.code = e.code;
+    if (typeof e.detail === 'string') payload.detail = e.detail;
+    if (typeof e.error === 'string') payload.error = e.error;
+    if (typeof e.tool_name === 'string') payload.tool_name = e.tool_name;
+    if (typeof e.tool_call_id === 'string') payload.tool_call_id = e.tool_call_id;
+    return payload;
+  });
+
+  // Internal: summarize the in-memory event backlog for deterministic E2E checks.
+  const queryBacklogSummary = vscode.commands.registerCommand('openhands._queryBacklogSummary', () => {
+    let lastEventKind: string | undefined;
+    let lastEventSeq: number | undefined;
+    let lastAssistantMessageSeq: number | undefined;
+    let lastUserMessageSeq: number | undefined;
+
+    for (const item of iterConversationEventBacklog()) {
+      lastEventKind = item.event.kind;
+      lastEventSeq = item.seq;
+
+      if (item.event.kind === 'MessageEvent') {
+        const role = (item.event as unknown as { llm_message?: { role?: unknown } }).llm_message?.role;
+        if (role === 'assistant') lastAssistantMessageSeq = item.seq;
+        if (role === 'user') lastUserMessageSeq = item.seq;
+      }
+    }
+
+    return {
+      activeConversationId,
+      size: conversationEventBacklogSize,
+      latestSeq: conversationEventSeq,
+      lastEventSeq,
+      lastEventKind,
+      lastUserMessageSeq,
+      lastAssistantMessageSeq,
+    };
+  });
+
   // Test command to send mock events to webview for E2E testing
   const sendTestEvent = vscode.commands.registerCommand('openhands._sendTestEvent', (event: Event) => {
     sentTestEvents.push(event);
@@ -1379,6 +1432,8 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     open,
     diag,
+    queryLastError,
+    queryBacklogSummary,
     sendTestEvent,
     queryRenderedEvents,
     queryUiState,

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1395,10 +1395,14 @@ export function App() {
             const type = eventSnapshots[index] ?? 'unknown';
             const marker = (event as { e2e_marker?: unknown }).e2e_marker;
             const toolCallId = (event as { tool_call_id?: unknown }).tool_call_id;
+            const role = type === 'MessageEvent'
+              ? (event as { llm_message?: { role?: unknown } }).llm_message?.role
+              : undefined;
             return {
               type,
               marker: typeof marker === 'string' ? marker : undefined,
               toolCallId: typeof toolCallId === 'string' ? toolCallId : undefined,
+              role: typeof role === 'string' ? role : undefined,
             };
           });
           if (typeof payload.requestId === 'string') {

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -14,6 +14,7 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **history.test.ts**: Tests conversation history and restore functionality
 - **messaging.test.ts**: Tests message events and rendering
 - **serverSelection.test.ts**: Tests server selection and local/remote mode switching
+- **llmSwitching.test.ts**: Tests switching LLM provider/model/api mode (local, mock server)
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels
 - **errorHandling.test.ts**: Tests error events and error state handling
 - **agentServerRemote.test.ts**: (Optional) Starts a local python agent-server and tests remote mode end-to-end (gated by `E2E_AGENT_SERVER=1`)
@@ -27,6 +28,7 @@ These run inside VS Code and execute the actual tests:
 - **suite/history.ts**: Tests conversation state and event backlog
 - **suite/messaging.ts**: Tests message event rendering and multi-part content
 - **suite/serverSelection.ts**: Tests mode switching and diagnostics state
+- **suite/llmSwitching.ts**: Exercises local LLM switching against a mock server
 - **suite/confirmation.ts**: Tests actions with different security risk levels
 - **suite/errorHandling.ts**: Tests error events and recovery
 

--- a/tests/e2e/llmSwitching.test.ts
+++ b/tests/e2e/llmSwitching.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-llm-${Date.now().toString(36)}`);
+
+// E2E test for switching LLM provider/model/apiMode in local mode.
+describe('OpenHands-Tab LLM Switching E2E', function () {
+  this.timeout(180000);
+
+  it('switches provider/model/apiMode during a conversation', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'llmSwitching',
+        OPENAI_API_KEY: 'e2e-openai-key',
+        ANTHROPIC_API_KEY: 'e2e-anthropic-key',
+        OPENROUTER_API_KEY: 'e2e-openrouter-key',
+        LITELLM_API_KEY: 'e2e-litellm-key',
+      }
+    });
+
+    assert.ok(true);
+  });
+});

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -49,6 +49,11 @@ export async function run(): Promise<void> {
     return runAgentServerRemoteTest();
   }
 
+  if (testName === 'llmSwitching') {
+    const { run: runLlmSwitchingTest } = await import('./llmSwitching');
+    return runLlmSwitchingTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -1,0 +1,189 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import { startMockLlmServer } from './mockLlmServer';
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+type DiagnosticsInfo = {
+  eventBacklog?: { latestSeq?: number };
+};
+
+type ErrorInfo = { seq?: number } | null;
+
+async function sendAndWaitForRequestPath(options: {
+  text: string;
+  expectedPath: string;
+  timeoutMs?: number;
+  getRequests: () => Array<{ path: string }>;
+}): Promise<void> {
+  const { text, expectedPath, timeoutMs = 45000, getRequests } = options;
+  const beforeReqCount = getRequests().length;
+  const beforeDiag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  const beforeSeq = typeof beforeDiag?.eventBacklog?.latestSeq === 'number' ? beforeDiag.eventBacklog.latestSeq : 0;
+  const beforeError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+  const beforeErrorSeq = typeof beforeError?.seq === 'number' ? beforeError.seq : -1;
+
+  const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text }
+  });
+  if (!send?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+  }
+
+  try {
+    await pollUntil(async () => {
+      const reqs = getRequests();
+      const hasExpected = reqs.slice(beforeReqCount).some((r) => r.path === expectedPath);
+      if (!hasExpected) return false;
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+      const seq = typeof diag?.eventBacklog?.latestSeq === 'number' ? diag.eventBacklog.latestSeq : 0;
+      return seq > beforeSeq;
+    }, timeoutMs, 200);
+  } catch (err) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
+    const recent = getRequests()
+      .slice(beforeReqCount)
+      .map((r) => r.path)
+      .slice(-20);
+    throw new Error(
+      `Timed out waiting for mock request (${expectedPath}).\n` +
+      `- diag: ${JSON.stringify(diag)}\n` +
+      `- lastError: ${JSON.stringify(lastError)}\n` +
+      `- requestsSinceSend: ${recent.join(', ') || '(none)'}\n` +
+      `- original: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+  const afterErrorSeq = typeof afterError?.seq === 'number' ? afterError.seq : -1;
+  if (afterError && afterErrorSeq > beforeErrorSeq) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    throw new Error(
+      `Detected error event(s) after sending message.\n` +
+      `- diag: ${JSON.stringify(diag)}\n` +
+      `- lastError: ${JSON.stringify(afterError)}`,
+    );
+  }
+}
+
+export async function run(): Promise<void> {
+  const mock = await startMockLlmServer();
+
+  try {
+    console.log('[llmSwitching] env:', {
+      OPENAI_API_KEY: Boolean(process.env.OPENAI_API_KEY),
+      ANTHROPIC_API_KEY: Boolean(process.env.ANTHROPIC_API_KEY),
+      OPENROUTER_API_KEY: Boolean(process.env.OPENROUTER_API_KEY),
+      LITELLM_API_KEY: Boolean(process.env.LITELLM_API_KEY),
+    });
+
+    await vscode.commands.executeCommand('openhands.open');
+
+    await pollUntil(async () => {
+      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+    }, 15000);
+
+    const cfg = vscode.workspace.getConfiguration();
+
+    // Force local mode + short runs for E2E.
+    await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
+    // Iterations are tracked across a conversation, not per-user-message.
+    // Keep it small but large enough to cover this suite’s multiple sends.
+    await cfg.update('openhands.conversation.maxIterations', 10, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.confirmation.policy', 'never', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.agent.enableSecurityAnalyzer', false, vscode.ConfigurationTarget.Global);
+
+    // 1) Anthropic
+    await cfg.update('openhands.llm.provider', 'anthropic', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'claude-sonnet-4-20250514', vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 1: anthropic',
+      expectedPath: '/messages',
+      getRequests: () => mock.requests,
+    });
+
+    // 2) OpenAI-compatible (chat_completions)
+    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.openaiApiMode', 'chat_completions', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'gpt-4o-mini', vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 2: openai chat',
+      expectedPath: '/chat/completions',
+      getRequests: () => mock.requests,
+    });
+
+    // 3) OpenAI GPT-5 auto mode + custom baseUrl should fall back to chat_completions.
+    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.openaiApiMode', 'auto', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'gpt-5-mini', vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 3: openai gpt-5 auto (custom baseUrl)',
+      expectedPath: '/chat/completions',
+      getRequests: () => mock.requests,
+    });
+
+    // 4) OpenAI Responses API (gpt-5 + openaiApiMode=responses)
+    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.openaiApiMode', 'responses', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'gpt-5-mini', vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 4: openai responses',
+      expectedPath: '/responses',
+      getRequests: () => mock.requests,
+    });
+
+    // 5) Provider variation: openrouter adds extra headers and still hits chat_completions.
+    await cfg.update('openhands.llm.provider', 'openrouter', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.openaiApiMode', 'chat_completions', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'google/gemini-2.0-flash', vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 5: openrouter header check',
+      expectedPath: '/chat/completions',
+      getRequests: () => mock.requests,
+    });
+
+    const openrouterReq = mock.requests
+      .slice()
+      .reverse()
+      .find((r) => r.path === '/chat/completions');
+    if (!openrouterReq) {
+      throw new Error('Expected an OpenRouter /chat/completions request');
+    }
+    const referer = openrouterReq.headers['http-referer'];
+    const title = openrouterReq.headers['x-title'];
+    if (!referer || !title) {
+      throw new Error(`Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`);
+    }
+
+    // Basic sanity: at least one request per step.
+    const paths = mock.requests.map((r) => r.path);
+    const required = ['/messages', '/chat/completions', '/responses'];
+    for (const p of required) {
+      if (!paths.includes(p)) throw new Error(`Missing required mock request path: ${p} (saw: ${paths.join(', ')})`);
+    }
+
+    console.log('✓ LLM switching E2E test passed');
+  } catch (err) {
+    console.error('[llmSwitching] mock requests:', mock.requests.map((r) => ({ method: r.method, path: r.path })));
+    throw err;
+  } finally {
+    await mock.close();
+  }
+}

--- a/tests/e2e/suite/mockLlmServer.ts
+++ b/tests/e2e/suite/mockLlmServer.ts
@@ -1,0 +1,196 @@
+import * as http from 'http';
+import * as net from 'net';
+
+const REDACTED = '<redacted>';
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'x-goog-api-key',
+  'cookie',
+  'set-cookie',
+]);
+
+export type MockLlmRequest = {
+  method: string;
+  path: string;
+  headers: Record<string, string | string[] | undefined>;
+  bodyText: string;
+  json?: unknown;
+};
+
+export type MockLlmServer = {
+  baseUrl: string;
+  requests: MockLlmRequest[];
+  close: () => Promise<void>;
+  reset: () => void;
+};
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        server.close(() => reject(new Error('Failed to allocate free port')));
+        return;
+      }
+      const { port } = addr;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string | string[] | undefined> {
+  const sanitized: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
+      if (Array.isArray(value)) {
+        sanitized[key] = value.map(() => REDACTED);
+      } else if (typeof value === 'string') {
+        sanitized[key] = REDACTED;
+      } else {
+        sanitized[key] = value;
+      }
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
+function sendOpenAiChatCompletionsSse(res: http.ServerResponse, text: string): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: [{ type: 'text', text }] } }] })}\n`);
+  res.write(
+    `data: ${JSON.stringify({
+      choices: [{ delta: {}, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
+    })}\n`,
+  );
+  res.write('data: [DONE]\n');
+  res.end();
+}
+
+function sendAnthropicMessagesSse(res: http.ServerResponse, text: string): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write('event: message_start\n');
+  res.write(`data: ${JSON.stringify({ message: { usage: { input_tokens: 1, output_tokens: 1 } } })}\n`);
+  res.write('event: content_block_delta\n');
+  res.write(`data: ${JSON.stringify({ delta: { type: 'text_delta', text } })}\n`);
+  res.write('event: message_delta\n');
+  res.write(`data: ${JSON.stringify({ delta: { stop_reason: 'end_turn' } })}\n`);
+  res.end();
+}
+
+function sendOpenAiResponsesJson(res: http.ServerResponse, text: string): void {
+  const payload = {
+    output: [
+      {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text }],
+      },
+    ],
+    usage: { input_tokens: 1, output_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+export async function startMockLlmServer(): Promise<MockLlmServer> {
+  const requests: MockLlmRequest[] = [];
+  const port = await getFreePort();
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? 'GET';
+      const rawUrl = req.url ?? '/';
+      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
+      const path = url.pathname;
+
+      if (path === '/__log' && method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ requests }));
+        return;
+      }
+
+      if (path === '/__reset' && method === 'POST') {
+        requests.splice(0, requests.length);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      const bodyChunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
+      await new Promise<void>((resolve) => req.on('end', resolve));
+      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
+      let json: unknown;
+      try {
+        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
+      } catch {
+        json = undefined;
+      }
+
+      requests.push({
+        method,
+        path,
+        headers: sanitizeHeaders(req.headers),
+        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
+        ...(json !== undefined ? { json } : {}),
+      });
+
+      if (method !== 'POST') {
+        res.writeHead(405, { 'Content-Type': 'text/plain' });
+        res.end('Method not allowed');
+        return;
+      }
+
+      if (path === '/chat/completions') {
+        sendOpenAiChatCompletionsSse(res, 'OK (chat_completions)');
+        return;
+      }
+
+      if (path === '/responses') {
+        sendOpenAiResponsesJson(res, 'OK (responses)');
+        return;
+      }
+
+      if (path === '/messages') {
+        sendAnthropicMessagesSse(res, 'OK (anthropic)');
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end(`Not found: ${path}`);
+    })().catch((err) => {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(port, '127.0.0.1', resolve));
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    reset: () => {
+      requests.splice(0, requests.length);
+    },
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}


### PR DESCRIPTION
Implements Beads `oh-tab-838` (and deps `oh-tab-3pl`, `oh-tab-ypa`, `oh-tab-h0d`).

- Add new VS Code E2E suite `llmSwitching` that switches `openhands.llm.*` mid-conversation and asserts the correct API endpoints were hit (Anthropic `/messages`, OpenAI `/chat/completions` + `/responses`, OpenRouter header behavior).
- Add an in-process mock LLM server for E2E (`tests/e2e/suite/mockLlmServer.ts`).
- Improve E2E determinism: add internal debug/test command `openhands._queryLastError` and include `role` in `queryRenderedEvents` snapshots.
- Fix `AnthropicClient` timeout handling: treat non-positive `timeoutSeconds` as default (prevents immediate abort when VS Code returns 0).

Tests:
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run e2e`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling in the LLM SDK to properly validate and apply timeout values.

* **New Features**
  * Added commands to query the latest error event and retrieve backlog summaries.
  * Enhanced message event payloads to include role information.

* **Tests**
  * Added comprehensive end-to-end tests for switching between LLM providers, models, and API modes.
  * Introduced mock LLM server utility supporting multiple provider endpoints for testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->