### PR TITLE
oh-tab-70m: Per-provider LLM API keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,11 @@
     "onCommand:openhands.startNewConversation",
     "onCommand:openhands.configure",
     "onCommand:openhands.setApiKey",
+    "onCommand:openhands.setOpenAiApiKey",
+    "onCommand:openhands.setAnthropicApiKey",
+    "onCommand:openhands.setOpenRouterApiKey",
+    "onCommand:openhands.setLiteLlmApiKey",
+    "onCommand:openhands.setGeminiLlmApiKey",
     "onCommand:openhands.setSessionApiKey",
     "onCommand:openhands.setGithubToken",
     "onCommand:openhands.setElevenLabsApiKey",
@@ -61,6 +66,26 @@
         "title": "OpenHands: Set API Key"
       },
       {
+        "command": "openhands.setOpenAiApiKey",
+        "title": "OpenHands: Set OpenAI API Key"
+      },
+      {
+        "command": "openhands.setAnthropicApiKey",
+        "title": "OpenHands: Set Anthropic API Key"
+      },
+      {
+        "command": "openhands.setOpenRouterApiKey",
+        "title": "OpenHands: Set OpenRouter API Key"
+      },
+      {
+        "command": "openhands.setLiteLlmApiKey",
+        "title": "OpenHands: Set LiteLLM Proxy API Key"
+      },
+      {
+        "command": "openhands.setGeminiLlmApiKey",
+        "title": "OpenHands: Set Gemini API Key (LLM)"
+      },
+      {
         "command": "openhands.setSessionApiKey",
         "title": "OpenHands: Set Session API Key"
       },
@@ -74,7 +99,7 @@
       },
       {
         "command": "openhands.setGeminiApiKey",
-        "title": "OpenHands: Set Gemini API Key"
+        "title": "OpenHands: Set Gemini API Key (HAL)"
       },
       {
         "command": "openhands.setCustomSecret1",
@@ -466,17 +491,52 @@
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
           },
-          "openhands.secrets.geminiApiKey": {
+          "openhands.secrets.openaiApiKey": {
             "type": "string",
             "default": "",
             "order": 3,
             "editPresentation": "singlelineText",
-            "markdownDescription": "**To set your Gemini API key securely:**\n\n[🔑 Configure Gemini API Key](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
+            "markdownDescription": "**To set your OpenAI API key securely:**\n\n[🔑 Configure OpenAI API Key](command:openhands.setOpenAiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `OPENAI_API_KEY`.)_"
+          },
+          "openhands.secrets.anthropicApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 4,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your Anthropic API key securely:**\n\n[🔑 Configure Anthropic API Key](command:openhands.setAnthropicApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `ANTHROPIC_API_KEY`.)_"
+          },
+          "openhands.secrets.openrouterApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 5,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your OpenRouter API key securely:**\n\n[🔑 Configure OpenRouter API Key](command:openhands.setOpenRouterApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `OPENROUTER_API_KEY`.)_"
+          },
+          "openhands.secrets.litellmApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 6,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your LiteLLM Proxy API key securely:**\n\n[🔑 Configure LiteLLM Proxy API Key](command:openhands.setLiteLlmApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `LITELLM_API_KEY`.)_"
+          },
+          "openhands.secrets.geminiLlmApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 7,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your Gemini API key for LLM requests securely:**\n\n[🔑 Configure Gemini API Key (LLM)](command:openhands.setGeminiLlmApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `GEMINI_API_KEY`.)_"
+          },
+          "openhands.secrets.geminiApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 8,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your Gemini API key for HAL decision classification securely:**\n\n[🔑 Configure Gemini API Key (HAL)](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `openhands.geminiApiKey`.)_"
           },
           "openhands.secrets.elevenLabsApiKey": {
             "type": "string",
             "default": "",
-            "order": 4,
+            "order": 9,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your ElevenLabs API key securely:**\n\n[🔑 Configure ElevenLabs API Key](command:openhands.setElevenLabsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
           },

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi, afterEach } from 'vitest';
 import { AgentOrchestrator } from '../runtime';
 import { DEFAULT_RETRY_OPTIONS, OpenAICompatibleClient, OpenAIResponsesClient, GeminiClient, LLMFactory, LLMCredentialProvider } from '../llm';
 import type { ChatCompletionRequest, LLMConfiguration } from '../llm';
