### PR TITLE
[oh-tab-l6nq] OpenAI Responses: encrypted reasoning round-trip

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -230,7 +230,7 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     expect(response.message.responses_reasoning_item).toMatchObject({ id: 'rs_1', summary: ['short summary'], encrypted_content: 'encrypted' });
   });
 
-  it('does not include responses_reasoning_item in Responses request input (store=false)', async () => {
+  it('requests reasoning.encrypted_content include for stateless Responses', async () => {
     const payload = {
       output: [
         {
@@ -263,8 +263,54 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
     const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
     expect(body?.store).toBe(false);
+    expect(body?.include).toEqual(['reasoning.encrypted_content']);
+  });
+
+  it('only re-sends responses_reasoning_item when encrypted_content is present (store=false)', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient(baseConfig, 'test-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    await orchestrator.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'previous answer' }],
+          responses_reasoning_item: { id: 'rs_1', summary: ['short summary'] },
+        },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'previous answer 2' }],
+          responses_reasoning_item: { id: 'rs_2', summary: ['short summary'], encrypted_content: 'encrypted' },
+        },
+        { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+      ],
+      tools: [{ type: 'function', function: { name: 'ping' } }],
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    expect(body?.store).toBe(false);
     expect(Array.isArray(body?.input)).toBe(true);
-    expect(body?.input?.some((item: { type?: unknown }) => item.type === 'reasoning')).toBe(false);
+    expect(body?.input?.some((item: { type?: unknown; id?: unknown }) => item.type === 'reasoning' && item.id === 'rs_1')).toBe(false);
+    expect(body?.input?.some((item: { type?: unknown; id?: unknown; encrypted_content?: unknown }) => (
+      item.type === 'reasoning'
+        && item.id === 'rs_2'
+        && item.encrypted_content === 'encrypted'
+    ))).toBe(true);
   });
 
   it('includes reasoning summary in Responses request body when configured', async () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -230,6 +230,43 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     expect(response.message.responses_reasoning_item).toMatchObject({ id: 'rs_1', summary: ['short summary'], encrypted_content: 'encrypted' });
   });
 
