### PR TITLE
Add tool-call summarization setting (oh-tab-ucx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -304,10 +304,16 @@
             "order": 2,
             "markdownDescription": "Enable local-mode debug events (e.g., llm_request/tool_call_raw)."
           },
-          "openhands.devBridge.enabled": {
+          "openhands.agent.summarizeToolCalls": {
             "type": "boolean",
             "default": false,
             "order": 3,
+            "markdownDescription": "Generate short `gemini-flash` summaries for tool calls (requires a Gemini API key)."
+          },
+          "openhands.devBridge.enabled": {
+            "type": "boolean",
+            "default": false,
+            "order": 4,
             "markdownDescription": "Enable webview→extension debug logging bridge (Output channel + file in extension log path)."
           }
         }

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -327,6 +327,35 @@ describe('Chat view behavior', () => {
     // Mode switches clear the saved id for the target scope so no implicit restore can occur later.
     expect(mockContext.workspaceState.update).toHaveBeenCalledWith('openhands.conversationId.local', undefined);
   });
+
+  it('auto-disables tool-call summarization when Gemini key is missing (local mode)', async () => {
+    const priorEnv = process.env.GEMINI_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+    try {
+      mockSettings = {
+        ...mockSettings,
+        serverUrl: '',
+        llm: { ...mockSettings.llm, provider: 'openai' },
+        agent: { ...mockSettings.agent, summarizeToolCalls: true },
+      };
+
+      const view = await resolveChatView(mockContext);
+      expect(mockSettings.agent.summarizeToolCalls).toBe(false);
+
+      const posted = (view.webview.postMessage as Mock).mock.calls.map((call) => call[0]);
+      expect(posted).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'statusMessage',
+            level: 'error',
+            message: expect.stringContaining('tool summarization disabled'),
+          }),
+        ])
+      );
+    } finally {
+      if (priorEnv !== undefined) process.env.GEMINI_API_KEY = priorEnv;
+    }
+  });
 });
 
 describe('Command handlers', () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -575,11 +575,51 @@ export function activate(context: vscode.ExtensionContext) {
 
   async function ensureConversationAndConnection(options?: { uiJustCreated?: boolean; modeSwitched?: boolean }) {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-    const settings = await settingsMgr.get();
+    let settings = await settingsMgr.get();
     lastKnownLlmLabel = resolveConfiguredLlmLabel(settings);
 
     const cfg = vscode.workspace.getConfiguration();
     verboseEventLogging = Boolean(settings.agent?.debug) || Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
+
+    if (!settings.serverUrl && settings.agent?.summarizeToolCalls === true) {
+      const hasGeminiKey = await (async (): Promise<boolean> => {
+        let storedGeminiKey: string | undefined;
+        try {
+          storedGeminiKey = await context.secrets.get('GEMINI_API_KEY');
+        } catch {
+          storedGeminiKey = undefined;
+        }
+        if (typeof storedGeminiKey === 'string' && storedGeminiKey.trim()) return true;
+        if (typeof process.env.GEMINI_API_KEY === 'string' && process.env.GEMINI_API_KEY.trim()) return true;
+
+        // If the main agent LLM is configured to use Gemini, allow the generic LLM key as well.
+        if (settings.llm.provider === 'gemini') {
+          const mainKey = settings.secrets.llmApiKey;
+          if (typeof mainKey === 'string' && mainKey.trim()) return true;
+        }
+
+        return false;
+      })();
+
+      if (!hasGeminiKey) {
+        try {
+          await settingsMgr.update({ agent: { ...settings.agent, summarizeToolCalls: false } });
+          settings = await settingsMgr.get();
+        } catch (err) {
+          outputChannel?.appendLine(`[settings] Failed to auto-disable tool summarization: ${renderError(err)}`);
+        }
+
+        if (chatView) {
+          void chatView.webview.postMessage({
+            type: 'statusMessage',
+            level: 'error',
+            message: 'No Gemini key found, tool summarization disabled',
+            autoDismiss: true,
+            autoDismissDelay: 5000,
+          } satisfies HostToWebviewMessage);
+        }
+      }
+    }
 
     const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = workspaceRoot;

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -48,7 +48,7 @@ const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
   servers: [],
   llm: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
-  agent: { enableSecurityAnalyzer: false, debug: false },
+  agent: { enableSecurityAnalyzer: false, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
   elevenlabs: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },
@@ -212,6 +212,7 @@ export class SettingsManager {
     const agent: AgentSettings = {
       enableSecurityAnalyzer: this.adapter.get<boolean>('openhands.agent.enableSecurityAnalyzer', DEFAULTS.agent.enableSecurityAnalyzer) ?? DEFAULTS.agent.enableSecurityAnalyzer,
       debug: this.adapter.get<boolean>('openhands.agent.debug', DEFAULTS.agent.debug) ?? DEFAULTS.agent.debug,
+      summarizeToolCalls: this.adapter.get<boolean>('openhands.agent.summarizeToolCalls', DEFAULTS.agent.summarizeToolCalls) ?? DEFAULTS.agent.summarizeToolCalls,
     };
     const conversation: ConversationSettings = {
       maxIterations: this.adapter.get<number>('openhands.conversation.maxIterations', DEFAULTS.conversation.maxIterations) ?? DEFAULTS.conversation.maxIterations,
@@ -303,6 +304,9 @@ export class SettingsManager {
       }
       if (partial.agent.debug !== undefined) {
         ops.push(this.adapter.update('openhands.agent.debug', partial.agent.debug, target));
+      }
+      if (partial.agent.summarizeToolCalls !== undefined) {
+        ops.push(this.adapter.update('openhands.agent.summarizeToolCalls', partial.agent.summarizeToolCalls, target));
       }
     }
 

--- a/src/settings/host/createConfigurationChangeHandler.ts
+++ b/src/settings/host/createConfigurationChangeHandler.ts
@@ -71,6 +71,15 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
       deps.setVerboseEventLogging(debug || devBridgeEnabled);
     }
 
+    if (e.affectsConfiguration('openhands.agent.summarizeToolCalls')) {
+      try {
+        await deps.ensureConversationAndConnection();
+        deps.getOutputChannel()?.appendLine('[settings] Tool-call summarization setting updated');
+      } catch (err: unknown) {
+        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply tool-call summarization update: ${deps.renderError(err)}`);
+      }
+    }
+
     if (e.affectsConfiguration('openhands.llm')) {
       try {
         await deps.ensureConversationAndConnection();

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -10,6 +10,7 @@ export type HostToWebviewMessage =
     llmModel?: string | null;
   }
   | { type: 'error'; error: string }
+  | { type: 'statusMessage'; level: 'info' | 'warn' | 'error'; message: string; autoDismiss?: boolean; autoDismissDelay?: number }
   | { type: 'llmProfilesUpdated'; profiles: string[]; activeProfileId: string | null }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
   | { type: 'elevenlabsSettings'; elevenlabs: OpenHandsSettings['elevenlabs'] }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -61,6 +61,8 @@ type StatusBannerState = {
   message: string;
   level: 'info' | 'warn' | 'error';
   dismissible?: boolean;
+  autoDismiss?: boolean;
+  autoDismissDelay?: number;
 };
 
 type InlineImageAttachment = {
@@ -461,14 +463,18 @@ export function App() {
   }, [elevenlabs.mode, halDecision, halEnabled, halEye, halLastError, halPhase, halStepIndex]);
 
   // Show status message with debouncing
-  const showStatusMessage = useCallback((level: 'info' | 'warn' | 'error', message: string) => {
+  const showStatusMessage = useCallback((
+    level: 'info' | 'warn' | 'error',
+    message: string,
+    options?: { autoDismiss?: boolean; autoDismissDelay?: number },
+  ) => {
     const now = Date.now();
     const prev = lastStatusMessageRef.current;
     if (prev.level === level && prev.message === message && now - prev.at < STATUS_DEBOUNCE_MS) {
       return;
     }
     lastStatusMessageRef.current = { level, message, at: now };
-    setStatusBanner({ message, level });
+    setStatusBanner({ message, level, autoDismiss: options?.autoDismiss, autoDismissDelay: options?.autoDismissDelay });
   }, []);
 
   const handlePasteImageFiles = useCallback(async (files: File[]) => {
@@ -1155,6 +1161,10 @@ export function App() {
         conversations?: ConversationsList;
         servers?: { url: string; label?: string }[];
         attachments?: Array<{ uri: string; label: string; sizeBytes?: number }>;
+        level?: unknown;
+        message?: unknown;
+        autoDismiss?: unknown;
+        autoDismissDelay?: unknown;
       };
 
       switch (payload?.type) {
@@ -1194,6 +1204,18 @@ export function App() {
             }
           }
           break;
+        case 'statusMessage': {
+          const level = payload.level;
+          const message = payload.message;
+          if ((level === 'info' || level === 'warn' || level === 'error') && typeof message === 'string' && message.trim()) {
+            const autoDismiss = payload.autoDismiss === true;
+            const autoDismissDelay = typeof payload.autoDismissDelay === 'number' && Number.isFinite(payload.autoDismissDelay)
+              ? Math.max(0, payload.autoDismissDelay)
+              : undefined;
+            showStatusMessage(level, message.trim(), { autoDismiss, autoDismissDelay });
+          }
+          break;
+        }
         case 'llmProfilesUpdated': {
           if (Array.isArray(payload.profiles)) {
             setLlmProfiles(payload.profiles.filter((id): id is string => typeof id === 'string'));
@@ -1939,7 +1961,8 @@ export function App() {
               level={statusBanner.level}
               dismissible={statusBanner.dismissible}
               onDismiss={() => setStatusBanner(null)}
-              autoDismiss={statusBanner.level !== 'error'}
+              autoDismiss={statusBanner.autoDismiss ?? statusBanner.level !== 'error'}
+              autoDismissDelay={statusBanner.autoDismissDelay}
             />
           )}
         </div>

--- a/src/webview-src/components/StatusBanner.tsx
+++ b/src/webview-src/components/StatusBanner.tsx
@@ -18,11 +18,10 @@ export function StatusBanner({
   autoDismissDelay = 5000,
 }: StatusBannerProps) {
   useEffect(() => {
-    if (autoDismiss && level !== 'error') {
-      const timer = setTimeout(onDismiss, autoDismissDelay);
-      return () => clearTimeout(timer);
-    }
-  }, [autoDismiss, autoDismissDelay, level, onDismiss]);
+    if (!autoDismiss) return;
+    const timer = setTimeout(onDismiss, autoDismissDelay);
+    return () => clearTimeout(timer);
+  }, [autoDismiss, autoDismissDelay, onDismiss]);
 
   const levelConfig = {
     info: {


### PR DESCRIPTION
Adds VS Code setting `openhands.agent.summarizeToolCalls` and wires it through SettingsManager + host/webview messaging.

Local mode UX: if enabled but no Gemini key is configured, it auto-disables the setting and shows a short banner so users aren’t stuck with silent failures.

Tests: adds coverage for the auto-disable behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added configurable tool-call summarization feature for agent operations
  - Chat status messages now auto-dismiss with customizable timeout settings

* **Bug Fixes**
  - Tool summarization automatically disables when required API key is unavailable

* **Configuration**
  - Updated agent settings organization and ordering

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->