### PR TITLE
oh-tab-71f: Paste images into chat

### DIFF
--- a/src/webview-src/__tests__/paste.images.test.tsx
+++ b/src/webview-src/__tests__/paste.images.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import React from 'react';
+import { App } from '../components/App';
+import type { MessageEvent as AgentMessageEvent } from '@openhands/agent-sdk-ts';
+
+function postToWindow(payload: unknown) {
+  window.postMessage(payload, '*');
+}
+
+describe('Pasted images', () => {
+  const mockApi = { postMessage: vi.fn() } as any;
+
+  beforeEach(() => {
+    // @ts-expect-error VS Code API injected at runtime
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+    // @ts-expect-error reset cached api
+    delete window.__OH_VSCODE_API__;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('adds pasted images as previews and includes them in sent message', async () => {
+    render(<App />);
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const textarea = screen.getByRole('textbox');
+    await waitFor(() => expect(textarea).not.toBeDisabled());
+    fireEvent.change(textarea, { target: { value: 'hello' } });
+
+    const file = new File([Uint8Array.from([1, 2, 3])], 'pasted.png', { type: 'image/png' });
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => file,
+          },
+        ],
+      },
+    } as any);
+
+    await waitFor(() => {
+      expect(screen.getByAltText('pasted.png')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    const sent = await waitFor(() => {
+      const msg = mockApi.postMessage.mock.calls
+        .map((call: any[]) => call[0])
+        .find((m: any) => m?.type === 'send');
+      if (!msg) throw new Error('Missing send message');
+      return msg;
+    });
+
+    expect(sent.text).toContain('hello');
+    expect(sent.text).toContain('data:image/png;base64');
+  });
+
+  it('renders markdown data:image as an <img>', async () => {
+    render(<App />);
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: '![preview](data:image/png;base64,AQID)' }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByAltText('preview')).toBeInTheDocument();
+  });
+});

--- a/src/webview-src/__tests__/paste.images.test.tsx
+++ b/src/webview-src/__tests__/paste.images.test.tsx
@@ -62,6 +62,44 @@ describe('Pasted images', () => {
     expect(sent.text).toContain('data:image/png;base64');
   });
 
+  it('allows sending a message with pasted images and no text', async () => {
+    render(<App />);
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const textarea = screen.getByRole('textbox');
+    await waitFor(() => expect(textarea).not.toBeDisabled());
+
+    const file = new File([Uint8Array.from([1, 2, 3])], 'pasted.png', { type: 'image/png' });
+    fireEvent.paste(textarea, {
+      clipboardData: {
+        items: [
+          {
+            kind: 'file',
+            type: 'image/png',
+            getAsFile: () => file,
+          },
+        ],
+      },
+    } as any);
+
+    await waitFor(() => {
+      expect(screen.getByAltText('pasted.png')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /send message/i }));
+
+    const sent = await waitFor(() => {
+      const msg = mockApi.postMessage.mock.calls
+        .map((call: any[]) => call[0])
+        .find((m: any) => m?.type === 'send');
+      if (!msg) throw new Error('Missing send message');
+      return msg;
+    });
+
+    expect(sent.text).toContain('![pasted.png](');
+    expect(sent.text).toContain('data:image/png;base64');
+  });
+
   it('renders markdown data:image as an <img>', async () => {
     render(<App />);
     postToWindow({ type: 'status', status: 'online', mode: 'local' });
@@ -78,5 +116,24 @@ describe('Pasted images', () => {
     postToWindow({ type: 'event', event: ev });
 
     expect(await screen.findByAltText('preview')).toBeInTheDocument();
+  });
+
+  it('does not render SVG data:image payloads', async () => {
+    render(<App />);
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: '![bad](data:image/svg+xml;base64,AQID)' }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(screen.queryByAltText('bad')).not.toBeInTheDocument();
+    expect(await screen.findByText('bad')).toBeInTheDocument();
   });
 });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -62,6 +62,13 @@ type StatusBannerState = {
   dismissible?: boolean;
 };
 
