### PR TITLE
oh-tab-1fq: cover litellm_proxy in llmSwitching E2E

### DIFF
--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -188,52 +188,66 @@ export async function run(): Promise<void> {
       throw new Error('Expected an OpenRouter /chat/completions request');
     }
     const referer = openrouterReq.headers['http-referer'];
-    const title = openrouterReq.headers['x-title'];
-    if (!referer || !title) {
-      throw new Error(`Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`);
-    }
+	    const title = openrouterReq.headers['x-title'];
+	    if (!referer || !title) {
+	      throw new Error(`Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`);
+	    }
 
-    // 6) Gemini native API (streamGenerateContent SSE).
-    await setLlmConfig({
-      profileId: null,
-      provider: 'gemini',
-      openaiApiMode: null,
-      baseUrl: `${mock.baseUrl}/v1beta`,
-      model: 'gemini-2.5-flash',
-    });
-    await sendAndWaitForRequestPath({
-      text: 'E2E step 6: gemini',
-      expectedPath: '/v1beta/models/gemini-2.5-flash:streamGenerateContent',
-      getRequests: () => mock.requests,
-    });
+	    // 6) litellm_proxy is OpenAI-compatible.
+	    await setLlmConfig({
+	      profileId: null,
+	      provider: 'litellm_proxy',
+	      openaiApiMode: 'chat_completions',
+	      baseUrl: mock.baseUrl,
+	      model: 'gpt-4o-mini',
+	    });
+	    await sendAndWaitForRequestPath({
+	      text: 'E2E step 6: litellm_proxy',
+	      expectedPath: '/chat/completions',
+	      getRequests: () => mock.requests,
+	    });
 
-    // 7) LLM profile selection: Sonnet profile should override raw provider/model.
-    await setLlmConfig({
-      profileId: 'sonnet-45',
-      provider: 'openai',
-      model: 'gpt-4o-mini',
+	    // 7) Gemini native API (streamGenerateContent SSE).
+	    await setLlmConfig({
+	      profileId: null,
+	      provider: 'gemini',
+	      openaiApiMode: null,
+	      baseUrl: `${mock.baseUrl}/v1beta`,
+	      model: 'gemini-2.5-flash',
+	    });
+	    await sendAndWaitForRequestPath({
+	      text: 'E2E step 7: gemini',
+	      expectedPath: '/v1beta/models/gemini-2.5-flash:streamGenerateContent',
+	      getRequests: () => mock.requests,
+	    });
+
+	    // 8) LLM profile selection: Sonnet profile should override raw provider/model.
+	    await setLlmConfig({
+	      profileId: 'sonnet-45',
+	      provider: 'openai',
+	      model: 'gpt-4o-mini',
       openaiApiMode: 'chat_completions',
       baseUrl: mock.baseUrl,
-    });
-    await sendAndWaitForRequestPath({
-      text: 'E2E step 7: profile sonnet-45',
-      expectedPath: '/messages',
-      getRequests: () => mock.requests,
-    });
+	    });
+	    await sendAndWaitForRequestPath({
+	      text: 'E2E step 8: profile sonnet-45',
+	      expectedPath: '/messages',
+	      getRequests: () => mock.requests,
+	    });
 
-    // 8) LLM profile selection: gpt-5-mini profile should override raw provider/model.
-    await setLlmConfig({
-      profileId: 'gpt-5-mini',
-      provider: 'anthropic',
-      model: 'claude-sonnet-4-20250514',
+	    // 9) LLM profile selection: gpt-5-mini profile should override raw provider/model.
+	    await setLlmConfig({
+	      profileId: 'gpt-5-mini',
+	      provider: 'anthropic',
+	      model: 'claude-sonnet-4-20250514',
       openaiApiMode: 'auto',
       baseUrl: mock.baseUrl,
-    });
-    await sendAndWaitForRequestPath({
-      text: 'E2E step 8: profile gpt-5-mini',
-      expectedPath: '/chat/completions',
-      getRequests: () => mock.requests,
-    });
+	    });
+	    await sendAndWaitForRequestPath({
+	      text: 'E2E step 9: profile gpt-5-mini',
+	      expectedPath: '/chat/completions',
+	      getRequests: () => mock.requests,
+	    });
 
     // Basic sanity: at least one request per step.
     const paths = mock.requests.map((r) => r.path);

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -188,72 +188,81 @@ export async function run(): Promise<void> {
       throw new Error('Expected an OpenRouter /chat/completions request');
     }
     const referer = openrouterReq.headers['http-referer'];
-	    const title = openrouterReq.headers['x-title'];
-	    if (!referer || !title) {
-	      throw new Error(`Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`);
-	    }
+    const title = openrouterReq.headers['x-title'];
+    if (!referer || !title) {
+      throw new Error(
+        `Expected OpenRouter headers on request. http-referer=${String(referer)} x-title=${String(title)}`,
+      );
+    }
 
