### PR TITLE
oh-tab-eqa: Don’t send llm.profile_id to remote server

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
@@ -1,7 +1,11 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { OpenHandsSettings } from '../types/settings';
 import type { RemoteConversationTool, RemoteConversationWorkspace } from './RemoteConversation';
 import { RemoteConversation } from './RemoteConversation';
+import { saveProfile } from '../llm/profiles';
 
 const baseSettings: OpenHandsSettings = {
   llm: { model: 'test-model' },
@@ -15,6 +19,59 @@ describe('RemoteConversation', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it('expands profileId into server-supported llm fields without sending profile_id', async () => {
+    const connectSpy = vi
+      .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')
+      .mockImplementation(() => {});
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      void _url;
+      void init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'conv-profile' }),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const profilesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-llm-profiles-'));
+    try {
+      saveProfile(
+        'gpt-5',
+        { provider: 'openai', model: 'gpt-5', baseUrl: 'http://profile.example' },
+        { rootDir: profilesRoot }
+      );
+
+      const settings: OpenHandsSettings = {
+        ...baseSettings,
+        llm: {
+          model: 'settings-model-should-not-win',
+          profileId: 'gpt-5',
+          baseUrl: 'http://override.example',
+        },
+      };
+
+      const conversation = new RemoteConversation({
+        serverUrl: 'http://localhost:3000',
+        settings,
+        profileStoreOptions: { rootDir: profilesRoot },
+      });
+
+      await conversation.startNewConversation();
+
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+      const parsed = JSON.parse(init?.body as string) as { agent: { llm: Record<string, unknown> } };
+      expect(parsed.agent.llm.profile_id).toBeUndefined();
+      expect(parsed.agent.llm.model).toBe('gpt-5');
+      expect(parsed.agent.llm.base_url).toBe('http://override.example');
+    } finally {
+      fs.rmSync(profilesRoot, { recursive: true, force: true });
+    }
   });
 
   it('passes provided tools and workspace through to POST /api/conversations', async () => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -3,6 +3,9 @@ import WebSocket from 'ws';
 import type { BashEvent, Event, Message } from '../types';
 import { isEvent as isAgentEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
+import type { LLMProfileStoreOptions } from '../llm/profiles';
+import { loadProfile } from '../llm/profiles';
+import type { LLMConfiguration } from '../llm/types';
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
@@ -48,6 +51,7 @@ export interface RemoteConversationOptions {
   tools?: RemoteConversationTool[];
   workspace?: RemoteConversationWorkspace;
   conversationId?: string;
+  profileStoreOptions?: LLMProfileStoreOptions;
 }
 
 export type RemoteConversationEventMap = {
@@ -75,6 +79,7 @@ export class RemoteConversation extends EventEmitter {
   private readonly workspaceRoot: string;
   private readonly tools?: RemoteConversationTool[];
   private readonly workspace?: RemoteConversationWorkspace;
+  private readonly profileStoreOptions?: LLMProfileStoreOptions;
   private static readonly historyPageLimit = 100;
   private static readonly wsHandshakeTimeoutMs = 10_000;
   private static readonly httpTimeoutMs = 15_000;
@@ -87,6 +92,7 @@ export class RemoteConversation extends EventEmitter {
     this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
     this.tools = options.tools;
     this.workspace = options.workspace;
+    this.profileStoreOptions = options.profileStoreOptions;
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
@@ -145,22 +151,65 @@ export class RemoteConversation extends EventEmitter {
       const model = toOptionalString(s?.llm.model);
       const baseUrl = toOptionalString(s?.llm.baseUrl);
       const apiVersion = toOptionalString(s?.llm.apiVersion);
-      if (usageId) llm.usage_id = usageId;
-      if (profileId) llm.profile_id = profileId;
-      if (model) llm.model = model;
-      if (baseUrl) llm.base_url = baseUrl;
-      if (apiVersion) llm.api_version = apiVersion;
-      if (s?.llm.timeout !== undefined) llm.timeout = s.llm.timeout;
-      if (s?.llm.temperature !== undefined) llm.temperature = s.llm.temperature;
-      if (s?.llm.topP !== undefined) llm.top_p = s.llm.topP;
-      if (s?.llm.topK !== undefined) llm.top_k = s.llm.topK;
-      if (typeof s?.llm.maxInputTokens === 'number' && s.llm.maxInputTokens > 0) {
-        llm.max_input_tokens = Math.trunc(s.llm.maxInputTokens);
+
+      const profileConfig: LLMConfiguration | null = (() => {
+        if (!profileId) return null;
+        try {
+          const profile = loadProfile(profileId, this.profileStoreOptions);
+          return profile.config;
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          throw new Error(`Failed to load LLM profile '${profileId}': ${reason}`);
+        }
+      })();
+
+      // NOTE: profileId is a local alias only. Remote agent-server rejects unknown llm fields
+      // (like `profile_id`) with strict schema validation.
+      const profileUsageId = toOptionalString(profileConfig?.usageId);
+      const profileModel = profileConfig ? toOptionalString(profileConfig.model) : undefined;
+      const profileBaseUrl = toOptionalString(profileConfig?.baseUrl);
+      const profileApiVersion = toOptionalString(profileConfig?.apiVersion);
+
+      const effectiveUsageId = usageId ?? profileUsageId;
+      const effectiveModel = profileModel ?? model;
+      const effectiveBaseUrl = baseUrl ?? profileBaseUrl;
+      const effectiveApiVersion = apiVersion ?? profileApiVersion;
+
+      if (effectiveUsageId) llm.usage_id = effectiveUsageId;
+      if (effectiveModel) llm.model = effectiveModel;
+      if (effectiveBaseUrl) llm.base_url = effectiveBaseUrl;
+      if (effectiveApiVersion) llm.api_version = effectiveApiVersion;
+
+      const effectiveTimeout = s?.llm.timeout ?? profileConfig?.timeoutSeconds;
+      if (typeof effectiveTimeout === 'number' && Number.isFinite(effectiveTimeout)) {
+        llm.timeout = effectiveTimeout;
       }
-      if (typeof s?.llm.maxOutputTokens === 'number' && s.llm.maxOutputTokens > 0) {
-        llm.max_output_tokens = Math.trunc(s.llm.maxOutputTokens);
+      const effectiveTemperature = s?.llm.temperature ?? profileConfig?.temperature;
+      if (typeof effectiveTemperature === 'number' && Number.isFinite(effectiveTemperature)) {
+        llm.temperature = effectiveTemperature;
       }
-      if (s?.llm.reasoningEffort !== undefined) llm.reasoning_effort = s.llm.reasoningEffort;
+      const effectiveTopP = s?.llm.topP ?? profileConfig?.topP;
+      if (typeof effectiveTopP === 'number' && Number.isFinite(effectiveTopP)) {
+        llm.top_p = effectiveTopP;
+      }
+      const effectiveTopK = s?.llm.topK ?? profileConfig?.topK;
+      if (typeof effectiveTopK === 'number' && Number.isFinite(effectiveTopK)) {
+        llm.top_k = effectiveTopK;
+      }
+
+      const maxInputTokens = s?.llm.maxInputTokens ?? profileConfig?.maxInputTokens;
+      if (typeof maxInputTokens === 'number' && Number.isFinite(maxInputTokens) && maxInputTokens > 0) {
+        llm.max_input_tokens = Math.trunc(maxInputTokens);
+      }
+      const maxOutputTokens = s?.llm.maxOutputTokens ?? profileConfig?.maxOutputTokens;
+      if (typeof maxOutputTokens === 'number' && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0) {
+        llm.max_output_tokens = Math.trunc(maxOutputTokens);
+      }
+
+      const effectiveReasoningEffort = s?.llm.reasoningEffort ?? profileConfig?.reasoningEffort;
+      if (typeof effectiveReasoningEffort === 'string' && effectiveReasoningEffort) {
+        llm.reasoning_effort = effectiveReasoningEffort;
+      }
       if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;
       if (s?.secrets.awsAccessKeyId) llm.aws_access_key_id = s.secrets.awsAccessKeyId;
       if (s?.secrets.awsSecretAccessKey) llm.aws_secret_access_key = s.secrets.awsSecretAccessKey;


### PR DESCRIPTION
Fixes P0 Bead `oh-tab-eqa`.

Problem: remote agent-server rejects unknown `llm.profile_id` field (strict schema), breaking remote mode when a profile is selected.

Change:
- `RemoteConversation` no longer sends `llm.profile_id`.
- When `settings.llm.profileId` is set, loads the profile locally and expands into server-supported fields (`model`, `base_url`, `api_version`, etc.).
- Adds unit coverage asserting payload omits `profile_id` and uses the profile-derived `model`.

Validation: `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added LLM profile integration to manage and reuse model and API configurations
  * Profiles can be loaded by ID during conversation initialization
  * Explicit LLM parameters override profile settings when both are provided
  * Enhanced error handling with descriptive messages for profile loading failures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->