### PR TITLE
oh-tab-vcb: Explain selection from editor context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "main": "./dist/extension.js",
   "activationEvents": [
     "onCommand:openhands.open",
+    "onCommand:openhands.explainSelection",
     "onCommand:openhands.startNewConversation",
     "onCommand:openhands.configure",
     "onCommand:openhands.setApiKey",
@@ -42,6 +43,10 @@
       {
         "command": "openhands.open",
         "title": "OpenHands: Open"
+      },
+      {
+        "command": "openhands.explainSelection",
+        "title": "OpenHands: Explain Selection"
       },
       {
         "command": "openhands.startNewConversation",
@@ -100,6 +105,28 @@
         "title": "OpenHands: Diagnostics (Internal)"
       }
     ],
+    "submenus": [
+      {
+        "id": "openhands.editorContext",
+        "label": "OpenHands"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "submenu": "openhands.editorContext",
+          "when": "editorTextFocus && editorHasSelection",
+          "group": "navigation@90"
+        }
+      ],
+      "openhands.editorContext": [
+        {
+          "command": "openhands.explainSelection",
+          "when": "editorTextFocus && editorHasSelection",
+          "group": "1_explain"
+        }
+      ]
+    },
     "configuration": [
       {
         "type": "object",

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -351,6 +351,34 @@ describe('Command handlers', () => {
     expect(conversationInstance.startNewConversation).toHaveBeenCalled();
   });
 
+  it('starts a new conversation to explain the editor selection', async () => {
+    (vscode.window as any).activeTextEditor = {
+      selection: {
+        isEmpty: false,
+        start: { line: 3, character: 2 },
+        end: { line: 5, character: 10 },
+      },
+      document: {
+        languageId: 'typescript',
+        uri: {
+          scheme: 'file',
+          fsPath: '/test/workspace/src/example.ts',
+          toString: () => 'file:///test/workspace/src/example.ts',
+        },
+        getText: vi.fn(() => 'const x = 1;'),
+      },
+    };
+
+    await vscode.commands.executeCommand('openhands.explainSelection');
+
+    expect(conversationInstance.startNewConversation).toHaveBeenCalled();
+    expect(conversationInstance.sendUserMessage).toHaveBeenCalled();
+    const message = (conversationInstance.sendUserMessage as unknown as Mock).mock.calls[0]?.[0] as string;
+    expect(message).toContain('Please explain this code:');
+    expect(message).toContain('/test/workspace/src/example.ts:4:3-6:11');
+    expect(message).toContain('const x = 1;');
+  });
+
   it('sends reconnect/pause/resume commands', async () => {
     await vscode.commands.executeCommand('openhands.reconnect');
     await vscode.commands.executeCommand('openhands.pauseCurrentRun');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -965,6 +965,59 @@ export function activate(context: vscode.ExtensionContext) {
     await ensureConversationAndConnection();
   });
 
+  const explainSelection = vscode.commands.registerCommand('openhands.explainSelection', async () => {
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) {
+      void vscode.window.showErrorMessage('OpenHands: No active editor to explain.');
+      return;
+    }
+
+    const selection = editor.selection;
+    if (!selection || selection.isEmpty) {
+      void vscode.window.showErrorMessage('OpenHands: Select code to explain first.');
+      return;
+    }
+
+    const selectedText = editor.document.getText(selection);
+    if (!selectedText.trim()) {
+      void vscode.window.showErrorMessage('OpenHands: Selection is empty.');
+      return;
+    }
+
+    const maxChars = 12_000;
+    const truncated =
+      selectedText.length > maxChars
+        ? `${selectedText.slice(0, maxChars)}\n\n[Truncated ${selectedText.length - maxChars} characters.]`
+        : selectedText;
+
+    const languageId = editor.document.languageId;
+    const filePath = editor.document.uri.scheme === 'file' ? editor.document.uri.fsPath : editor.document.uri.toString();
+    const start = selection.start;
+    const end = selection.end;
+    const range = `${filePath}:${start.line + 1}:${start.character + 1}-${end.line + 1}:${end.character + 1}`;
+
+    const maxBackticks = Math.max(0, ...Array.from(truncated.matchAll(/`+/g), (m) => m[0].length));
+    const fence = '`'.repeat(Math.max(3, maxBackticks + 1));
+    const fencedCode = `${fence}${languageId}\n${truncated}\n${fence}`;
+
+    const prompt = [
+      'Please explain this code:',
+      '',
+      `File: ${range}`,
+      `Language: ${languageId}`,
+      '',
+      fencedCode,
+    ].join('\n');
+
+    await vscode.commands.executeCommand('openhands.open');
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+    if (!conversation) {
+      void vscode.window.showErrorMessage('OpenHands: Conversation is not available.');
+      return;
+    }
+    await conversation.sendUserMessage(prompt);
+  });
+
   // Diagnostics command for E2E tests and troubleshooting
   const getServerUrl = () => vscode.workspace.getConfiguration().get<string>('openhands.serverUrl') ?? '';
   const diag = vscode.commands.registerCommand('openhands._diagnostics', () => {
@@ -1433,6 +1486,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     open,
+    explainSelection,
     diag,
     queryLastError,
     queryBacklogSummary,


### PR DESCRIPTION
Implements **oh-tab-vcb**: adds an editor context-menu entry (Right click → OpenHands → Explain Selection) that starts a fresh conversation and sends a prompt containing file path + range + language + selected code.

- Command id: `openhands.explainSelection`
- Menu visibility: `editorTextFocus && editorHasSelection`
- Truncates large selections (12k chars) with a note.

Tests:
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "OpenHands" submenu in the editor context menu
  * Select any code snippet and choose "Explain Selection" to have OpenHands explain it with full context
  * The feature automatically includes file location and code context in the explanation request

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->