### PR TITLE
[oh-tab-d7w4] Extract event backlog module

### DIFF
--- a/src/conversation/__tests__/eventBacklog.test.ts
+++ b/src/conversation/__tests__/eventBacklog.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import type { HostToWebviewMessage } from '../../shared/webviewMessages';
+import { ConversationEventBacklog } from '../eventBacklog';
+
+function mkMessageEvent(marker: string) {
+  return {
+    kind: 'MessageEvent',
+    source: 'user',
+    e2e_marker: marker,
+    llm_message: { role: 'user', content: [{ type: 'text', text: marker }] },
+  } as any;
+}
+
+describe('ConversationEventBacklog', () => {
+  it('keeps the last N events and iterates in order', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 3 });
+    backlog.reset('conv-1');
+
+    backlog.push(mkMessageEvent('m1'));
+    backlog.push(mkMessageEvent('m2'));
+    backlog.push(mkMessageEvent('m3'));
+    backlog.push(mkMessageEvent('m4'));
+
+    expect(backlog.getSize()).toBe(3);
+    expect(backlog.getEarliestSeq()).toBe(2);
+    expect(backlog.getLatestSeq()).toBe(4);
+
+    const seqs = Array.from(backlog.iter(), (item) => item.seq);
+    expect(seqs).toEqual([2, 3, 4]);
+  });
+
+  it('flushes a full replay when client conversation id mismatches', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 5 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+    backlog.push(mkMessageEvent('m2'));
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-other',
+      clientLastSeenSeq: 2,
+    });
+
+    expect(sent[0]).toEqual({ type: 'conversationStarted', conversationId: 'conv-1' });
+    expect(sent.slice(1).map((m) => m.type)).toEqual(['event', 'event']);
+    expect(sent.slice(1).map((m) => (m as any).seq)).toEqual([1, 2]);
+  });
+
+  it('flushes incremental events when lastSeenSeq is in range', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 5 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+    backlog.push(mkMessageEvent('m2'));
+    backlog.push(mkMessageEvent('m3'));
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-1',
+      clientLastSeenSeq: 2,
+    });
+
+    expect(sent.map((m) => m.type)).toEqual(['event']);
+    expect((sent[0] as any).seq).toBe(3);
+  });
+
+  it('flushes a full replay when lastSeenSeq falls outside the buffer range', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 3 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+    backlog.push(mkMessageEvent('m2'));
+    backlog.push(mkMessageEvent('m3'));
+    backlog.push(mkMessageEvent('m4')); // buffer now holds seq 2..4
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-1',
+      clientLastSeenSeq: 0,
+    });
+
+    expect(sent[0]).toEqual({ type: 'conversationStarted', conversationId: 'conv-1' });
+    expect(sent.slice(1).map((m) => (m as any).seq)).toEqual([2, 3, 4]);
+  });
+
+  it('flushes a full replay when lastSeenSeq is invalid', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 5 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-1',
+      clientLastSeenSeq: Number.NaN,
+    });
+
+    expect(sent[0]).toEqual({ type: 'conversationStarted', conversationId: 'conv-1' });
+    expect(sent.slice(1).map((m) => m.type)).toEqual(['event']);
+  });
+
+  it('does nothing when client is already up to date', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 5 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+    backlog.push(mkMessageEvent('m2'));
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-1',
+      clientLastSeenSeq: 2,
+    });
+
+    expect(sent).toEqual([]);
+  });
+
+  it('uses fallback conversation id when none is stored', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 5 });
+    backlog.reset(undefined);
+    backlog.push(mkMessageEvent('m1'));
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-1',
+      clientLastSeenSeq: 0,
+      fallbackConversationId: 'conv-1',
+    });
+
+    expect(sent.map((m) => m.type)).toEqual(['event']);
+    expect((sent[0] as any).seq).toBe(1);
+  });
+
+  it('applies transformEvent to flushed events', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 5 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+
+    const sent: HostToWebviewMessage[] = [];
+    backlog.flushToClient({
+      postMessage: (message) => {
+        sent.push(message);
+        return Promise.resolve(true);
+      },
+      clientConversationId: 'conv-x',
+      transformEvent: (event) => ({ ...(event as any), e2e_marker: 'transformed' }) as any,
+    });
+
+    expect((sent[1] as any).event.e2e_marker).toBe('transformed');
+  });
+});