-import { ConversationState, EventLog } from '../runtime';
+import { ConversationState, EventLog, SecretRegistry } from '../runtime';
 
 const encoder = new TextEncoder();
 
@@ -286,6 +286,18 @@ describe('LLMFactory integration', () => {
 
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
     expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('uses provider default API key from SecretRegistry when apiKey is unset', async () => {
+    const secrets = new SecretRegistry();
+    secrets.register('OPENAI_API_KEY', 'sk-storage');
+    const spy = vi.spyOn(secrets, 'get');
+
+    const factory = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai' }, { secrets });
+    const client = await factory.createClient();
+
+    expect(client).toBeInstanceOf(OpenAICompatibleClient);
+    expect(spy).toHaveBeenCalledWith('OPENAI_API_KEY');
   });
 
   it('routes GPT-5 models through Responses API', async () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/runtime.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/runtime.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ConversationState, EventLog, SecretRegistry, AsyncLock } from '../runtime';
 import { isConversationStateUpdateEvent } from '../types';
 
@@ -21,6 +21,16 @@ describe('SecretRegistry', () => {
     registry.register('token', 'abc');
     await expect(registry.get('token')).resolves.toBe('abc');
   });
+
+  it('reads secrets from SecretStorage when provided', async () => {
+    const storage = {
+      get: vi.fn(async (key: string) => (key === 'OPENAI_API_KEY' ? 'sk-storage' : undefined)),
+    };
+    const registry = new SecretRegistry(storage as any);
+
+    await expect(registry.get('OPENAI_API_KEY')).resolves.toBe('sk-storage');
+    expect(storage.get).toHaveBeenCalledWith('OPENAI_API_KEY');
+  });
 });
 
 describe('AsyncLock', () => {
@@ -40,4 +50,3 @@ describe('AsyncLock', () => {
     expect(order).toEqual([1, 2]);
   });
 });
-

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -64,6 +64,12 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     constructor(_params?: unknown) {}
   }
 
