### PR TITLE
oh-tab-8na: Raw LLM config label when no profile

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
@@ -41,5 +41,27 @@ describe('LLMFactory profile selection', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
-});
 
+  it('falls back to raw LLM config when profileId is unset', async () => {
+    const registry = new LLMRegistry();
+    const stats = new ConversationStats();
+    registry.subscribe((event) => stats.registerLlm(event));
+
+    const factory = new LLMFactory(
+      {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        usageId: 'default',
+        apiKey: 'sk-inline',
+      },
+      { registry },
+    );
+
+    const client = await factory.createClient();
+    expect(client).toBeInstanceOf(TrackedLLMClient);
+    const tracked = client as TrackedLLMClient;
+    expect(tracked.modelName).toBe('gpt-5-mini');
+    expect(tracked.label).toBe('gpt-5-mini');
+    expect(stats.usageToLabels.default).toBe('gpt-5-mini');
+  });
+});

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -42,16 +42,19 @@ describe('App toolbar interactions', () => {
     expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('gpt-4.1');
   });
 
-  it('shows None when no LLM profile is configured', async () => {
+  it('shows the effective model label when no LLM profile is configured', async () => {
     render(<App />);
 
     await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
+      }));
       window.dispatchEvent(new MessageEvent('message', {
         data: { type: 'llmProfilesUpdated', profiles: ['gpt-4.1', 'gpt-5'], activeProfileId: null }
       }));
     });
 
-    expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('None');
+    expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('gpt-4.1');
   });
 
   it('updates the LLM profile when selected in the dropdown', async () => {

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -269,11 +269,13 @@ function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: Ll
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose: () => setIsOpen(false), ref: popoverRef, delay: 100 });
 
   const normalizedFallbackLabel = typeof fallbackLabel === 'string' ? fallbackLabel.trim() : '';
-  const fallback = normalizedFallbackLabel || 'default';
-  const shown = profileId ?? fallback;
+  const hasFallback = normalizedFallbackLabel.length > 0;
+  const shown = profileId ?? (hasFallback ? normalizedFallbackLabel : 'None');
   const tooltip = profileId
     ? `LLM profile: ${profileId}`
-    : `LLM profile: None (using ${fallback})`;
+    : hasFallback
+      ? `LLM profile: None (using ${normalizedFallbackLabel})`
+      : 'LLM profile: None';
   const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
 
   const handleSelect = (next: string | null) => {

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -268,10 +268,12 @@ function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: Ll
 
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose: () => setIsOpen(false), ref: popoverRef, delay: 100 });
 
-  const shown = profileId ?? 'None';
+  const normalizedFallbackLabel = typeof fallbackLabel === 'string' ? fallbackLabel.trim() : '';
+  const fallback = normalizedFallbackLabel || 'default';
+  const shown = profileId ?? fallback;
   const tooltip = profileId
     ? `LLM profile: ${profileId}`
-    : `LLM profile: None${fallbackLabel ? ` (using ${fallbackLabel})` : ''}`;
+    : `LLM profile: None (using ${fallback})`;
   const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
 
   const handleSelect = (next: string | null) => {


### PR DESCRIPTION
Implements Bead `oh-tab-8na` (raw LLM config back-compat).

- When `profileId` is unset, the UI shows the effective model label (instead of the literal `None`).
- Adds SDK unit coverage that `LLMFactory` falls back to raw config when `profileId` is unset.
- Updates webview test expectations accordingly.

Validation: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LLM model label display to show effective model information when no profile is explicitly configured, instead of displaying "None."
  * Enhanced fallback label handling with proper whitespace normalization for more consistent display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->