### PR TITLE
[oh-tab-7lc] Extension plumbing for LLM profileId + label

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,12 @@
         "title": "OpenHands: LLM",
         "order": 1,
         "properties": {
+          "openhands.llm.profileId": {
+            "type": "string",
+            "default": "",
+            "order": 0,
+            "markdownDescription": "Optional LLM profile identifier (filename stem). When set, OpenHands loads the effective provider/model/baseUrl/etc from `~/.openhands/llm-profiles/<profileId>.json`."
+          },
           "openhands.llm.model": {
             "type": "string",
             "default": "claude-sonnet-4-20250514",

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -119,51 +119,51 @@ export class RemoteConversation extends EventEmitter {
     this.serverUrl = normalizeRemoteServerUrl(url);
   }
 
-    async startNewConversation(): Promise<string | undefined> {
-      try {
-        if (this.ws) {
-          this.ws.removeAllListeners();
-          this.ws.close();
-          this.ws = undefined;
+  async startNewConversation(): Promise<string | undefined> {
+    try {
+      if (this.ws) {
+        this.ws.removeAllListeners();
+        this.ws.close();
+        this.ws = undefined;
+      }
+      this.clearWsHandshakeTimer();
+      this.seenEventIds.clear();
+      this.setStatus('connecting');
+      const base = this.serverUrl.replace(/\/$/, '');
+      const s = this.settings;
+      const llm: Record<string, unknown> = {};
+      const toOptionalString = (value: unknown): string | undefined => {
+        if (typeof value === 'string') return value.trim() || undefined;
+        if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+          const text = String(value).trim();
+          return text.length > 0 ? text : undefined;
         }
-        this.clearWsHandshakeTimer();
-        this.seenEventIds.clear();
-        this.setStatus('connecting');
-        const base = this.serverUrl.replace(/\/$/, '');
-        const s = this.settings;
-        const llm: Record<string, unknown> = {};
-        const toOptionalString = (value: unknown): string | undefined => {
-          if (typeof value === 'string') return value.trim() || undefined;
-          if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-            const text = String(value).trim();
-            return text.length > 0 ? text : undefined;
-          }
-          return undefined;
-        };
-        const usageId = toOptionalString(s?.llm.usageId);
-        const profileId = toOptionalString(s?.llm.profileId);
-        const model = toOptionalString(s?.llm.model);
-        const baseUrl = toOptionalString(s?.llm.baseUrl);
-        const apiVersion = toOptionalString(s?.llm.apiVersion);
-        if (usageId) llm.usage_id = usageId;
-        if (profileId) llm.profile_id = profileId;
-        if (model) llm.model = model;
-        if (baseUrl) llm.base_url = baseUrl;
-        if (apiVersion) llm.api_version = apiVersion;
-        if (s?.llm.timeout !== undefined) llm.timeout = s.llm.timeout;
-        if (s?.llm.temperature !== undefined) llm.temperature = s.llm.temperature;
-        if (s?.llm.topP !== undefined) llm.top_p = s.llm.topP;
-        if (s?.llm.topK !== undefined) llm.top_k = s.llm.topK;
-        if (typeof s?.llm.maxInputTokens === 'number' && s.llm.maxInputTokens > 0) {
-          llm.max_input_tokens = Math.trunc(s.llm.maxInputTokens);
-        }
-        if (typeof s?.llm.maxOutputTokens === 'number' && s.llm.maxOutputTokens > 0) {
-          llm.max_output_tokens = Math.trunc(s.llm.maxOutputTokens);
-        }
-        if (s?.llm.reasoningEffort !== undefined) llm.reasoning_effort = s.llm.reasoningEffort;
-        if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;
-        if (s?.secrets.awsAccessKeyId) llm.aws_access_key_id = s.secrets.awsAccessKeyId;
-        if (s?.secrets.awsSecretAccessKey) llm.aws_secret_access_key = s.secrets.awsSecretAccessKey;
+        return undefined;
+      };
+      const usageId = toOptionalString(s?.llm.usageId);
+      const profileId = toOptionalString(s?.llm.profileId);
+      const model = toOptionalString(s?.llm.model);
+      const baseUrl = toOptionalString(s?.llm.baseUrl);
+      const apiVersion = toOptionalString(s?.llm.apiVersion);
+      if (usageId) llm.usage_id = usageId;
+      if (profileId) llm.profile_id = profileId;
+      if (model) llm.model = model;
+      if (baseUrl) llm.base_url = baseUrl;
+      if (apiVersion) llm.api_version = apiVersion;
+      if (s?.llm.timeout !== undefined) llm.timeout = s.llm.timeout;
+      if (s?.llm.temperature !== undefined) llm.temperature = s.llm.temperature;
+      if (s?.llm.topP !== undefined) llm.top_p = s.llm.topP;
+      if (s?.llm.topK !== undefined) llm.top_k = s.llm.topK;
+      if (typeof s?.llm.maxInputTokens === 'number' && s.llm.maxInputTokens > 0) {
+        llm.max_input_tokens = Math.trunc(s.llm.maxInputTokens);
+      }
+      if (typeof s?.llm.maxOutputTokens === 'number' && s.llm.maxOutputTokens > 0) {
+        llm.max_output_tokens = Math.trunc(s.llm.maxOutputTokens);
+      }
+      if (s?.llm.reasoningEffort !== undefined) llm.reasoning_effort = s.llm.reasoningEffort;
+      if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;
+      if (s?.secrets.awsAccessKeyId) llm.aws_access_key_id = s.secrets.awsAccessKeyId;
+      if (s?.secrets.awsSecretAccessKey) llm.aws_secret_access_key = s.secrets.awsSecretAccessKey;
 
       const typedSecrets: Record<string, StaticSecret> = {};
       const maybeSetSecret = (key: string, value: unknown) => {
@@ -203,9 +203,9 @@ export class RemoteConversation extends EventEmitter {
       const workspace = this.workspace ?? { kind: 'LocalWorkspace', working_dir: this.workspaceRoot };
       const tools = this.tools ?? defaultTools;
       const req = {
-          agent: {
-            llm,
-            tools,
+        agent: {
+          llm,
+          tools,
           security_analyzer: s?.agent.enableSecurityAnalyzer ? { kind: 'LLMSecurityAnalyzer' } : undefined,
         },
         workspace,
@@ -216,12 +216,12 @@ export class RemoteConversation extends EventEmitter {
       const res = await this.fetchWithTimeout(`${base}/api/conversations`, {
         method: 'POST',
         headers,
-        body: JSON.stringify(req)
+        body: JSON.stringify(req),
       }, RemoteConversation.httpTimeoutMs);
-        if (!res.ok) {
-          const info = await res.text().catch(() => '');
-          const status = res.status;
-          let userMessage = `Failed to start conversation (HTTP ${status})`;
+      if (!res.ok) {
+        const info = await res.text().catch(() => '');
+        const status = res.status;
+        let userMessage = `Failed to start conversation (HTTP ${status})`;
         if (status === 401 || status === 403) {
           userMessage += '. Authentication failed - check your Session API Key in settings.';
         } else if (status === 404) {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -141,10 +141,12 @@ export class RemoteConversation extends EventEmitter {
           return undefined;
         };
         const usageId = toOptionalString(s?.llm.usageId);
+        const profileId = toOptionalString(s?.llm.profileId);
         const model = toOptionalString(s?.llm.model);
         const baseUrl = toOptionalString(s?.llm.baseUrl);
         const apiVersion = toOptionalString(s?.llm.apiVersion);
         if (usageId) llm.usage_id = usageId;
+        if (profileId) llm.profile_id = profileId;
         if (model) llm.model = model;
         if (baseUrl) llm.base_url = baseUrl;
         if (apiVersion) llm.api_version = apiVersion;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -858,13 +858,16 @@ export class Agent extends EventEmitter {
   }
 
   private createLlmClientFromSettings(): Promise<LLMClient> {
-    if (!this.options.settings.llm?.model) {
+    const s = this.options.settings;
+    const profileId = toOptionalNonEmptyString(s.llm?.profileId);
+    const model = toOptionalNonEmptyString(s.llm?.model);
+    if (!profileId && !model) {
       return Promise.reject(new Error('LLM model is not configured'));
     }
-    const s = this.options.settings;
     const config = {
+      profileId,
       provider: s.llm.provider ?? undefined,
-      model: s.llm.model ?? '',
+      model: model ?? '',
       openaiApiMode: s.llm.openaiApiMode ?? undefined,
       usageId: s.llm.usageId ?? undefined,
       baseUrl: s.llm.baseUrl ?? undefined,

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -2,6 +2,11 @@ import type { LLMProvider, OpenAIChatApi, ReasoningSummary } from '../llm/types'
 
 export type LLMSettings = {
   usageId?: string | null;
+  /**
+   * Optional LLM profile identifier (filename stem under the profile store).
+   * When set, the effective provider/model/baseUrl/etc are resolved from the profile store.
+   */
+  profileId?: string | null;
   provider?: LLMProvider | null;
   model?: string | null;
   /** OpenAI-specific API selection (local-mode only). */

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -10,7 +10,7 @@ export type AttachConversationListenersDeps = {
   getChatView: () => vscode.WebviewView | undefined;
   isChatWebviewReady: () => boolean;
   getConversationMode: () => 'local' | 'remote';
-  getLastKnownLlmModel: () => string | null;
+  getLastKnownLlmLabel: () => string | null;
   isVerboseEventLogging: () => boolean;
 
   bufferConversationEvent: (event: Event) => number;
@@ -36,7 +36,8 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
       type: 'status',
       status: s,
       mode: deps.getConversationMode(),
-      llmModel: deps.getLastKnownLlmModel(),
+      llmProfileLabel: deps.getLastKnownLlmLabel(),
+      llmModel: deps.getLastKnownLlmLabel(),
     });
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { SettingsManager, type OpenHandsSettings } from './settings/SettingsMana
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from './shared/halTeleport';
 import { type HalStateSnapshot, isElevenLabsMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
+import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import {
   AgentContext,
   Conversation,
@@ -77,7 +78,7 @@ let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
 let conversationStoreRoot: string | undefined;
-let lastKnownLlmModel: string | null = null;
+let lastKnownLlmLabel: string | null = null;
 let verboseEventLogging = false;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
@@ -713,10 +714,10 @@ export function activate(context: vscode.ExtensionContext) {
           chatLastConversationId = conversationId;
           chatLastSeenSeq = lastSeenSeq;
         },
-        setLastKnownLlmModel: (model) => {
-          lastKnownLlmModel = model;
+        setLastKnownLlmLabel: (label) => {
+          lastKnownLlmLabel = label;
         },
-        getLastKnownLlmModel: () => lastKnownLlmModel,
+        getLastKnownLlmLabel: () => lastKnownLlmLabel,
         flushConversationEventBacklog,
         onRenderedEventsResponse: (requestId, info) => {
           pendingRenderedEventsRequests.get(requestId)?.(info);
@@ -836,7 +837,7 @@ export function activate(context: vscode.ExtensionContext) {
   async function ensureConversationAndConnection(options?: { uiJustCreated?: boolean; modeSwitched?: boolean }) {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
-    lastKnownLlmModel = settings.llm.model ?? null;
+    lastKnownLlmLabel = resolveConfiguredLlmLabel(settings);
 
     const cfg = vscode.workspace.getConfiguration();
     verboseEventLogging = Boolean(settings.agent?.debug) || Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
@@ -916,7 +917,7 @@ export function activate(context: vscode.ExtensionContext) {
         getChatView: () => chatView,
         isChatWebviewReady: () => chatWebviewReady,
         getConversationMode: () => conversationMode,
-        getLastKnownLlmModel: () => lastKnownLlmModel,
+        getLastKnownLlmLabel: () => lastKnownLlmLabel,
         isVerboseEventLogging: () => verboseEventLogging,
         bufferConversationEvent,
         resetConversationEventBacklog,
@@ -946,7 +947,8 @@ export function activate(context: vscode.ExtensionContext) {
         type: 'status',
         status: conversation?.getStatus() ?? 'offline',
         mode: conversationMode,
-        llmModel: lastKnownLlmModel,
+        llmProfileLabel: lastKnownLlmLabel,
+        llmModel: lastKnownLlmLabel,
       });
     }
   }

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -170,6 +170,7 @@ export class SettingsManager {
     const explicitProvider = normalizeLlmProvider(this.adapter.getExplicit<string>('openhands.llm.provider'));
     const provider = isRemote ? explicitProvider : explicitProvider ?? (explicitBaseUrl ? undefined : DEFAULTS.llm.provider);
     const usageId = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.usageId'));
+    const profileId = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.profileId'));
     const explicitModel = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.model'));
     // Always provide a model name, even in remote mode: the python agent-server requires it in StartConversationRequest.
     const model = explicitModel ?? normalizeNonEmptyString(
@@ -179,6 +180,7 @@ export class SettingsManager {
       // Omit usageId unless explicitly configured (local-mode SDK can derive a stable id per config).
       // Always provide a model so LocalConversation and RemoteConversation can start reliably.
       usageId,
+      profileId,
       provider,
       model,
       openaiApiMode: normalizeOpenaiApiMode(
@@ -273,6 +275,7 @@ export class SettingsManager {
 
     if (partial.llm) {
       if (partial.llm.usageId !== undefined) ops.push(this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target));
+      if (partial.llm.profileId !== undefined) ops.push(this.adapter.update('openhands.llm.profileId', partial.llm.profileId, target));
       if (partial.llm.provider !== undefined) ops.push(this.adapter.update('openhands.llm.provider', partial.llm.provider, target));
       if (partial.llm.model !== undefined) ops.push(this.adapter.update('openhands.llm.model', partial.llm.model, target));
       if (partial.llm.openaiApiMode !== undefined) {

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -27,6 +27,7 @@ describe('SettingsManager', () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBeUndefined();
     expect(s.llm.usageId).toBeUndefined();
+    expect(s.llm.profileId).toBeUndefined();
     expect(s.llm.provider).toBe('anthropic');
     expect(s.llm.openaiApiMode).toBeUndefined();
     expect(s.llm.reasoningSummary).toBeUndefined();
@@ -73,6 +74,7 @@ describe('SettingsManager', () => {
       serverUrl: 'http://example:1234',
       llm: {
         usageId: 'my-usage',
+        profileId: 'gpt-5',
         provider: 'openrouter',
         model: 'foo',
         baseUrl: 'https://api.example.com',
@@ -101,6 +103,7 @@ describe('SettingsManager', () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
     expect(s.llm.usageId).toBe('my-usage');
+    expect(s.llm.profileId).toBe('gpt-5');
     expect(s.llm.provider).toBe('openrouter');
     expect(s.llm.model).toBe('foo');
     expect(s.llm.baseUrl).toBe('https://api.example.com');

--- a/src/shared/llmProfiles.ts
+++ b/src/shared/llmProfiles.ts
@@ -1,0 +1,25 @@
+import { loadProfile } from '@openhands/agent-sdk-ts';
+import type { OpenHandsSettings } from '@openhands/agent-sdk-ts';
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed : undefined;
+};
+
+export const getConfiguredProfileId = (settings: OpenHandsSettings): string | undefined =>
+  toOptionalNonEmptyString(settings.llm?.profileId);
+
+export const resolveConfiguredLlmLabel = (settings: OpenHandsSettings): string | null => {
+  const profileId = getConfiguredProfileId(settings);
+  if (profileId) {
+    try {
+      const profile = loadProfile(profileId);
+      return toOptionalNonEmptyString(profile.config.profileName) ?? profileId;
+    } catch {
+      return profileId;
+    }
+  }
+
+  return toOptionalNonEmptyString(settings.llm?.model) ?? null;
+};
+

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -35,7 +35,7 @@ describe('App toolbar interactions', () => {
 
     await act(async () => {
       window.dispatchEvent(new MessageEvent('message', {
-        data: { type: 'status', status: 'online', mode: 'local', llmModel: 'gpt-4.1' }
+        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
       }));
     });
 
@@ -47,7 +47,7 @@ describe('App toolbar interactions', () => {
 
     await act(async () => {
       window.dispatchEvent(new MessageEvent('message', {
-        data: { type: 'status', status: 'online', mode: 'local', llmModel: null }
+        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: null }
       }));
     });
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1659,20 +1659,26 @@ export function App() {
   const llmModelLabel = llmProfileLabel === undefined
     ? undefined
     : (llmProfileLabel || (mode === 'remote' ? 'server default' : 'default'));
-    const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
-    const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
-    const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');
-    const halConversationKey = conversationId ?? 'unknown';
-    const voiceConfirmFallbackToButtons =
-      elevenlabs.mode === 'voice_confirm' && halVoiceConfirmFallbackKey === halConversationKey;
-    const halSessionKey =
-      halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
-        ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
-        : null;
+
+  const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
+  const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
+  const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');
+  const halConversationKey = conversationId ?? 'unknown';
+  const voiceConfirmFallbackToButtons =
+    elevenlabs.mode === 'voice_confirm' && halVoiceConfirmFallbackKey === halConversationKey;
+  const halSessionKey =
+    halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
+      ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
+      : null;
   const shouldShowHalOverlay =
-    halEnabled && (halPhase === 'waiting_remote' || (hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey));
+    halEnabled && (
+      halPhase === 'waiting_remote' ||
+      (hasPendingConfirmation && hasHighRiskPendingAction && halSuppressedKey !== halSessionKey)
+    );
   const halUiPhase: HalPhase = halPhase === 'idle' && shouldShowHalOverlay ? 'dialogue' : halPhase;
-  const halUiStepIndex = halUiPhase === 'dialogue' ? Math.max(0, Math.min(halStepIndex ?? 0, halDialogueLines.length - 1)) : null;
+  const halUiStepIndex = halUiPhase === 'dialogue'
+    ? Math.max(0, Math.min(halStepIndex ?? 0, halDialogueLines.length - 1))
+    : null;
   const halUiLine = halUiPhase === 'dialogue' ? halDialogueLines[halUiStepIndex ?? 0]?.text ?? null : null;
 
   return (

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -170,7 +170,7 @@ export function App() {
   const [status, setStatus] = useState<'online' | 'offline' | 'connecting'>('offline');
   const [mode, setMode] = useState<'local' | 'remote'>('remote');
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
-  const [llmModel, setLlmModel] = useState<string | null | undefined>(undefined);
+  const [llmProfileLabel, setLlmProfileLabel] = useState<string | null | undefined>(undefined);
 
   // Events and conversation state
   const [events, setEvents] = useState<RenderedEvent[]>([]);
@@ -1029,6 +1029,7 @@ export function App() {
         status?: 'online' | 'offline' | 'connecting';
         serverUrl?: string | null;
         mode?: 'local' | 'remote';
+        llmProfileLabel?: string | null;
         llmModel?: string | null;
         elevenlabs?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
@@ -1049,8 +1050,9 @@ export function App() {
             if (payload.mode === 'local' || payload.mode === 'remote') {
               setMode(payload.mode);
             }
-            if (typeof payload.llmModel === 'string' || payload.llmModel === null) {
-              setLlmModel(payload.llmModel);
+            const label = payload.llmProfileLabel !== undefined ? payload.llmProfileLabel : payload.llmModel;
+            if (typeof label === 'string' || label === null) {
+              setLlmProfileLabel(label);
             }
             if (payload.mode === 'local') {
               setStatusBanner({ message: 'Local mode: running without remote server', level: 'info', dismissible: false });
@@ -1654,9 +1656,9 @@ export function App() {
 
   // Derived state: conversation is empty when no events and no streaming
   const isEmptyConversation = events.length === 0 && streamingContent === null;
-  const llmModelLabel = llmModel === undefined
+  const llmModelLabel = llmProfileLabel === undefined
     ? undefined
-    : (llmModel || (mode === 'remote' ? 'server default' : 'default'));
+    : (llmProfileLabel || (mode === 'remote' ? 'server default' : 'default'));
     const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
     const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
     const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -13,6 +13,7 @@ import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
 import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
 import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLinesForMode } from '../../shared/halScript';
+import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
 
 export type WebviewHost = {
   postMessage: (message: unknown) => Thenable<boolean>;
@@ -298,8 +299,8 @@ export type CreateWebviewMessageHandlerDeps = {
   resolveConversationStoreRoot: () => Promise<string>;
 
   setWebviewReadyState: (conversationId?: string, lastSeenSeq?: number) => void;
-  setLastKnownLlmModel: (model: string | null) => void;
-  getLastKnownLlmModel: () => string | null;
+  setLastKnownLlmLabel: (label: string | null) => void;
+  getLastKnownLlmLabel: () => string | null;
 
   flushConversationEventBacklog: (args: {
     postMessage: WebviewHost['postMessage'];
@@ -432,13 +433,14 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         deps.setWebviewReadyState(message.conversationId, message.lastSeenSeq);
 
         const initSettings = await settingsMgr.get();
-        deps.setLastKnownLlmModel(initSettings.llm.model ?? null);
+        deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(initSettings));
 
         void host.postMessage({
           type: 'status',
           status: conversation?.getStatus() ?? 'offline',
           mode: deps.getConversationMode(),
-          llmModel: deps.getLastKnownLlmModel(),
+          llmProfileLabel: deps.getLastKnownLlmLabel(),
+          llmModel: deps.getLastKnownLlmLabel(),
         });
 
         void host.postMessage({


### PR DESCRIPTION
Implements Bead oh-tab-7lc (extension settings + status plumbing for LLM Profiles).

- Adds `openhands.llm.profileId` setting (string; filename stem under `~/.openhands/llm-profiles/`).
- Plumbs `profileId` through SettingsManager → local Agent LLMFactory and remote StartConversationRequest (`profile_id`).
- Adds `llmProfileLabel` to status messages (webview falls back to `llmModel`), and uses the profile name/id as the displayed label.
- Updates unit tests + webview toolbar test.

Validation:
- `npm test`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LLM profile support via a new openhands.llm.profileId setting so users can select a predefined LLM profile to load provider/model/base URL and related settings.
  * LLM display now surfaces a profile label (llmProfileLabel) throughout status and UI, improving clarity of which profile/model is in use.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->