--- a/src/conversation/eventBacklog.ts
+++ b/src/conversation/eventBacklog.ts
@@ -1,0 +1,106 @@
+import type { Event } from '@openhands/agent-sdk-ts';
+import type { HostToWebviewMessage } from '../shared/webviewMessages';
+
+export type BufferedConversationEvent = { seq: number; event: Event };
+
+export type ConversationEventBacklogFlushParams = {
+  postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
+  clientConversationId?: string;
+  clientLastSeenSeq?: number;
+  fallbackConversationId?: string;
+  transformEvent?: (event: Event) => Event;
+};
+
+export class ConversationEventBacklog {
+  private readonly maxSize: number;
+  private readonly buffer: Array<BufferedConversationEvent | undefined> = [];
+  private start = 0;
+  private size = 0;
+  private seq = 0;
+  private conversationId: string | undefined;
+
+  constructor(options?: { maxSize?: number }) {
+    this.maxSize = options?.maxSize ?? 2000;
+  }
+
+  reset(conversationId: string | undefined): void {
+    this.conversationId = conversationId;
+    this.seq = 0;
+    this.start = 0;
+    this.size = 0;
+    this.buffer.length = 0;
+  }
+
+  push(event: Event): number {
+    this.seq += 1;
+    const item: BufferedConversationEvent = { seq: this.seq, event };
+    if (this.size < this.maxSize) {
+      const idx = (this.start + this.size) % this.maxSize;
+      this.buffer[idx] = item;
+      this.size += 1;
+    } else {
+      this.buffer[this.start] = item;
+      this.start = (this.start + 1) % this.maxSize;
+    }
+    return this.seq;
+  }
+
+  *iter(): Iterable<BufferedConversationEvent> {
+    for (let i = 0; i < this.size; i += 1) {
+      const idx = (this.start + i) % this.maxSize;
+      const item = this.buffer[idx];
+      if (item) yield item;
+    }
+  }
+
+  getEarliestSeq(): number | undefined {
+    return this.size > 0 ? this.seq - this.size + 1 : undefined;
+  }
+
+  getSize(): number {
+    return this.size;
+  }
+
+  getLatestSeq(): number | undefined {
+    return this.size > 0 ? this.seq : undefined;
+  }
+
+  getConversationId(): string | undefined {
+    return this.conversationId;
+  }
+
+  flushToClient(params: ConversationEventBacklogFlushParams): void {
+    const currentConversationId = this.conversationId ?? params.fallbackConversationId;
+    if (!currentConversationId) {
+      return;
+    }
+
+    const earliestSeq = this.getEarliestSeq();
+    const latestSeq = this.getLatestSeq();
+    const lastSeenSeq = params.clientLastSeenSeq;
+
+    const lastSeenIsValid = typeof lastSeenSeq === 'number' && Number.isFinite(lastSeenSeq);
+    const isInRange = lastSeenIsValid && (earliestSeq === undefined || lastSeenSeq >= earliestSeq - 1);
+    const needsFullReplay = params.clientConversationId !== currentConversationId || !isInRange;
+
+    const transformEvent = params.transformEvent ?? ((event: Event) => event);
+
+    if (needsFullReplay) {
+      void params.postMessage({ type: 'conversationStarted', conversationId: currentConversationId });
+      for (const item of this.iter()) {
+        void params.postMessage({ type: 'event', seq: item.seq, event: transformEvent(item.event) });
+      }
+      return;
+    }
+
+    if (latestSeq === undefined || lastSeenSeq === undefined || lastSeenSeq >= latestSeq) {
+      return;
+    }
+
+    for (const item of this.iter()) {
+      if (item.seq > lastSeenSeq) {
+        void params.postMessage({ type: 'event', seq: item.seq, event: transformEvent(item.event) });
+      }
+    }
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { safeStringify } from './shared/safeStringify';
 import { getGlobalStorageBaseDir } from './shared/pastedImages';
 import { transformEventForWebview as transformEventForWebviewWithPastedImages } from './conversation/host/transformEventForWebview';
+import { ConversationEventBacklog, type BufferedConversationEvent } from './conversation/eventBacklog';
 import type { HostToWebviewMessage } from './shared/webviewMessages';
 import {
   AgentContext,
@@ -89,12 +90,7 @@ let verboseEventLogging = false;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
-type BufferedConversationEvent = { seq: number; event: Event };
-const conversationEventBacklog: Array<BufferedConversationEvent | undefined> = [];
-let conversationEventBacklogStart = 0;
-let conversationEventBacklogSize = 0;
-let conversationEventSeq = 0;
-let activeConversationId: string | undefined;
+const eventBacklog = new ConversationEventBacklog({ maxSize: MAX_EVENT_BACKLOG });
 // Buffer of test events sent via _sendTestEvent (used as fallback in E2E query)
 const MAX_TEST_EVENTS = MAX_EVENT_BACKLOG;
 const sentTestEvents: Event[] = [];
@@ -164,33 +160,15 @@ function fileLog(line: string) {
 }
 
 function resetConversationEventBacklog(conversationId: string | undefined) {
-  activeConversationId = conversationId;
-  conversationEventSeq = 0;
-  conversationEventBacklogStart = 0;
-  conversationEventBacklogSize = 0;
-  conversationEventBacklog.length = 0;
+  eventBacklog.reset(conversationId);
 }
 
 function bufferConversationEvent(event: Event): number {
-  conversationEventSeq += 1;
-  const item: BufferedConversationEvent = { seq: conversationEventSeq, event };
-  if (conversationEventBacklogSize < MAX_EVENT_BACKLOG) {
-    const idx = (conversationEventBacklogStart + conversationEventBacklogSize) % MAX_EVENT_BACKLOG;
-    conversationEventBacklog[idx] = item;
-    conversationEventBacklogSize += 1;
-  } else {
-    conversationEventBacklog[conversationEventBacklogStart] = item;
-    conversationEventBacklogStart = (conversationEventBacklogStart + 1) % MAX_EVENT_BACKLOG;
-  }
-  return conversationEventSeq;
+  return eventBacklog.push(event);
 }
 
 function* iterConversationEventBacklog(): Iterable<BufferedConversationEvent> {
-  for (let i = 0; i < conversationEventBacklogSize; i += 1) {
-    const idx = (conversationEventBacklogStart + i) % MAX_EVENT_BACKLOG;
-    const item = conversationEventBacklog[idx];
-    if (item) yield item;
-  }
+  yield* eventBacklog.iter();
 }
 
 function flushConversationEventBacklog(params: {
@@ -198,44 +176,18 @@ function flushConversationEventBacklog(params: {
   clientConversationId?: string;
   clientLastSeenSeq?: number;
 }) {
-  const currentConversationId = activeConversationId ?? conversation?.getConversationId();
-  if (!currentConversationId) {
-    return;
-  }
+  const webview = chatView?.webview;
+  const transformEvent = webview
+    ? (event: Event) => transformEventForWebviewWithPastedImages(event, { webview, pastedImagesBaseDir })
+    : undefined;
 
-  const earliestSeq = conversationEventBacklogSize > 0 ? conversationEventSeq - conversationEventBacklogSize + 1 : undefined;
-  const latestSeq = conversationEventBacklogSize > 0 ? conversationEventSeq : undefined;
-  const lastSeenSeq = params.clientLastSeenSeq;
-
-  const lastSeenIsValid = typeof lastSeenSeq === 'number' && Number.isFinite(lastSeenSeq);
-  const isInRange = lastSeenIsValid && (earliestSeq === undefined || lastSeenSeq >= earliestSeq - 1);
-  const needsFullReplay = params.clientConversationId !== currentConversationId || !isInRange;
-
-  if (needsFullReplay) {
-    void params.postMessage({ type: 'conversationStarted', conversationId: currentConversationId });
-    for (const item of iterConversationEventBacklog()) {
-      const webview = chatView?.webview;
-      const event = webview
-        ? transformEventForWebviewWithPastedImages(item.event, { webview, pastedImagesBaseDir })
-        : item.event;
-      void params.postMessage({ type: 'event', seq: item.seq, event });
-    }
-    return;
-  }
-
-  if (latestSeq === undefined || lastSeenSeq === undefined || lastSeenSeq >= latestSeq) {
-    return;
-  }
-
-  for (const item of iterConversationEventBacklog()) {
-    if (item.seq > lastSeenSeq) {
-      const webview = chatView?.webview;
-      const event = webview
-        ? transformEventForWebviewWithPastedImages(item.event, { webview, pastedImagesBaseDir })
-        : item.event;
-      void params.postMessage({ type: 'event', seq: item.seq, event });
-    }
-  }
+  eventBacklog.flushToClient({
+    postMessage: params.postMessage,
+    clientConversationId: params.clientConversationId,
+    clientLastSeenSeq: params.clientLastSeenSeq,
+    fallbackConversationId: conversation?.getConversationId(),
+    transformEvent,
+  });
 }
 
 const normalizeTerminalNewlines = (text: string): string => text.replace(/\r?\n/g, '\r\n');
@@ -999,9 +951,9 @@ export function activate(context: vscode.ExtensionContext) {
         clientLastSeenSeq: chatLastSeenSeq,
       },
       eventBacklog: {
-        activeConversationId,
-        size: conversationEventBacklogSize,
-        latestSeq: conversationEventSeq,
+        activeConversationId: eventBacklog.getConversationId(),
+        size: eventBacklog.getSize(),
+        latestSeq: eventBacklog.getLatestSeq() ?? 0,
       },
       hasConversation: !!conversation,
       conversationId: conversation?.getConversationId(),
@@ -1058,9 +1010,9 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     return {
-      activeConversationId,
-      size: conversationEventBacklogSize,
-      latestSeq: conversationEventSeq,
+      activeConversationId: eventBacklog.getConversationId(),
+      size: eventBacklog.getSize(),
+      latestSeq: eventBacklog.getLatestSeq() ?? 0,
       lastEventSeq,
       lastEventKind,
       lastUserMessageSeq,


### PR DESCRIPTION
Moves the extension conversation event ring buffer out of `src/extension.ts` into `src/conversation/eventBacklog.ts` and adds unit coverage.

- Extracts: reset/push/iter/flush-to-client logic (behavior-preserving)
- Updates `src/extension.ts` to delegate to the module
- Adds unit tests for wrap-around + flush decisions

Tests:
- npm test
- npm run typecheck
- npm run lint
