### PR TITLE
[oh-tab-i1lt] Dedupe terminal exit footer

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -819,10 +819,13 @@ export function activate(context: vscode.ExtensionContext) {
           markPrintedExitFor(cid);
         }
       } else if (isBashExit(event)) {
-        terminalLogPty.ensureNewline?.();
-        terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
-        if ('command_id' in event && (event as { command_id?: string }).command_id) {
-          markPrintedExitFor((event as { command_id?: string }).command_id as string);
+        const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
+        if (!cid || !printedExitFor.has(cid)) {
+          terminalLogPty.ensureNewline?.();
+          terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
+        }
+        if (cid) {
+          markPrintedExitFor(cid);
         }
       }
     } catch (e) {


### PR DESCRIPTION
Avoids double-printing `[Process exited with code …]` when both `BashOutput.exit_code` and a later `BashExit` arrive for the same `command_id`.

- Guards the BashExit footer print with `!printedExitFor.has(command_id)`
- Still bumps recency via `markPrintedExitFor`

Tests:
- npm test
- npm run typecheck
- npm run lint
