### PR TITLE
[oh-tab-q9wl] Cap rendered webview events

### DIFF
--- a/src/webview-src/__tests__/renderedEvents.cap.test.tsx
+++ b/src/webview-src/__tests__/renderedEvents.cap.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor, cleanup, act } from '@testing-library/react';
+import React from 'react';
+
+vi.mock('../shared/constants', () => ({
+  MAX_RENDERED_EVENTS: 10,
+}));
+
+describe('App - Rendered events cap', () => {
+  const mockApi = { postMessage: vi.fn() };
+
+  beforeEach(() => {
+    // @ts-expect-error -- VS Code API is injected by host environment during runtime
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('caps rendered events list and keeps newest events', async () => {
+    const { App } = await import('../components/App');
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'webviewReady' }));
+    });
+
+    mockApi.postMessage.mockClear();
+
+    act(() => {
+      for (let i = 0; i < 15; i++) {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'MessageEvent',
+              source: 'user',
+              e2e_marker: `m${i}`,
+              llm_message: { role: 'user', content: [{ type: 'text', text: `m${i}` }] },
+            },
+          },
+        }));
+      }
+    });
+
+    const requestId = 'rendered-events-cap';
+    act(() => {
+      window.dispatchEvent(new MessageEvent('message', { data: { type: 'queryRenderedEvents', requestId } }));
+    });
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'renderedEventsResponse',
+          requestId,
+          count: 10,
+        })
+      );
+    });
+
+    const responses = mockApi.postMessage.mock.calls
+      .map(([payload]) => payload)
+      .filter((payload) => (
+        typeof payload === 'object'
+        && payload !== null
+        && (payload as { type?: unknown }).type === 'renderedEventsResponse'
+        && (payload as { requestId?: unknown }).requestId === requestId
+      ));
+
+    expect(responses).toHaveLength(1);
+
+    const response = responses[0] as {
+      count: number;
+      events?: Array<{ marker?: string }>;
+    };
+
+    expect(response.count).toBe(10);
+    expect(response.events?.map((event) => event.marker)).toEqual([
+      'm5',
+      'm6',
+      'm7',
+      'm8',
+      'm9',
+      'm10',
+      'm11',
+      'm12',
+      'm13',
+      'm14',
+    ]);
+  });
+});

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -17,6 +17,7 @@ import {
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
 import { getHalDialogueLinesForMode, normalizeHalUserName, type HalScriptLine, type HalVoice } from '../../shared/halScript';
 import { getVscodeApi } from '../shared/vscodeApi';
+import { MAX_RENDERED_EVENTS } from '../shared/constants';
 
 // Component imports
 import { Header } from './Header';
@@ -1079,7 +1080,10 @@ export function App() {
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
 
-    setEvents((ev) => [...ev, { id: eventId.current++, event }]);
+    setEvents((ev) => {
+      const next = [...ev, { id: eventId.current++, event }];
+      return next.length > MAX_RENDERED_EVENTS ? next.slice(-MAX_RENDERED_EVENTS) : next;
+    });
   }, []);
 
   // Handle incoming events

--- a/src/webview-src/shared/constants.ts
+++ b/src/webview-src/shared/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_RENDERED_EVENTS = 2000;


### PR DESCRIPTION
Caps the webview rendered event list to prevent unbounded growth during long-running sessions.

- New shared constant: MAX_RENDERED_EVENTS (default 2000)
- App trims to last MAX_RENDERED_EVENTS on append
- Unit test mocks cap to 10 and verifies newest events are retained

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented an event rendering cap that limits displayed events to the most recent 2000, improving application performance and reducing memory consumption during extended sessions.

* **Tests**
  * Added comprehensive test suite validating the event rendering cap, confirming only the newest events are retained and the system operates as expected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->