### PR TITLE
oh-tab-z0gu: Share webview→host message types

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -1,0 +1,62 @@
+import type { SavedServer } from '../settings/SettingsManager';
+
+export type WebviewToHostMessage =
+  | { type: 'webviewReady'; conversationId?: string; lastSeenSeq?: number }
+  | { type: 'openSettingsPage' }
+  | { type: 'openSettings' }
+  | { type: 'requestWorkspaceFiles' }
+  | { type: 'requestSkills' }
+  | { type: 'openSkill'; path: string }
+  | { type: 'openWorkspaceFile'; path: string }
+  | { type: 'openMarkdownLink'; href: string }
+  | { type: 'openWorkspaceDiff'; path: string; oldContent: string; newContent: string }
+  | { type: 'requestHistory' }
+  | { type: 'restoreConversation'; id: string }
+  | { type: 'deleteConversation'; id: string }
+  | { type: 'getConfig' }
+  | { type: 'setLlmProfileId'; profileId: string | null }
+  | { type: 'selectServer'; url: string }
+  | { type: 'addServer'; server: SavedServer }
+  | { type: 'removeServer'; url: string }
+  | { type: 'switchToLocal' }
+  | { type: 'selectAttachments' }
+  | { type: 'openAttachment'; uri: string }
+  | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
+  | { type: 'halTtsRequest'; requestId: string; conversationId: string; stepIndex: number }
+  | { type: 'halVoiceConfirmRequest'; requestId: string; mimeType: string; audioBase64: string }
+  | { type: 'command'; command: string; reason?: string }
+  | {
+    type: 'renderedEventsResponse';
+    requestId: string;
+    count: number;
+    eventTypes: string[];
+    events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
+  }
+  | {
+    type: 'uiStateResponse';
+    requestId: string;
+    input: string;
+    showContextPicker: boolean;
+    showSkillsPopover: boolean;
+    showHistory: boolean;
+    workspaceFilesCount: number;
+    selectedContextFiles: string[];
+    skillsCount: number;
+    attachmentsCount: number;
+  }
+  | {
+    type: 'halStateResponse';
+    requestId: string;
+    enabled: boolean;
+    mode: string;
+    phase: string;
+    eye: string;
+    stepIndex: number | null;
+    decision: string | null;
+    lastError: string | null;
+  }
+  | { type: 'webviewConsole'; level: string; args: unknown[] }
+  | { type: 'webviewError'; message: string; stack?: string }
+  | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
+  | { type: 'webviewWebSocket'; phase: string; url: string; code?: number; reason?: string };
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -37,6 +37,7 @@ import {
   MessageEventBlock,
   StreamingMessageBlock,
 } from './EventBlock';
+import type { WebviewToHostMessage } from '../../shared/webviewMessages';
 
 type RenderedEvent = { id: number; event: Event };
 
@@ -273,7 +274,7 @@ export function App() {
   });
 
   // Post message helper
