### PR TITLE
Dedupe status banner updates

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -300,6 +300,32 @@ describe('App - Advanced Test Coverage', () => {
       });
     });
 
+    it('does not reset auto-dismiss timer for identical status banners', async () => {
+      vi.useFakeTimers();
+      render(<App />);
+
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', { data: { type: 'status', status: 'online', mode: 'remote' } }));
+      });
+
+      expect(screen.getByText(/Connected to server/)).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      // Re-send same status; should not reset the auto-dismiss timer.
+      act(() => {
+        window.dispatchEvent(new MessageEvent('message', { data: { type: 'status', status: 'online', mode: 'remote' } }));
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+
+      expect(screen.queryByText(/Connected to server/)).not.toBeInTheDocument();
+    });
+
     it('keeps the status row mounted when auto-dismiss hides the banner', async () => {
       vi.useFakeTimers();
       render(<App />);

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1161,14 +1161,29 @@ export function App() {
             if (typeof label === 'string' || label === null) {
               setLlmProfileLabel(label);
             }
-            if (payload.mode === 'local') {
-              setStatusBanner({ message: 'Local mode: running without remote server', level: 'info', dismissible: false });
-            } else if (payload.status === 'connecting') {
-              setStatusBanner({ message: 'Connecting to server…', level: 'info' });
-            } else if (payload.status === 'online') {
-              setStatusBanner({ message: 'Connected to server', level: 'info' });
-            } else if (payload.status === 'offline') {
-              setStatusBanner({ message: 'Disconnected from server', level: 'warn' });
+            const nextBanner: StatusBannerState | null =
+              payload.mode === 'local'
+                ? { message: 'Local mode: running without remote server', level: 'info', dismissible: false }
+                : payload.status === 'connecting'
+                  ? { message: 'Connecting to server…', level: 'info' }
+                  : payload.status === 'online'
+                    ? { message: 'Connected to server', level: 'info' }
+                    : payload.status === 'offline'
+                      ? { message: 'Disconnected from server', level: 'warn' }
+                      : null;
+
+            if (nextBanner) {
+              setStatusBanner((prev) => {
+                if (!prev) return nextBanner;
+                if (
+                  prev.message === nextBanner.message
+                  && prev.level === nextBanner.level
+                  && prev.dismissible === nextBanner.dismissible
+                ) {
+                  return prev;
+                }
+                return nextBanner;
+              });
             }
           }
           break;


### PR DESCRIPTION
Fixes oh-tab-2b5m.\n\n- Avoids resetting the auto-dismiss timer when identical status banners are received.\n- Adds a regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized status banner handling to prevent unnecessary timer resets when the same status update is received multiple times in succession. The status banner now correctly maintains its auto-dismiss timer throughout consecutive identical updates.

* **Tests**
  * Added comprehensive test coverage for status banner debouncing and timer reset scenarios to ensure stable and predictable dismissal behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->