### PR TITLE
oh-tab-50wg: Type host→webview messages

### DIFF
--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import type { BashEvent, ConversationInstance, Event } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
+import type { HostToWebviewMessage } from '../../shared/webviewMessages';
 
 export type AttachConversationListenersDeps = {
   context: vscode.ExtensionContext;
@@ -21,7 +22,10 @@ export type AttachConversationListenersDeps = {
   handleTerminalEvent: (event: BashEvent) => void;
 };
 
-function postToChatIfVisible(deps: Pick<AttachConversationListenersDeps, 'getChatView' | 'isChatWebviewReady'>, message: unknown) {
+function postToChatIfVisible(
+  deps: Pick<AttachConversationListenersDeps, 'getChatView' | 'isChatWebviewReady'>,
+  message: HostToWebviewMessage
+) {
   const view = deps.getChatView();
   if (!view || !deps.isChatWebviewReady() || !view.visible) return;
   void view.webview.postMessage(message);
@@ -94,7 +98,8 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     const view = deps.getChatView();
     if (!view || !deps.isChatWebviewReady() || !view.visible) return;
     const transformed = deps.transformEventForWebview ? deps.transformEventForWebview(ev, view.webview) : ev;
-    void view.webview.postMessage({ ...payload, event: transformed });
+    const message: HostToWebviewMessage = { ...payload, event: transformed };
+    void view.webview.postMessage(message);
   });
 
   conversation.on('error', (err: unknown) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { safeStringify } from './shared/safeStringify';
 import { getGlobalStorageBaseDir } from './shared/pastedImages';
 import { transformEventForWebview as transformEventForWebviewWithPastedImages } from './conversation/host/transformEventForWebview';
+import type { HostToWebviewMessage } from './shared/webviewMessages';
 import {
   AgentContext,
   Conversation,
@@ -179,7 +180,7 @@ function* iterConversationEventBacklog(): Iterable<BufferedConversationEvent> {
 }
 
 function flushConversationEventBacklog(params: {
-  postMessage: (message: unknown) => Thenable<boolean>;
+  postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
   clientConversationId?: string;
   clientLastSeenSeq?: number;
 }) {
@@ -733,7 +734,7 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     if (chatView && chatWebviewReady && chatView.visible) {
-      void chatView.webview.postMessage({ type: 'terminalEvent', event });
+      void chatView.webview.postMessage({ type: 'terminalEvent', event } satisfies HostToWebviewMessage);
     }
 
     if (conversationMode !== 'local') {
@@ -902,7 +903,7 @@ export function activate(context: vscode.ExtensionContext) {
         mode: conversationMode,
         llmProfileLabel: lastKnownLlmLabel,
         llmModel: lastKnownLlmLabel,
-      });
+      } satisfies HostToWebviewMessage);
     }
   }
 
@@ -1059,7 +1060,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (chatView) {
       const payload: { type: 'event'; event: Event; seq?: number } = { type: 'event', event };
       if (typeof seq === 'number') payload.seq = seq;
-      void chatView.webview.postMessage(payload);
+      void chatView.webview.postMessage(payload satisfies HostToWebviewMessage);
     }
     return { sent: true, buffered: true, seq };
   });
