### PR TITLE
[oh-tab-fx5] Profile-aware LLM selection + labels

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -11,13 +11,14 @@ function makeMetrics(token: number): Metrics {
 describe('ConversationStats', () => {
   it('registers llm metrics and combines', () => {
     const stats = new ConversationStats();
-    const llmA = { llm: { usageId: 'a', metrics: makeMetrics(1) } };
-    const llmB = { llm: { usageId: 'b', metrics: makeMetrics(2) } };
+    const llmA = { llm: { usageId: 'a', metrics: makeMetrics(1), label: 'profile-a' } };
+    const llmB = { llm: { usageId: 'b', metrics: makeMetrics(2), label: 'profile-b' } };
 
     stats.registerLlm(llmA);
     stats.registerLlm(llmB);
 
     expect(Object.keys(stats.usageToMetrics)).toEqual(['a', 'b']);
+    expect(stats.usageToLabels).toEqual({ a: 'profile-a', b: 'profile-b' });
 
     const combined = stats.getCombinedMetrics().getSnapshot();
     expect(combined.accumulatedTokenUsage?.promptTokens).toBe(3);
@@ -25,13 +26,14 @@ describe('ConversationStats', () => {
 
   it('serializes and restores from JSON', () => {
     const stats = new ConversationStats();
-    stats.registerLlm({ llm: { usageId: 'a', metrics: makeMetrics(3) } });
+    stats.registerLlm({ llm: { usageId: 'a', metrics: makeMetrics(3), label: 'profile-a' } });
 
     const json = stats.toJSON();
     const restored = ConversationStats.fromJSON(json);
 
     const m = restored.getMetricsForUsage('a');
     expect(m.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(3);
+    expect(restored.usageToLabels).toEqual({ a: 'profile-a' });
   });
 
   it('restores and merges metrics correctly on re-registration', () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { ConversationStats } from '../runtime/ConversationStats';
+import { LLMFactory, LLMRegistry, TrackedLLMClient, saveProfile } from '../llm';
+
+const makeTempDir = (prefix: string) => fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+describe('LLMFactory profile selection', () => {
+  it('loads config from profileId and exposes a user-facing label', async () => {
+    const dir = makeTempDir('llm-profile-selection-');
+    try {
+      saveProfile('p1', { provider: 'openai', model: 'gpt-5' }, { rootDir: dir });
+
+      const registry = new LLMRegistry();
+      const stats = new ConversationStats();
+      registry.subscribe((event) => stats.registerLlm(event));
+
+      const factory = new LLMFactory(
+        {
+          // Placeholder values should not override the profile's provider/model.
+          provider: 'anthropic',
+          model: 'IGNORED',
+          profileId: 'p1',
+          profileName: 'My Profile',
+          usageId: 'default',
+          apiKey: 'sk-inline',
+        },
+        { registry, profileStoreOptions: { rootDir: dir } },
+      );
+
+      const client = await factory.createClient();
+      expect(client).toBeInstanceOf(TrackedLLMClient);
+
+      const tracked = client as TrackedLLMClient;
+      expect(tracked.modelName).toBe('gpt-5');
+      expect(tracked.label).toBe('My Profile');
+      expect(stats.usageToLabels.default).toBe('My Profile');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -62,7 +62,7 @@ export class LLMFactory {
       for (const [key, value] of Object.entries(this.config)) {
         if (value === undefined) continue;
         if (key === 'profileId' || key === 'profileName' || key === 'provider' || key === 'model') continue;
-        (merged as Record<string, unknown>)[key] = value;
+        (merged as unknown as Record<string, unknown>)[key] = value;
       }
       return merged;
     })();

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -5,6 +5,8 @@ import { OpenAICompatibleClient } from './openai-compatible';
 import { OpenAIResponsesClient } from './openai-responses';
 import { GeminiClient } from './gemini';
 import type { ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
+import type { LLMProfileStoreOptions } from './profiles';
+import { loadProfile } from './profiles';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMRegistry, TrackedLLMClient, llmRegistryKeyToString, toLLMRegistryKey } from './registry';
 import { Metrics } from './metrics';
@@ -13,6 +15,7 @@ import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl } from './provide
 export interface LLMFactoryOptions {
   secrets?: SecretRegistry;
   preferredApiKeys?: string | string[];
+  profileStoreOptions?: LLMProfileStoreOptions;
   registry?: LLMRegistry;
   onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 }
@@ -20,12 +23,14 @@ export interface LLMFactoryOptions {
 export class LLMFactory {
   private readonly credentialProvider: LLMCredentialProvider;
   private readonly preferredKeys?: string | string[];
+  private readonly profileStoreOptions?: LLMProfileStoreOptions;
   private readonly registry?: LLMRegistry;
   private readonly onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 
   constructor(private readonly config: LLMConfiguration, options: LLMFactoryOptions = {}) {
     this.credentialProvider = new LLMCredentialProvider(options.secrets);
     this.preferredKeys = options.preferredApiKeys;
+    this.profileStoreOptions = options.profileStoreOptions;
     this.registry = options.registry;
     this.onMetricsUpdate = options.onMetricsUpdate;
   }
@@ -42,29 +47,50 @@ export class LLMFactory {
       return JSON.stringify(Object.fromEntries(entries));
     };
 
-    const provider = this.config.provider ?? detectProviderFromBaseUrl(this.config.baseUrl);
+    const profileId = normalizeOptionalString(this.config.profileId);
+    const config: LLMConfiguration = (() => {
+      if (!profileId) return this.config;
+      const profile = loadProfile(profileId, this.profileStoreOptions);
+      const merged: LLMConfiguration = {
+        ...profile.config,
+        profileId,
+        profileName: normalizeOptionalString(profile.config.profileName) ?? profileId,
+      };
+      const requestedProfileName = normalizeOptionalString(this.config.profileName);
+      if (requestedProfileName) merged.profileName = requestedProfileName;
+
+      for (const [key, value] of Object.entries(this.config)) {
+        if (value === undefined) continue;
+        if (key === 'profileId' || key === 'profileName' || key === 'provider' || key === 'model') continue;
+        (merged as Record<string, unknown>)[key] = value;
+      }
+      return merged;
+    })();
+
+    const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
+    const label = normalizeOptionalString(config.profileName) ?? normalizeOptionalString(config.profileId) ?? config.model;
 
     const inlineApiKey =
-      typeof this.config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(this.config.apiKey)
-        ? this.config.apiKey
+      typeof config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(config.apiKey)
+        ? config.apiKey
         : undefined;
     const apiKey =
       inlineApiKey ??
       (await this.credentialProvider.getApiKey(
-        this.config.apiKey ?? this.preferredKeys ?? this.getDefaultApiKeyName(provider),
+        config.apiKey ?? this.preferredKeys ?? this.getDefaultApiKeyName(provider),
       ));
     if (!apiKey) {
       throw new Error('Missing API key for LLM provider');
     }
 
-    const normalizedModel = this.config.model.toLowerCase();
-    const openaiApiMode = provider === 'openai' ? this.config.openaiApiMode ?? undefined : undefined;
+    const normalizedModel = config.model.toLowerCase();
+    const openaiApiMode = provider === 'openai' ? config.openaiApiMode ?? undefined : undefined;
     const normalizeUrl = (value: string | null | undefined): string | undefined => {
       const trimmed = typeof value === 'string' ? value.trim() : '';
       if (!trimmed) return undefined;
       return trimmed.replace(/\/+$/, '');
     };
-    const normalizedBaseUrl = normalizeUrl(this.config.baseUrl);
+    const normalizedBaseUrl = normalizeUrl(config.baseUrl);
     const normalizedDefaultOpenAIBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS.openai);
     const baseUrlSupportsResponses = !normalizedBaseUrl || normalizedBaseUrl === normalizedDefaultOpenAIBaseUrl;
     const isGpt5 = normalizedModel.startsWith('gpt-5');
@@ -76,28 +102,28 @@ export class LLMFactory {
     const effectiveOpenaiApiMode =
       provider === 'openai' ? (useResponses ? 'responses' : 'chat_completions') : undefined;
     const registryKey = toLLMRegistryKey({
-      ...this.config,
+      ...config,
       provider,
       openaiApiMode: effectiveOpenaiApiMode,
     });
 
-    const explicitUsageId = normalizeOptionalString(this.config.usageId);
+    const explicitUsageId = normalizeOptionalString(config.usageId);
     const derivedUsageId = (() => {
       if (explicitUsageId) return explicitUsageId;
       if (!this.registry) return undefined;
       const fingerprint = {
         key: llmRegistryKeyToString(registryKey),
-        timeoutSeconds: this.config.timeoutSeconds ?? null,
-        temperature: this.config.temperature ?? null,
-        topP: this.config.topP ?? null,
-        topK: this.config.topK ?? null,
-        maxInputTokens: this.config.maxInputTokens ?? null,
-        maxOutputTokens: this.config.maxOutputTokens ?? null,
-        reasoningEffort: this.config.reasoningEffort ?? null,
-        reasoningSummary: this.config.reasoningSummary ?? null,
-        headers: stableStringifyHeaders(this.config.headers),
-        inputCostPerToken: this.config.inputCostPerToken ?? null,
-        outputCostPerToken: this.config.outputCostPerToken ?? null,
+        timeoutSeconds: config.timeoutSeconds ?? null,
+        temperature: config.temperature ?? null,
+        topP: config.topP ?? null,
+        topK: config.topK ?? null,
+        maxInputTokens: config.maxInputTokens ?? null,
+        maxOutputTokens: config.maxOutputTokens ?? null,
+        reasoningEffort: config.reasoningEffort ?? null,
+        reasoningSummary: config.reasoningSummary ?? null,
+        headers: stableStringifyHeaders(config.headers),
+        inputCostPerToken: config.inputCostPerToken ?? null,
+        outputCostPerToken: config.outputCostPerToken ?? null,
         apiKeyHash: hashString(apiKey).slice(0, 16),
       };
       const digest = hashString(JSON.stringify(fingerprint)).slice(0, 12);
@@ -108,6 +134,7 @@ export class LLMFactory {
       try {
         const cached = this.registry.get(derivedUsageId);
         cached.setOnMetricsUpdate(this.onMetricsUpdate);
+        cached.setLabel(label);
         // Re-announce selection so stats/UI have a consistent "current llm" signal.
         this.registry.switchLlm(cached, registryKey);
         return cached;
@@ -117,21 +144,22 @@ export class LLMFactory {
     }
     let base: LLMClient;
     if (provider === 'anthropic') {
-      base = new AnthropicClient(this.config, apiKey);
+      base = new AnthropicClient(config, apiKey);
     } else if (provider === 'gemini') {
-      base = new GeminiClient({ ...this.config, provider }, apiKey);
+      base = new GeminiClient({ ...config, provider }, apiKey);
     } else if (useResponses) {
-      base = new OpenAIResponsesClient({ ...this.config, provider }, apiKey);
+      base = new OpenAIResponsesClient({ ...config, provider }, apiKey);
     } else {
-      base = new OpenAICompatibleClient({ ...this.config, provider }, apiKey);
+      base = new OpenAICompatibleClient({ ...config, provider }, apiKey);
     }
 
     if (derivedUsageId) {
-      const metrics = new Metrics(this.config.model);
+      const metrics = new Metrics(config.model);
       const tracked = new TrackedLLMClient({
         inner: base,
         usageId: derivedUsageId,
-        modelName: this.config.model,
+        modelName: config.model,
+        label,
         metrics,
         onMetricsUpdate: this.onMetricsUpdate,
       });

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -114,6 +114,19 @@ export const validateProfile = (payload: unknown): LLMConfiguration => {
     throw new LLMProfileValidationError('Profile must include a non-empty "model" string');
   }
 
+  if ('profileId' in payload && payload.profileId !== undefined && payload.profileId !== null) {
+    if (typeof payload.profileId !== 'string') {
+      throw new LLMProfileValidationError('profileId must be a string or null');
+    }
+    assertValidProfileId(payload.profileId);
+  }
+
+  if ('profileName' in payload && payload.profileName !== undefined && payload.profileName !== null) {
+    if (typeof payload.profileName !== 'string' || !payload.profileName.trim()) {
+      throw new LLMProfileValidationError('profileName must be a non-empty string or null');
+    }
+  }
+
   if ('provider' in payload && payload.provider !== undefined && payload.provider !== null) {
     if (!isLLMProvider(payload.provider)) {
       throw new LLMProfileValidationError(`Unsupported provider: ${JSON.stringify(payload.provider)}`);

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -104,19 +104,32 @@ export class TrackedLLMClient implements LLMClient {
   readonly inner: LLMClient;
   readonly usageId: string;
   readonly modelName: string;
+  label: string;
   readonly metrics: Metrics;
   private onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 
-  constructor(params: { inner: LLMClient; usageId: string; modelName: string; metrics: Metrics; onMetricsUpdate?: (usageId: string, metrics: Metrics) => void }) {
+  constructor(params: {
+    inner: LLMClient;
+    usageId: string;
+    modelName: string;
+    label?: string;
+    metrics: Metrics;
+    onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
+  }) {
     this.inner = params.inner;
     this.usageId = params.usageId;
     this.modelName = params.modelName;
+    this.label = params.label ?? params.modelName;
     this.metrics = params.metrics;
     this.onMetricsUpdate = params.onMetricsUpdate;
   }
 
   setOnMetricsUpdate(cb?: (usageId: string, metrics: Metrics) => void): void {
     this.onMetricsUpdate = cb;
+  }
+
+  setLabel(label: string): void {
+    this.label = label;
   }
 
   async *streamChat(request: import('./types').ChatCompletionRequest): AsyncGenerator<import('./types').LLMStreamChunk> {

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -18,6 +18,10 @@ export interface LLMToolDefinition {
 export interface LLMConfiguration {
   provider?: LLMProvider;
   model: string;
+  /** Optional LLM profile identifier (filename stem under ~/.openhands/llm-profiles/). */
+  profileId?: string | null;
+  /** User-facing profile label; preferred for UI over raw model name. */
+  profileName?: string | null;
   usageId?: string | null;
   /** Only applies to OpenAI provider. */
   openaiApiMode?: OpenAIChatApi | null;

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -2,6 +2,7 @@ import { Metrics } from '../llm/metrics';
 
 export class ConversationStats {
   usageToMetrics: Record<string, Metrics> = {};
+  usageToLabels: Record<string, string> = {};
   private restoredUsageIds = new Set<string>();
 
   static fromJSON(json: unknown): ConversationStats {
@@ -15,6 +16,14 @@ export class ConversationStats {
         stats.usageToMetrics[key] = Metrics.fromJSON(value);
       }
     }
+    const labels = obj['usage_to_labels'];
+    if (labels && typeof labels === 'object') {
+      for (const [usageId, label] of Object.entries(labels as Record<string, unknown>)) {
+        if (typeof label === 'string' && label.trim()) {
+          stats.usageToLabels[usageId] = label;
+        }
+      }
+    }
     const restored = obj['_restored_usage_ids'];
     if (Array.isArray(restored)) restored.forEach((id) => stats.restoredUsageIds.add(String(id)));
     return stats;
@@ -23,12 +32,14 @@ export class ConversationStats {
   toJSON(): Record<string, unknown> {
     return {
       usage_to_metrics: Object.fromEntries(Object.entries(this.usageToMetrics).map(([k, v]) => [k, v.toJSON()])),
+      usage_to_labels: { ...this.usageToLabels },
       _restored_usage_ids: Array.from(this.restoredUsageIds),
     };
   }
 
   restore(other: ConversationStats): void {
     this.usageToMetrics = other.usageToMetrics;
+    this.usageToLabels = other.usageToLabels;
     this.restoredUsageIds = new Set(other.restoredUsageIds);
   }
 
@@ -44,7 +55,7 @@ export class ConversationStats {
     return metrics;
   }
 
-  registerLlm(event: { llm: { usageId: string; metrics: Metrics } }): void {
+  registerLlm(event: { llm: { usageId: string; metrics: Metrics; label?: string } }): void {
     const llm = event.llm;
     const usageId = llm.usageId;
     if (usageId in this.usageToMetrics && !this.restoredUsageIds.has(usageId)) {
@@ -54,5 +65,8 @@ export class ConversationStats {
     }
     // Ensure we track the live metrics object
     this.usageToMetrics[usageId] = llm.metrics;
+    if (llm.label) {
+      this.usageToLabels[usageId] = llm.label;
+    }
   }
 }


### PR DESCRIPTION
Implements `oh-tab-fx5` (profile-aware LLM selection).

- Adds `profileId`/`profileName` to `LLMConfiguration`.
- `LLMFactory` loads the on-disk profile when `profileId` is set and uses it as the canonical provider/model; optional fields (e.g. `apiKey`, temperature, etc.) can still be overridden at runtime.
- `TrackedLLMClient` now carries a user-facing `label` (profile name preferred, then profile id, then model).
- `ConversationStats` now persists `usage_to_labels` alongside `usage_to_metrics`.

Tests:
- Adds a unit test proving profile resolution + label propagation.
- Extends `ConversationStats` tests to cover labels.

Validation:
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm test -w @openhands/agent-sdk-ts`
