### PR TITLE
oh-tab-n9h7: Avoid base64 in LLM prompt for pasted images

### DIFF
--- a/src/__tests__/pastedImages.host.test.ts
+++ b/src/__tests__/pastedImages.host.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import * as vscode from 'vscode';
+import { createWebviewMessageHandler } from '../webview/host/createWebviewMessageHandler';
+import { OPENHANDS_IMAGE_URL_PREFIX, parseBase64DataImageUrl } from '../shared/pastedImages';
+
+describe('Pasted images host handling', () => {
+  let tmpDir = '';
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-pasted-images-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('persists data:image markdown and strips base64 from conversation text', async () => {
+    const conversation = { sendUserMessage: vi.fn(async () => {}) } as any;
+    const handler = createWebviewMessageHandler({
+      context: { globalStorageUri: { fsPath: tmpDir } } as any,
+      host: { postMessage: vi.fn(async () => true) },
+      getConversation: () => conversation,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => tmpDir,
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    const dataUrl = 'data:image/png;base64,AQID';
+    const parsed = parseBase64DataImageUrl(dataUrl);
+    expect(parsed).toBeTruthy();
+
+    await handler({
+      type: 'send',
+      text: `hello\n\n![pasted.png](${dataUrl})`,
+      contextFiles: [],
+      attachments: [],
+    });
+
+    expect(conversation.sendUserMessage).toHaveBeenCalledTimes(1);
+    const finalText = conversation.sendUserMessage.mock.calls[0][0] as string;
+    expect(finalText).not.toContain('data:image/');
+    expect(finalText).toContain(`${OPENHANDS_IMAGE_URL_PREFIX}${parsed!.imageId}`);
+
+    const bytes = await fs.readFile(path.join(tmpDir, 'pasted-images', parsed!.imageId));
+    expect([...bytes]).toEqual([1, 2, 3]);
+    expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/__tests__/transformEventForWebview.test.ts
+++ b/src/__tests__/transformEventForWebview.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { transformEventForWebview } from '../conversation/host/transformEventForWebview';
+import { OPENHANDS_IMAGE_URL_PREFIX } from '../shared/pastedImages';
+
+describe('transformEventForWebview', () => {
+  it('rewrites openhands-image URLs to webview resource URIs', () => {
+    const imageId = '0123456789abcdef.png';
+    const baseDir = '/tmp/oh-tab-test';
+    const webview = {
+      asWebviewUri: (uri: any) => ({
+        toString: () => `vscode-webview-resource://test${uri.fsPath}`,
+      }),
+    } as any;
+
+    const event: any = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: `![img](${OPENHANDS_IMAGE_URL_PREFIX}${imageId})` }],
+      },
+    };
+
+    const transformed: any = transformEventForWebview(event, { webview, pastedImagesBaseDir: baseDir });
+    const text = transformed.llm_message.content[0].text;
+    expect(text).toContain('vscode-webview-resource://');
+    expect(text).toContain('/tmp/oh-tab-test/pasted-images/0123456789abcdef.png');
+    expect(text).not.toContain(OPENHANDS_IMAGE_URL_PREFIX);
+  });
+});
+

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -12,6 +12,7 @@ export type AttachConversationListenersDeps = {
   getConversationMode: () => 'local' | 'remote';
   getLastKnownLlmLabel: () => string | null;
   isVerboseEventLogging: () => boolean;
+  transformEventForWebview?: (event: Event, webview: vscode.Webview) => Event;
 
   bufferConversationEvent: (event: Event) => number;
   resetConversationEventBacklog: (conversationId: string | undefined) => void;
@@ -90,8 +91,10 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     const seq = shouldBufferForReplay ? deps.bufferConversationEvent(ev) : undefined;
     const payload: { type: 'event'; event: Event; seq?: number } = { type: 'event', event: ev };
     if (typeof seq === 'number') payload.seq = seq;
-
-    postToChatIfVisible(deps, payload);
+    const view = deps.getChatView();
+    if (!view || !deps.isChatWebviewReady() || !view.visible) return;
+    const transformed = deps.transformEventForWebview ? deps.transformEventForWebview(ev, view.webview) : ev;
+    void view.webview.postMessage({ ...payload, event: transformed });
   });
 
   conversation.on('error', (err: unknown) => {

--- a/src/conversation/host/transformEventForWebview.ts
+++ b/src/conversation/host/transformEventForWebview.ts
@@ -1,0 +1,41 @@
+import * as vscode from 'vscode';
+import type { Event, MessageEvent } from '@openhands/agent-sdk-ts';
+import { isTextContent } from '@openhands/agent-sdk-ts';
+import { getPastedImagePath, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
+
+export function transformEventForWebview(
+  event: Event,
+  params: { webview: vscode.Webview; pastedImagesBaseDir: string }
+): Event {
+  if (event.kind !== 'MessageEvent') return event;
+  const msgEvent: MessageEvent = event;
+  const msg = msgEvent.llm_message;
+  if (!msg || !Array.isArray(msg.content)) return event;
+
+  let changed = false;
+  const content = msg.content.map((part) => {
+    if (!isTextContent(part)) return part;
+
+    const nextText = rewriteOpenHandsImageUrls(part.text, (imageId) => {
+      try {
+        const filePath = getPastedImagePath(params.pastedImagesBaseDir, imageId);
+        return params.webview.asWebviewUri(vscode.Uri.file(filePath)).toString();
+      } catch {
+        return undefined;
+      }
+    });
+
+    if (nextText === part.text) return part;
+    changed = true;
+    return { ...part, text: nextText };
+  });
+
+  if (!changed) return event;
+  return {
+    ...msgEvent,
+    llm_message: {
+      ...msg,
+      content,
+    },
+  };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,8 @@ import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPO
 import { type HalStateSnapshot, isElevenLabsMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
 import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { safeStringify } from './shared/safeStringify';
+import { getGlobalStorageBaseDir } from './shared/pastedImages';
+import { transformEventForWebview as transformEventForWebviewWithPastedImages } from './conversation/host/transformEventForWebview';
 import {
   AgentContext,
   Conversation,
@@ -72,6 +74,7 @@ let conversationMode: 'local' | 'remote' = 'remote';
 let terminal: vscode.Terminal | undefined;
 let terminalLogPty: OpenHandsTerminalLogPseudoterminal | undefined;
 let nextE2ERequestId = 0;
+let pastedImagesBaseDir = getGlobalStorageBaseDir(undefined);
 const pendingRenderedEventsRequests = new Map<string, (info: RenderedEventsInfo) => void>();
 const pendingUiStateRequests = new Map<string, (info: UiStateSnapshot) => void>();
 const pendingHalStateRequests = new Map<string, (info: HalStateSnapshot) => void>();
@@ -196,7 +199,11 @@ function flushConversationEventBacklog(params: {
   if (needsFullReplay) {
     void params.postMessage({ type: 'conversationStarted', conversationId: currentConversationId });
     for (const item of iterConversationEventBacklog()) {
-      void params.postMessage({ type: 'event', seq: item.seq, event: item.event });
+      const webview = chatView?.webview;
+      const event = webview
+        ? transformEventForWebviewWithPastedImages(item.event, { webview, pastedImagesBaseDir })
+        : item.event;
+      void params.postMessage({ type: 'event', seq: item.seq, event });
     }
     return;
   }
@@ -207,7 +214,11 @@ function flushConversationEventBacklog(params: {
 
   for (const item of iterConversationEventBacklog()) {
     if (item.seq > lastSeenSeq) {
-      void params.postMessage({ type: 'event', seq: item.seq, event: item.event });
+      const webview = chatView?.webview;
+      const event = webview
+        ? transformEventForWebviewWithPastedImages(item.event, { webview, pastedImagesBaseDir })
+        : item.event;
+      void params.postMessage({ type: 'event', seq: item.seq, event });
     }
   }
 }
@@ -638,6 +649,7 @@ export function activate(context: vscode.ExtensionContext) {
   }
 
   const secretRegistry = new SecretRegistry(context.secrets);
+  pastedImagesBaseDir = getGlobalStorageBaseDir(context.globalStorageUri?.fsPath);
 
   const chatViewProvider = new OpenHandsChatViewProvider(context, {
     createMessageHandler: (view) =>
@@ -861,6 +873,7 @@ export function activate(context: vscode.ExtensionContext) {
         isVerboseEventLogging: () => verboseEventLogging,
         bufferConversationEvent,
         resetConversationEventBacklog,
+        transformEventForWebview: (event, webview) => transformEventForWebviewWithPastedImages(event, { webview, pastedImagesBaseDir }),
         safeStringify,
         renderError,
         handleTerminalEvent,

--- a/src/shared/pastedImages.ts
+++ b/src/shared/pastedImages.ts
@@ -1,0 +1,100 @@
+import { createHash } from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export const OPENHANDS_IMAGE_URL_PREFIX = 'openhands-image://';
+
+export const PASTED_IMAGE_MIME_TO_EXT: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+export const PASTED_IMAGE_ALLOWED_EXTENSIONS = new Set(Object.values(PASTED_IMAGE_MIME_TO_EXT));
+
+export function getGlobalStorageBaseDir(globalStorageFsPath?: string): string {
+  return globalStorageFsPath || path.join(os.tmpdir(), 'oh-tab-global-storage');
+}
+
+export function getPastedImagesDir(baseDir: string): string {
+  return path.join(baseDir, 'pasted-images');
+}
+
+export function isValidPastedImageId(imageId: string): boolean {
+  const match = /^([a-f0-9]{16})\.([a-z0-9]+)$/.exec(imageId);
+  if (!match) return false;
+  const ext = match[2];
+  return PASTED_IMAGE_ALLOWED_EXTENSIONS.has(ext);
+}
+
+export function getPastedImagePath(baseDir: string, imageId: string): string {
+  if (!isValidPastedImageId(imageId)) {
+    throw new Error(`Invalid pasted image id: ${imageId}`);
+  }
+  return path.join(getPastedImagesDir(baseDir), imageId);
+}
+
+export function parseBase64DataImageUrl(dataUrl: string): { mimeType: string; bytes: Uint8Array; imageId: string } | undefined {
+  const raw = typeof dataUrl === 'string' ? dataUrl.trim() : '';
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/=]+)$/.exec(raw);
+  if (!match) return undefined;
+
+  const mimeType = match[1].toLowerCase();
+  const ext = PASTED_IMAGE_MIME_TO_EXT[mimeType];
+  if (!ext) return undefined;
+
+  let bytes: Uint8Array;
+  try {
+    bytes = Uint8Array.from(Buffer.from(match[2], 'base64'));
+  } catch {
+    return undefined;
+  }
+
+  const hash = createHash('sha256').update(bytes).digest('hex').slice(0, 16);
+  const imageId = `${hash}.${ext}`;
+  return { mimeType, bytes, imageId };
+}
+
+export function rewriteDataImageMarkdown(
+  text: string,
+  rewrite: (dataUrl: string) => { url: string } | undefined
+): { text: string; rewritten: number } {
+  const raw = typeof text === 'string' ? text : '';
+  const imageRegex = /!\[([^\]]*)\]\((data:image\/[^)\s]+)\)/g;
+
+  let rewritten = 0;
+  let out = '';
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = imageRegex.exec(raw)) !== null) {
+    const start = match.index;
+    const full = match[0];
+    const alt = match[1] ?? '';
+    const dataUrl = match[2] ?? '';
+    const replacement = rewrite(dataUrl);
+    if (!replacement) continue;
+
+    out += raw.slice(last, start);
+    out += `![${alt}](${replacement.url})`;
+    last = start + full.length;
+    rewritten += 1;
+  }
+
+  if (rewritten === 0) return { text: raw, rewritten: 0 };
+  out += raw.slice(last);
+  return { text: out, rewritten };
+}
+
+export function rewriteOpenHandsImageUrls(
+  text: string,
+  resolve: (imageId: string) => string | undefined
+): string {
+  const raw = typeof text === 'string' ? text : '';
+  return raw.replaceAll(new RegExp(`${OPENHANDS_IMAGE_URL_PREFIX}([a-f0-9]{16}\\.[a-z0-9]+)`, 'g'), (full, imageId: string) => {
+    const replacement = resolve(imageId);
+    return replacement ?? full;
+  });
+}
+

--- a/src/sidebar/OpenHandsChatViewProvider.ts
+++ b/src/sidebar/OpenHandsChatViewProvider.ts
@@ -27,9 +27,12 @@ export class OpenHandsChatViewProvider implements vscode.WebviewViewProvider {
   resolveWebviewView(webviewView: vscode.WebviewView): void {
     this.disposeViewDisposables();
 
+    const mediaRoot = vscode.Uri.joinPath(this.context.extensionUri, 'media');
+    const pastedImagesRoot = vscode.Uri.joinPath(this.context.globalStorageUri, 'pasted-images');
+
     webviewView.webview.options = {
       enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')],
+      localResourceRoots: [mediaRoot, pastedImagesRoot],
     };
 
     webviewView.webview.html = getWebviewHtml(this.context, webviewView.webview);

--- a/src/webview-src/__tests__/paste.images.test.tsx
+++ b/src/webview-src/__tests__/paste.images.test.tsx
@@ -118,6 +118,24 @@ describe('Pasted images', () => {
     expect(await screen.findByAltText('preview')).toBeInTheDocument();
   });
 
+  it('renders markdown vscode-webview-resource images as an <img>', async () => {
+    render(<App />);
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: '![local](vscode-webview-resource://test/pasted-images/abcd.png)' }],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByAltText('local')).toBeInTheDocument();
+  });
+
   it('does not render SVG data:image payloads', async () => {
     render(<App />);
     postToWindow({ type: 'status', status: 'online', mode: 'local' });

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -162,7 +162,7 @@ function isAllowedWebviewImageUrl(url: string): boolean {
 }
 
 function MarkdownMessage({ text }: { text: string }) {
-  const safeUrlTransform = (url: string) => {
+  const safeUrlTransform = (url: string, key?: string) => {
     const trimmed = typeof url === 'string' ? url.trim() : '';
     if (!trimmed) return '';
     if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed; // Windows absolute path
@@ -172,8 +172,10 @@ function MarkdownMessage({ text }: { text: string }) {
 
     const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
     if (scheme === 'http' || scheme === 'https' || scheme === 'mailto') return trimmed;
-    if (scheme === 'data' && isAllowedDataImageUrl(trimmed)) return trimmed;
-    if (isAllowedWebviewImageUrl(trimmed)) return trimmed;
+    if (key === 'src') {
+      if (scheme === 'data' && isAllowedDataImageUrl(trimmed)) return trimmed;
+      if (isAllowedWebviewImageUrl(trimmed)) return trimmed;
+    }
 
     return '';
   };

--- a/src/webview-src/components/EventBlock.tsx
+++ b/src/webview-src/components/EventBlock.tsx
@@ -130,6 +130,7 @@ function MarkdownLink({
 
 const ALLOWED_DATA_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp']);
 const MAX_DATA_IMAGE_URL_CHARS = 1_000_000;
+const ALLOWED_WEBVIEW_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
 
 function isAllowedDataImageUrl(url: string): boolean {
   const trimmed = typeof url === 'string' ? url.trim() : '';
@@ -141,6 +142,23 @@ function isAllowedDataImageUrl(url: string): boolean {
   if (!mime) return false;
   if (!mime.startsWith('image/')) return false;
   return ALLOWED_DATA_IMAGE_MIME_TYPES.has(mime);
+}
+
+function isAllowedWebviewImageUrl(url: string): boolean {
+  const trimmed = typeof url === 'string' ? url.trim() : '';
+  if (!trimmed) return false;
+  if (trimmed.length > MAX_DATA_IMAGE_URL_CHARS) return false;
+
+  const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.exec(trimmed);
+  if (!schemeMatch) return false;
+
+  const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
+  if (scheme !== 'vscode-webview-resource' && scheme !== 'vscode-resource' && scheme !== 'vscode-webview') {
+    return false;
+  }
+
+  const withoutQuery = trimmed.split(/[?#]/)[0].toLowerCase();
+  return ALLOWED_WEBVIEW_IMAGE_EXTENSIONS.some((ext) => withoutQuery.endsWith(ext));
 }
 
 function MarkdownMessage({ text }: { text: string }) {
@@ -155,6 +173,7 @@ function MarkdownMessage({ text }: { text: string }) {
     const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
     if (scheme === 'http' || scheme === 'https' || scheme === 'mailto') return trimmed;
     if (scheme === 'data' && isAllowedDataImageUrl(trimmed)) return trimmed;
+    if (isAllowedWebviewImageUrl(trimmed)) return trimmed;
 
     return '';
   };
@@ -172,7 +191,7 @@ function MarkdownMessage({ text }: { text: string }) {
 
           if (!cleanSrc) return <span className="text-stone-400">{label}</span>;
 
-          if (isAllowedDataImageUrl(cleanSrc)) {
+          if (isAllowedDataImageUrl(cleanSrc) || isAllowedWebviewImageUrl(cleanSrc)) {
             return (
               <img
                 src={cleanSrc}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -13,6 +13,7 @@ import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
 import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLinesForMode } from '../../shared/halScript';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
+import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
 import type { WebviewToHostMessage } from '../../shared/webviewMessages';
 
 export type WebviewHost = {
@@ -21,6 +22,13 @@ export type WebviewHost = {
 
 const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES = 500 * 1024;
+const MAX_PASTED_IMAGE_BYTES = 350 * 1024;
+
+async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
+  const filePath = getPastedImagePath(baseDir, imageId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, bytes);
+}
 
 const OPENHANDS_DIFF_SCHEME = 'openhands-diff';
 const MAX_STORED_DIFF_DOCUMENTS = 60;
@@ -762,9 +770,39 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
             .filter((u): u is vscode.Uri => u !== undefined)
           : [];
 
+        const globalStorageBaseDir = getGlobalStorageBaseDir(context.globalStorageUri?.fsPath);
+        const pastedImages = new Map<string, Uint8Array>();
+        const rewriteResult = rewriteDataImageMarkdown(baseText, (dataUrl) => {
+          const parsed = parseBase64DataImageUrl(dataUrl);
+          if (!parsed) return { url: '' };
+          if (parsed.bytes.length > MAX_PASTED_IMAGE_BYTES) return { url: '' };
+          pastedImages.set(parsed.imageId, parsed.bytes);
+          return { url: `${OPENHANDS_IMAGE_URL_PREFIX}${parsed.imageId}` };
+        });
+
+        let sanitizedText = rewriteResult.text;
+        if (pastedImages.size > 0) {
+          const failed = new Set<string>();
+          for (const [imageId, bytes] of pastedImages.entries()) {
+            try {
+              await persistPastedImage(globalStorageBaseDir, imageId, bytes);
+            } catch (err) {
+              failed.add(imageId);
+              const reason = err instanceof Error ? err.message : String(err);
+              outputChannel?.appendLine(`[pasted-images] Failed to persist ${imageId}: ${reason}`);
+            }
+          }
+          if (failed.size > 0) {
+            sanitizedText = rewriteOpenHandsImageUrls(sanitizedText, (imageId) => (failed.has(imageId) ? '' : undefined));
+            void vscode.window.showWarningMessage(`Some pasted images could not be saved (${failed.size}). They were omitted from the message.`);
+          }
+        } else if (rewriteResult.rewritten > 0) {
+          void vscode.window.showWarningMessage('Some pasted images were not supported and were omitted from the message.');
+        }
+
         const attachmentsText = await buildAttachmentBlocks(attachmentUris);
 
-        let finalText = baseText;
+        let finalText = sanitizedText;
         if (attachmentsText) {
           finalText += attachmentsText;
         }


### PR DESCRIPTION
Fix follow-up to #345: stop embedding base64 image data into the user message text (prompt bloat), while still rendering pasted images in the webview.

- Rewrites outgoing markdown `data:image/...;base64,...` into `openhands-image://<id>.<ext>` placeholders.
- Persists the actual bytes under extension `globalStorageUri/pasted-images/`.
- Rewrites placeholders -> `webview.asWebviewUri(file://...)` for rendering.
- Webview markdown sanitization allows only raster data URLs + vscode-webview image URIs (and blocks SVG).

Tests: `npm test`, `npm run typecheck`, `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can paste images directly into conversations. Images are stored locally and displayed securely in the chat interface.
  * Pasted images are automatically converted to secure webview resources for proper rendering while maintaining reference integrity.

* **Tests**
  * Added comprehensive test coverage for pasted image functionality and webview image rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->