### PR TITLE
Cap HAL TTS gate tracking

### DIFF
--- a/src/hal/elevenlabs/__tests__/ttsConversationGate.test.ts
+++ b/src/hal/elevenlabs/__tests__/ttsConversationGate.test.ts
@@ -32,6 +32,42 @@ describe('TtsConversationGate', () => {
     expect(tts.synthesize).toHaveBeenCalledTimes(1);
   });
 
+  it('prunes disabled/notified tracking when over the cap', async () => {
+    const tts = {
+      synthesize: vi.fn(async () => {
+        throw new ElevenLabsError('Nope', { kind: 'auth', status: 401 });
+      }),
+    } as unknown as ElevenLabsTtsService;
+    const gate = new TtsConversationGate(tts, { maxTrackedConversationIds: 3 });
+
+    await gate.synthesize({ conversationId: 'c1', apiKey: 'xi-test', voiceId: 'voice-123', text: '1', cacheEnabled: true });
+    await gate.synthesize({ conversationId: 'c2', apiKey: 'xi-test', voiceId: 'voice-123', text: '2', cacheEnabled: true });
+    await gate.synthesize({ conversationId: 'c3', apiKey: 'xi-test', voiceId: 'voice-123', text: '3', cacheEnabled: true });
+    await gate.synthesize({ conversationId: 'c4', apiKey: 'xi-test', voiceId: 'voice-123', text: '4', cacheEnabled: true });
+
+    // c2 should still be disabled (no more TTS calls)
+    const c2Again = await gate.synthesize({
+      conversationId: 'c2',
+      apiKey: 'xi-test',
+      voiceId: 'voice-123',
+      text: '2 again',
+      cacheEnabled: true,
+    });
+    expect(c2Again).toMatchObject({ ok: false, disabled: true, shouldNotify: false });
+
+    // c1 should have been pruned, so it will attempt again and notify again.
+    const c1Again = await gate.synthesize({
+      conversationId: 'c1',
+      apiKey: 'xi-test',
+      voiceId: 'voice-123',
+      text: '1 again',
+      cacheEnabled: true,
+    });
+    expect(c1Again).toMatchObject({ ok: false, disabled: true, shouldNotify: true });
+
+    expect(tts.synthesize).toHaveBeenCalledTimes(5);
+  });
+
   it('passes through bytes on success', async () => {
     const tts = {
       synthesize: vi.fn(async () => ({ bytes: new Uint8Array([7]), fromCache: false })),
@@ -48,4 +84,3 @@ describe('TtsConversationGate', () => {
     expect(res).toEqual({ ok: true, bytes: new Uint8Array([7]) });
   });
 });
-

--- a/src/hal/elevenlabs/ttsConversationGate.ts
+++ b/src/hal/elevenlabs/ttsConversationGate.ts
@@ -14,11 +14,41 @@ export type HalTtsResult =
   | { ok: true; bytes: Uint8Array }
   | { ok: false; error: string; kind: ElevenLabsErrorKind; disabled: boolean; shouldNotify: boolean };
 
-export class TtsConversationGate {
-  private readonly disabled = new Set<string>();
-  private readonly notified = new Set<string>();
+type CappedSetOptions = { maxSize: number };
 
-  constructor(private readonly tts: ElevenLabsTtsService) {}
+class CappedSet {
+  private readonly map = new Map<string, true>();
+  private readonly maxSize: number;
+
+  constructor(opts: CappedSetOptions) {
+    this.maxSize = Math.max(1, opts.maxSize);
+  }
+
+  has(value: string): boolean {
+    return this.map.has(value);
+  }
+
+  add(value: string): void {
+    if (this.map.has(value)) return;
+    this.map.set(value, true);
+    if (this.map.size <= this.maxSize) return;
+    const oldest = this.map.keys().next().value;
+    if (oldest) this.map.delete(oldest);
+  }
+}
+
+export class TtsConversationGate {
+  private readonly disabled: CappedSet;
+  private readonly notified: CappedSet;
+
+  constructor(
+    private readonly tts: ElevenLabsTtsService,
+    opts?: { maxTrackedConversationIds?: number }
+  ) {
+    const maxTrackedConversationIds = opts?.maxTrackedConversationIds ?? 200;
+    this.disabled = new CappedSet({ maxSize: maxTrackedConversationIds });
+    this.notified = new CappedSet({ maxSize: maxTrackedConversationIds });
+  }
 
   async synthesize(req: HalTtsRequest): Promise<HalTtsResult> {
     if (this.disabled.has(req.conversationId)) {
@@ -51,4 +81,3 @@ export class TtsConversationGate {
     }
   }
 }
-


### PR DESCRIPTION
Fixes oh-tab-h1wu.

- Caps per-conversation disabled/notified tracking in `TtsConversationGate` to prevent unbounded in-memory growth.
- Adds unit test covering pruning behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text-to-speech service now supports configurable limits on tracked conversations to optimize memory usage and maintain performance during extended sessions.

* **Tests**
  * Added test coverage for conversation tracking pruning and re-notification behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->