+  class SecretRegistry {
+    constructor(_storage?: unknown) {}
+
+    set = vi.fn();
+  }
+
   const Conversation = vi.fn((options: any) => {
     const emitter = new EventEmitter() as any;
     emitter.mode = options?.serverUrl ? 'remote' : 'local';
@@ -105,6 +111,7 @@ vi.mock('@openhands/agent-sdk-ts', () => {
   return {
     AgentContext,
     Conversation,
+    SecretRegistry,
     isBashCommand: vi.fn((event: any) => event?.type === 'BashCommand'),
     isBashOutput: vi.fn((event: any) => event?.type === 'BashOutput'),
     isBashExit: vi.fn((event: any) => event?.type === 'BashExit'),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {
   type ConversationInstance,
   FileEditorTool,
   LLMFactory,
+  SecretRegistry,
   TaskTrackerTool,
   TerminalTool,
   type BashEvent,
@@ -570,21 +571,18 @@ async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ r
   }
 }
 
-async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string): Promise<string> {
+async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string, secrets: SecretRegistry): Promise<string> {
   const model = normalizeNonEmptyString(settings.llm.model) ?? '';
   if (!model) {
     throw new Error('LLM model is not configured');
   }
   const apiKey = normalizeNonEmptyString(settings.secrets.llmApiKey);
-  if (!apiKey) {
-    throw new Error('Missing LLM API key');
-  }
 
   const factory = new LLMFactory({
     provider: settings.llm.provider ?? undefined,
     model,
     baseUrl: normalizeNonEmptyString(settings.llm.baseUrl),
-    apiKey,
+    apiKey: apiKey ?? undefined,
     apiVersion: normalizeNonEmptyString(settings.llm.apiVersion),
     timeoutSeconds: settings.llm.timeout ?? undefined,
     temperature: settings.llm.temperature ?? undefined,
@@ -595,7 +593,7 @@ async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string
     reasoningEffort: settings.llm.reasoningEffort ?? undefined,
     inputCostPerToken: settings.llm.inputCostPerToken ?? undefined,
     outputCostPerToken: settings.llm.outputCostPerToken ?? undefined,
-  });
+  }, { secrets });
 
   const client = await factory.createClient();
   const request = {
@@ -699,6 +697,8 @@ export function activate(context: vscode.ExtensionContext) {
     console.warn('[OpenHands] Failed to create output channel:', err);
     outputChannel = undefined;
   }
+
+  const secretRegistry = new SecretRegistry(context.secrets);
 
   const chatViewProvider = new OpenHandsChatViewProvider(context, {
     createMessageHandler: (view) =>
@@ -889,6 +889,7 @@ export function activate(context: vscode.ExtensionContext) {
         settings,
         workspaceRoot,
         tools: settings.serverUrl ? undefined : createDefaultLocalTools(),
+        secrets: secretRegistry,
         persistenceDir,
         agentContext,
       };
@@ -1229,7 +1230,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       let firstRemoteMessage: string;
       try {
-        const summary = await summarizeWithLocalLlm(settings, prompt);
+        const summary = await summarizeWithLocalLlm(settings, prompt, secretRegistry);
         firstRemoteMessage = `${intro}\n\n---\n\n${summary}`;
       } catch (err) {
         const last10 = takeLastTeleportableEvents(backlogEvents, TELEPORT_FALLBACK_EVENT_LIMIT).map((e) => safeStringify(e));
@@ -1342,6 +1343,72 @@ export function activate(context: vscode.ExtensionContext) {
       }
     });
 
+  const registerSecretStorageCommand = (
+    commandId: string,
+    options: {
+      title: string;
+      storageKey: string;
+      prompt: string;
+      placeHolder?: string;
+      successMessage: string;
+      clearedMessage: string;
+      errorPrefix: string;
+    }
+  ) =>
+    vscode.commands.registerCommand(commandId, async () => {
+      try {
+        const currentValue = await context.secrets.get(options.storageKey);
+        const isCurrentlySet = typeof currentValue === 'string' && currentValue.trim().length > 0;
+
+        if (isCurrentlySet) {
+          const action = await vscode.window.showQuickPick(
+            [
+              { label: 'Update', value: 'update', description: 'Enter a new value (stored securely)' },
+              { label: 'Clear', value: 'clear', description: 'Remove the stored value' },
+            ],
+            {
+              title: options.title,
+              placeHolder: 'Choose an action',
+              canPickMany: false,
+            }
+          );
+          if (!action) return;
+
+          if (action.value === 'clear') {
+            const confirmed = await vscode.window.showWarningMessage(
+              `Clear ${options.title}?`,
+              { modal: true },
+              'Clear'
+            );
+            if (confirmed !== 'Clear') return;
+
+            await context.secrets.delete(options.storageKey);
+            secretRegistry.set(options.storageKey, undefined);
+            vscode.window.showInformationMessage(options.clearedMessage);
+            return;
+          }
+        }
+
+        const value = await vscode.window.showInputBox({
+          title: options.title,
+          password: true,
+          prompt: options.prompt,
+          placeHolder: options.placeHolder,
+        });
+
+        if (value === undefined) return;
+        const trimmed = value.trim();
+        if (!trimmed) return;
+
+        await context.secrets.store(options.storageKey, trimmed);
+        secretRegistry.set(options.storageKey, trimmed);
+        vscode.window.showInformationMessage(options.successMessage);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        vscode.window.showErrorMessage(`${options.errorPrefix}: ${message}`);
+      }
+    });
+
   const setApiKey = registerSecretCommand('openhands.setApiKey', {
     title: 'LLM API Key',
     secretKey: 'llmApiKey',
@@ -1350,6 +1417,56 @@ export function activate(context: vscode.ExtensionContext) {
     successMessage: 'LLM API Key saved securely.',
     clearedMessage: 'LLM API Key cleared.',
     errorPrefix: 'Failed to save API Key',
+  });
+
+  const setOpenAiApiKey = registerSecretStorageCommand('openhands.setOpenAiApiKey', {
+    title: 'OpenAI API Key',
+    storageKey: 'OPENAI_API_KEY',
+    prompt: 'Enter your OpenAI API key. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'sk-...',
+    successMessage: 'OpenAI API key saved securely.',
+    clearedMessage: 'OpenAI API key cleared.',
+    errorPrefix: 'Failed to save OpenAI API key',
+  });
+
+  const setAnthropicApiKey = registerSecretStorageCommand('openhands.setAnthropicApiKey', {
+    title: 'Anthropic API Key',
+    storageKey: 'ANTHROPIC_API_KEY',
+    prompt: 'Enter your Anthropic API key. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'sk-ant-...',
+    successMessage: 'Anthropic API key saved securely.',
+    clearedMessage: 'Anthropic API key cleared.',
+    errorPrefix: 'Failed to save Anthropic API key',
+  });
+
+  const setOpenRouterApiKey = registerSecretStorageCommand('openhands.setOpenRouterApiKey', {
+    title: 'OpenRouter API Key',
+    storageKey: 'OPENROUTER_API_KEY',
+    prompt: 'Enter your OpenRouter API key. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'sk-or-...',
+    successMessage: 'OpenRouter API key saved securely.',
+    clearedMessage: 'OpenRouter API key cleared.',
+    errorPrefix: 'Failed to save OpenRouter API key',
+  });
+
+  const setLiteLlmApiKey = registerSecretStorageCommand('openhands.setLiteLlmApiKey', {
+    title: 'LiteLLM Proxy API Key',
+    storageKey: 'LITELLM_API_KEY',
+    prompt: 'Enter your LiteLLM Proxy API key. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'sk-...',
+    successMessage: 'LiteLLM Proxy API key saved securely.',
+    clearedMessage: 'LiteLLM Proxy API key cleared.',
+    errorPrefix: 'Failed to save LiteLLM Proxy API key',
+  });
+
+  const setGeminiLlmApiKey = registerSecretStorageCommand('openhands.setGeminiLlmApiKey', {
+    title: 'Gemini API Key (LLM)',
+    storageKey: 'GEMINI_API_KEY',
+    prompt: 'Enter your Gemini API key. It will be stored securely in VS Code SecretStorage.',
+    placeHolder: 'AIza...',
+    successMessage: 'Gemini API key saved securely.',
+    clearedMessage: 'Gemini API key cleared.',
+    errorPrefix: 'Failed to save Gemini API key',
   });
 
   const setSessionApiKey = registerSecretCommand('openhands.setSessionApiKey', {
@@ -1382,9 +1499,9 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const setGeminiApiKey = registerSecretCommand('openhands.setGeminiApiKey', {
-    title: 'Gemini API Key',
+    title: 'Gemini API Key (HAL)',
     secretKey: 'geminiApiKey',
-    prompt: 'Enter your Gemini API key. It will be stored securely in VS Code SecretStorage.',
+    prompt: 'Enter your Gemini API key for HAL decision classification. It will be stored securely in VS Code SecretStorage.',
     successMessage: 'Gemini API key saved securely.',
     clearedMessage: 'Gemini API key cleared.',
     errorPrefix: 'Failed to save Gemini API key',
@@ -1499,6 +1616,11 @@ export function activate(context: vscode.ExtensionContext) {
     teleportToRemoteRuntime,
     configure,
     setApiKey,
+    setOpenAiApiKey,
+    setAnthropicApiKey,
+    setOpenRouterApiKey,
+    setLiteLlmApiKey,
+    setGeminiLlmApiKey,
     setSessionApiKey,
     setGithubToken,
     setElevenLabsApiKey,


### PR DESCRIPTION
Implements per-provider LLM API keys in VS Code SecretStorage so switching providers doesn’t require overwriting the generic OpenHands LLM key.

- Passes a shared SecretRegistry(context.secrets) into local Conversation(...) so LLMFactory can resolve OPENAI_API_KEY / ANTHROPIC_API_KEY / OPENROUTER_API_KEY / LITELLM_API_KEY / GEMINI_API_KEY when the generic key is unset.
- Adds commands + settings placeholders for configuring those provider keys.
- Renames the existing Gemini key used by HAL to avoid confusion with the new LLM Gemini key.
- Adds unit tests for SecretRegistry SecretStorage reads and LLMFactory provider-default credential resolution.

Tests:
- npm run typecheck
- npm test
- npm run lint
