### PR TITLE
[oh-tab-mzac] Make status debounce per App instance

### DIFF
--- a/src/webview-src/__tests__/App.statusDebounce.test.tsx
+++ b/src/webview-src/__tests__/App.statusDebounce.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup, act } from '@testing-library/react';
+import React from 'react';
+import { App } from '../components/App';
+
+function dispatchToWindow(payload: unknown) {
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', { data: payload }));
+  });
+}
+
+describe('App - status banner debounce', () => {
+  const mockApi = { postMessage: vi.fn() };
+
+  beforeEach(() => {
+    // @ts-expect-error -- VS Code API is injected by host environment during runtime
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('does not debounce across App mounts', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000);
+
+    const first = render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'webviewReady' }));
+    });
+
+    await waitFor(() => {
+      dispatchToWindow({ type: 'halTeleportUnavailable', error: 'No server available' });
+      expect(screen.getByText('No server available')).toBeInTheDocument();
+    });
+
+    first.unmount();
+    mockApi.postMessage.mockClear();
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'webviewReady' }));
+    });
+
+    await waitFor(() => {
+      dispatchToWindow({ type: 'halTeleportUnavailable', error: 'No server available' });
+      expect(screen.getByText('No server available')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -210,7 +210,6 @@ function EventBlock({ event, index }: { event: Event; index: number }) {
  * Status message debouncing configuration
  */
 const STATUS_DEBOUNCE_MS = 600;
-let lastStatusMessage = { level: '' as 'info' | 'warn' | 'error', message: '', at: 0 };
 
 /**
  * Main App component: React webview root for OpenHands extension.
@@ -242,6 +241,9 @@ export function App() {
   // UI state
   const [statusBanner, setStatusBanner] = useState<StatusBannerState | null>(
     { message: 'Initializing…', level: 'info' }
+  );
+  const lastStatusMessageRef = useRef<{ level: 'info' | 'warn' | 'error'; message: string; at: number }>(
+    { level: 'info', message: '', at: 0 }
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
@@ -461,10 +463,11 @@ export function App() {
   // Show status message with debouncing
   const showStatusMessage = useCallback((level: 'info' | 'warn' | 'error', message: string) => {
     const now = Date.now();
-    if (lastStatusMessage.level === level && lastStatusMessage.message === message && now - lastStatusMessage.at < STATUS_DEBOUNCE_MS) {
+    const prev = lastStatusMessageRef.current;
+    if (prev.level === level && prev.message === message && now - prev.at < STATUS_DEBOUNCE_MS) {
       return;
     }
-    lastStatusMessage = { level, message, at: now };
+    lastStatusMessageRef.current = { level, message, at: now };
     setStatusBanner({ message, level });
   }, []);
 


### PR DESCRIPTION
Moves the status-banner debounce state from a module-level mutable `let` into the `App()` instance via `useRef`, preventing cross-test / multi-webview leakage.

- Replaces module-level `lastStatusMessage` with `lastStatusMessageRef`
- Adds a regression test that unmounts/remounts and asserts the banner still shows

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for status message debouncing behavior during component lifecycle changes.

* **Refactor**
  * Improved status message state management to ensure consistent debouncing behavior across component remounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->