### PR TITLE
oh-tab-vzv: cover Gemini provider in llmSwitching E2E

### DIFF
--- a/tests/e2e/llmSwitching.test.ts
+++ b/tests/e2e/llmSwitching.test.ts
@@ -42,6 +42,7 @@ describe('OpenHands-Tab LLM Switching E2E', function () {
         ANTHROPIC_API_KEY: 'e2e-anthropic-key',
         OPENROUTER_API_KEY: 'e2e-openrouter-key',
         LITELLM_API_KEY: 'e2e-litellm-key',
+        GEMINI_API_KEY: 'e2e-gemini-key',
       }
     });
 

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -79,6 +79,7 @@ export async function run(): Promise<void> {
       ANTHROPIC_API_KEY: Boolean(process.env.ANTHROPIC_API_KEY),
       OPENROUTER_API_KEY: Boolean(process.env.OPENROUTER_API_KEY),
       LITELLM_API_KEY: Boolean(process.env.LITELLM_API_KEY),
+      GEMINI_API_KEY: Boolean(process.env.GEMINI_API_KEY),
     });
 
     await vscode.commands.executeCommand('openhands.open');
@@ -192,7 +193,21 @@ export async function run(): Promise<void> {
       throw new Error(`Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`);
     }
 
-    // 6) LLM profile selection: Sonnet profile should override raw provider/model.
+    // 6) Gemini native API (streamGenerateContent SSE).
+    await setLlmConfig({
+      profileId: null,
+      provider: 'gemini',
+      openaiApiMode: null,
+      baseUrl: `${mock.baseUrl}/v1beta`,
+      model: 'gemini-2.5-flash',
+    });
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 6: gemini',
+      expectedPath: '/v1beta/models/gemini-2.5-flash:streamGenerateContent',
+      getRequests: () => mock.requests,
+    });
+
+    // 7) LLM profile selection: Sonnet profile should override raw provider/model.
     await setLlmConfig({
       profileId: 'sonnet-45',
       provider: 'openai',
@@ -201,12 +216,12 @@ export async function run(): Promise<void> {
       baseUrl: mock.baseUrl,
     });
     await sendAndWaitForRequestPath({
-      text: 'E2E step 6: profile sonnet-45',
+      text: 'E2E step 7: profile sonnet-45',
       expectedPath: '/messages',
       getRequests: () => mock.requests,
     });
 
-    // 7) LLM profile selection: gpt-5-mini profile should override raw provider/model.
+    // 8) LLM profile selection: gpt-5-mini profile should override raw provider/model.
     await setLlmConfig({
       profileId: 'gpt-5-mini',
       provider: 'anthropic',
@@ -215,14 +230,14 @@ export async function run(): Promise<void> {
       baseUrl: mock.baseUrl,
     });
     await sendAndWaitForRequestPath({
-      text: 'E2E step 7: profile gpt-5-mini',
+      text: 'E2E step 8: profile gpt-5-mini',
       expectedPath: '/chat/completions',
       getRequests: () => mock.requests,
     });
 
     // Basic sanity: at least one request per step.
     const paths = mock.requests.map((r) => r.path);
-    const required = ['/messages', '/chat/completions', '/responses'];
+    const required = ['/messages', '/chat/completions', '/responses', '/v1beta/models/gemini-2.5-flash:streamGenerateContent'];
     for (const p of required) {
       if (!paths.includes(p)) throw new Error(`Missing required mock request path: ${p} (saw: ${paths.join(', ')})`);
     }

--- a/tests/e2e/suite/mockLlmServer.ts
+++ b/tests/e2e/suite/mockLlmServer.ts
@@ -107,6 +107,22 @@ function sendOpenAiResponsesJson(res: http.ServerResponse, text: string): void {
   res.end(JSON.stringify(payload));
 }
 
+function sendGeminiStreamGenerateContentSse(res: http.ServerResponse, text: string): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write(
+    `data: ${JSON.stringify({
+      candidates: [{ content: { role: 'model', parts: [{ text }] } }],
+      usageMetadata: { promptTokenCount: 1, candidatesTokenCount: 1, totalTokenCount: 2 },
+    })}\n`,
+  );
+  res.write('data: [DONE]\n');
+  res.end();
+}
+
 export async function startMockLlmServer(): Promise<MockLlmServer> {
   const requests: MockLlmRequest[] = [];
   const port = await getFreePort();
@@ -168,6 +184,14 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
 
       if (path === '/messages') {
         sendAnthropicMessagesSse(res, 'OK (anthropic)');
+        return;
+      }
+
+      if (
+        (path.startsWith('/models/') || path.startsWith('/v1beta/models/')) &&
+        path.endsWith(':streamGenerateContent')
+      ) {
+        sendGeminiStreamGenerateContentSse(res, 'OK (gemini)');
         return;
       }
 


### PR DESCRIPTION
Implements `oh-tab-vzv`.

- Adds Gemini `:streamGenerateContent` SSE route to the E2E mock LLM server.
- Extends `llmSwitching` E2E to switch to `provider=gemini` and assert the request path.
- Adds `GEMINI_API_KEY` to the E2E extension host env.

Tested: `npm run e2e -- -g "LLM Switching"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Extended end-to-end test suite with Gemini LLM switching validation, including native streaming API integration testing
  * Enhanced mock LLM server to support Gemini streaming response scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->