### PR TITLE
[oh-tab-21rx] Cap/cleanup pasted images storage

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,8 @@ import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPO
 import { type HalStateSnapshot, isElevenLabsMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
 import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { safeStringify } from './shared/safeStringify';
-import { getGlobalStorageBaseDir } from './shared/pastedImages';
+import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, isValidPastedImageId } from './shared/pastedImages';
+import { cleanupPastedImages } from './shared/pastedImagesCleanup';
 import { transformEventForWebview as transformEventForWebviewWithPastedImages } from './conversation/host/transformEventForWebview';
 import { ConversationEventBacklog, type BufferedConversationEvent } from './conversation/eventBacklog';
 import type { HostToWebviewMessage } from './shared/webviewMessages';
@@ -90,6 +91,9 @@ let verboseEventLogging = false;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
+// Pasted images are persisted under globalStorage/pasted-images; enforce a best-effort cap.
+const MAX_PASTED_IMAGES_STORAGE_FILES = 2000;
+const MAX_PASTED_IMAGES_STORAGE_BYTES = 200 * 1024 * 1024;
 const eventBacklog = new ConversationEventBacklog({ maxSize: MAX_EVENT_BACKLOG });
 // Buffer of test events sent via _sendTestEvent (used as fallback in E2E query)
 const MAX_TEST_EVENTS = MAX_EVENT_BACKLOG;
@@ -159,12 +163,86 @@ function fileLog(line: string) {
   });
 }
 
