### PR TITLE
[oh-tab-rvxn] Centralize DEFAULT_HAL_STATE

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { SettingsManager, type OpenHandsSettings } from './settings/SettingsMana
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from './shared/halTeleport';
 import { type HalStateSnapshot, isElevenLabsMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
+import { DEFAULT_HAL_STATE } from './shared/halDefaults';
 import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { safeStringify } from './shared/safeStringify';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, isValidPastedImageId } from './shared/pastedImages';
@@ -60,16 +61,6 @@ const DEFAULT_UI_STATE: UiStateSnapshot = {
   selectedContextFiles: [],
   skillsCount: 0,
   attachmentsCount: 0,
-};
-
-const DEFAULT_HAL_STATE: HalStateSnapshot = {
-  enabled: false,
-  mode: 'tts_only',
-  phase: 'idle',
-  eye: 'off',
-  stepIndex: null,
-  decision: null,
-  lastError: null,
 };
 
 let chatView: vscode.WebviewView | undefined;

--- a/src/shared/halDefaults.ts
+++ b/src/shared/halDefaults.ts
@@ -1,0 +1,12 @@
+import type { HalStateSnapshot } from './halTypes';
+
+export const DEFAULT_HAL_STATE: HalStateSnapshot = {
+  enabled: false,
+  mode: 'tts_only',
+  phase: 'idle',
+  eye: 'off',
+  stepIndex: null,
+  decision: null,
+  lastError: null,
+};
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -18,6 +18,7 @@ import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/
 import { getHalDialogueLinesForMode, normalizeHalUserName, type HalScriptLine, type HalVoice } from '../../shared/halScript';
 import { getVscodeApi } from '../shared/vscodeApi';
 import { MAX_RENDERED_EVENTS } from '../shared/constants';
+import { DEFAULT_HAL_STATE } from '../../shared/halDefaults';
 
 // Component imports
 import { Header } from './Header';
@@ -78,15 +79,6 @@ type ElevenLabsSettingsSnapshot = {
 };
 
 const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1 };
-const DEFAULT_HAL_STATE: HalStateSnapshot = {
-  enabled: false,
-  mode: DEFAULT_ELEVENLABS_SETTINGS.mode,
-  phase: 'idle',
-  eye: 'off',
-  stepIndex: null,
-  decision: null,
-  lastError: null,
-};
 
 type HalUiState = Pick<HalStateSnapshot, 'phase' | 'eye' | 'stepIndex' | 'decision' | 'lastError'>;
 


### PR DESCRIPTION
Bead: `oh-tab-rvxn`

- Added `src/shared/halDefaults.ts` exporting `DEFAULT_HAL_STATE`.
- Updated host (`src/extension.ts`) + webview (`src/webview-src/components/App.tsx`) to import the shared default (removes duplication).
- No behavior changes (values identical).

Local verification:
- `npm test`
- `npm run typecheck`
- `npm run lint`
