### PR TITLE
Fix context mention insertion spacing

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -855,10 +855,13 @@ describe('App - Advanced Test Coverage', () => {
         expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
       });
 
-      postToWindow({ type: 'workspaceFiles', files: ['README.md', 'src/index.ts'] });
-
       await waitFor(() => {
-        expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
+        act(() => {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: { type: 'workspaceFiles', files: ['README.md', 'src/index.ts'] }
+          }));
+        });
+        expect(screen.getByText('README.md')).toBeInTheDocument();
       });
 
       fireEvent.click(screen.getByText('README.md'));

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -836,9 +836,36 @@ describe('App - Advanced Test Coverage', () => {
   });
 
   describe('Context file insertion', () => {
-    it.skip('inserts context file with proper spacing at cursor position', async () => {
-      // Cursor position tracking during file insertion is complex
-      // Skipping this test for now - basic file insertion is tested elsewhere
+    it('inserts context file with proper spacing at cursor position', async () => {
+      render(<App />);
+
+      const textarea = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+      expect(textarea).toBeTruthy();
+
+      const initial = 'Please read@rethen';
+      const caret = initial.indexOf('@') + 1 + 2; // after "@re"
+
+      Object.defineProperty(textarea, 'selectionStart', { value: caret, configurable: true });
+      Object.defineProperty(textarea, 'selectionEnd', { value: caret, configurable: true });
+      fireEvent.select(textarea);
+
+      fireEvent.change(textarea, { target: { value: initial } });
+
+      await waitFor(() => {
+        expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
+      });
+
+      postToWindow({ type: 'workspaceFiles', files: ['README.md', 'src/index.ts'] });
+
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('README.md'));
+
+      await waitFor(() => {
+        expect(textarea.value).toBe('Please read @README.md then');
+      });
     });
 
     it('filters workspace files based on query', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1735,7 +1735,10 @@ export function App() {
       const start = mentionStartRef.current;
       const before = input.slice(0, start);
       const after = input.slice(caret);
-      const inserted = `@${file} `;
+      const mention = `@${file}`;
+      const needsLeadingSpace = before.length > 0 && !/\s$/.test(before);
+      const needsTrailingSpace = after.length > 0 && !/^\s/.test(after);
+      const inserted = `${needsLeadingSpace ? ' ' : ''}${mention}${needsTrailingSpace ? ' ' : ''}`;
       const next = before + inserted + after;
       setInput(next);
 


### PR DESCRIPTION
Fixes oh-tab-j2t6.

- Context mention insertion now adds leading/trailing spaces only when needed, avoiding missing separators and double-spaces.
- Enables + implements the skipped unit test for mid-string insertion.