-  const postMessage = useCallback((msg: unknown) => {
+  const postMessage = useCallback((msg: WebviewToHostMessage) => {
     const api = getVscodeApi();
     api.postMessage(msg);
   }, []);
@@ -1001,13 +1002,13 @@ export function App() {
     let didRequestSkills = false;
     const sendReady = () => {
       const state = vscodeApi.getState?.<WebviewPersistedState>() ?? {};
-      const payload: { type: 'webviewReady'; conversationId?: string; lastSeenSeq?: number } = { type: 'webviewReady' };
+      const payload: WebviewToHostMessage = { type: 'webviewReady' };
       if (typeof state.conversationId === 'string') payload.conversationId = state.conversationId;
       if (typeof state.lastSeenSeq === 'number') payload.lastSeenSeq = state.lastSeenSeq;
-      vscodeApi.postMessage(payload);
+      postMessage(payload);
       if (!didRequestSkills) {
         didRequestSkills = true;
-        vscodeApi.postMessage({ type: 'requestSkills' });
+        postMessage({ type: 'requestSkills' });
       }
     };
 
@@ -1020,7 +1021,7 @@ export function App() {
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
-  }, []);
+  }, [postMessage]);
 
   // Message handler: processes incoming messages from extension host
   useEffect(() => {

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -30,6 +30,7 @@ import {
   isTextContent,
 } from '@openhands/agent-sdk-ts';
 import { getVscodeApi } from '../shared/vscodeApi';
+import type { WebviewToHostMessage } from '../../shared/webviewMessages';
 import { SecurityRiskBadge } from './SecurityRiskBadge';
 
 // ============================================================================
@@ -87,19 +88,21 @@ const formatSizeDelta = (previous?: number, next?: number): string | undefined =
   return 'File size changed by ' + sign + delta.toLocaleString() + ' ' + unit + '.';
 };
 
-const openWorkspaceFile = (path: string) => {
+const postMessage = (message: WebviewToHostMessage) => {
   const api = getVscodeApi();
-  api.postMessage({ type: 'openWorkspaceFile', path });
+  api.postMessage(message);
+};
+
+const openWorkspaceFile = (path: string) => {
+  postMessage({ type: 'openWorkspaceFile', path });
 };
 
 const openWorkspaceDiff = (path: string, oldContent: string, newContent: string) => {
-  const api = getVscodeApi();
-  api.postMessage({ type: 'openWorkspaceDiff', path, oldContent, newContent });
+  postMessage({ type: 'openWorkspaceDiff', path, oldContent, newContent });
 };
 
 const openMarkdownLink = (href: string) => {
-  const api = getVscodeApi();
-  api.postMessage({ type: 'openMarkdownLink', href });
+  postMessage({ type: 'openMarkdownLink', href });
 };
 
 function MarkdownLink({

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -6,77 +6,18 @@ import * as os from 'os';
 import * as readline from 'readline';
 import { TextDecoder } from 'util';
 import { FileStore, isEvent, isMessageEvent, isTextContent, listProfiles } from '@openhands/agent-sdk-ts';
-import { SettingsManager, type SavedServer } from '../../settings/SettingsManager';
+import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
 import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
 import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLinesForMode } from '../../shared/halScript';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
+import type { WebviewToHostMessage } from '../../shared/webviewMessages';
 
 export type WebviewHost = {
   postMessage: (message: unknown) => Thenable<boolean>;
 };
-
-type WebviewMessage =
-  | { type: 'webviewReady'; conversationId?: string; lastSeenSeq?: number }
-  | { type: 'openSettingsPage' }
-  | { type: 'openSettings' }
-  | { type: 'requestWorkspaceFiles' }
-  | { type: 'requestSkills' }
-  | { type: 'openSkill'; path: string }
-  | { type: 'openWorkspaceFile'; path: string }
-  | { type: 'openMarkdownLink'; href: string }
-  | { type: 'openWorkspaceDiff'; path: string; oldContent: string; newContent: string }
-  | { type: 'requestHistory' }
-  | { type: 'restoreConversation'; id: string }
-  | { type: 'deleteConversation'; id: string }
-  | { type: 'getConfig' }
-  | { type: 'setLlmProfileId'; profileId: string | null }
-  | { type: 'selectServer'; url: string }
-  | { type: 'addServer'; server: SavedServer }
-  | { type: 'removeServer'; url: string }
-  | { type: 'switchToLocal' }
-  | { type: 'selectAttachments' }
-  | { type: 'openAttachment'; uri: string }
-  | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
-  | { type: 'halTtsRequest'; requestId: string; conversationId: string; stepIndex: number }
-  | { type: 'halVoiceConfirmRequest'; requestId: string; mimeType: string; audioBase64: string }
-  | { type: 'command'; command: string; reason?: string }
-  | {
-    type: 'renderedEventsResponse';
-    requestId: string;
-    count: number;
-    eventTypes: string[];
-    events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
-  }
-  | {
-    type: 'uiStateResponse';
-    requestId: string;
-    input: string;
-    showContextPicker: boolean;
-    showSkillsPopover: boolean;
-    showHistory: boolean;
-    workspaceFilesCount: number;
-    selectedContextFiles: string[];
-    skillsCount: number;
-    attachmentsCount: number;
-  }
-  | {
-    type: 'halStateResponse';
-    requestId: string;
-    enabled: boolean;
-    mode: string;
-    phase: string;
-    eye: string;
-    stepIndex: number | null;
-    decision: string | null;
-    lastError: string | null;
-  }
-  | { type: 'webviewConsole'; level: string; args: unknown[] }
-  | { type: 'webviewError'; message: string; stack?: string }
-  | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
-  | { type: 'webviewWebSocket'; phase: string; url: string; code?: number; reason?: string };
 
 const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES = 500 * 1024;
@@ -369,7 +310,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
   return async (msg: unknown) => {
     if (!msg || typeof msg !== 'object' || !('type' in msg)) return;
-    const message = msg as WebviewMessage;
+    const message = msg as WebviewToHostMessage;
 
     const outputChannel = deps.getOutputChannel();
     const conversation = deps.getConversation();


### PR DESCRIPTION
Implements `oh-tab-z0gu`.

- Adds `src/shared/webviewMessages.ts` as the single source of truth for the webview→host message union.
- Host `createWebviewMessageHandler` and webview send sites (`App.tsx`, `EventBlock.tsx`) now use the shared type for compile-time contract safety.

Tests:
- `npm run compile`