+type InlineImageAttachment = {
+  id: string;
+  label: string;
+  dataUrl: string;
+  sizeBytes: number;
+};
+
 type ElevenLabsSettingsSnapshot = {
   enabled: boolean;
   mode: ElevenLabsMode;
@@ -92,6 +99,47 @@ const DEFAULT_HAL_UI_STATE: HalUiState = {
 
 const DEFAULT_BUNDLED_DIALOGUE_DELAY_MS = 650;
 const DEFAULT_BUNDLED_AUDIO_EXTENSION = 'wav';
+
+const MAX_PASTED_IMAGE_BYTES = 350 * 1024;
+const MAX_PASTED_IMAGES = 4;
+
+function readBlobAsDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read image.'));
+        return;
+      }
+      resolve(result);
+    };
+    reader.onerror = () => {
+      const error = reader.error ?? new Error('Failed to read image.');
+      reject(error);
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+function escapeMarkdownAltText(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/\]/g, '\\]').replace(/[\r\n]+/g, ' ').trim();
+}
+
+function mimeTypeToExtension(mimeType: string): string {
+  const subtype = mimeType.split('/')[1] ?? '';
+  if (subtype === 'jpeg') return 'jpg';
+  if (subtype === 'svg+xml') return 'svg';
+  if (subtype) return subtype;
+  return 'png';
+}
+
+function normalizePastedImageLabel(file: File): string {
+  const name = typeof file.name === 'string' ? file.name.trim() : '';
+  if (name) return name.replace(/[\r\n]+/g, ' ').trim();
+  const ext = mimeTypeToExtension(file.type);
+  return `pasted-image.${ext}`;
+}
 
 function getOpenHandsMediaBaseUri(): string | null {
   if (typeof document === 'undefined') return null;
@@ -188,6 +236,7 @@ export function App() {
 
   // Attachments state
   const [attachments, setAttachments] = useState<Array<{ uri: string; label: string; sizeBytes?: number }>>([]);
+  const [inlineImages, setInlineImages] = useState<InlineImageAttachment[]>([]);
 
   // UI state
   const [statusBanner, setStatusBanner] = useState<StatusBannerState | null>(
@@ -416,6 +465,46 @@ export function App() {
     }
     lastStatusMessage = { level, message, at: now };
     setStatusBanner({ message, level });
+  }, []);
+
+  const handlePasteImageFiles = useCallback(async (files: File[]) => {
+    if (files.length === 0) return;
+
+    const nextImages: InlineImageAttachment[] = [];
+    let didSkipLarge = false;
+
+    for (const file of files) {
+      if (nextImages.length >= MAX_PASTED_IMAGES) break;
+      if (!file.type.startsWith('image/')) continue;
+      if (file.size > MAX_PASTED_IMAGE_BYTES) {
+        didSkipLarge = true;
+        continue;
+      }
+
+      try {
+        const dataUrl = await readBlobAsDataUrl(file);
+        nextImages.push({
+          id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+          label: normalizePastedImageLabel(file),
+          dataUrl,
+          sizeBytes: file.size,
+        });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        showStatusMessage('error', `Failed to paste image: ${reason}`);
+      }
+    }
+
+    if (didSkipLarge) {
+      showStatusMessage('warn', `Some images were too large to paste (max ${Math.trunc(MAX_PASTED_IMAGE_BYTES / 1024)}KB).`);
+    }
+
+    if (nextImages.length === 0) return;
+    setInlineImages((prev) => [...prev, ...nextImages].slice(0, MAX_PASTED_IMAGES));
+  }, [showStatusMessage]);
+
+  const handleRemoveInlineImage = useCallback((id: string) => {
+    setInlineImages((prev) => prev.filter((img) => img.id !== id));
   }, []);
 
   const handleConversationStateUpdate = useCallback((event: Event) => {
@@ -1532,6 +1621,7 @@ export function App() {
     setInput('');
     setSelectedContextFiles([]);
     setAttachments([]);
+    setInlineImages([]);
     postMessage({ type: 'command', command: 'startNewConversation' });
   }, [postMessage]);
 
@@ -1552,20 +1642,26 @@ export function App() {
     const text = input.trim();
     if (!text) return;
 
+    const imageMarkdown = inlineImages
+      .map((img) => `![${escapeMarkdownAltText(img.label)}](${img.dataUrl})`)
+      .join('\n\n');
+    const finalText = imageMarkdown ? `${text}\n\n${imageMarkdown}` : text;
+
     setInput('');
     setShowContextPicker(false);
     setShowSkillsPopover(false);
     setContextQuery('');
     setSelectedContextFiles([]);
     setAttachments([]);
+    setInlineImages([]);
     selectionRef.current = { start: 0, end: 0 };
     postMessage({
       type: 'send',
-      text,
+      text: finalText,
       contextFiles: selectedContextFiles.slice(),
       attachments: attachments.map((a) => a.uri),
     });
-  }, [attachments, input, postMessage, selectedContextFiles]);
+  }, [attachments, inlineImages, input, postMessage, selectedContextFiles]);
 
   // Context picker handlers
   const handleOpenContext = useCallback(() => {
@@ -1821,6 +1917,9 @@ export function App() {
           attachments={attachments}
           onOpenAttachment={handleOpenAttachment}
           onRemoveAttachment={handleRemoveAttachment}
+          inlineImages={inlineImages}
+          onPasteImageFiles={(files) => { void handlePasteImageFiles(files); }}
+          onRemoveInlineImage={handleRemoveInlineImage}
           onSelectionChange={handleSelectionChange}
         />
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -472,10 +472,20 @@ export function App() {
 
     const nextImages: InlineImageAttachment[] = [];
     let didSkipLarge = false;
+    let didSkipSvg = false;
+    const remainingSlots = Math.max(0, MAX_PASTED_IMAGES - inlineImages.length);
+    if (remainingSlots === 0) {
+      showStatusMessage('warn', `You can paste up to ${MAX_PASTED_IMAGES} images per message.`);
+      return;
+    }
 
     for (const file of files) {
-      if (nextImages.length >= MAX_PASTED_IMAGES) break;
+      if (nextImages.length >= remainingSlots) break;
       if (!file.type.startsWith('image/')) continue;
+      if (file.type === 'image/svg+xml') {
+        didSkipSvg = true;
+        continue;
+      }
       if (file.size > MAX_PASTED_IMAGE_BYTES) {
         didSkipLarge = true;
         continue;
@@ -498,10 +508,13 @@ export function App() {
     if (didSkipLarge) {
       showStatusMessage('warn', `Some images were too large to paste (max ${Math.trunc(MAX_PASTED_IMAGE_BYTES / 1024)}KB).`);
     }
+    if (didSkipSvg) {
+      showStatusMessage('warn', 'SVG images are not supported for pasted images.');
+    }
 
     if (nextImages.length === 0) return;
     setInlineImages((prev) => [...prev, ...nextImages].slice(0, MAX_PASTED_IMAGES));
-  }, [showStatusMessage]);
+  }, [inlineImages.length, showStatusMessage]);
 
   const handleRemoveInlineImage = useCallback((id: string) => {
     setInlineImages((prev) => prev.filter((img) => img.id !== id));
@@ -1640,12 +1653,11 @@ export function App() {
 
   const handleSendMessage = useCallback(() => {
     const text = input.trim();
-    if (!text) return;
-
     const imageMarkdown = inlineImages
       .map((img) => `![${escapeMarkdownAltText(img.label)}](${img.dataUrl})`)
       .join('\n\n');
-    const finalText = imageMarkdown ? `${text}\n\n${imageMarkdown}` : text;
+    const finalText = [text, imageMarkdown].filter(Boolean).join('\n\n');
+    if (!finalText) return;
 
     setInput('');
     setShowContextPicker(false);

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -128,6 +128,21 @@ function MarkdownLink({
   );
 }
 
+const ALLOWED_DATA_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp']);
+const MAX_DATA_IMAGE_URL_CHARS = 1_000_000;
+
+function isAllowedDataImageUrl(url: string): boolean {
+  const trimmed = typeof url === 'string' ? url.trim() : '';
+  if (!trimmed.startsWith('data:')) return false;
+  if (trimmed.length > MAX_DATA_IMAGE_URL_CHARS) return false;
+
+  const match = /^data:([^;,]+)[;,]/.exec(trimmed);
+  const mime = match?.[1]?.toLowerCase();
+  if (!mime) return false;
+  if (!mime.startsWith('image/')) return false;
+  return ALLOWED_DATA_IMAGE_MIME_TYPES.has(mime);
+}
+
 function MarkdownMessage({ text }: { text: string }) {
   const safeUrlTransform = (url: string) => {
     const trimmed = typeof url === 'string' ? url.trim() : '';
@@ -139,7 +154,7 @@ function MarkdownMessage({ text }: { text: string }) {
 
     const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
     if (scheme === 'http' || scheme === 'https' || scheme === 'mailto') return trimmed;
-    if (scheme === 'data' && trimmed.startsWith('data:image/')) return trimmed;
+    if (scheme === 'data' && isAllowedDataImageUrl(trimmed)) return trimmed;
 
     return '';
   };
@@ -157,7 +172,7 @@ function MarkdownMessage({ text }: { text: string }) {
 
           if (!cleanSrc) return <span className="text-stone-400">{label}</span>;
 
-          if (cleanSrc.startsWith('data:image/')) {
+          if (isAllowedDataImageUrl(cleanSrc)) {
             return (
               <img
                 src={cleanSrc}

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -129,9 +129,25 @@ function MarkdownLink({
 }
 
 function MarkdownMessage({ text }: { text: string }) {
+  const safeUrlTransform = (url: string) => {
+    const trimmed = typeof url === 'string' ? url.trim() : '';
+    if (!trimmed) return '';
+    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed; // Windows absolute path
+
+    const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.exec(trimmed);
+    if (!schemeMatch) return trimmed;
+
+    const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
+    if (scheme === 'http' || scheme === 'https' || scheme === 'mailto') return trimmed;
+    if (scheme === 'data' && trimmed.startsWith('data:image/')) return trimmed;
+
+    return '';
+  };
+
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm, remarkBreaks]}
+      urlTransform={safeUrlTransform}
       components={{
         a: ({ href, children }) => <MarkdownLink href={href}>{children}</MarkdownLink>,
         img: ({ src, alt }) => {
@@ -139,10 +155,19 @@ function MarkdownMessage({ text }: { text: string }) {
           const cleanAlt = typeof alt === 'string' ? alt.trim() : '';
           const label = cleanAlt || cleanSrc || 'image';
 
-          if (cleanSrc) {
-            return <MarkdownLink href={src}>{label}</MarkdownLink>;
+          if (!cleanSrc) return <span className="text-stone-400">{label}</span>;
+
+          if (cleanSrc.startsWith('data:image/')) {
+            return (
+              <img
+                src={cleanSrc}
+                alt={cleanAlt}
+                className="max-w-full rounded-lg border border-white/[0.06] shadow-event my-2"
+              />
+            );
           }
-          return <span className="text-stone-400">{label}</span>;
+
+          return <MarkdownLink href={src}>{label}</MarkdownLink>;
         },
         p: ({ children }) => <p className="mt-2 first:mt-0 leading-relaxed">{children}</p>,
         ul: ({ children }) => <ul className="mt-2 first:mt-0 list-disc pl-6 space-y-1">{children}</ul>,

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -23,6 +23,10 @@ interface InputAreaProps {
   attachments?: Array<{ uri: string; label: string }>;
   onOpenAttachment?: (uri: string) => void;
   onRemoveAttachment?: (uri: string) => void;
+  // Inline images (clipboard paste)
+  inlineImages?: Array<{ id: string; dataUrl: string; label: string }>;
+  onPasteImageFiles?: (files: File[]) => void;
+  onRemoveInlineImage?: (id: string) => void;
   // MCP (placeholder for future)
   onOpenMCP?: () => void;
   // Selection tracking (for mention-style context)
@@ -47,6 +51,9 @@ export function InputArea({
   attachments = [],
   onOpenAttachment,
   onRemoveAttachment,
+  inlineImages = [],
+  onPasteImageFiles,
+  onRemoveInlineImage,
   onOpenMCP,
   onSelectionChange,
 }: InputAreaProps) {
@@ -88,6 +95,26 @@ export function InputArea({
     }
   };
 
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (disabled || !onPasteImageFiles) return;
+
+    const items = e.clipboardData?.items;
+    if (!items || items.length === 0) return;
+
+    const imageFiles: File[] = [];
+    for (const item of Array.from(items)) {
+      if (item.kind !== 'file') continue;
+      if (typeof item.type !== 'string' || !item.type.startsWith('image/')) continue;
+      const file = item.getAsFile();
+      if (file) imageFiles.push(file);
+    }
+
+    if (imageFiles.length === 0) return;
+
+    e.preventDefault();
+    onPasteImageFiles(imageFiles);
+  };
+
   return (
     <div className="sticky bottom-0 z-30 border-t border-white/[0.06] bg-[var(--vscode-editor-background)]/95 backdrop-blur-md">
       <div className="px-4 py-4">
@@ -120,6 +147,7 @@ export function InputArea({
             onSelect={() => emitSelection(textareaRef.current)}
             onFocus={() => { setIsFocused(true); emitSelection(textareaRef.current); }}
             onBlur={() => setIsFocused(false)}
+            onPaste={handlePaste}
             disabled={disabled}
             placeholder={placeholder}
             rows={1}
@@ -236,6 +264,35 @@ export function InputArea({
                     title="Remove"
                   >
                     <span className="codicon codicon-close" />
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {inlineImages.length > 0 && (
+          <div className="flex flex-wrap gap-2 mt-3">
+            {inlineImages.map((img) => (
+              <div
+                key={img.id}
+                className="relative h-16 w-16 rounded-lg overflow-hidden bg-white/[0.04] border border-white/[0.06]"
+                title={img.label}
+              >
+                <img
+                  src={img.dataUrl}
+                  alt={img.label}
+                  className="h-full w-full object-cover"
+                />
+                {onRemoveInlineImage && (
+                  <button
+                    type="button"
+                    onClick={() => onRemoveInlineImage(img.id)}
+                    className="absolute top-1 right-1 h-5 w-5 rounded-md bg-black/60 text-stone-200 hover:bg-black/70 flex items-center justify-center"
+                    aria-label={`Remove pasted image ${img.label}`}
+                    title="Remove"
+                  >
+                    <span className="codicon codicon-close text-[11px]" />
                   </button>
                 )}
               </div>

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -83,14 +83,14 @@ export function InputArea({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (!disabled && value.trim()) {
+      if (!disabled && (value.trim() || inlineImages.length > 0)) {
         onSubmit();
       }
     }
   };
 
   const handleSubmit = () => {
-    if (!disabled && value.trim()) {
+    if (!disabled && (value.trim() || inlineImages.length > 0)) {
       onSubmit();
     }
   };
@@ -105,6 +105,7 @@ export function InputArea({
     for (const item of Array.from(items)) {
       if (item.kind !== 'file') continue;
       if (typeof item.type !== 'string' || !item.type.startsWith('image/')) continue;
+      if (item.type === 'image/svg+xml') continue;
       const file = item.getAsFile();
       if (file) imageFiles.push(file);
     }
@@ -114,6 +115,8 @@ export function InputArea({
     e.preventDefault();
     onPasteImageFiles(imageFiles);
   };
+
+  const canSend = value.trim().length > 0 || inlineImages.length > 0;
 
   return (
     <div className="sticky bottom-0 z-30 border-t border-white/[0.06] bg-[var(--vscode-editor-background)]/95 backdrop-blur-md">
@@ -169,14 +172,14 @@ export function InputArea({
           {/* Send button */}
           <button
             onClick={handleSubmit}
-            disabled={disabled || !value.trim()}
+            disabled={disabled || !canSend}
             className={`
               absolute right-2 bottom-2
               h-9 w-9 rounded-lg
               flex items-center justify-center
               transition-all duration-200
               focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
-              ${value.trim() && !disabled
+              ${canSend && !disabled
                 ? 'bg-gradient-to-b from-brand-500 to-brand-600 text-white shadow-glow-sm hover:from-brand-400 hover:to-brand-500'
                 : 'bg-white/[0.06] text-stone-500 cursor-not-allowed border border-white/[0.04]'
               }


### PR DESCRIPTION
Implements `oh-tab-71f` (Option A: inline `data:` images).

- Paste image(s) into the chat input to add thumbnail previews.
- On send, embeds pasted images as Markdown `data:image/*;base64,...` so history renders under current CSP.
- Markdown renderer now allows only `data:image/*` through `react-markdown` URL transform; other schemes remain blocked/linked.

Tests:
- `npm test`