+let pastedImagesCleanupInFlight: Promise<void> | undefined;
+let pastedImagesCleanupQueued = false;
+const OPENHANDS_IMAGE_ID_REGEX = new RegExp(`${OPENHANDS_IMAGE_URL_PREFIX}([a-f0-9]{16}\\.[a-z0-9]+)`, 'g');
+
+function messageHasPastedImages(event: Event): boolean {
+  if (event.kind !== 'MessageEvent') return false;
+  const content = (event as unknown as { llm_message?: { content?: unknown } }).llm_message?.content;
+  if (!Array.isArray(content)) return false;
+  for (const item of content) {
+    if (!item || (item as { type?: unknown }).type !== 'text') continue;
+    const text = (item as { text?: unknown }).text;
+    if (typeof text === 'string' && text.includes(OPENHANDS_IMAGE_URL_PREFIX)) return true;
+  }
+  return false;
+}
+
+function collectReferencedPastedImageIdsFromBacklog(): Set<string> {
+  const imageIds = new Set<string>();
+  for (const item of eventBacklog.iter()) {
+    const event = item.event;
+    if (event.kind !== 'MessageEvent') continue;
+    const content = (event as unknown as { llm_message?: { content?: unknown } }).llm_message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const part of content) {
+      if (!part || (part as { type?: unknown }).type !== 'text') continue;
+      const text = (part as { text?: unknown }).text;
+      if (typeof text !== 'string' || !text.includes(OPENHANDS_IMAGE_URL_PREFIX)) continue;
+
+      for (const match of text.matchAll(OPENHANDS_IMAGE_ID_REGEX)) {
+        const imageId = match[1];
+        if (typeof imageId === 'string' && isValidPastedImageId(imageId)) {
+          imageIds.add(imageId);
+        }
+      }
+    }
+  }
+  return imageIds;
+}
+
+function schedulePastedImagesCleanup(): void {
+  if (pastedImagesCleanupInFlight) {
+    pastedImagesCleanupQueued = true;
+    return;
+  }
+
+  pastedImagesCleanupInFlight = (async () => {
+    try {
+      const keepImageIds = collectReferencedPastedImageIdsFromBacklog();
+      await cleanupPastedImages({
+        baseDir: pastedImagesBaseDir,
+        keepImageIds,
+        maxFiles: MAX_PASTED_IMAGES_STORAGE_FILES,
+        maxBytes: MAX_PASTED_IMAGES_STORAGE_BYTES,
+        log: (line) => outputChannel?.appendLine(line),
+      });
+    } catch (err) {
+      outputChannel?.appendLine(`[pasted-images] Cleanup failed: ${renderError(err)}`);
+    } finally {
+      pastedImagesCleanupInFlight = undefined;
+    }
+  })()
+    .finally(() => {
+      if (pastedImagesCleanupQueued) {
+        pastedImagesCleanupQueued = false;
+        schedulePastedImagesCleanup();
+      }
+    });
+}
+
 function resetConversationEventBacklog(conversationId: string | undefined) {
   eventBacklog.reset(conversationId);
 }
 
 function bufferConversationEvent(event: Event): number {
-  return eventBacklog.push(event);
+  const seq = eventBacklog.push(event);
+  if (messageHasPastedImages(event)) {
+    schedulePastedImagesCleanup();
+  }
+  return seq;
 }
 
 function* iterConversationEventBacklog(): Iterable<BufferedConversationEvent> {

--- a/src/shared/__tests__/pastedImagesCleanup.test.ts
+++ b/src/shared/__tests__/pastedImagesCleanup.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { cleanupPastedImages } from '../pastedImagesCleanup';
+import { getPastedImagesDir } from '../pastedImages';
+
+async function writeImage(baseDir: string, imageId: string, sizeBytes: number, mtimeMs: number): Promise<void> {
+  const dir = getPastedImagesDir(baseDir);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, imageId), Buffer.alloc(sizeBytes, 0));
+  const mtime = new Date(mtimeMs);
+  await fs.utimes(path.join(dir, imageId), mtime, mtime);
+}
+
+describe('cleanupPastedImages', () => {
+  let tmpDir = '';
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-pasted-images-cleanup-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('deletes oldest files to satisfy maxFiles cap', async () => {
+    await writeImage(tmpDir, '0000000000000001.png', 10, 1);
+    await writeImage(tmpDir, '0000000000000002.png', 10, 2);
+    await writeImage(tmpDir, '0000000000000003.png', 10, 3);
+
+    await cleanupPastedImages({
+      baseDir: tmpDir,
+      keepImageIds: new Set(),
+      maxFiles: 2,
+      maxBytes: 10_000,
+    });
+
+    const remaining = (await fs.readdir(getPastedImagesDir(tmpDir))).sort();
+    expect(remaining).toEqual(['0000000000000002.png', '0000000000000003.png']);
+  });
+
+  it('deletes oldest files to satisfy maxBytes cap', async () => {
+    await writeImage(tmpDir, '0000000000000001.png', 50, 1);
+    await writeImage(tmpDir, '0000000000000002.png', 50, 2);
+    await writeImage(tmpDir, '0000000000000003.png', 50, 3);
+
+    const result = await cleanupPastedImages({
+      baseDir: tmpDir,
+      keepImageIds: new Set(),
+      maxFiles: 10,
+      maxBytes: 100,
+    });
+
+    expect(result.deleted).toBe(1);
+    expect(result.remainingBytes).toBe(100);
+    const remaining = (await fs.readdir(getPastedImagesDir(tmpDir))).sort();
+    expect(remaining).toEqual(['0000000000000002.png', '0000000000000003.png']);
+  });
+
+  it('never deletes protected image ids', async () => {
+    await writeImage(tmpDir, '0000000000000001.png', 10, 1);
+    await writeImage(tmpDir, '0000000000000002.png', 10, 2);
+    await writeImage(tmpDir, '0000000000000003.png', 10, 3);
+
+    const keep = new Set(['0000000000000001.png']);
+
+    await cleanupPastedImages({
+      baseDir: tmpDir,
+      keepImageIds: keep,
+      maxFiles: 1,
+      maxBytes: 10_000,
+    });
+
+    const remaining = await fs.readdir(getPastedImagesDir(tmpDir));
+    expect(remaining).toEqual(['0000000000000001.png']);
+  });
+
+  it('logs when caps cannot be met due to protected images', async () => {
+    await writeImage(tmpDir, '0000000000000001.png', 10, 1);
+    await writeImage(tmpDir, '0000000000000002.png', 10, 2);
+
+    const logs: string[] = [];
+    const keep = new Set(['0000000000000001.png', '0000000000000002.png']);
+
+    const result = await cleanupPastedImages({
+      baseDir: tmpDir,
+      keepImageIds: keep,
+      maxFiles: 0,
+      maxBytes: 0,
+      log: (line) => logs.push(line),
+    });
+
+    expect(result.deleted).toBe(0);
+    expect(logs.some((line) => line.includes('Storage cap exceeded'))).toBe(true);
+  });
+});

