### PR TITLE
Centralize paste limits constants (oh-tab-jjub)

### DIFF
--- a/src/shared/pasteLimits.ts
+++ b/src/shared/pasteLimits.ts
@@ -1,0 +1,3 @@
+export const MAX_PASTED_IMAGE_BYTES = 350 * 1024;
+export const MAX_PASTED_IMAGES = 4;
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -19,6 +19,7 @@ import { getHalDialogueLinesForMode, normalizeHalUserName, type HalScriptLine, t
 import { getVscodeApi } from '../shared/vscodeApi';
 import { MAX_RENDERED_EVENTS } from '../shared/constants';
 import { DEFAULT_HAL_STATE } from '../../shared/halDefaults';
+import { MAX_PASTED_IMAGE_BYTES, MAX_PASTED_IMAGES } from '../../shared/pasteLimits';
 
 // Component imports
 import { Header } from './Header';
@@ -94,9 +95,6 @@ const DEFAULT_HAL_UI_STATE: HalUiState = {
 
 const DEFAULT_BUNDLED_DIALOGUE_DELAY_MS = 650;
 const DEFAULT_BUNDLED_AUDIO_EXTENSION = 'wav';
-
-const MAX_PASTED_IMAGE_BYTES = 350 * 1024;
-const MAX_PASTED_IMAGES = 4;
 
 function readBlobAsDataUrl(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -11,6 +11,7 @@ import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLinesForMode } from '../../shared/halScript';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
+import { MAX_PASTED_IMAGE_BYTES } from '../../shared/pasteLimits';
 import type { HostToWebviewMessage, WebviewToHostMessage } from '../../shared/webviewMessages';
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
 import { getConversationHistoryList } from './conversationHistory';
@@ -22,8 +23,6 @@ import { resolveWorkspaceFilePath } from './workspacePaths';
 export type WebviewHost = {
   postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
 };
-
-const MAX_PASTED_IMAGE_BYTES = 350 * 1024;
 
 async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
   const filePath = getPastedImagePath(baseDir, imageId);


### PR DESCRIPTION
Refactor only: centralizes paste limits constants to avoid drift between host and webview.

- Adds `src/shared/pasteLimits.ts` exporting `MAX_PASTED_IMAGE_BYTES` (350KB) and `MAX_PASTED_IMAGES` (4)
- Updates host + webview to import these constants
- No behavior/message changes intended

Local checks: `npm test`, `npm run typecheck`, `npm run lint` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized paste image limit settings into a shared location for more consistent behavior across the app. No functional changes or user-facing behavior differences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->