### PR TITLE
oh-tab-bf8c: Validate skillsList payload

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -594,12 +594,31 @@ describe('App - Advanced Test Coverage', () => {
       });
     });
 
-    it.skip('handles malformed skills list', async () => {
-      // TODO: The implementation doesn't filter malformed skills data.
-      // In production, the extension (listSkillFiles in extension.ts) only sends
-      // properly formatted { label, path } objects from .md files, so this scenario
-      // shouldn't occur. However, defensive filtering in the UI would be better.
-      // Skipping until implementation adds validation/filtering of skills data.
+    it('handles malformed skills list', async () => {
+      render(<App />);
+
+      await userEvent.click(screen.getByLabelText('Skills'));
+
+      postToWindow({
+        type: 'skillsList',
+        skills: [
+          { label: 'Good skill', path: '/tmp/good.md' },
+          { label: 'Another good skill', path: '/tmp/good2.md' },
+          { label: 123, path: '/tmp/bad1.md' },
+          { label: 'Missing path' },
+          { path: '/tmp/bad2.md' },
+          null,
+          'not-an-object',
+        ],
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Good skill')).toBeInTheDocument();
+        expect(screen.getByText('Another good skill')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Missing path')).not.toBeInTheDocument();
+      expect(screen.getAllByRole('option')).toHaveLength(2);
     });
 
     it('handles empty input submission', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1409,7 +1409,14 @@ export function App() {
           break;
         case 'skillsList':
           if (Array.isArray(payload.skills)) {
-            setSkills(payload.skills);
+            setSkills(
+              payload.skills.filter((skill): skill is { label: string; path: string } => (
+                typeof skill === 'object'
+                && skill !== null
+                && typeof (skill as { label?: unknown }).label === 'string'
+                && typeof (skill as { path?: unknown }).path === 'string'
+              ))
+            );
           }
           break;
         case 'queryUiState': {


### PR DESCRIPTION
Defensive webview hardening: filter malformed `skillsList` payload entries so the UI can’t crash if host payload ever drifts.

- `App.tsx` now keeps only `{label: string, path: string}` entries.
- Unskips + implements the `handles malformed skills list` test.

Tests: `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* Skills workflow now validates incoming skill data and automatically filters out malformed entries, ensuring only properly formatted skills with valid information are stored and displayed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->