### PR TITLE
[oh-tab-txe6] Skills popover icons use brand color

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -120,6 +120,11 @@ describe('App toolbar interactions', () => {
       }));
     });
 
+    const skillOption = screen.getByRole('option', { name: 'Example Skill' });
+    const icon = skillOption.querySelector('.codicon-file-code');
+    expect(icon).toBeTruthy();
+    expect(icon).toHaveClass('text-brand-400/70');
+
     fireEvent.click(screen.getByText('Example Skill'));
     expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'openSkill', path: '/tmp/skill.md' });
   });

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -687,7 +687,7 @@ export function SkillsPopover({
       {/* Header */}
       <div className="px-4 py-3 border-b border-white/[0.06]">
         <div className="flex items-center gap-2">
-          <span className="codicon codicon-mortar-board text-violet-400" />
+          <span className="codicon codicon-mortar-board text-brand-400" />
           <h3 className="font-semibold text-sm text-stone-200">Available Skills</h3>
         </div>
         <input
@@ -737,7 +737,7 @@ export function SkillsPopover({
                 `}
                 data-active={isActive ? 'true' : 'false'}
               >
-                <span className="codicon codicon-file-code text-violet-400/70" />
+                <span className="codicon codicon-file-code text-brand-400/70" />
                 <span className="flex-1 truncate">{skill.label}</span>
                 <span className="codicon codicon-arrow-right text-stone-600 group-hover:text-stone-400 transition-colors" />
               </button>


### PR DESCRIPTION
Fixes `oh-tab-txe6`.

- Skills popover: skill item icon + header icon now use the OpenHands brand (gold) accent.
- Adds a unit test assertion to prevent icon color regressions.

Tests:
- `npx vitest run src/webview-src/__tests__/App.toolbar.test.tsx`