--- a/src/shared/pastedImagesCleanup.ts
+++ b/src/shared/pastedImagesCleanup.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { getPastedImagesDir, isValidPastedImageId } from './pastedImages';
+
+export type PastedImageFileInfo = {
+  imageId: string;
+  filePath: string;
+  sizeBytes: number;
+  mtimeMs: number;
+};
+
+export type PastedImagesCleanupResult = {
+  deleted: number;
+  freedBytes: number;
+  totalFiles: number;
+  totalBytes: number;
+  remainingFiles: number;
+  remainingBytes: number;
+};
+
+async function listPastedImageFiles(baseDir: string): Promise<PastedImageFileInfo[]> {
+  const dir = getPastedImagesDir(baseDir);
+  let entries: Array<{ name: string; isFile: () => boolean }>;
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const files: PastedImageFileInfo[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const imageId = entry.name;
+    if (!isValidPastedImageId(imageId)) continue;
+
+    const filePath = path.join(dir, imageId);
+    try {
+      const stat = await fs.stat(filePath);
+      files.push({ imageId, filePath, sizeBytes: stat.size, mtimeMs: stat.mtimeMs });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+  }
+
+  return files;
+}
+
+export async function cleanupPastedImages(options: {
+  baseDir: string;
+  keepImageIds: ReadonlySet<string>;
+  maxFiles: number;
+  maxBytes: number;
+  log?: (message: string) => void;
+}): Promise<PastedImagesCleanupResult> {
+  const log = options.log;
+  const items = await listPastedImageFiles(options.baseDir);
+  const totalFiles = items.length;
+  const totalBytes = items.reduce((sum, item) => sum + item.sizeBytes, 0);
+
+  let remainingFiles = totalFiles;
+  let remainingBytes = totalBytes;
+  let deleted = 0;
+  let freedBytes = 0;
+
+  if (remainingFiles <= options.maxFiles && remainingBytes <= options.maxBytes) {
+    return { deleted, freedBytes, totalFiles, totalBytes, remainingFiles, remainingBytes };
+  }
+
+  const candidates = items
+    .filter((item) => !options.keepImageIds.has(item.imageId))
+    .sort((a, b) => {
+      const byTime = a.mtimeMs - b.mtimeMs;
+      if (byTime !== 0) return byTime;
+      return a.imageId.localeCompare(b.imageId);
+    });
+
+  for (const item of candidates) {
+    if (remainingFiles <= options.maxFiles && remainingBytes <= options.maxBytes) break;
+    try {
+      await fs.unlink(item.filePath);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw err;
+    }
+    deleted += 1;
+    freedBytes += item.sizeBytes;
+    remainingFiles -= 1;
+    remainingBytes -= item.sizeBytes;
+  }
+
+  if (deleted > 0) {
+    log?.(`[pasted-images] Deleted ${deleted} old image(s) (freed ${freedBytes} bytes).`);
+  }
+
+  if (remainingFiles > options.maxFiles || remainingBytes > options.maxBytes) {
+    log?.(`[pasted-images] Storage cap exceeded (files=${remainingFiles}/${options.maxFiles}, bytes=${remainingBytes}/${options.maxBytes}). All remaining images are protected by the active conversation.`);
+  }
+
+  return { deleted, freedBytes, totalFiles, totalBytes, remainingFiles, remainingBytes };
+}


### PR DESCRIPTION
Adds a best-effort cleanup strategy for persisted pasted images under globalStorage (`pasted-images/`) to prevent unbounded growth.

- New helper: `src/shared/pastedImagesCleanup.ts` (LRU-ish delete by mtime, skips protected ids)
- Extension schedules cleanup when a MessageEvent contains `openhands-image://...` URLs
- Unit tests cover maxFiles/maxBytes behavior and protected-id behavior

Caps:
- maxFiles=2000
- maxBytes=200MB

Tests:
- npm test
- npm run typecheck
- npm run lint
