### PR TITLE
[oh-tab-7r4] agent-sdk-ts: LLM profile persistence APIs

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { LLMConfiguration } from '../llm';
+import { LLMProfileValidationError, listProfiles, loadProfile, saveProfile, validateProfile } from '../llm';
+
+const makeTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'llm-profiles-'));
+
+describe('LLM profiles', () => {
+  it('saves, loads, and lists profiles', () => {
+    const dir = makeTempDir();
+    try {
+      const configA: LLMConfiguration = { provider: 'openai', model: 'gpt-5', apiKey: 'OPENAI_API_KEY' };
+      const configB: LLMConfiguration = { provider: 'anthropic', model: 'claude', apiKey: 'ANTHROPIC_API_KEY' };
+      saveProfile('b', configB, { rootDir: dir });
+      saveProfile('a', configA, { rootDir: dir });
+
+      expect(listProfiles({ rootDir: dir })).toEqual(['a', 'b']);
+
+      const loaded = loadProfile('a', { rootDir: dir });
+      expect(loaded.profileId).toBe('a');
+      expect(loaded.config.model).toBe('gpt-5');
+      expect(loaded.config.provider).toBe('openai');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('omits inline apiKey when includeSecrets=false', () => {
+    const dir = makeTempDir();
+    try {
+      saveProfile('no-secrets', { provider: 'openai', model: 'gpt-5', apiKey: 'sk-secret' }, { rootDir: dir });
+      const filePath = path.join(dir, 'no-secrets.json');
+      const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+
+      expect(payload.apiKey).toBeUndefined();
+      expect(loadProfile('no-secrets', { rootDir: dir }).config.apiKey).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('persists inline apiKey when includeSecrets=true', () => {
+    const dir = makeTempDir();
+    try {
+      saveProfile(
+        'with-secrets',
+        { provider: 'openai', model: 'gpt-5', apiKey: 'sk-secret' },
+        { rootDir: dir, includeSecrets: true },
+      );
+      const filePath = path.join(dir, 'with-secrets.json');
+      const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+
+      expect(payload.apiKey).toBe('sk-secret');
+      if (process.platform !== 'win32') {
+        expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+      }
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('validates profile payloads', () => {
+    expect(() => validateProfile({})).toThrow(LLMProfileValidationError);
+    expect(() => validateProfile({ model: '' })).toThrow(LLMProfileValidationError);
+    expect(validateProfile({ model: 'gpt-5', provider: 'openai' }).model).toBe('gpt-5');
+  });
+
+  it('rejects invalid profile ids', () => {
+    const dir = makeTempDir();
+    try {
+      expect(() => saveProfile('../evil', { model: 'gpt-5' }, { rootDir: dir })).toThrow(
+        LLMProfileValidationError,
+      );
+      expect(() => loadProfile('../evil', { rootDir: dir })).toThrow(LLMProfileValidationError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
@@ -27,15 +27,27 @@ describe('LLM profiles', () => {
     }
   });
 
-  it('omits inline apiKey when includeSecrets=false', () => {
+  it('omits inline apiKey and headers when includeSecrets=false', () => {
     const dir = makeTempDir();
     try {
-      saveProfile('no-secrets', { provider: 'openai', model: 'gpt-5', apiKey: 'sk-secret' }, { rootDir: dir });
+      saveProfile(
+        'no-secrets',
+        {
+          provider: 'openai',
+          model: 'gpt-5',
+          apiKey: 'sk-secret',
+          headers: { Authorization: 'Bearer sk-secret', 'X-Title': 'not-a-secret' },
+        },
+        { rootDir: dir },
+      );
       const filePath = path.join(dir, 'no-secrets.json');
       const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
 
       expect(payload.apiKey).toBeUndefined();
-      expect(loadProfile('no-secrets', { rootDir: dir }).config.apiKey).toBeUndefined();
+      expect(payload.headers).toBeUndefined();
+      const loaded = loadProfile('no-secrets', { rootDir: dir }).config;
+      expect(loaded.apiKey).toBeUndefined();
+      expect(loaded.headers).toBeUndefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -67,6 +79,28 @@ describe('LLM profiles', () => {
     expect(validateProfile({ model: 'gpt-5', provider: 'openai' }).model).toBe('gpt-5');
   });
 
+  it('validates profiles before saving', () => {
+    const dir = makeTempDir();
+    try {
+      expect(() => saveProfile('invalid', { model: '' } as unknown as LLMConfiguration, { rootDir: dir })).toThrow(
+        LLMProfileValidationError,
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores invalid profile ids when listing files on disk', () => {
+    const dir = makeTempDir();
+    try {
+      fs.writeFileSync(path.join(dir, 'bad name.json'), '{}', 'utf8');
+      saveProfile('good', { model: 'gpt-5' }, { rootDir: dir });
+      expect(listProfiles({ rootDir: dir })).toEqual(['good']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('rejects invalid profile ids', () => {
     const dir = makeTempDir();
     try {
@@ -79,4 +113,3 @@ describe('LLM profiles', () => {
     }
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -8,3 +8,4 @@ export * from './factory';
 export * from './provider';
 export * from './metrics';
 export * from './registry';
+export * from './profiles';

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -1,0 +1,261 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { LLMConfiguration, LLMProvider, OpenAIChatApi, ReasoningSummary } from './types';
+
+export const DEFAULT_LLM_PROFILES_DIR = path.join(os.homedir(), '.openhands', 'llm-profiles');
+
+export interface LLMProfile {
+  profileId: string;
+  config: LLMConfiguration;
+}
+
+export class LLMProfileValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LLMProfileValidationError';
+  }
+}
+
+export interface LLMProfileStoreOptions {
+  rootDir?: string;
+}
+
+export interface SaveProfileOptions extends LLMProfileStoreOptions {
+  includeSecrets?: boolean;
+}
+
+const expandHomeDir = (value: string): string => {
+  if (value === '~') return os.homedir();
+  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
+  return value;
+};
+
+const resolveRootDir = (options: LLMProfileStoreOptions = {}): string => {
+  const rootDir = options.rootDir ?? DEFAULT_LLM_PROFILES_DIR;
+  return path.resolve(expandHomeDir(rootDir));
+};
+
+const assertValidProfileId = (profileId: string): void => {
+  if (!profileId.trim()) {
+    throw new LLMProfileValidationError('Profile id must be a non-empty string');
+  }
+  if (profileId !== profileId.trim()) {
+    throw new LLMProfileValidationError('Profile id must not have leading/trailing whitespace');
+  }
+  if (profileId.includes('/') || profileId.includes('\\')) {
+    throw new LLMProfileValidationError('Profile id must not contain path separators');
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(profileId)) {
+    throw new LLMProfileValidationError('Profile id contains invalid characters');
+  }
+};
+
+const getProfilePath = (profileId: string, rootDir: string): string => {
+  assertValidProfileId(profileId);
+  const normalizedRootDir = path.resolve(rootDir);
+  const candidate = path.resolve(normalizedRootDir, `${profileId}.json`);
+  const rootWithSep = normalizedRootDir.endsWith(path.sep)
+    ? normalizedRootDir
+    : `${normalizedRootDir}${path.sep}`;
+  if (!candidate.startsWith(rootWithSep)) {
+    throw new LLMProfileValidationError('Profile id resolves outside the profile root directory');
+  }
+  return candidate;
+};
+
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const LLM_PROVIDERS: readonly LLMProvider[] = [
+  'openai',
+  'litellm_proxy',
+  'openrouter',
+  'anthropic',
+  'gemini',
+];
+
+const isLLMProvider = (value: unknown): value is LLMProvider =>
+  typeof value === 'string' && (LLM_PROVIDERS as readonly string[]).includes(value);
+
+const OPENAI_API_MODES: readonly OpenAIChatApi[] = ['chat_completions', 'responses'];
+
+const isOpenAIApiMode = (value: unknown): value is OpenAIChatApi =>
+  typeof value === 'string' && (OPENAI_API_MODES as readonly string[]).includes(value);
+
+const REASONING_SUMMARIES: readonly ReasoningSummary[] = ['auto', 'concise', 'detailed'];
+
+const isReasoningSummary = (value: unknown): value is ReasoningSummary =>
+  typeof value === 'string' && (REASONING_SUMMARIES as readonly string[]).includes(value);
+
+const isNullableString = (value: unknown): value is string | null =>
+  value === null || typeof value === 'string';
+
+const isNullableNumber = (value: unknown): value is number | null =>
+  value === null || (typeof value === 'number' && Number.isFinite(value));
+
+const validateHeaders = (headers: unknown): void => {
+  if (!isObjectRecord(headers)) {
+    throw new LLMProfileValidationError('headers must be an object mapping string keys to string values');
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (typeof key !== 'string' || typeof value !== 'string') {
+      throw new LLMProfileValidationError('headers must be an object mapping string keys to string values');
+    }
+  }
+};
+
+export const validateProfile = (payload: unknown): LLMConfiguration => {
+  if (!isObjectRecord(payload)) {
+    throw new LLMProfileValidationError('Profile payload must be an object');
+  }
+
+  if (typeof payload.model !== 'string' || !payload.model.trim()) {
+    throw new LLMProfileValidationError('Profile must include a non-empty "model" string');
+  }
+
+  if ('provider' in payload && payload.provider !== undefined && payload.provider !== null) {
+    if (!isLLMProvider(payload.provider)) {
+      throw new LLMProfileValidationError(`Unsupported provider: ${JSON.stringify(payload.provider)}`);
+    }
+  }
+
+  if ('usageId' in payload && payload.usageId !== undefined && payload.usageId !== null) {
+    if (typeof payload.usageId !== 'string') {
+      throw new LLMProfileValidationError('usageId must be a string or null');
+    }
+  }
+
+  if ('openaiApiMode' in payload && payload.openaiApiMode !== undefined && payload.openaiApiMode !== null) {
+    if (!isOpenAIApiMode(payload.openaiApiMode)) {
+      throw new LLMProfileValidationError('openaiApiMode must be "chat_completions", "responses", or null');
+    }
+  }
+
+  for (const key of ['baseUrl', 'apiVersion'] as const) {
+    if (key in payload && payload[key] !== undefined) {
+      if (!isNullableString(payload[key])) {
+        throw new LLMProfileValidationError(`${key} must be a string or null`);
+      }
+    }
+  }
+
+  if ('apiKey' in payload && payload.apiKey !== undefined) {
+    if (typeof payload.apiKey !== 'string') {
+      throw new LLMProfileValidationError('apiKey must be a string');
+    }
+  }
+
+  for (const key of ['timeoutSeconds', 'temperature', 'topP', 'topK'] as const) {
+    if (key in payload && payload[key] !== undefined) {
+      if (!isNullableNumber(payload[key])) {
+        throw new LLMProfileValidationError(`${key} must be a number or null`);
+      }
+    }
+  }
+
+  for (const key of ['maxInputTokens', 'maxOutputTokens'] as const) {
+    if (key in payload && payload[key] !== undefined) {
+      if (!isNullableNumber(payload[key])) {
+        throw new LLMProfileValidationError(`${key} must be a number or null`);
+      }
+    }
+  }
+
+  if ('reasoningEffort' in payload && payload.reasoningEffort !== undefined && payload.reasoningEffort !== null) {
+    if (
+      typeof payload.reasoningEffort !== 'string' ||
+      !['low', 'medium', 'high', 'none'].includes(payload.reasoningEffort)
+    ) {
+      throw new LLMProfileValidationError('reasoningEffort must be "low", "medium", "high", "none", or null');
+    }
+  }
+
+  if (
+    'reasoningSummary' in payload &&
+    payload.reasoningSummary !== undefined &&
+    payload.reasoningSummary !== null
+  ) {
+    if (!isReasoningSummary(payload.reasoningSummary)) {
+      throw new LLMProfileValidationError('reasoningSummary must be "auto", "concise", "detailed", or null');
+    }
+  }
+
+  if ('headers' in payload && payload.headers !== undefined) {
+    validateHeaders(payload.headers);
+  }
+
+  for (const key of ['inputCostPerToken', 'outputCostPerToken'] as const) {
+    if (key in payload && payload[key] !== undefined) {
+      if (!isNullableNumber(payload[key])) {
+        throw new LLMProfileValidationError(`${key} must be a number or null`);
+      }
+    }
+  }
+
+  return payload as unknown as LLMConfiguration;
+};
+
+const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
+  const sanitized: LLMConfiguration = { ...config };
+  if (typeof sanitized.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(sanitized.apiKey)) {
+    delete sanitized.apiKey;
+  }
+  return sanitized;
+};
+
+export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] => {
+  const rootDir = resolveRootDir(options);
+  if (!fs.existsSync(rootDir)) return [];
+
+  return fs
+    .readdirSync(rootDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+    .map((entry) => entry.name.slice(0, -'.json'.length))
+    .sort((a, b) => a.localeCompare(b));
+};
+
+export const loadProfile = (profileId: string, options: LLMProfileStoreOptions = {}): LLMProfile => {
+  const rootDir = resolveRootDir(options);
+  const filePath = getProfilePath(profileId, rootDir);
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Profile '${profileId}' not found`);
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+  let payload: unknown;
+  try {
+    payload = JSON.parse(content) as unknown;
+  } catch (error) {
+    throw new LLMProfileValidationError(
+      `Profile '${profileId}' contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const config = validateProfile(payload);
+  return { profileId, config };
+};
+
+export const saveProfile = (
+  profileId: string,
+  config: LLMConfiguration,
+  options: SaveProfileOptions = {},
+): void => {
+  const rootDir = resolveRootDir(options);
+  fs.mkdirSync(rootDir, { recursive: true, mode: 0o700 });
+  const filePath = getProfilePath(profileId, rootDir);
+
+  const includeSecrets = options.includeSecrets ?? false;
+  const payload = includeSecrets ? { ...config } : stripSecrets(config);
+  delete (payload as { profileId?: unknown }).profileId;
+
+  const json = `${JSON.stringify(payload, null, 2)}\n`;
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, json, { encoding: 'utf8', mode: 0o600 });
+  fs.renameSync(tmpPath, filePath);
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Best-effort on platforms that support chmod.
+  }
+};

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -219,7 +219,7 @@ export const loadProfile = (profileId: string, options: LLMProfileStoreOptions =
   const rootDir = resolveRootDir(options);
   const filePath = getProfilePath(profileId, rootDir);
   if (!fs.existsSync(filePath)) {
-    throw new Error(`Profile '${profileId}' not found`);
+    throw new LLMProfileValidationError(`Profile '${profileId}' not found`);
   }
 
   const content = fs.readFileSync(filePath, 'utf8');
@@ -252,7 +252,16 @@ export const saveProfile = (
   const json = `${JSON.stringify(payload, null, 2)}\n`;
   const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
   fs.writeFileSync(tmpPath, json, { encoding: 'utf8', mode: 0o600 });
-  fs.renameSync(tmpPath, filePath);
+  try {
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      // Best-effort cleanup.
+    }
+    throw error;
+  }
   try {
     fs.chmodSync(filePath, 0o600);
   } catch {

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -201,6 +201,9 @@ const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
   if (typeof sanitized.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(sanitized.apiKey)) {
     delete sanitized.apiKey;
   }
+  // Headers can plausibly contain auth material (Authorization, x-api-key, etc.).
+  // In "no secrets" mode, be conservative and do not persist headers.
+  delete sanitized.headers;
   return sanitized;
 };
 
@@ -208,11 +211,18 @@ export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] => 
   const rootDir = resolveRootDir(options);
   if (!fs.existsSync(rootDir)) return [];
 
-  return fs
-    .readdirSync(rootDir, { withFileTypes: true })
-    .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
-    .map((entry) => entry.name.slice(0, -'.json'.length))
-    .sort((a, b) => a.localeCompare(b));
+  const profileIds: string[] = [];
+  for (const entry of fs.readdirSync(rootDir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) continue;
+    const profileId = entry.name.slice(0, -'.json'.length);
+    try {
+      assertValidProfileId(profileId);
+      profileIds.push(profileId);
+    } catch {
+      // Ignore files that cannot possibly be loaded.
+    }
+  }
+  return profileIds.sort((a, b) => a.localeCompare(b));
 };
 
 export const loadProfile = (profileId: string, options: LLMProfileStoreOptions = {}): LLMProfile => {
@@ -248,6 +258,7 @@ export const saveProfile = (
   const includeSecrets = options.includeSecrets ?? false;
   const payload = includeSecrets ? { ...config } : stripSecrets(config);
   delete (payload as { profileId?: unknown }).profileId;
+  validateProfile(payload);
 
   const json = `${JSON.stringify(payload, null, 2)}\n`;
   const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;


### PR DESCRIPTION
Implements disk-backed LLM profiles in `@openhands/agent-sdk-ts`.

- Adds `packages/agent-sdk-ts/src/sdk/llm/profiles.ts` with `listProfiles`, `loadProfile`, `saveProfile`, `validateProfile`.
- Default root: `~/.openhands/llm-profiles/` (override via `{ rootDir }`).
- `saveProfile(..., includeSecrets: false)` omits inline `apiKey` by default; `includeSecrets: true` persists it (0600 perms best-effort).
- Adds Vitest coverage for happy path + invalid payload/id.

Validation:
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added LLM profile management system enabling users to save, load, and list profiles
  * Profiles include validation to ensure correct LLM configuration
  * Secure storage with configurable secret handling and atomic writes

* **Tests**
  * Added comprehensive test suite for profile operations and validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->