@@ -1073,7 +1074,7 @@ export function activate(context: vscode.ExtensionContext) {
     void chatView.show?.(true);
     const requestId = nextRequestId('renderedEvents');
     const pending = createPendingResponse(pendingRenderedEventsRequests, requestId, 5000);
-    const posted = await chatView.webview.postMessage({ type: 'queryRenderedEvents', requestId });
+    const posted = await chatView.webview.postMessage({ type: 'queryRenderedEvents', requestId } satisfies HostToWebviewMessage);
     if (!posted) {
       pending.cancel();
       return { count: 0, eventTypes: [] };
@@ -1097,7 +1098,7 @@ export function activate(context: vscode.ExtensionContext) {
     void chatView.show?.(true);
     const requestId = nextRequestId('uiState');
     const pending = createPendingResponse(pendingUiStateRequests, requestId, 5000);
-    const posted = await chatView.webview.postMessage({ type: 'queryUiState', requestId });
+    const posted = await chatView.webview.postMessage({ type: 'queryUiState', requestId } satisfies HostToWebviewMessage);
     if (!posted) {
       pending.cancel();
       return DEFAULT_UI_STATE;
@@ -1115,7 +1116,7 @@ export function activate(context: vscode.ExtensionContext) {
     void chatView.show?.(true);
     const requestId = nextRequestId('halState');
     const pending = createPendingResponse(pendingHalStateRequests, requestId, 5000);
-    const posted = await chatView.webview.postMessage({ type: 'queryHalState', requestId });
+    const posted = await chatView.webview.postMessage({ type: 'queryHalState', requestId } satisfies HostToWebviewMessage);
     if (!posted) {
       pending.cancel();
       return DEFAULT_HAL_STATE;
@@ -1131,7 +1132,7 @@ export function activate(context: vscode.ExtensionContext) {
       if (!chatView) return { sent: false };
       if (!req || typeof req.action !== 'string' || req.action.length === 0) return { sent: false };
       void chatView.show?.(true);
-      const sent = await chatView.webview.postMessage({ type: 'e2eAction', action: req.action, payload: req.payload });
+      const sent = await chatView.webview.postMessage({ type: 'e2eAction', action: req.action, payload: req.payload } satisfies HostToWebviewMessage);
       return { sent };
     }
   );
@@ -1142,7 +1143,7 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
-    const postToWebview = (message: unknown) => {
+    const postToWebview = (message: HostToWebviewMessage) => {
       if (!chatView || !chatWebviewReady) return false;
       void chatView.webview.postMessage(message);
       return true;
@@ -1544,7 +1545,7 @@ export function activate(context: vscode.ExtensionContext) {
         const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const settings = await settingsMgr.get();
         if (chatView && chatWebviewReady) {
-          void chatView.webview.postMessage({ type: 'elevenlabsSettings', elevenlabs: settings.elevenlabs });
+          void chatView.webview.postMessage({ type: 'elevenlabsSettings', elevenlabs: settings.elevenlabs } satisfies HostToWebviewMessage);
         }
       } catch (err: unknown) {
         outputChannel?.appendLine(`[settings] Failed to apply elevenlabs settings update: ${renderError(err)}`);

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -1,4 +1,45 @@
-import type { SavedServer } from '../settings/SettingsManager';
+import type { BashEvent, Event } from '@openhands/agent-sdk-ts';
+import type { OpenHandsSettings, SavedServer } from '../settings/SettingsManager';
+
+export type HostToWebviewMessage =
+  | {
+    type: 'status';
+    status: string;
+    mode: 'local' | 'remote';
+    llmProfileLabel?: string | null;
+    llmModel?: string | null;
+  }
+  | { type: 'error'; error: string }
+  | { type: 'llmProfilesUpdated'; profiles: string[]; activeProfileId: string | null }
+  | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
+  | { type: 'elevenlabsSettings'; elevenlabs: OpenHandsSettings['elevenlabs'] }
+  | {
+    type: 'historyList';
+    conversations: Array<{
+      id: string;
+      title?: string;
+      firstMessage?: string;
+      timestamp: number;
+      messageCount?: number;
+    }>;
+  }
+  | { type: 'workspaceFiles'; files: string[] }
+  | { type: 'skillsList'; skills: Array<{ label: string; path: string }> }
+  | { type: 'attachmentsSelected'; attachments: Array<{ uri: string; label: string; sizeBytes?: number }> }
+  | { type: 'config'; serverUrl: string | null; mode: 'local' | 'remote' }
+  | { type: 'conversationStarted'; conversationId: string }
+  | { type: 'event'; seq?: number; event: Event }
+  | { type: 'terminalEvent'; event: BashEvent }
+  | { type: 'queryRenderedEvents'; requestId: string }
+  | { type: 'queryUiState'; requestId: string }
+  | { type: 'queryHalState'; requestId: string }
+  | { type: 'e2eAction'; action: string; payload?: unknown }
+  | { type: 'halTeleportUnavailable'; error: string }
+  | { type: 'halTeleportFailed'; error: string }
+  | { type: 'halTtsResponse'; requestId: string; ok: true; audioBase64: string; volume: number }
+  | { type: 'halTtsResponse'; requestId: string; ok: false; error: string; shouldNotify?: boolean; disabled?: boolean }
+  | { type: 'halVoiceConfirmResponse'; requestId: string; ok: true; decision: string }
+  | { type: 'halVoiceConfirmResponse'; requestId: string; ok: false; error: string };
 
 export type WebviewToHostMessage =
   | { type: 'webviewReady'; conversationId?: string; lastSeenSeq?: number }
@@ -59,4 +100,3 @@ export type WebviewToHostMessage =
   | { type: 'webviewError'; message: string; stack?: string }
   | { type: 'webviewNetwork'; phase: string; id: string; method: string; url: string; status?: number; ok?: boolean }
   | { type: 'webviewWebSocket'; phase: string; url: string; code?: number; reason?: string };
-

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -14,10 +14,10 @@ import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLinesForMode } from '../../shared/halScript';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
-import type { WebviewToHostMessage } from '../../shared/webviewMessages';
+import type { HostToWebviewMessage, WebviewToHostMessage } from '../../shared/webviewMessages';
 
 export type WebviewHost = {
-  postMessage: (message: unknown) => Thenable<boolean>;
+  postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
 };
 
 const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;


### PR DESCRIPTION
Adds a typed host→webview message contract to prevent malformed payloads being sent at runtime.

- Introduces `HostToWebviewMessage` union in `src/shared/webviewMessages.ts`.
- Types host send sites (`createWebviewMessageHandler`, `attachConversationListeners`, `extension.ts` postMessage calls) so payloads are compile-checked.
- Uses `satisfies HostToWebviewMessage` at direct `webview.postMessage(...)` call sites.

No behavior change.

Checks: `npm test`, `npm run typecheck`, `npm run lint`
