### PR TITLE
[oh-tab-ekuk] Stabilize webview postToWindow helper

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -3,15 +3,12 @@ import { render, screen, waitFor, cleanup, act, fireEvent } from '@testing-libra
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { App } from '../components/App';
+import { postToWindow } from './testUtils';
 import type {
   ActionEvent,
   ConversationStateUpdateEvent,
   AgentErrorEvent,
 } from '@openhands/agent-sdk-ts';
-
-function postToWindow(payload: unknown) {
-  window.postMessage(payload, '*');
-}
 
 describe('App - Advanced Test Coverage', () => {
   const mockApi = { postMessage: vi.fn() };

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -4,10 +4,7 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { App } from '../components/App';
 import type { ActionEvent, ConversationStateUpdateEvent } from '@openhands/agent-sdk-ts';
-
-function postToWindow(payload: any) {
-  window.postMessage(payload, '*');
-}
+import { postToWindow } from './testUtils';
 
 describe('App - Confirmation Flow', () => {
   const mockApi = { postMessage: vi.fn() } as any;

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -3,10 +3,7 @@ import { render, screen, act, waitFor, cleanup, fireEvent } from '@testing-libra
 import React from 'react';
 import { App } from '../components/App';
 import type { ActionEvent, ConversationStateUpdateEvent } from '@openhands/agent-sdk-ts';
-
-function postToWindow(payload: any) {
-  window.postMessage(payload, '*');
-}
+import { postToWindow } from './testUtils';
 
 describe('HAL voice_confirm', () => {
   const mockApi = { postMessage: vi.fn() } as any;

--- a/src/webview-src/__tests__/actions.test.tsx
+++ b/src/webview-src/__tests__/actions.test.tsx
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { App } from '../components/App';
+import { postToWindow } from './testUtils';
 
 const mockApi = { postMessage: vi.fn() };
 
@@ -46,9 +47,7 @@ describe('App actions post messages to extension', () => {
     render(<App />);
 
     // Set status to online so input is enabled
-    await act(async () => {
-      window.postMessage({ type: 'status', status: 'online', mode: 'remote' }, '*');
-    });
+    postToWindow({ type: 'status', status: 'online', mode: 'remote' });
 
     await userEvent.click(screen.getAllByLabelText('Add context')[0]);
     expect(await screen.findByPlaceholderText('Search files...')).toBeInTheDocument();
@@ -65,21 +64,15 @@ describe('App actions post messages to extension', () => {
     render(<App />);
 
     // Set status to online so input is enabled
-    await act(async () => {
-      window.postMessage({ type: 'status', status: 'online', mode: 'remote' }, '*');
-    });
+    postToWindow({ type: 'status', status: 'online', mode: 'remote' });
 
     await userEvent.click(screen.getAllByLabelText('Skills')[0]);
 
-    await act(async () => {
-      window.dispatchEvent(new MessageEvent('message', {
-        data: {
-          type: 'skillsList',
-          skills: [
-            { label: 'Alpha', path: '/tmp/a.md' }
-          ]
-        }
-      }));
+    postToWindow({
+      type: 'skillsList',
+      skills: [
+        { label: 'Alpha', path: '/tmp/a.md' },
+      ],
     });
 
     mockApi.postMessage.mockClear();

--- a/src/webview-src/__tests__/event.attachments.test.tsx
+++ b/src/webview-src/__tests__/event.attachments.test.tsx
@@ -3,14 +3,11 @@ import { cleanup, fireEvent, render, screen, within } from '@testing-library/rea
 import React from 'react';
 import { App } from '../components/App';
 import type { MessageEvent as AgentMessageEvent } from '@openhands/agent-sdk-ts';
+import { postToWindow } from './testUtils';
 
 afterEach(() => {
   cleanup();
 });
-
-function postToWindow(payload: unknown) {
-  window.postMessage(payload, '*');
-}
 
 describe('Attachment marker parsing', () => {
   it('does not treat end-marker substrings inside content as end markers', async () => {

--- a/src/webview-src/__tests__/event.handlers.test.tsx
+++ b/src/webview-src/__tests__/event.handlers.test.tsx
@@ -2,10 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, waitFor, cleanup } from '@testing-library/react';
 import React from 'react';
 import { App } from '../components/App';
-
-function postToWindow(payload: unknown) {
-  window.postMessage(payload, '*');
-}
+import { postToWindow } from './testUtils';
 
 describe('App event handling helpers', () => {
   const mockApi = { postMessage: vi.fn() };

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { App } from '../components/App';
+import { postToWindow } from './testUtils';
 import type {
   MessageEvent as AgentMessageEvent,
   AgentErrorEvent,
@@ -11,10 +12,6 @@ import type {
 afterEach(() => {
   cleanup();
 });
-
-function postToWindow(payload: any) {
-  window.postMessage(payload, '*');
-}
 
 const mockApi = { postMessage: vi.fn() } as any;
 

--- a/src/webview-src/__tests__/paste.images.test.tsx
+++ b/src/webview-src/__tests__/paste.images.test.tsx
@@ -3,10 +3,7 @@ import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/re
 import React from 'react';
 import { App } from '../components/App';
 import type { MessageEvent as AgentMessageEvent } from '@openhands/agent-sdk-ts';
-
-function postToWindow(payload: unknown) {
-  window.postMessage(payload, '*');
-}
+import { postToWindow } from './testUtils';
 
 describe('Pasted images', () => {
   const mockApi = { postMessage: vi.fn() } as any;

--- a/src/webview-src/__tests__/testUtils.ts
+++ b/src/webview-src/__tests__/testUtils.ts
@@ -1,0 +1,7 @@
+import { act } from '@testing-library/react';
+
+export function postToWindow(payload: unknown): void {
+  act(() => {
+    window.dispatchEvent(new MessageEvent('message', { data: payload }));
+  });
+}

--- a/src/webview-src/__tests__/toasts.test.tsx
+++ b/src/webview-src/__tests__/toasts.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { App } from '../components/App';
+import { postToWindow } from './testUtils';
 
 // Note: We can't easily assert toaster DOM here without wiring a query target since it's portal-based.
 // This test ensures no runtime errors when system/error events trigger toaster.
@@ -9,7 +10,7 @@ import { App } from '../components/App';
 describe('toasts', () => {
   it('does not throw when system/error events are posted', () => {
     render(<App />);
-    window.postMessage({ type: 'event', event: { type: 'system', message: 'hello' } }, '*');
-    window.postMessage({ type: 'event', event: { type: 'error', error: 'oops' } }, '*');
+    postToWindow({ type: 'event', event: { type: 'system', message: 'hello' } });
+    postToWindow({ type: 'event', event: { type: 'error', error: 'oops' } });
   });
 });


### PR DESCRIPTION
Refactors webview unit tests to avoid `window.postMessage(...)` races with App's message-listener `useEffect`.

- Adds `src/webview-src/__tests__/testUtils.ts` with `postToWindow()` implemented via `dispatchEvent(new MessageEvent(...))` wrapped in `act()`
- Updates all webview tests to use the shared helper

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Consolidated test utilities by extracting shared helper functions into a centralized utility module for improved test maintainability and consistency across test suites.

* **Refactor**
  * Removed duplicate code across multiple test files and unified testing helper implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->