-	    // 6) litellm_proxy is OpenAI-compatible.
-	    await setLlmConfig({
-	      profileId: null,
-	      provider: 'litellm_proxy',
-	      openaiApiMode: 'chat_completions',
-	      baseUrl: mock.baseUrl,
-	      model: 'gpt-4o-mini',
-	    });
-	    await sendAndWaitForRequestPath({
-	      text: 'E2E step 6: litellm_proxy',
-	      expectedPath: '/chat/completions',
-	      getRequests: () => mock.requests,
-	    });
-
-	    // 7) Gemini native API (streamGenerateContent SSE).
-	    await setLlmConfig({
-	      profileId: null,
-	      provider: 'gemini',
-	      openaiApiMode: null,
-	      baseUrl: `${mock.baseUrl}/v1beta`,
-	      model: 'gemini-2.5-flash',
-	    });
-	    await sendAndWaitForRequestPath({
-	      text: 'E2E step 7: gemini',
-	      expectedPath: '/v1beta/models/gemini-2.5-flash:streamGenerateContent',
-	      getRequests: () => mock.requests,
-	    });
-
-	    // 8) LLM profile selection: Sonnet profile should override raw provider/model.
-	    await setLlmConfig({
-	      profileId: 'sonnet-45',
-	      provider: 'openai',
-	      model: 'gpt-4o-mini',
+    // 6) litellm_proxy is OpenAI-compatible.
+    await setLlmConfig({
+      profileId: null,
+      provider: 'litellm_proxy',
       openaiApiMode: 'chat_completions',
       baseUrl: mock.baseUrl,
-	    });
-	    await sendAndWaitForRequestPath({
-	      text: 'E2E step 8: profile sonnet-45',
-	      expectedPath: '/messages',
-	      getRequests: () => mock.requests,
-	    });
+      model: 'gpt-4o-mini',
+    });
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 6: litellm_proxy',
+      expectedPath: '/chat/completions',
+      getRequests: () => mock.requests,
+    });
 
-	    // 9) LLM profile selection: gpt-5-mini profile should override raw provider/model.
-	    await setLlmConfig({
-	      profileId: 'gpt-5-mini',
-	      provider: 'anthropic',
-	      model: 'claude-sonnet-4-20250514',
+    // 7) Gemini native API (streamGenerateContent SSE).
+    await setLlmConfig({
+      profileId: null,
+      provider: 'gemini',
+      openaiApiMode: null,
+      baseUrl: `${mock.baseUrl}/v1beta`,
+      model: 'gemini-2.5-flash',
+    });
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 7: gemini',
+      expectedPath: '/v1beta/models/gemini-2.5-flash:streamGenerateContent',
+      getRequests: () => mock.requests,
+    });
+
+    // 8) LLM profile selection: Sonnet profile should override raw provider/model.
+    await setLlmConfig({
+      profileId: 'sonnet-45',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      openaiApiMode: 'chat_completions',
+      baseUrl: mock.baseUrl,
+    });
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 8: profile sonnet-45',
+      expectedPath: '/messages',
+      getRequests: () => mock.requests,
+    });
+
+    // 9) LLM profile selection: gpt-5-mini profile should override raw provider/model.
+    await setLlmConfig({
+      profileId: 'gpt-5-mini',
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-20250514',
       openaiApiMode: 'auto',
       baseUrl: mock.baseUrl,
-	    });
-	    await sendAndWaitForRequestPath({
-	      text: 'E2E step 9: profile gpt-5-mini',
-	      expectedPath: '/chat/completions',
-	      getRequests: () => mock.requests,
-	    });
+    });
+    await sendAndWaitForRequestPath({
+      text: 'E2E step 9: profile gpt-5-mini',
+      expectedPath: '/chat/completions',
+      getRequests: () => mock.requests,
+    });
 
     // Basic sanity: at least one request per step.
     const paths = mock.requests.map((r) => r.path);
-    const required = ['/messages', '/chat/completions', '/responses', '/v1beta/models/gemini-2.5-flash:streamGenerateContent'];
+    const required = [
+      '/messages',
+      '/chat/completions',
+      '/responses',
+      '/v1beta/models/gemini-2.5-flash:streamGenerateContent'
+    ];
     for (const p of required) {
-      if (!paths.includes(p)) throw new Error(`Missing required mock request path: ${p} (saw: ${paths.join(', ')})`);
+      if (!paths.includes(p)) {
+        throw new Error(`Missing required mock request path: ${p} (saw: ${paths.join(', ')})`);
+      }
     }
 
     console.log('✓ LLM switching E2E test passed');


### PR DESCRIPTION
Adds coverage for `litellm_proxy` in the `llmSwitching` E2E suite (`oh-tab-1fq`).

- Adds a new step setting `provider=litellm_proxy` + `openaiApiMode=chat_completions` and asserts the mock sees `/chat/completions`.

Tests:
- `npm run e2e -- -g "LLM Switching"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test coverage for LLM provider switching with additional configurations and verification steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->