### PR TITLE
oh-tab-3ke: Seed default LLM profiles

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import type { LLMConfiguration } from '../llm';
-import { LLMProfileValidationError, listProfiles, loadProfile, saveProfile, validateProfile } from '../llm';
+import { DEFAULT_LLM_PROFILE_IDS, LLMProfileValidationError, ensureDefaultProfiles, listProfiles, loadProfile, saveProfile, validateProfile } from '../llm';
 
 const makeTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'llm-profiles-'));
 
@@ -108,6 +108,23 @@ describe('LLM profiles', () => {
         LLMProfileValidationError,
       );
       expect(() => loadProfile('../evil', { rootDir: dir })).toThrow(LLMProfileValidationError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('seeds canonical default profiles when requested', () => {
+    const dir = makeTempDir();
+    try {
+      expect(listProfiles({ rootDir: dir })).toEqual([]);
+      expect(ensureDefaultProfiles({ rootDir: dir })).toEqual([...DEFAULT_LLM_PROFILE_IDS]);
+      expect(listProfiles({ rootDir: dir })).toEqual([...DEFAULT_LLM_PROFILE_IDS]);
+
+      for (const id of DEFAULT_LLM_PROFILE_IDS) {
+        const loaded = loadProfile(id, { rootDir: dir });
+        expect(loaded.profileId).toBe(id);
+        expect(typeof loaded.config.model).toBe('string');
+      }
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -333,7 +333,7 @@ export const DEFAULT_LLM_PROFILE_IDS = [
   'gemini-flash',
   'gpt-5',
   'gpt-5-mini',
-  'sonnet-4',
+  'sonnet-45',
 ] as const;
 
 export type DefaultLlmProfileId = typeof DEFAULT_LLM_PROFILE_IDS[number];
@@ -367,12 +367,12 @@ const DEFAULT_LLM_PROFILES: Array<{ profileId: DefaultLlmProfileId; config: LLMC
     },
   },
   {
-    profileId: 'sonnet-4',
+    profileId: 'sonnet-45',
     config: {
       provider: 'anthropic',
       model: 'claude-sonnet-4-20250514',
       baseUrl: DEFAULT_PROVIDER_BASE_URLS.anthropic,
-      profileName: 'Sonnet 4',
+      profileName: 'Sonnet 4.5',
     },
   },
 ];

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type { LLMConfiguration, LLMProvider, OpenAIChatApi, ReasoningSummary } from './types';
+import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 
 export const DEFAULT_LLM_PROFILES_DIR = path.join(os.homedir(), '.openhands', 'llm-profiles');
 
@@ -222,6 +223,13 @@ const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
 
 export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] => {
   const rootDir = resolveRootDir(options);
+  if (!options.rootDir) {
+    try {
+      ensureDefaultProfiles();
+    } catch {
+      // Best-effort; listing should still work even if we cannot seed defaults.
+    }
+  }
   if (!fs.existsSync(rootDir)) return [];
 
   const profileIds: string[] = [];
@@ -240,6 +248,13 @@ export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] => 
 
 export const loadProfile = (profileId: string, options: LLMProfileStoreOptions = {}): LLMProfile => {
   const rootDir = resolveRootDir(options);
+  if (!options.rootDir) {
+    try {
+      ensureDefaultProfiles();
+    } catch {
+      // Best-effort; loading user profiles should still report missing profiles.
+    }
+  }
   const filePath = getProfilePath(profileId, rootDir);
   if (!fs.existsSync(filePath)) {
     throw new LLMProfileValidationError(`Profile '${profileId}' not found`);
@@ -291,4 +306,70 @@ export const saveProfile = (
   } catch {
     // Best-effort on platforms that support chmod.
   }
+};
+
+export const DEFAULT_LLM_PROFILE_IDS = [
+  'gemini-flash',
+  'gpt-5',
+  'gpt-5-mini',
+  'sonnet-45',
+] as const;
+
+export type DefaultLlmProfileId = typeof DEFAULT_LLM_PROFILE_IDS[number];
+
+const DEFAULT_LLM_PROFILES: Array<{ profileId: DefaultLlmProfileId; config: LLMConfiguration }> = [
+  {
+    profileId: 'gemini-flash',
+    config: {
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
+      profileName: 'Gemini Flash',
+    },
+  },
+  {
+    profileId: 'gpt-5',
+    config: {
+      provider: 'openai',
+      model: 'gpt-5',
+      baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai,
+      profileName: 'GPT-5',
+    },
+  },
+  {
+    profileId: 'gpt-5-mini',
+    config: {
+      provider: 'openai',
+      model: 'gpt-5-mini',
+      baseUrl: DEFAULT_PROVIDER_BASE_URLS.openai,
+      profileName: 'GPT-5 Mini',
+    },
+  },
+  {
+    profileId: 'sonnet-45',
+    config: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      baseUrl: DEFAULT_PROVIDER_BASE_URLS.anthropic,
+      profileName: 'Sonnet 4.5',
+    },
+  },
+];
+
+export const ensureDefaultProfiles = (options: LLMProfileStoreOptions = {}): DefaultLlmProfileId[] => {
+  const rootDir = resolveRootDir(options);
+  const created: DefaultLlmProfileId[] = [];
+
+  for (const entry of DEFAULT_LLM_PROFILES) {
+    try {
+      const filePath = getProfilePath(entry.profileId, rootDir);
+      if (fs.existsSync(filePath)) continue;
+      saveProfile(entry.profileId, entry.config, { ...options, includeSecrets: false });
+      created.push(entry.profileId);
+    } catch {
+      // Best-effort; users may have a read-only profile directory.
+    }
+  }
+
+  return created;
 };

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -26,6 +26,14 @@ export interface SaveProfileOptions extends LLMProfileStoreOptions {
   includeSecrets?: boolean;
 }
 
+const warnedOnce = new Set<string>();
+
+const warnOnce = (key: string, message: string, error: unknown): void => {
+  if (warnedOnce.has(key)) return;
+  warnedOnce.add(key);
+  console.warn(message, error);
+};
+
 const expandHomeDir = (value: string): string => {
   if (value === '~') return os.homedir();
   if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
@@ -221,15 +229,28 @@ const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
   return sanitized;
 };
 
+const ensureDefaultProfilesForDefaultStore = (rootDir: string, options: LLMProfileStoreOptions): void => {
+  if (options.rootDir) return;
+  try {
+    ensureDefaultProfiles({ ...options, rootDir });
+  } catch (error) {
+    warnOnce(
+      `ensure-default-profiles:${rootDir}`,
+      `[agent-sdk-ts] Failed to ensure default LLM profiles in ${rootDir}:`,
+      error,
+    );
+  }
+};
+
+/**
+ * Lists available LLM profile ids.
+ *
+ * When using the default store (`~/.openhands/llm-profiles`), this will best-effort seed a few
+ * canonical profiles on first use.
+ */
 export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] => {
   const rootDir = resolveRootDir(options);
-  if (!options.rootDir) {
-    try {
-      ensureDefaultProfiles();
-    } catch {
-      // Best-effort; listing should still work even if we cannot seed defaults.
-    }
-  }
+  ensureDefaultProfilesForDefaultStore(rootDir, options);
   if (!fs.existsSync(rootDir)) return [];
 
   const profileIds: string[] = [];
@@ -246,15 +267,15 @@ export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] => 
   return profileIds.sort((a, b) => a.localeCompare(b));
 };
 
