### PR TITLE
scripts: add OpenAI Responses reasoning round-trip experiment

### DIFF
--- a/scripts/test-openai-responses-reasoning.mjs
+++ b/scripts/test-openai-responses-reasoning.mjs
@@ -1,0 +1,266 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * OpenAI Responses API: reasoning round-trip experiment
+ *
+ * Goal
+ * ----
+ * Empirically test how `/v1/responses` behaves in stateless mode (`store: false`)
+ * when we manually manage conversation context and "round-trip" reasoning items
+ * between turns.
+ *
+ * What we test
+ * ------------
+ * We run the same 3-turn conversation twice, varying how we send reasoning items
+ * back in the next request `input`:
+ *
+ * - mode=full:
+ *   Re-send the reasoning item with all fields we received (id, summary,
+ *   encrypted_content, content, status).
+ *
+ * - mode=minimal:
+ *   Re-send only the minimal subset used for stateless continuity:
+ *   (id, summary, encrypted_content).
+ *
+ * Why this matters
+ * ---------------
+ * With `store: false`, OpenAI does not persist response items server-side.
+ * If we send back a reasoning item that only references an `rs_*` id without
+ * the returned `encrypted_content`, OpenAI may treat it as a stored reference
+ * and respond with 404 ("Items are not persisted when store is set to false...").
+ *
+ * Security / secrets
+ * ------------------
+ * - This script reads ONLY `OPENAI_API_KEY` from the environment and never prints it.
+ * - It does NOT read `.env` itself. Export `OPENAI_API_KEY` before running.
+ *
+ * Usage
+ * -----
+ *   # Option A: export the key explicitly
+ *   export OPENAI_API_KEY="..."
+ *   node scripts/test-openai-responses-reasoning.mjs minimal
+ *
+ *   # Option B (shell): source the repo .env for your current shell, then run
+ *   set -a; source .env; set +a
+ *   node scripts/test-openai-responses-reasoning.mjs full
+ *
+ * Modes: "full" | "minimal" | "both" (default: both)
+ */
+
+const OPENAI_RESPONSES_URL = 'https://api.openai.com/v1/responses';
+const MODEL = 'gpt-5-mini';
+
+const MODE_FULL = 'full';
+const MODE_MINIMAL = 'minimal';
+const MODE_BOTH = 'both';
+
+const MAX_OUTPUT_TOKENS = 350;
+
+const apiKey = process.env.OPENAI_API_KEY;
+if (typeof apiKey !== 'string' || apiKey.trim() === '') {
+  console.error('Missing OPENAI_API_KEY in environment.');
+  console.error('Set it via: export OPENAI_API_KEY="..."');
+  process.exit(1);
+}
+
+const safeJson = (value) => JSON.stringify(value, null, 2);
+
+const summarizeReasoningForLog = (item) => {
+  const summary = Array.isArray(item.summary)
+    ? item.summary
+      .map((s) => (s && typeof s === 'object' && typeof s.text === 'string' ? s.text : null))
+      .filter(Boolean)
+    : [];
+
+  const contentCount = Array.isArray(item.content) ? item.content.length : 0;
+  const encrypted = typeof item.encrypted_content === 'string' ? item.encrypted_content : null;
+
+  return {
+    id: typeof item.id === 'string' ? item.id : null,
+    status: typeof item.status === 'string' ? item.status : null,
+    summary,
+    content_count: contentCount,
+    encrypted_content: encrypted ? `<redacted len=${encrypted.length}>` : null,
+  };
+};
+
+const normalizeMessageForInput = (messageOutputItem) => {
+  const role = messageOutputItem.role === 'assistant' ? 'assistant' : 'assistant';
+  const content = Array.isArray(messageOutputItem.content) ? messageOutputItem.content : [];
+
+  const normalizedContent = content
+    .filter((part) => part && typeof part === 'object' && part.type === 'output_text' && typeof part.text === 'string')
+    .map((part) => ({ type: 'output_text', text: part.text }));
+
+  return {
+    type: 'message',
+    role,
+    content: normalizedContent.length ? normalizedContent : [{ type: 'output_text', text: '' }],
+  };
+};
+
+const normalizeReasoningForInput = (reasoningOutputItem, mode) => {
+  const id = typeof reasoningOutputItem.id === 'string' ? reasoningOutputItem.id : '';
+  const summary = Array.isArray(reasoningOutputItem.summary) ? reasoningOutputItem.summary : [];
+  const encrypted_content = typeof reasoningOutputItem.encrypted_content === 'string' ? reasoningOutputItem.encrypted_content : null;
+
+  // Keep the object as close to the API schema as possible.
+  const base = {
+    type: 'reasoning',
+    id,
+    summary,
+    encrypted_content,
+  };
+
+  if (mode === MODE_MINIMAL) {
+    return base;
+  }
+
+  // mode=full
+  const content = Array.isArray(reasoningOutputItem.content) ? reasoningOutputItem.content : undefined;
+  const status = typeof reasoningOutputItem.status === 'string' ? reasoningOutputItem.status : undefined;
+  return {
+    ...base,
+    ...(content ? { content } : {}),
+    ...(status ? { status } : {}),
+  };
+};
+
+const extractOutputItems = (responseJson) => (Array.isArray(responseJson.output) ? responseJson.output : []);
+
+const extractReasoningItems = (outputItems) => outputItems.filter((item) => item && typeof item === 'object' && item.type === 'reasoning');
+
+const extractAssistantMessageItems = (outputItems) => outputItems.filter((item) => item && typeof item === 'object' && item.type === 'message');
+
+const extractAssistantText = (outputItems) => {
+  const parts = [];
+  for (const item of outputItems) {
+    if (!item || typeof item !== 'object') continue;
+    if (item.type !== 'message') continue;
+    const content = Array.isArray(item.content) ? item.content : [];
+    for (const part of content) {
+      if (!part || typeof part !== 'object') continue;
+      if (part.type === 'output_text' && typeof part.text === 'string') parts.push(part.text);
+    }
+  }
+  return parts.join('\n').trim();
+};
+
+const callResponses = async ({ input, reasoningModeLabel }) => {
+  const body = {
+    model: MODEL,
+    input,
+    store: false,
+    include: ['reasoning.encrypted_content'],
+    reasoning: { effort: 'medium', summary: 'detailed' },
+    max_output_tokens: MAX_OUTPUT_TOKENS,
+  };
+
+  const res = await fetch(OPENAI_RESPONSES_URL, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+
+  if (!res.ok) {
+    const message = json?.error?.message || `HTTP ${res.status}`;
+    const type = json?.error?.type || null;
+    console.error(`[${reasoningModeLabel}] /v1/responses error: ${message}${type ? ` (type=${type})` : ''}`);
+    if (json?.error) {
+      // Safe to print; do not include request headers/body.
+      console.error(`[${reasoningModeLabel}] error payload:\n${safeJson(json.error)}`);
+    }
+    throw new Error(message);
+  }
+
+  return json;
+};
+
+const runConversation = async (mode) => {
+  console.log(`\n=== OpenAI Responses reasoning experiment: mode=${mode} ===`);
+  console.log(`model=${MODEL}, store=false, include=[reasoning.encrypted_content], reasoning.summary=detailed`);
+
+  const prompts = [
+    'Tell a short story about Napoleon. Keep it under ~120 words.',
+    'Analyze historical events related to his return to the throne (the Hundred Days). Keep it under ~150 words.',
+    'Think deeply about those events and give an opinion on how lessons from them can help us today. Keep it under ~150 words.',
+  ];
+
+  /** @type {any[]} */
+  const input = [];
+
+  for (let turn = 0; turn < prompts.length; turn += 1) {
+    const userText = prompts[turn];
+    input.push({
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: userText }],
+    });
+
+    console.log(`\n--- Turn ${turn + 1} request ---`);
+    console.log(`user: ${userText}`);
+
+    const responseJson = await callResponses({ input, reasoningModeLabel: mode });
+    const outputItems = extractOutputItems(responseJson);
+
+    const assistantText = extractAssistantText(outputItems);
+    const reasoningItems = extractReasoningItems(outputItems);
+    const messageItems = extractAssistantMessageItems(outputItems);
+
+    console.log(`\n--- Turn ${turn + 1} response ---`);
+    console.log(`output items: ${outputItems.length} (${outputItems.map((i) => i?.type).filter(Boolean).join(', ')})`);
+    console.log(`assistant text (${assistantText.length} chars):\n${assistantText}\n`);
+
+    if (reasoningItems.length) {
+      console.log(`reasoning items: ${reasoningItems.length}`);
+      for (const item of reasoningItems) {
+        console.log(safeJson(summarizeReasoningForLog(item)));
+      }
+    } else {
+      console.log('reasoning items: none');
+    }
+
+    // Append reasoning + assistant message(s) into the next request context.
+    // This is where we vary behavior based on `mode`.
+    for (const item of reasoningItems) {
+      const normalized = normalizeReasoningForInput(item, mode);
+      input.push(normalized);
+    }
+    for (const item of messageItems) {
+      input.push(normalizeMessageForInput(item));
+    }
+  }
+
+  console.log(`\n=== Completed mode=${mode} without request errors ===`);
+};
+
+const main = async () => {
+  const modeArg = (process.argv[2] || MODE_BOTH).toLowerCase();
+  const mode = [MODE_FULL, MODE_MINIMAL, MODE_BOTH].includes(modeArg) ? modeArg : MODE_BOTH;
+
+  if (mode === MODE_BOTH) {
+    await runConversation(MODE_FULL);
+    await runConversation(MODE_MINIMAL);
+    return;
+  }
+
+  await runConversation(mode);
+};
+
+main().catch((err) => {
+  console.error(err?.stack || String(err));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
Adds a standalone experiment script to validate OpenAI `/v1/responses` stateless multi-turn behavior when round-tripping reasoning items.

- Script: `scripts/test-openai-responses-reasoning.mjs`
- Safety: reads **only** `OPENAI_API_KEY` from env and never prints it.
- Runs two modes:
  - `full`: re-send reasoning items with all returned fields
  - `minimal`: re-send only `id` + `summary` + `encrypted_content`

How to run:
- `set -a; source .env; set +a; node scripts/test-openai-responses-reasoning.mjs both`

Notes:
- The script uses `include: ['reasoning.encrypted_content']` and `store: false`.
- Reasoning summaries are logged; `encrypted_content` is redacted in logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new test script for OpenAI Responses reasoning round-trip experiments.
  * Supports full and minimal reasoning modes for API validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->