### PR TITLE
oh-tab-hm8: Disallow tabs in TS/TSX

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,6 +82,7 @@ module.exports = [
       'no-console': 'off',
       'no-undef': 'off',
       'no-empty': ['error', { allowEmptyCatch: true }],
+      'no-tabs': 'error',
       'prefer-const': 'error',
       'no-var': 'error',
       'eqeqeq': ['error', 'always', { null: 'ignore' }],
@@ -143,6 +144,7 @@ module.exports = [
       '@typescript-eslint/no-empty-function': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       'no-empty': 'off',
+      'no-tabs': 'error',
     },
   },
 ];

--- a/packages/agent-sdk-ts/eslint.config.js
+++ b/packages/agent-sdk-ts/eslint.config.js
@@ -30,6 +30,7 @@ module.exports = [
       '@typescript-eslint/no-explicit-any': 'error',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      'no-tabs': 'error',
       'prefer-const': 'error',
       eqeqeq: ['error', 'always'],
     },
@@ -51,6 +52,7 @@ module.exports = [
       ...eslint.configs.recommended.rules,
       ...tseslint.configs.recommended.rules,
       '@typescript-eslint/no-explicit-any': 'off',
+      'no-tabs': 'error',
     },
   },
 ];


### PR DESCRIPTION
Adds ESLint `no-tabs` to prevent accidental tab indentation in `.ts`/`.tsx`.

- Root `eslint.config.js`: enforces `no-tabs` for prod + test TS/TSX.
- `packages/agent-sdk-ts/eslint.config.js`: enforces `no-tabs` for SDK sources + tests.

Checks:
- `npm run lint`
- `npm test`