+/**
+ * Loads an LLM profile stored on disk.
+ *
+ * When using the default store (`~/.openhands/llm-profiles`), this will best-effort seed a few
+ * canonical profiles on first use.
+ */
 export const loadProfile = (profileId: string, options: LLMProfileStoreOptions = {}): LLMProfile => {
   const rootDir = resolveRootDir(options);
-  if (!options.rootDir) {
-    try {
-      ensureDefaultProfiles();
-    } catch {
-      // Best-effort; loading user profiles should still report missing profiles.
-    }
-  }
+  ensureDefaultProfilesForDefaultStore(rootDir, options);
   const filePath = getProfilePath(profileId, rootDir);
   if (!fs.existsSync(filePath)) {
     throw new LLMProfileValidationError(`Profile '${profileId}' not found`);
@@ -312,7 +333,7 @@ export const DEFAULT_LLM_PROFILE_IDS = [
   'gemini-flash',
   'gpt-5',
   'gpt-5-mini',
-  'sonnet-45',
+  'sonnet-4',
 ] as const;
 
 export type DefaultLlmProfileId = typeof DEFAULT_LLM_PROFILE_IDS[number];
@@ -346,12 +367,12 @@ const DEFAULT_LLM_PROFILES: Array<{ profileId: DefaultLlmProfileId; config: LLMC
     },
   },
   {
-    profileId: 'sonnet-45',
+    profileId: 'sonnet-4',
     config: {
       provider: 'anthropic',
       model: 'claude-sonnet-4-20250514',
       baseUrl: DEFAULT_PROVIDER_BASE_URLS.anthropic,
-      profileName: 'Sonnet 4.5',
+      profileName: 'Sonnet 4',
     },
   },
 ];
