### PR TITLE
oh-tab-4m6: LLM profile selector dropdown

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -30,28 +30,42 @@ describe('App toolbar interactions', () => {
     });
   });
 
-  it('shows the configured LLM model in the input row', async () => {
+  it('shows the configured LLM profile in the input row', async () => {
     render(<App />);
 
     await act(async () => {
       window.dispatchEvent(new MessageEvent('message', {
-        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
+        data: { type: 'llmProfilesUpdated', profiles: ['gpt-4.1', 'gpt-5'], activeProfileId: 'gpt-4.1' }
       }));
     });
 
-    expect(await screen.findByLabelText('LLM model')).toHaveTextContent('gpt-4.1');
+    expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('gpt-4.1');
   });
 
-  it('shows a default label when no LLM model is configured', async () => {
+  it('shows None when no LLM profile is configured', async () => {
     render(<App />);
 
     await act(async () => {
       window.dispatchEvent(new MessageEvent('message', {
-        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: null }
+        data: { type: 'llmProfilesUpdated', profiles: ['gpt-4.1', 'gpt-5'], activeProfileId: null }
       }));
     });
 
-    expect(await screen.findByLabelText('LLM model')).toHaveTextContent('default');
+    expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('None');
+  });
+
+  it('updates the LLM profile when selected in the dropdown', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'llmProfilesUpdated', profiles: ['gpt-4.1', 'gpt-5'], activeProfileId: null }
+      }));
+    });
+
+    fireEvent.click(await screen.findByLabelText('LLM profile'));
+    fireEvent.click(await screen.findByText('gpt-5'));
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'setLlmProfileId', profileId: 'gpt-5' });
   });
 
   it('requests workspace files and inserts context mention at cursor', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -171,6 +171,8 @@ export function App() {
   const [mode, setMode] = useState<'local' | 'remote'>('remote');
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
   const [llmProfileLabel, setLlmProfileLabel] = useState<string | null | undefined>(undefined);
+  const [llmProfileId, setLlmProfileId] = useState<string | null>(null);
+  const [llmProfiles, setLlmProfiles] = useState<string[]>([]);
 
   // Events and conversation state
   const [events, setEvents] = useState<RenderedEvent[]>([]);
@@ -1031,6 +1033,8 @@ export function App() {
         mode?: 'local' | 'remote';
         llmProfileLabel?: string | null;
         llmModel?: string | null;
+        profiles?: string[];
+        activeProfileId?: string | null;
         elevenlabs?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
         seq?: unknown;
@@ -1065,6 +1069,15 @@ export function App() {
             }
           }
           break;
+        case 'llmProfilesUpdated': {
+          if (Array.isArray(payload.profiles)) {
+            setLlmProfiles(payload.profiles.filter((id): id is string => typeof id === 'string'));
+          }
+          if (typeof payload.activeProfileId === 'string' || payload.activeProfileId === null) {
+            setLlmProfileId(payload.activeProfileId);
+          }
+          break;
+        }
         case 'configUpdated':
           if (typeof payload.serverUrl === 'string' || payload.serverUrl === null) {
             const url = payload.serverUrl || undefined;
@@ -1654,11 +1667,13 @@ export function App() {
     postMessage({ type: 'switchToLocal' });
   }, [postMessage]);
 
+  const handleSelectLlmProfileId = useCallback((profileId: string | null) => {
+    setLlmProfileId(profileId);
+    postMessage({ type: 'setLlmProfileId', profileId });
+  }, [postMessage]);
+
   // Derived state: conversation is empty when no events and no streaming
   const isEmptyConversation = events.length === 0 && streamingContent === null;
-  const llmModelLabel = llmProfileLabel === undefined
-    ? undefined
-    : (llmProfileLabel || (mode === 'remote' ? 'server default' : 'default'));
 
   const hasPendingConfirmation = agentStatus === 'WAITING_FOR_CONFIRMATION' && pendingActions.length > 0;
   const hasHighRiskPendingAction = pendingActions.some((action) => action.security_risk === 'HIGH');
@@ -1784,8 +1799,10 @@ export function App() {
           onChange={handleInputChange}
           onSubmit={handleSendMessage}
           disabled={status === 'offline'}
-          modelLabel={llmModelLabel}
-          onOpenModelSettings={handleOpenSettings}
+          llmProfileId={llmProfileId}
+          llmProfiles={llmProfiles}
+          llmProfileLabel={llmProfileLabel}
+          onSelectLlmProfileId={handleSelectLlmProfileId}
           onOpenContext={handleOpenContext}
           contextCount={selectedContextFiles.length}
           onOpenSkills={handleOpenSkills}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -7,9 +7,11 @@ interface InputAreaProps {
   onSubmit: () => void;
   disabled?: boolean;
   placeholder?: string;
-  // LLM model display
-  modelLabel?: string;
-  onOpenModelSettings?: () => void;
+  // LLM profile selector
+  llmProfileId: string | null;
+  llmProfiles: string[];
+  llmProfileLabel?: string | null;
+  onSelectLlmProfileId: (profileId: string | null) => void;
   // Context picker
   onOpenContext: () => void;
   contextCount?: number;
@@ -33,8 +35,10 @@ export function InputArea({
   onSubmit,
   disabled = false,
   placeholder = 'Ask OpenHands anything...',
-  modelLabel,
-  onOpenModelSettings,
+  llmProfileId,
+  llmProfiles,
+  llmProfileLabel,
+  onSelectLlmProfileId,
   onOpenContext,
   contextCount = 0,
   onOpenSkills,
@@ -158,35 +162,12 @@ export function InputArea({
 
         {/* Accessory buttons row */}
         <div className="flex items-center gap-2 mt-3">
-	          {modelLabel !== undefined && (
-	            <button
-	              type="button"
-	              onClick={onOpenModelSettings}
-              className={`
-                inline-flex items-center gap-2
-                px-3 py-2 rounded-lg
-                text-xs font-medium
-                transition-all duration-200
-                border
-                focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
-                ${onOpenModelSettings
-                  ? 'bg-white/[0.04] text-stone-400 border-white/[0.06] hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]'
-                  : 'bg-white/[0.02] text-stone-600 border-white/[0.03] cursor-not-allowed'
-	              }
-	            `}
-	              aria-label="LLM model"
-	              title={
-	                onOpenModelSettings
-	                  ? `LLM model: ${modelLabel} (click to change in settings)`
-	                  : `LLM model: ${modelLabel}`
-	              }
-	              disabled={!onOpenModelSettings}
-	            >
-              <span className="codicon codicon-symbol-parameter text-[13px] text-brand-400/70" />
-              <span className="text-stone-500">Model</span>
-              <span className="font-mono text-stone-300 truncate max-w-[14rem]">{modelLabel}</span>
-            </button>
-          )}
+          <LlmProfileSelector
+            profileId={llmProfileId}
+            profiles={llmProfiles}
+            fallbackLabel={llmProfileLabel}
+            onSelect={onSelectLlmProfileId}
+          />
 
           <AccessoryButton
             icon="mention"
@@ -272,6 +253,122 @@ interface AccessoryButtonProps {
   onClick: () => void;
   badge?: number;
   comingSoon?: boolean;
+}
+
+interface LlmProfileSelectorProps {
+  profileId: string | null;
+  profiles: string[];
+  fallbackLabel?: string | null;
+  onSelect: (profileId: string | null) => void;
+}
+
+function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: LlmProfileSelectorProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useCloseOnEscapeAndOutsideClick({ isOpen, onClose: () => setIsOpen(false), ref: popoverRef, delay: 100 });
+
+  const shown = profileId ?? 'None';
+  const tooltip = profileId
+    ? `LLM profile: ${profileId}`
+    : `LLM profile: None${fallbackLabel ? ` (using ${fallbackLabel})` : ''}`;
+  const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
+
+  const handleSelect = (next: string | null) => {
+    onSelect(next);
+    setIsOpen(false);
+  };
+
+  const isSelected = (candidate: string | null) => candidate === profileId;
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className={`
+          inline-flex items-center gap-2
+          px-3 py-2 rounded-lg
+          text-xs font-medium
+          transition-all duration-200
+          border
+          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+          bg-white/[0.04] text-stone-400 border-white/[0.06]
+          hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]
+        `}
+        aria-label="LLM profile"
+        title={tooltip}
+      >
+        <span className="codicon codicon-symbol-parameter text-[13px] text-brand-400/70" />
+        <span className="font-mono text-stone-300 truncate max-w-[14rem]">{shown}</span>
+        <span className={`codicon codicon-chevron-${isOpen ? 'up' : 'down'} text-[12px] opacity-70`} />
+      </button>
+
+      {isOpen && (
+        <div
+          ref={popoverRef}
+          className="absolute bottom-full left-0 mb-2 w-72 bg-[var(--vscode-editor-background)] border border-white/10 rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
+        >
+          <div className="px-4 py-3 border-b border-white/10">
+            <div className="flex items-center gap-2">
+              <span className="codicon codicon-symbol-parameter text-brand-400" />
+              <h3 className="font-semibold text-sm">LLM Profile</h3>
+            </div>
+          </div>
+
+          <div className="p-2 space-y-1" role="listbox" aria-label="LLM profiles">
+            <button
+              type="button"
+              onClick={() => handleSelect(null)}
+              role="option"
+              aria-selected={isSelected(null)}
+              className={`
+                w-full text-left px-3 py-2 rounded-lg
+                text-sm
+                transition-colors duration-150
+                hover:bg-white/10
+                flex items-center gap-2
+                ${isSelected(null) ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
+              `}
+            >
+              <span className="codicon codicon-circle-slash" />
+              <span className="flex-1">None</span>
+              {isSelected(null) && <span className="codicon codicon-check text-brand-400" />}
+            </button>
+
+            {sanitizedProfiles.length === 0 ? (
+              <div className="px-3 py-2 text-sm opacity-60">No profiles found</div>
+            ) : (
+              sanitizedProfiles.map((id) => {
+                const selected = isSelected(id);
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => handleSelect(id)}
+                    role="option"
+                    aria-selected={selected}
+                    className={`
+                      w-full text-left px-3 py-2 rounded-lg
+                      text-sm
+                      transition-colors duration-150
+                      hover:bg-white/10
+                      flex items-center gap-2
+                      ${selected ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
+                    `}
+                  >
+                    <span className="codicon codicon-symbol-misc" />
+                    <span className="flex-1 font-mono truncate">{id}</span>
+                    {selected && <span className="codicon codicon-check text-brand-400" />}
+                  </button>
+                );
+              })
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }
 
 function AccessoryButton({ icon, label, onClick, badge, comingSoon }: AccessoryButtonProps) {

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -5,8 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
 import { TextDecoder } from 'util';
-import { FileStore } from '@openhands/agent-sdk-ts';
-import { isEvent, isMessageEvent, isTextContent } from '@openhands/agent-sdk-ts';
+import { FileStore, isEvent, isMessageEvent, isTextContent, listProfiles } from '@openhands/agent-sdk-ts';
 import { SettingsManager, type SavedServer } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -32,6 +31,7 @@ type WebviewMessage =
   | { type: 'restoreConversation'; id: string }
   | { type: 'deleteConversation'; id: string }
   | { type: 'getConfig' }
+  | { type: 'setLlmProfileId'; profileId: string | null }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }
   | { type: 'removeServer'; url: string }
@@ -373,6 +373,16 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
     const outputChannel = deps.getOutputChannel();
     const conversation = deps.getConversation();
 
+    const listAvailableLlmProfiles = (): string[] => {
+      try {
+        return listProfiles();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        outputChannel?.appendLine(`[llm] Failed to list profiles: ${reason}`);
+        return [];
+      }
+    };
+
     const sendHistoryList = async (): Promise<void> => {
       try {
         const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
@@ -441,6 +451,12 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           mode: deps.getConversationMode(),
           llmProfileLabel: deps.getLastKnownLlmLabel(),
           llmModel: deps.getLastKnownLlmLabel(),
+        });
+
+        void host.postMessage({
+          type: 'llmProfilesUpdated',
+          profiles: listAvailableLlmProfiles(),
+          activeProfileId: initSettings.llm.profileId ?? null,
         });
 
         void host.postMessage({
@@ -585,6 +601,28 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'getConfig': {
         const settings = await settingsMgr.get();
         void host.postMessage({ type: 'config', serverUrl: settings.serverUrl ?? null, mode: deps.getConversationMode() });
+        break;
+      }
+      case 'setLlmProfileId': {
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        await settingsMgr.update({ llm: { profileId } });
+
+        const updated = await settingsMgr.get();
+        deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(updated));
+
+        void host.postMessage({
+          type: 'status',
+          status: conversation?.getStatus() ?? 'offline',
+          mode: deps.getConversationMode(),
+          llmProfileLabel: deps.getLastKnownLlmLabel(),
+          llmModel: deps.getLastKnownLlmLabel(),
+        });
+
+        void host.postMessage({
+          type: 'llmProfilesUpdated',
+          profiles: listAvailableLlmProfiles(),
+          activeProfileId: updated.llm.profileId ?? null,
+        });
         break;
       }
       case 'selectServer': {


### PR DESCRIPTION
Implements Bead `oh-tab-4m6`.

- Replaces the InputArea LLM “Model” pill with a profile selector dropdown.
- Adds a `None` option (clears `openhands.llm.profileId` back to raw `openhands.llm.*`).
- Host/webview plumbing: `llmProfilesUpdated` (profiles + active id) and `setLlmProfileId`.
- Updates webview toolbar tests.

Validation: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a dedicated LLM profile selector dropdown in the input area, offering users an intuitive and simple way to quickly select from all available LLM profiles or choose "None".
  * Active profile selections are automatically saved and persist reliably across all sessions, keeping user preferences always synchronized throughout the application interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->