+  it('does not include responses_reasoning_item in Responses request input (store=false)', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient(baseConfig, 'test-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    await orchestrator.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'previous answer' }],
+          responses_reasoning_item: { id: 'rs_1', summary: ['short summary'] },
+        },
+        { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+      ],
+      tools: [{ type: 'function', function: { name: 'ping' } }],
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    expect(body?.store).toBe(false);
+    expect(Array.isArray(body?.input)).toBe(true);
+    expect(body?.input?.some((item: { type?: unknown }) => item.type === 'reasoning')).toBe(false);
+  });
+
   it('includes reasoning summary in Responses request body when configured', async () => {
     const payload = {
       output: [

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -38,10 +38,18 @@ type ResponsesFunctionCallOutputInputItem = {
   output: string;
 };
 
+type ResponsesReasoningInputItem = {
+  type: 'reasoning';
+  id: string;
+  summary: Array<{ type: 'summary_text'; text: string }>;
+  encrypted_content: string;
+};
+
 type ResponsesInputItem =
   | ResponsesMessageInputItem
   | ResponsesFunctionCallInputItem
-  | ResponsesFunctionCallOutputInputItem;
+  | ResponsesFunctionCallOutputInputItem
+  | ResponsesReasoningInputItem;
 
 type ResponsesToolParam = {
   type: 'function';
@@ -100,6 +108,24 @@ const toResponsesTool = (tool: LLMToolDefinition): ResponsesToolParam => ({
   strict: false,
 });
 
+const toResponsesReasoningInputItem = (reasoning: ResponsesReasoningItem): ResponsesReasoningInputItem | undefined => {
+  if (!reasoning.id) return undefined;
+
+  // In stateless mode (store=false) we can only safely re-send reasoning items if the response included
+  // `encrypted_content` (requested via include: ['reasoning.encrypted_content']). Otherwise OpenAI treats
+  // the `rs_*` id as a server-stored reference and returns 404 when store=false.
+  const encrypted = typeof reasoning.encrypted_content === 'string' ? reasoning.encrypted_content.trim() : '';
+  if (!encrypted) return undefined;
+
+  const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text' as const, text }));
+  return {
+    type: 'reasoning',
+    id: reasoning.id,
+    summary,
+    encrypted_content: encrypted,
+  };
+};
+
 const toResponsesInputItems = (messages: Message[]): ResponsesInputItem[] => {
   const items: ResponsesInputItem[] = [];
 
@@ -127,6 +153,11 @@ const toResponsesInputItems = (messages: Message[]): ResponsesInputItem[] => {
     }
 
     if (message.role === 'assistant') {
+      if (message.responses_reasoning_item) {
+        const reasoningItem = toResponsesReasoningInputItem(message.responses_reasoning_item);
+        if (reasoningItem) items.push(reasoningItem);
+      }
+
       const content: ResponsesMessageInputItem['content'] = [];
       for (const part of message.content) {
         if (part.type === 'text' && part.text) {
@@ -178,6 +209,7 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
   model: config.model,
   instructions: request.systemPrompt,
   input: toResponsesInputItems(request.messages),
+  include: ['reasoning.encrypted_content'],
   tools: request.tools?.length ? request.tools.map(toResponsesTool) : undefined,
   tool_choice: request.tools?.length ? 'auto' : undefined,
   store: false,

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -38,20 +38,10 @@ type ResponsesFunctionCallOutputInputItem = {
   output: string;
 };
 
-type ResponsesReasoningInputItem = {
-  type: 'reasoning';
-  id: string;
-  summary: Array<{ type: 'summary_text'; text: string }>;
-  content?: Array<{ type: 'reasoning_text'; text: string }>;
-  encrypted_content?: string;
-  status?: string;
-};
-
 type ResponsesInputItem =
   | ResponsesMessageInputItem
   | ResponsesFunctionCallInputItem
-  | ResponsesFunctionCallOutputInputItem
-  | ResponsesReasoningInputItem;
+  | ResponsesFunctionCallOutputInputItem;
 
 type ResponsesToolParam = {
   type: 'function';
@@ -110,20 +100,6 @@ const toResponsesTool = (tool: LLMToolDefinition): ResponsesToolParam => ({
   strict: false,
 });
 
-const toResponsesReasoningInputItem = (reasoning: ResponsesReasoningItem): ResponsesReasoningInputItem | undefined => {
-  if (!reasoning.id) return undefined;
-  const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text' as const, text }));
-  const content = reasoning.content?.length ? reasoning.content.map((text) => ({ type: 'reasoning_text' as const, text })) : undefined;
-  return {
-    type: 'reasoning',
-    id: reasoning.id,
-    summary,
-    ...(content ? { content } : {}),
-    ...(reasoning.encrypted_content ? { encrypted_content: reasoning.encrypted_content } : {}),
-    ...(reasoning.status ? { status: reasoning.status } : {}),
-  };
-};
-
 const toResponsesInputItems = (messages: Message[]): ResponsesInputItem[] => {
   const items: ResponsesInputItem[] = [];
 
@@ -151,11 +127,6 @@ const toResponsesInputItems = (messages: Message[]): ResponsesInputItem[] => {
     }
 
     if (message.role === 'assistant') {
-      if (message.responses_reasoning_item) {
-        const reasoningItem = toResponsesReasoningInputItem(message.responses_reasoning_item);
-        if (reasoningItem) items.push(reasoningItem);
-      }
-
       const content: ResponsesMessageInputItem['content'] = [];
       for (const part of message.content) {
         if (part.type === 'text' && part.text) {


### PR DESCRIPTION
Fixes a local-mode failure when using OpenAI `/v1/responses` in stateless mode (`store=false`).

**Problem**
- We were re-sending `responses_reasoning_item` as a `type: 'reasoning'` input item that only contained an `rs_*` id (and summary).
- With `store=false`, OpenAI does not persist items server-side, so `rs_*` cannot be resolved and the request fails with a 404 ("Items are not persisted when store is set to false...").

**Fix**
- Always request stateless reasoning continuity via `include: ['reasoning.encrypted_content']`.
- Only re-send a `type: 'reasoning'` input item when `responses_reasoning_item.encrypted_content` is present; otherwise omit it (prevents the `rs_*` 404).

**Changes**
- `packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts`
- `packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts`

**Tests**
- `npm test -w @openhands/agent-sdk-ts`

Bead: `oh-tab-l6nq`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying behavior when responses are sent stateless (store=false): requests include encrypted reasoning content and only resend reasoning items that contain encrypted content.

* **Chores**
  * Tightened reasoning input handling to require encrypted reasoning content and ensure stateless requests request encrypted reasoning content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
