### PR TITLE
[oh-tab-yve] Gemini main LLM: docs + settings clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This repo uses Husky + lint-staged to run ESLint on staged `*.ts`/`*.tsx` files 
 - **OpenHands: Set Custom Secret 1/2/3** - Set custom secrets for additional integrations
 - Leave server URL blank for local mode, or set it to connect to an [agent-server](https://github.com/OpenHands/software-agent-sdk)
 
+**Using Gemini as the main agent LLM (today)**: use an OpenAI-compatible proxy (OpenRouter or LiteLLM). For example, set `openhands.llm.provider = openrouter`, set `openhands.llm.model = google/gemini-2.0-flash`, and store your OpenRouter key via **OpenHands: Set API Key**. (The `openhands.gemini.*` settings are only used for HAL voice-confirm decision classification, not the agent’s main LLM.)
+
 ## Documentation
 
 | Document | Description |

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -124,6 +124,10 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - `openhands.confirmation.policy` - never/always/risky; `risky.threshold` default MEDIUM; `risky.confirmUnknown`
 - `openhands.conversation.maxIterations` - iteration limit
 
+Gemini note:
+- `openhands.gemini.*` is used for HAL `voice_confirm` decision classification only (not the agent’s main LLM).
+- To use Gemini models as the main agent LLM today, route via an OpenAI-compatible proxy: OpenRouter (`openhands.llm.provider = openrouter`) or a LiteLLM proxy (`openhands.llm.provider = litellm_proxy`).
+
 For internal diagnostics and the dev logging bridge, see docs/vscode_local_setup.md.
 
 ### Connection & Conversation Lifecycle

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -116,6 +116,12 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
   - LLM defaults: user-level defaults, overridable per workspace
   - Secrets: always global SecretStorage (per machine), not synced in settings
 
+Gemini note (main agent LLM):
+- The extension’s `openhands.gemini.*` settings are used for HAL `voice_confirm` decision classification only.
+- The main agent LLM does not support the native Gemini API yet; to use Gemini models today, use an OpenAI-compatible proxy:
+  - OpenRouter: set `openhands.llm.provider = openrouter` and use an OpenRouter Gemini model id like `google/gemini-2.0-flash`.
+  - LiteLLM: run a LiteLLM OpenAI-compatible proxy and set `openhands.llm.provider = litellm_proxy` + `openhands.llm.baseUrl` to the proxy URL.
+
 5) Practical mapping at runtime
 - Start New Conversation request body (extension → server)
   - agent.llm: built from

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
             "type": "string",
             "default": "claude-sonnet-4-20250514",
             "order": 1,
-            "markdownDescription": "Default model name for LLM requests."
+            "markdownDescription": "Default model name for LLM requests.\n\nTip: to use Gemini models today, select `openhands.llm.provider = openrouter` and set this to an OpenRouter Gemini model id like `google/gemini-2.0-flash`."
           },
           "openhands.llm.apiKey": {
             "type": "string",
@@ -135,7 +135,7 @@
             ],
             "default": "auto",
             "order": 4,
-            "markdownDescription": "LLM provider selection. Use `auto` to infer from `openhands.llm.baseUrl` when set; otherwise local mode defaults to Anthropic."
+            "markdownDescription": "LLM provider selection. Use `auto` to infer from `openhands.llm.baseUrl` when set; otherwise local mode defaults to Anthropic.\n\nGemini note: the main agent LLM does not support the native Gemini API yet. To use Gemini models today, use `openrouter` (recommended) or `litellm_proxy`."
           },
           "openhands.llm.temperature": {
             "type": "number",


### PR DESCRIPTION
Adds a clear note that Gemini is not yet a first-class `openhands.llm.provider`, and documents the recommended workaround via OpenRouter or a LiteLLM OpenAI-compatible proxy.

Changes:
- Updates `package.json` setting descriptions for `openhands.llm.provider` + `openhands.llm.model`
- Adds a short note to `README.md`, `docs/PRD.md`, `docs/settings_prd.md`

Validation:
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using Gemini models as the main agent LLM via OpenRouter or LiteLLM proxies
  * Clarified that Gemini settings are reserved for voice decision classification only
  * Updated configuration descriptions with Gemini setup instructions and example model IDs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->