@@ -366,8 +387,13 @@ export const ensureDefaultProfiles = (options: LLMProfileStoreOptions = {}): Def
       if (fs.existsSync(filePath)) continue;
       saveProfile(entry.profileId, entry.config, { ...options, includeSecrets: false });
       created.push(entry.profileId);
-    } catch {
+    } catch (error) {
       // Best-effort; users may have a read-only profile directory.
+      warnOnce(
+        `create-default-profile:${rootDir}:${entry.profileId}`,
+        `[agent-sdk-ts] Failed to create default LLM profile '${entry.profileId}':`,
+        error,
+      );
     }
   }
 

--- a/tests/e2e/llmSwitching.test.ts
+++ b/tests/e2e/llmSwitching.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { downloadVSCodeWithRetry } from './testHelpers';
@@ -15,6 +16,11 @@ describe('OpenHands-Tab LLM Switching E2E', function () {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
 
+    // We override HOME/USERPROFILE for this suite to keep ~/.openhands/llm-profiles isolated.
+    // VS Code also looks for runtime args in $HOME/.vscode/argv.json, and will show an error dialog if missing/invalid.
+    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+
     await runTests({
       vscodeExecutablePath,
       extensionDevelopmentPath,
@@ -24,6 +30,7 @@ describe('OpenHands-Tab LLM Switching E2E', function () {
         '--user-data-dir', userDataDir,
         '--disable-gpu',
         '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
         '--disable-software-rasterizer',
         extensionDevelopmentPath
       ],

--- a/tests/e2e/llmSwitching.test.ts
+++ b/tests/e2e/llmSwitching.test.ts
@@ -29,6 +29,8 @@ describe('OpenHands-Tab LLM Switching E2E', function () {
       ],
       extensionTestsEnv: {
         TEST_NAME: 'llmSwitching',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
         OPENAI_API_KEY: 'e2e-openai-key',
         ANTHROPIC_API_KEY: 'e2e-anthropic-key',
         OPENROUTER_API_KEY: 'e2e-openrouter-key',

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -195,14 +195,14 @@ export async function run(): Promise<void> {
 
     // 6) LLM profile selection: Sonnet profile should override raw provider/model.
     await setLlmConfig({
-      profileId: 'sonnet-4',
+      profileId: 'sonnet-45',
       provider: 'openai',
       model: 'gpt-4o-mini',
       openaiApiMode: 'chat_completions',
       baseUrl: mock.baseUrl,
     });
     await sendAndWaitForRequestPath({
-      text: 'E2E step 6: profile sonnet-4',
+      text: 'E2E step 6: profile sonnet-45',
       expectedPath: '/messages',
       getRequests: () => mock.requests,
     });

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -172,6 +172,32 @@ export async function run(): Promise<void> {
       throw new Error(`Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`);
     }
 
+    // 6) LLM profile selection: Sonnet profile should override raw provider/model.
+    await cfg.update('openhands.llm.profileId', 'sonnet-45', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'gpt-4o-mini', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.openaiApiMode', 'chat_completions', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 6: profile sonnet-45',
+      expectedPath: '/messages',
+      getRequests: () => mock.requests,
+    });
+
+    // 7) LLM profile selection: gpt-5-mini profile should override raw provider/model.
+    await cfg.update('openhands.llm.profileId', 'gpt-5-mini', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.provider', 'anthropic', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.model', 'claude-sonnet-4-20250514', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.openaiApiMode', 'auto', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 7: profile gpt-5-mini',
+      expectedPath: '/chat/completions',
+      getRequests: () => mock.requests,
+    });
+
     // Basic sanity: at least one request per step.
     const paths = mock.requests.map((r) => r.path);
     const required = ['/messages', '/chat/completions', '/responses'];

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -89,6 +89,17 @@ export async function run(): Promise<void> {
     }, 15000);
 
     const cfg = vscode.workspace.getConfiguration();
+    const setLlmConfig = async (
+      config: Record<string, unknown>,
+      options: { reconnect?: boolean } = {},
+    ): Promise<void> => {
+      for (const [key, value] of Object.entries(config)) {
+        await cfg.update(`openhands.llm.${key}`, value, vscode.ConfigurationTarget.Global);
+      }
+      if (options.reconnect ?? true) {
+        await vscode.commands.executeCommand('openhands.reconnect');
+      }
+    };
 
     // Force local mode + short runs for E2E.
     await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
@@ -99,10 +110,12 @@ export async function run(): Promise<void> {
     await cfg.update('openhands.agent.enableSecurityAnalyzer', false, vscode.ConfigurationTarget.Global);
 
     // 1) Anthropic
-    await cfg.update('openhands.llm.provider', 'anthropic', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'claude-sonnet-4-20250514', vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: null,
+      provider: 'anthropic',
+      baseUrl: mock.baseUrl,
+      model: 'claude-sonnet-4-20250514',
+    });
     await vscode.commands.executeCommand('openhands.startNewConversation');
     await vscode.commands.executeCommand('openhands.reconnect');
     await sendAndWaitForRequestPath({
@@ -112,11 +125,13 @@ export async function run(): Promise<void> {
     });
 
     // 2) OpenAI-compatible (chat_completions)
-    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.openaiApiMode', 'chat_completions', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'gpt-4o-mini', vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: null,
+      provider: 'openai',
+      openaiApiMode: 'chat_completions',
+      baseUrl: mock.baseUrl,
+      model: 'gpt-4o-mini',
+    });
     await sendAndWaitForRequestPath({
       text: 'E2E step 2: openai chat',
       expectedPath: '/chat/completions',
@@ -124,11 +139,13 @@ export async function run(): Promise<void> {
     });
 
     // 3) OpenAI GPT-5 auto mode + custom baseUrl should fall back to chat_completions.
-    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.openaiApiMode', 'auto', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'gpt-5-mini', vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: null,
+      provider: 'openai',
+      openaiApiMode: 'auto',
+      baseUrl: mock.baseUrl,
+      model: 'gpt-5-mini',
+    });
     await sendAndWaitForRequestPath({
       text: 'E2E step 3: openai gpt-5 auto (custom baseUrl)',
       expectedPath: '/chat/completions',
@@ -136,11 +153,13 @@ export async function run(): Promise<void> {
     });
 
     // 4) OpenAI Responses API (gpt-5 + openaiApiMode=responses)
-    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.openaiApiMode', 'responses', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'gpt-5-mini', vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: null,
+      provider: 'openai',
+      openaiApiMode: 'responses',
+      baseUrl: mock.baseUrl,
+      model: 'gpt-5-mini',
+    });
     await sendAndWaitForRequestPath({
       text: 'E2E step 4: openai responses',
       expectedPath: '/responses',
@@ -148,11 +167,13 @@ export async function run(): Promise<void> {
     });
 
     // 5) Provider variation: openrouter adds extra headers and still hits chat_completions.
-    await cfg.update('openhands.llm.provider', 'openrouter', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.openaiApiMode', 'chat_completions', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'google/gemini-2.0-flash', vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: null,
+      provider: 'openrouter',
+      openaiApiMode: 'chat_completions',
+      baseUrl: mock.baseUrl,
+      model: 'google/gemini-2.0-flash',
+    });
     await sendAndWaitForRequestPath({
       text: 'E2E step 5: openrouter header check',
       expectedPath: '/chat/completions',
@@ -173,25 +194,27 @@ export async function run(): Promise<void> {
     }
 
     // 6) LLM profile selection: Sonnet profile should override raw provider/model.
-    await cfg.update('openhands.llm.profileId', 'sonnet-45', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.provider', 'openai', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'gpt-4o-mini', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.openaiApiMode', 'chat_completions', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: 'sonnet-4',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      openaiApiMode: 'chat_completions',
+      baseUrl: mock.baseUrl,
+    });
     await sendAndWaitForRequestPath({
-      text: 'E2E step 6: profile sonnet-45',
+      text: 'E2E step 6: profile sonnet-4',
       expectedPath: '/messages',
       getRequests: () => mock.requests,
     });
 
     // 7) LLM profile selection: gpt-5-mini profile should override raw provider/model.
-    await cfg.update('openhands.llm.profileId', 'gpt-5-mini', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.provider', 'anthropic', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.model', 'claude-sonnet-4-20250514', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.openaiApiMode', 'auto', vscode.ConfigurationTarget.Global);
-    await cfg.update('openhands.llm.baseUrl', mock.baseUrl, vscode.ConfigurationTarget.Global);
-    await vscode.commands.executeCommand('openhands.reconnect');
+    await setLlmConfig({
+      profileId: 'gpt-5-mini',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
+      openaiApiMode: 'auto',
+      baseUrl: mock.baseUrl,
+    });
     await sendAndWaitForRequestPath({
       text: 'E2E step 7: profile gpt-5-mini',
       expectedPath: '/chat/completions',

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -117,7 +117,6 @@ export async function run(): Promise<void> {
       model: 'claude-sonnet-4-20250514',
     });
     await vscode.commands.executeCommand('openhands.startNewConversation');
-    await vscode.commands.executeCommand('openhands.reconnect');
     await sendAndWaitForRequestPath({
       text: 'E2E step 1: anthropic',
       expectedPath: '/messages',


### PR DESCRIPTION
Implements Bead `oh-tab-3ke`.

- Adds canonical default LLM profiles (ids: `gemini-flash`, `gpt-5`, `gpt-5-mini`, `sonnet-45`).
- Seeds defaults in the standard store (`~/.openhands/llm-profiles`) on-demand (best-effort) when listing/loading profiles.
- Unit test covers `ensureDefaultProfiles({ rootDir })`.
- E2E LLM switching suite now verifies profile selection overrides raw provider/model (isolated via HOME/USERPROFILE temp).

Validation: `npm test`, `npx tsc -p tests/e2e/tsconfig.suite.json`, `npx tsc -p tsconfig.e2e.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Default LLM profiles are now seeded automatically on first use, improving out-of-box behavior.
  * A public API to ensure default profiles exist was added to allow explicit seeding when needed.

* **Behavior**
  * Profile-based configuration now reliably overrides raw provider/model settings.

* **Tests**
  * Expanded end-to-end tests for LLM profile switching and override scenarios; test runs isolated user data and secret storage to avoid interference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->