### PR TITLE
oh-tab-dfz: E2E webview profile selector wiring

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1363,6 +1363,15 @@ export function App() {
               postMessage({ type: 'send', text: normalized, contextFiles: [], attachments: [] });
               break;
             }
+            case 'setLlmProfileId': {
+              const profileIdRaw = (rawPayload as { profileId?: unknown } | undefined)?.profileId;
+              if (profileIdRaw === undefined) break;
+              if (profileIdRaw !== null && typeof profileIdRaw !== 'string') break;
+              const profileId = profileIdRaw;
+              setLlmProfileId(profileId);
+              postMessage({ type: 'setLlmProfileId', profileId });
+              break;
+            }
             case 'halApprove':
               setHalDecision('approve_local');
               postMessage({ type: 'command', command: 'approveAction' });

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -236,12 +236,26 @@ export async function run(): Promise<void> {
 
     // 8) LLM profile selection: Sonnet profile should override raw provider/model.
     await setLlmConfig({
-      profileId: 'sonnet-45',
+      profileId: null,
       provider: 'openai',
       model: 'gpt-4o-mini',
       openaiApiMode: 'chat_completions',
       baseUrl: v1BaseUrl,
     });
+
+    const setProfile = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+      action: 'setLlmProfileId',
+      payload: { profileId: 'sonnet-45' },
+    });
+    if (!setProfile?.sent) {
+      throw new Error(`setLlmProfileId action was not sent: ${JSON.stringify(setProfile)}`);
+    }
+
+    await pollUntil(async () => {
+      const inspected = vscode.workspace.getConfiguration().inspect<string>('openhands.llm.profileId');
+      const value = inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
+      return value === 'sonnet-45';
+    }, 15000);
     await sendAndWaitForRequestPath({
       text: 'E2E step 8: profile sonnet-45',
       expectedPath: expectedPaths.anthropicMessages,


### PR DESCRIPTION
Implements `oh-tab-dfz`.

- Adds test-only `e2eAction` `setLlmProfileId` in the webview.
- Extends `llmSwitching` E2E to drive that action and assert profile selection affects routing.

Tests:
- `npm run e2e -- -g "LLM Switching"`
