### PR TITLE
Support mailto links in openMarkdownLink

### DIFF
--- a/src/__tests__/openMarkdownLink.security.test.ts
+++ b/src/__tests__/openMarkdownLink.security.test.ts
@@ -65,6 +65,18 @@ describe('openMarkdownLink security rules', () => {
     expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
   });
 
+  it('opens mailto links via vscode.env.openExternal', async () => {
+    const handler = createHandler();
+
+    await handler({ type: 'openMarkdownLink', href: 'mailto:test@example.com' } as any);
+
+    expect((vscode as any).env.openExternal).toHaveBeenCalledTimes(1);
+    const uriArg = ((vscode as any).env.openExternal as any).mock.calls[0][0] as vscode.Uri;
+    expect(uriArg.scheme).toBe('mailto');
+    expect((vscode.workspace as any).openTextDocument).not.toHaveBeenCalled();
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
   it('does not open javascript: links externally', async () => {
     const handler = createHandler();
 
@@ -104,4 +116,3 @@ describe('openMarkdownLink security rules', () => {
     expect((vscode.workspace as any).openTextDocument).not.toHaveBeenCalled();
   });
 });
-

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -480,10 +480,10 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         const raw = typeof message.href === 'string' ? message.href.trim() : '';
         if (!raw || raw.startsWith('#')) break;
 
-        // Only allow http(s) links and workspace-internal file links.
-        if (/^https?:\/\//i.test(raw)) {
+        // Only allow http(s)/mailto links and workspace-internal file links.
+        if (/^https?:\/\//i.test(raw) || /^mailto:/i.test(raw)) {
           const uri = safeParseUri(raw);
-          if (!uri || (uri.scheme !== 'http' && uri.scheme !== 'https')) {
+          if (!uri || (uri.scheme !== 'http' && uri.scheme !== 'https' && uri.scheme !== 'mailto')) {
             void vscode.window.showErrorMessage('Blocked unsafe link.');
             break;
           }


### PR DESCRIPTION
Fixes oh-tab-t8ch.

- Allows `mailto:` links to open via `vscode.env.openExternal`, matching the webview markdown allowlist.
- Adds unit test coverage.