### PR TITLE
oh-tab-6rd: agent-sdk-ts: persist LLM config for local restore

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -67,6 +67,22 @@ describe('FileStore', () => {
     replayedState.loadEvents(persistence.readEvents());
     expect(replayedState.snapshot).toEqual(state.snapshot);
   });
+
+  it('persists and restores LLM config', () => {
+    const dir = makeTempDir('conversation-llm-config-');
+    const persistence = new FileStore({ rootDir: dir, conversationId: 'conv-llm' });
+    persistence.writeLlmConfig?.({
+      profileId: 'sonnet-45',
+      baseUrl: 'http://example.test',
+      temperature: 0.25,
+    });
+
+    expect(persistence.readLlmConfig?.()).toEqual({
+      profileId: 'sonnet-45',
+      baseUrl: 'http://example.test',
+      temperature: 0.25,
+    });
+  });
 });
 
 describe('LocalConversation persistence', () => {
@@ -100,6 +116,61 @@ describe('LocalConversation persistence', () => {
     const restoredState = (restored as unknown as { state: ConversationState }).state.snapshot;
     expect(restoredState.iteration).toBe(initialState.iteration);
     expect(restoredState.values.llm_usage).toEqual(initialState.values.llm_usage);
+  });
+
+  it('restores persisted LLM config on conversation restore', async () => {
+    const dir = makeTempDir('local-conversation-llm-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const llm = new MockLLM([{ type: 'text', text: 'hello' }, { type: 'finish' }]);
+
+    const conversation = new LocalConversation({
+      settings: { ...baseSettings, llm: { profileId: 'sonnet-45' } },
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+    const id = await conversation.startNewConversation();
+    await conversation.sendUserMessage('hello');
+
+    const restored = new LocalConversation({
+      settings: { ...baseSettings, llm: { model: 'restored-model' } },
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+    restored.restoreConversation(id!);
+
+    const restoredSettings = (restored as unknown as { settings: OpenHandsSettings }).settings;
+    expect(restoredSettings.llm.profileId).toBe('sonnet-45');
+    expect(restoredSettings.llm.model).toBeUndefined();
+  });
+
+  it('ignores corrupted persisted LLM config', async () => {
+    const dir = makeTempDir('local-conversation-llm-corrupt-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const llm = new MockLLM([{ type: 'text', text: 'hello' }, { type: 'finish' }]);
+
+    const conversation = new LocalConversation({
+      settings: { ...baseSettings, llm: { profileId: 'sonnet-45' } },
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+    const id = await conversation.startNewConversation();
+    await conversation.sendUserMessage('hello');
+
+    fs.writeFileSync(path.join(dir, id!, 'llm.json'), '{not-json', 'utf8');
+
+    const restored = new LocalConversation({
+      settings: { ...baseSettings, llm: { model: 'restored-model' } },
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+
+    expect(() => restored.restoreConversation(id!)).not.toThrow();
+    const restoredSettings = (restored as unknown as { settings: OpenHandsSettings }).settings;
+    expect(restoredSettings.llm.model).toBe('restored-model');
   });
 
   it('continues conversation after restoration', async () => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -1,5 +1,14 @@
 import EventEmitter from 'events';
-import { Agent, AsyncLock, ConversationState, EventLog, FileStore, SecretRegistry, ConversationStats } from '../runtime';
+import {
+  Agent,
+  AsyncLock,
+  ConversationState,
+  ConversationStats,
+  EventLog,
+  FileStore,
+  SecretRegistry,
+  type PersistedLlmConfig,
+} from '../runtime';
 import type { LLMClient } from '../llm';
 import type { BashEvent, Event } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
@@ -10,6 +19,11 @@ import type { RegistryEvent } from '../llm/registry';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime';
 import { AgentContext } from '../context';
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed : undefined;
+};
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
@@ -76,6 +90,7 @@ export class LocalConversation extends EventEmitter {
   setSettings(settings: OpenHandsSettings) {
     this.settings = settings;
     this.agent.setSettings(settings);
+    this.persistLlmConfig();
   }
 
   startNewConversation(): Promise<string | undefined> {
@@ -98,6 +113,7 @@ export class LocalConversation extends EventEmitter {
     // Online and persistence wiring for new conversation
     this.setStatus('online');
     this.initializePersistence();
+    this.persistLlmConfig();
     this.state.persistSnapshot();
 
     this.emit('conversationStarted', this.conversationId);
@@ -132,6 +148,7 @@ export class LocalConversation extends EventEmitter {
       this.persistence = store;
       this.events.attachPersistence(store);
       this.state.attachPersistence(store);
+      this.restorePersistedLlmConfig(store);
 
       // Notify UI first so it clears any previous render before we stream restored events
       this.emit('conversationStarted', id);
@@ -244,6 +261,88 @@ export class LocalConversation extends EventEmitter {
     this.persistence = this.persistence ?? new FileStore({ rootDir, conversationId: this.conversationId });
     this.events.attachPersistence(this.persistence);
     this.state.attachPersistence(this.persistence);
+  }
+
+  private persistLlmConfig(): void {
+    if (!this.conversationId) return;
+    if (!this.persistence?.writeLlmConfig) return;
+
+    const llm = this.settings.llm ?? {};
+    const profileId = toOptionalNonEmptyString(llm.profileId);
+    const model = toOptionalNonEmptyString(llm.model);
+    const config: PersistedLlmConfig = {};
+    if (profileId) {
+      config.profileId = profileId;
+    } else {
+      if (llm.provider) config.provider = llm.provider;
+      if (model) config.model = model;
+    }
+
+    const usageId = toOptionalNonEmptyString(llm.usageId);
+    if (usageId) config.usageId = usageId;
+
+    if (llm.openaiApiMode) config.openaiApiMode = llm.openaiApiMode;
+
+    const baseUrl = toOptionalNonEmptyString(llm.baseUrl);
+    if (baseUrl) config.baseUrl = baseUrl;
+    const apiVersion = toOptionalNonEmptyString(llm.apiVersion);
+    if (apiVersion) config.apiVersion = apiVersion;
+
+    if (typeof llm.timeout === 'number' && Number.isFinite(llm.timeout)) config.timeoutSeconds = llm.timeout;
+    if (typeof llm.temperature === 'number' && Number.isFinite(llm.temperature)) config.temperature = llm.temperature;
+    if (typeof llm.topP === 'number' && Number.isFinite(llm.topP)) config.topP = llm.topP;
+    if (typeof llm.topK === 'number' && Number.isFinite(llm.topK)) config.topK = llm.topK;
+    if (typeof llm.maxInputTokens === 'number' && Number.isFinite(llm.maxInputTokens)) {
+      config.maxInputTokens = llm.maxInputTokens;
+    }
+    if (typeof llm.maxOutputTokens === 'number' && Number.isFinite(llm.maxOutputTokens)) {
+      config.maxOutputTokens = llm.maxOutputTokens;
+    }
+
+    if (llm.reasoningEffort) config.reasoningEffort = llm.reasoningEffort;
+    if (llm.reasoningSummary) config.reasoningSummary = llm.reasoningSummary;
+
+    if (typeof llm.inputCostPerToken === 'number' && Number.isFinite(llm.inputCostPerToken)) {
+      config.inputCostPerToken = llm.inputCostPerToken;
+    }
+    if (typeof llm.outputCostPerToken === 'number' && Number.isFinite(llm.outputCostPerToken)) {
+      config.outputCostPerToken = llm.outputCostPerToken;
+    }
+
+    if (!Object.keys(config).length) return;
+    this.persistence.writeLlmConfig(config);
+  }
+
+  private restorePersistedLlmConfig(store: ConversationPersistence): void {
+    if (!store.readLlmConfig) return;
+    const persisted = store.readLlmConfig();
+    if (!persisted) return;
+    if (!persisted.profileId && !persisted.model) return;
+
+    const existing = this.settings.llm ?? {};
+    const merged: OpenHandsSettings['llm'] = {
+      ...existing,
+      profileId: persisted.profileId ?? undefined,
+      provider: persisted.provider ?? undefined,
+      model: persisted.model ?? undefined,
+      usageId: persisted.usageId ?? undefined,
+      openaiApiMode: persisted.openaiApiMode ?? undefined,
+      baseUrl: persisted.baseUrl ?? undefined,
+      apiVersion: persisted.apiVersion ?? undefined,
+      timeout: persisted.timeoutSeconds ?? undefined,
+      temperature: persisted.temperature ?? undefined,
+      topP: persisted.topP ?? undefined,
+      topK: persisted.topK ?? undefined,
+      maxInputTokens: persisted.maxInputTokens ?? undefined,
+      maxOutputTokens: persisted.maxOutputTokens ?? undefined,
+      reasoningEffort: persisted.reasoningEffort ?? undefined,
+      reasoningSummary: persisted.reasoningSummary ?? undefined,
+      inputCostPerToken: persisted.inputCostPerToken ?? undefined,
+      outputCostPerToken: persisted.outputCostPerToken ?? undefined,
+    };
+
+    this.settings = { ...this.settings, llm: merged };
+    this.agent.setSettings(this.settings);
   }
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
@@ -2,6 +2,106 @@ import fs from 'fs';
 import path from 'path';
 import type { AgentState } from './ConversationState';
 import type { Event } from '../types';
+import type { LLMProvider, OpenAIChatApi, ReasoningSummary } from '../llm/types';
+
+export type PersistedLlmConfig = {
+  profileId?: string;
+  provider?: LLMProvider;
+  model?: string;
+  usageId?: string;
+  openaiApiMode?: OpenAIChatApi;
+  baseUrl?: string;
+  apiVersion?: string;
+  timeoutSeconds?: number;
+  temperature?: number;
+  topP?: number;
+  topK?: number;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+  reasoningEffort?: 'low' | 'medium' | 'high' | 'none';
+  reasoningSummary?: ReasoningSummary;
+  inputCostPerToken?: number;
+  outputCostPerToken?: number;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const toOptionalFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  return value;
+};
+
+const PROVIDERS: readonly LLMProvider[] = ['openai', 'litellm_proxy', 'openrouter', 'anthropic', 'gemini'];
+const OPENAI_API_MODES: readonly OpenAIChatApi[] = ['chat_completions', 'responses'];
+const REASONING_SUMMARIES: readonly ReasoningSummary[] = ['auto', 'concise', 'detailed'];
+const REASONING_EFFORTS: readonly PersistedLlmConfig['reasoningEffort'][] = ['low', 'medium', 'high', 'none'];
+
+const toOptionalProvider = (value: unknown): LLMProvider | undefined =>
+  typeof value === 'string' && PROVIDERS.includes(value as LLMProvider) ? (value as LLMProvider) : undefined;
+
+const toOptionalOpenAiApiMode = (value: unknown): OpenAIChatApi | undefined =>
+  typeof value === 'string' && OPENAI_API_MODES.includes(value as OpenAIChatApi) ? (value as OpenAIChatApi) : undefined;
+
+const toOptionalReasoningSummary = (value: unknown): ReasoningSummary | undefined =>
+  typeof value === 'string' && REASONING_SUMMARIES.includes(value as ReasoningSummary) ? (value as ReasoningSummary) : undefined;
+
+const toOptionalReasoningEffort = (value: unknown): PersistedLlmConfig['reasoningEffort'] | undefined =>
+  typeof value === 'string' && REASONING_EFFORTS.includes(value as PersistedLlmConfig['reasoningEffort'])
+    ? (value as PersistedLlmConfig['reasoningEffort'])
+    : undefined;
+
+export const parsePersistedLlmConfig = (value: unknown): PersistedLlmConfig | undefined => {
+  if (!isRecord(value)) return undefined;
+
+  const config: PersistedLlmConfig = {};
+  const profileId = toOptionalNonEmptyString(value.profileId);
+  if (profileId) config.profileId = profileId;
+  const provider = toOptionalProvider(value.provider);
+  if (provider) config.provider = provider;
+  const model = toOptionalNonEmptyString(value.model);
+  if (model) config.model = model;
+  const usageId = toOptionalNonEmptyString(value.usageId);
+  if (usageId) config.usageId = usageId;
+  const openaiApiMode = toOptionalOpenAiApiMode(value.openaiApiMode);
+  if (openaiApiMode) config.openaiApiMode = openaiApiMode;
+  const baseUrl = toOptionalNonEmptyString(value.baseUrl);
+  if (baseUrl) config.baseUrl = baseUrl;
+  const apiVersion = toOptionalNonEmptyString(value.apiVersion);
+  if (apiVersion) config.apiVersion = apiVersion;
+
+  const timeoutSeconds = toOptionalFiniteNumber(value.timeoutSeconds);
+  if (timeoutSeconds !== undefined) config.timeoutSeconds = timeoutSeconds;
+  const temperature = toOptionalFiniteNumber(value.temperature);
+  if (temperature !== undefined) config.temperature = temperature;
+  const topP = toOptionalFiniteNumber(value.topP);
+  if (topP !== undefined) config.topP = topP;
+  const topK = toOptionalFiniteNumber(value.topK);
+  if (topK !== undefined) config.topK = topK;
+
+  const maxInputTokens = toOptionalFiniteNumber(value.maxInputTokens);
+  if (maxInputTokens !== undefined) config.maxInputTokens = maxInputTokens;
+  const maxOutputTokens = toOptionalFiniteNumber(value.maxOutputTokens);
+  if (maxOutputTokens !== undefined) config.maxOutputTokens = maxOutputTokens;
+
+  const reasoningEffort = toOptionalReasoningEffort(value.reasoningEffort);
+  if (reasoningEffort) config.reasoningEffort = reasoningEffort;
+  const reasoningSummary = toOptionalReasoningSummary(value.reasoningSummary);
+  if (reasoningSummary) config.reasoningSummary = reasoningSummary;
+
+  const inputCostPerToken = toOptionalFiniteNumber(value.inputCostPerToken);
+  if (inputCostPerToken !== undefined) config.inputCostPerToken = inputCostPerToken;
+  const outputCostPerToken = toOptionalFiniteNumber(value.outputCostPerToken);
+  if (outputCostPerToken !== undefined) config.outputCostPerToken = outputCostPerToken;
+
+  return Object.keys(config).length ? config : undefined;
+};
 
 export interface ConversationPersistence {
   conversationId: string;
@@ -9,6 +109,8 @@ export interface ConversationPersistence {
   readEvents(): Event[];
   writeState(state: AgentState): void;
   readState(): AgentState | undefined;
+  writeLlmConfig?(config: PersistedLlmConfig): void;
+  readLlmConfig?(): PersistedLlmConfig | undefined;
 }
 
 export interface FileStoreOptions {
@@ -22,6 +124,7 @@ export class FileStore implements ConversationPersistence {
   private readonly conversationDir: string;
   private readonly eventsFile: string;
   private readonly stateFile: string;
+  private readonly llmFile: string;
 
   constructor(options: FileStoreOptions) {
     this.rootDir = options.rootDir ?? path.join(process.cwd(), '.openhands', 'conversations');
@@ -29,6 +132,7 @@ export class FileStore implements ConversationPersistence {
     this.conversationDir = path.join(this.rootDir, this.conversationId);
     this.eventsFile = path.join(this.conversationDir, 'events.jsonl');
     this.stateFile = path.join(this.conversationDir, 'state.json');
+    this.llmFile = path.join(this.conversationDir, 'llm.json');
     fs.mkdirSync(this.conversationDir, { recursive: true });
   }
 
@@ -64,6 +168,26 @@ export class FileStore implements ConversationPersistence {
       return JSON.parse(content) as AgentState;
     } catch (error) {
       console.error(`[FileStore] Could not read or parse state file: ${String(error)}`);
+      return undefined;
+    }
+  }
+
+  writeLlmConfig(config: PersistedLlmConfig): void {
+    try {
+      fs.writeFileSync(this.llmFile, `${JSON.stringify(config)}\n`, { encoding: 'utf8', mode: 0o600 });
+    } catch (error) {
+      console.error(`[FileStore] Failed to write llm config: ${String(error)}`);
+    }
+  }
+
+  readLlmConfig(): PersistedLlmConfig | undefined {
+    if (!fs.existsSync(this.llmFile)) return undefined;
+    try {
+      const content = fs.readFileSync(this.llmFile, 'utf8');
+      const parsed = JSON.parse(content) as unknown;
+      return parsePersistedLlmConfig(parsed);
+    } catch (error) {
+      console.error(`[FileStore] Could not read or parse llm config file: ${String(error)}`);
       return undefined;
     }
   }


### PR DESCRIPTION
Implements **oh-tab-6rd** by persisting non-secret LLM config per local conversation (including `profileId`) and restoring it on `restoreConversation`.

- Adds `llm.json` alongside events/state in the conversation directory.
- `LocalConversation` writes LLM config on new conversation + settings updates and restores it best-effort.
- Unit tests cover FileStore LLM config persistence and LocalConversation restore behavior.

Tests:
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run build -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation LLM configuration (model profile, base URL, temperature) is now persisted and automatically restored.

* **Chores**
  * Enhanced error handling to gracefully manage corrupted configuration files during conversation recovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->