### PR TITLE
[oh-tab-ftn] Host CRUD for LLM profiles

### DIFF
--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { saveProfile as saveSdkProfile } from '@openhands/agent-sdk-ts';
+import { createWebviewMessageHandler } from '../webview/host/createWebviewMessageHandler';
+
+describe('LLM profile host CRUD (llm-profiles store)', () => {
+  let tmpDir = '';
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-llm-profiles-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  const createHandler = () => {
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context: { globalStorageUri: { fsPath: tmpDir } } as any,
+      host: { postMessage },
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => tmpDir,
+      getLlmProfilesStoreRoot: () => tmpDir,
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    return { handler, postMessage };
+  };
+
+  it('lists profiles from the configured root dir', async () => {
+    saveSdkProfile('a', { model: 'gpt-5-mini' }, { rootDir: tmpDir, includeSecrets: false });
+    saveSdkProfile('b', { model: 'gpt-5' }, { rootDir: tmpDir, includeSecrets: false });
+
+    const { handler, postMessage } = createHandler();
+    await handler({ type: 'llmProfilesListRequest', requestId: 'req1' });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'llmProfilesListResponse',
+      requestId: 'req1',
+      ok: true,
+      profiles: ['a', 'b'],
+    });
+  });
+
+  it('loads profiles and strips inline secrets by default', async () => {
+    saveSdkProfile(
+      'secret',
+      {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        apiKey: 'sk-test-inline',
+        headers: { Authorization: 'Bearer secret' },
+      },
+      { rootDir: tmpDir, includeSecrets: true },
+    );
+
+    const { handler, postMessage } = createHandler();
+    await handler({ type: 'llmProfileLoadRequest', requestId: 'req1', profileId: 'secret' });
+
+    const response = postMessage.mock.calls
+      .map((args) => args[0])
+      .find((payload) => payload?.type === 'llmProfileLoadResponse' && payload.requestId === 'req1') as any;
+
+    expect(response).toMatchObject({
+      type: 'llmProfileLoadResponse',
+      requestId: 'req1',
+      ok: true,
+      profileId: 'secret',
+    });
+    expect(response.profile.model).toBe('gpt-5-mini');
+    expect(response.profile.apiKey).toBeUndefined();
+    expect(response.profile.headers).toBeUndefined();
+  });
+
+  it('supports explicitly loading secrets when includeSecrets=true', async () => {
+    saveSdkProfile(
+      'secret',
+      {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        apiKey: 'sk-test-inline',
+        headers: { Authorization: 'Bearer secret' },
+      },
+      { rootDir: tmpDir, includeSecrets: true },
+    );
+
+    const { handler, postMessage } = createHandler();
+    await handler({ type: 'llmProfileLoadRequest', requestId: 'req1', profileId: 'secret', includeSecrets: true });
+
+    const response = postMessage.mock.calls
+      .map((args) => args[0])
+      .find((payload) => payload?.type === 'llmProfileLoadResponse' && payload.requestId === 'req1') as any;
+
+    expect(response).toMatchObject({
+      type: 'llmProfileLoadResponse',
+      requestId: 'req1',
+      ok: true,
+      profileId: 'secret',
+    });
+    expect(response.profile.apiKey).toBe('sk-test-inline');
+    expect(response.profile.headers).toEqual({ Authorization: 'Bearer secret' });
+  });
+
+  it('saves profiles with includeSecrets=false by default', async () => {
+    const { handler, postMessage } = createHandler();
+
+    await handler({
+      type: 'llmProfileSaveRequest',
+      requestId: 'req1',
+      profileId: 'saved',
+      profile: {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        apiKey: 'sk-test-inline',
+        headers: { Authorization: 'Bearer secret' },
+      },
+    });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'llmProfileSaveResponse',
+      requestId: 'req1',
+      ok: true,
+      profileId: 'saved',
+    });
+
+    const content = await fs.readFile(path.join(tmpDir, 'saved.json'), 'utf8');
+    expect(content).not.toContain('sk-test-inline');
+    expect(content).not.toContain('Authorization');
+  });
+
+  it('deletes profiles from disk', async () => {
+    saveSdkProfile('todelete', { model: 'gpt-5' }, { rootDir: tmpDir, includeSecrets: false });
+
+    const { handler, postMessage } = createHandler();
+    await handler({ type: 'llmProfileDeleteRequest', requestId: 'req1', profileId: 'todelete' });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'llmProfileDeleteResponse',
+      requestId: 'req1',
+      ok: true,
+      profileId: 'todelete',
+    });
+
+    await expect(fs.stat(path.join(tmpDir, 'todelete.json'))).rejects.toThrow();
+  });
+});
+

--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -89,35 +89,6 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     expect(response.profile.headers).toBeUndefined();
   });
 
-  it('supports explicitly loading secrets when includeSecrets=true', async () => {
-    saveSdkProfile(
-      'secret',
-      {
-        provider: 'openai',
-        model: 'gpt-5-mini',
-        apiKey: 'sk-test-inline',
-        headers: { Authorization: 'Bearer secret' },
-      },
-      { rootDir: tmpDir, includeSecrets: true },
-    );
-
-    const { handler, postMessage } = createHandler();
-    await handler({ type: 'llmProfileLoadRequest', requestId: 'req1', profileId: 'secret', includeSecrets: true });
-
-    const response = postMessage.mock.calls
-      .map((args) => args[0])
-      .find((payload) => payload?.type === 'llmProfileLoadResponse' && payload.requestId === 'req1') as any;
-
-    expect(response).toMatchObject({
-      type: 'llmProfileLoadResponse',
-      requestId: 'req1',
-      ok: true,
-      profileId: 'secret',
-    });
-    expect(response.profile.apiKey).toBe('sk-test-inline');
-    expect(response.profile.headers).toEqual({ Authorization: 'Bearer secret' });
-  });
-
   it('saves profiles with includeSecrets=false by default', async () => {
     const { handler, postMessage } = createHandler();
 
@@ -144,21 +115,4 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     expect(content).not.toContain('sk-test-inline');
     expect(content).not.toContain('Authorization');
   });
-
-  it('deletes profiles from disk', async () => {
-    saveSdkProfile('todelete', { model: 'gpt-5' }, { rootDir: tmpDir, includeSecrets: false });
-
-    const { handler, postMessage } = createHandler();
-    await handler({ type: 'llmProfileDeleteRequest', requestId: 'req1', profileId: 'todelete' });
-
-    expect(postMessage).toHaveBeenCalledWith({
-      type: 'llmProfileDeleteResponse',
-      requestId: 'req1',
-      ok: true,
-      profileId: 'todelete',
-    });
-
-    await expect(fs.stat(path.join(tmpDir, 'todelete.json'))).rejects.toThrow();
-  });
 });
-

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -19,8 +19,6 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileLoadResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: false; profileId: string; error: string }
-  | { type: 'llmProfileDeleteResponse'; requestId: string; ok: true; profileId: string }
-  | { type: 'llmProfileDeleteResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
   | { type: 'elevenlabsSettings'; elevenlabs: OpenHandsSettings['elevenlabs'] }
   | {
@@ -67,9 +65,8 @@ export type WebviewToHostMessage =
   | { type: 'getConfig' }
   | { type: 'setLlmProfileId'; profileId: string | null }
   | { type: 'llmProfilesListRequest'; requestId: string }
-  | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string; includeSecrets?: boolean }
-  | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown; includeSecrets?: boolean }
-  | { type: 'llmProfileDeleteRequest'; requestId: string; profileId: string }
+  | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string }
+  | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }
   | { type: 'removeServer'; url: string }

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -1,4 +1,5 @@
 import type { BashEvent, Event } from '@openhands/agent-sdk-ts';
+import type { LLMConfiguration } from '@openhands/agent-sdk-ts';
 import type { OpenHandsSettings, SavedServer } from '../settings/SettingsManager';
 
 export type HostToWebviewMessage =
@@ -12,6 +13,14 @@ export type HostToWebviewMessage =
   | { type: 'error'; error: string }
   | { type: 'statusMessage'; level: 'info' | 'warn' | 'error'; message: string; autoDismiss?: boolean; autoDismissDelay?: number }
   | { type: 'llmProfilesUpdated'; profiles: string[]; activeProfileId: string | null }
+  | { type: 'llmProfilesListResponse'; requestId: string; ok: true; profiles: string[] }
+  | { type: 'llmProfilesListResponse'; requestId: string; ok: false; error: string }
+  | { type: 'llmProfileLoadResponse'; requestId: string; ok: true; profileId: string; profile: LLMConfiguration }
+  | { type: 'llmProfileLoadResponse'; requestId: string; ok: false; profileId: string; error: string }
+  | { type: 'llmProfileSaveResponse'; requestId: string; ok: true; profileId: string }
+  | { type: 'llmProfileSaveResponse'; requestId: string; ok: false; profileId: string; error: string }
+  | { type: 'llmProfileDeleteResponse'; requestId: string; ok: true; profileId: string }
+  | { type: 'llmProfileDeleteResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
   | { type: 'elevenlabsSettings'; elevenlabs: OpenHandsSettings['elevenlabs'] }
   | {
@@ -57,6 +66,10 @@ export type WebviewToHostMessage =
   | { type: 'deleteConversation'; id: string }
   | { type: 'getConfig' }
   | { type: 'setLlmProfileId'; profileId: string | null }
+  | { type: 'llmProfilesListRequest'; requestId: string }
+  | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string; includeSecrets?: boolean }
+  | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown; includeSecrets?: boolean }
+  | { type: 'llmProfileDeleteRequest'; requestId: string; profileId: string }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }
   | { type: 'removeServer'; url: string }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -387,11 +387,10 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'llmProfileLoadRequest': {
         const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
         const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        const includeSecrets = message.includeSecrets === true;
         if (!requestId || !profileId) break;
 
         try {
-          const profile = llmProfilesStore.loadProfile(profileId, { ...llmProfileStoreOptions(), includeSecrets });
+          const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
           void host.postMessage({
             type: 'llmProfileLoadResponse',
             requestId,
@@ -408,11 +407,10 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'llmProfileSaveRequest': {
         const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
         const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        const includeSecrets = message.includeSecrets === true;
         if (!requestId || !profileId) break;
 
         try {
-          llmProfilesStore.saveProfile(profileId, message.profile, { ...llmProfileStoreOptions(), includeSecrets });
+          llmProfilesStore.saveProfile(profileId, message.profile, llmProfileStoreOptions());
           void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: true, profileId });
 
           const updated = await settingsMgr.get();
@@ -424,31 +422,6 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: false, profileId, error: reason });
-        }
-        break;
-      }
-      case 'llmProfileDeleteRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        if (!requestId || !profileId) break;
-
-        try {
-          await llmProfilesStore.deleteProfile(profileId, llmProfileStoreOptions());
-          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: true, profileId });
-
-          const updated = await settingsMgr.get();
-          if (updated.llm.profileId === profileId) {
-            await settingsMgr.update({ llm: { profileId: '' } });
-          }
-          const refreshed = await settingsMgr.get();
-          void host.postMessage({
-            type: 'llmProfilesUpdated',
-            profiles: listAvailableLlmProfiles(),
-            activeProfileId: refreshed.llm.profileId ?? null,
-          });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: false, profileId, error: reason });
         }
         break;
       }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -2,7 +2,6 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
-import { listProfiles } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -16,6 +15,7 @@ import type { HostToWebviewMessage, WebviewToHostMessage } from '../../shared/we
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
 import { getConversationHistoryList } from './conversationHistory';
 import { showWorkspaceDiff } from './diffDocuments';
+import * as llmProfilesStore from './llmProfilesStore';
 import { listSkillFiles } from './skills';
 import { listWorkspaceFiles } from './workspaceFiles';
 import { resolveWorkspaceFilePath } from './workspacePaths';
@@ -38,6 +38,12 @@ export type CreateWebviewMessageHandlerDeps = {
   getConversationMode: () => 'local' | 'remote';
   getConversationStoreRoot: () => string | undefined;
   resolveConversationStoreRoot: () => Promise<string>;
+
+  /**
+   * Optional override for the LLM profile store root directory. Defaults to `~/.openhands/llm-profiles`.
+   * Intended for tests only (no workspace overrides).
+   */
+  getLlmProfilesStoreRoot?: () => string | undefined;
 
   setWebviewReadyState: (conversationId?: string, lastSeenSeq?: number) => void;
   setLastKnownLlmLabel: (label: string | null) => void;
@@ -114,9 +120,16 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
     const outputChannel = deps.getOutputChannel();
     const conversation = deps.getConversation();
 
+    const llmProfileStoreOptions = (): { rootDir?: string } => {
+      const rootDir = typeof deps.getLlmProfilesStoreRoot === 'function' ? deps.getLlmProfilesStoreRoot() : undefined;
+      if (typeof rootDir !== 'string') return {};
+      const trimmed = rootDir.trim();
+      return trimmed ? { rootDir: trimmed } : {};
+    };
+
     const listAvailableLlmProfiles = (): string[] => {
       try {
-        return listProfiles();
+        return llmProfilesStore.listProfiles(llmProfileStoreOptions());
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         outputChannel?.appendLine(`[llm] Failed to list profiles: ${reason}`);
@@ -357,6 +370,86 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           profiles: listAvailableLlmProfiles(),
           activeProfileId: updated.llm.profileId ?? null,
         });
+        break;
+      }
+      case 'llmProfilesListRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        if (!requestId) break;
+        try {
+          const profiles = listAvailableLlmProfiles();
+          void host.postMessage({ type: 'llmProfilesListResponse', requestId, ok: true, profiles });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfilesListResponse', requestId, ok: false, error: reason });
+        }
+        break;
+      }
+      case 'llmProfileLoadRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        const includeSecrets = message.includeSecrets === true;
+        if (!requestId || !profileId) break;
+
+        try {
+          const profile = llmProfilesStore.loadProfile(profileId, { ...llmProfileStoreOptions(), includeSecrets });
+          void host.postMessage({
+            type: 'llmProfileLoadResponse',
+            requestId,
+            ok: true,
+            profileId: profile.profileId,
+            profile: profile.config,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfileLoadResponse', requestId, ok: false, profileId, error: reason });
+        }
+        break;
+      }
+      case 'llmProfileSaveRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        const includeSecrets = message.includeSecrets === true;
+        if (!requestId || !profileId) break;
+
+        try {
+          llmProfilesStore.saveProfile(profileId, message.profile, { ...llmProfileStoreOptions(), includeSecrets });
+          void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: true, profileId });
+
+          const updated = await settingsMgr.get();
+          void host.postMessage({
+            type: 'llmProfilesUpdated',
+            profiles: listAvailableLlmProfiles(),
+            activeProfileId: updated.llm.profileId ?? null,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: false, profileId, error: reason });
+        }
+        break;
+      }
+      case 'llmProfileDeleteRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        if (!requestId || !profileId) break;
+
+        try {
+          await llmProfilesStore.deleteProfile(profileId, llmProfileStoreOptions());
+          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: true, profileId });
+
+          const updated = await settingsMgr.get();
+          if (updated.llm.profileId === profileId) {
+            await settingsMgr.update({ llm: { profileId: '' } });
+          }
+          const refreshed = await settingsMgr.get();
+          void host.postMessage({
+            type: 'llmProfilesUpdated',
+            profiles: listAvailableLlmProfiles(),
+            activeProfileId: refreshed.llm.profileId ?? null,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: false, profileId, error: reason });
+        }
         break;
       }
       case 'selectServer': {

--- a/src/webview/host/llmProfilesStore.ts
+++ b/src/webview/host/llmProfilesStore.ts
@@ -1,9 +1,4 @@
-import * as fs from 'fs/promises';
-import * as os from 'os';
-import * as path from 'path';
 import {
-  DEFAULT_LLM_PROFILES_DIR,
-  LLMProfileValidationError,
   listProfiles as listSdkProfiles,
   loadProfile as loadSdkProfile,
   saveProfile as saveSdkProfile,
@@ -13,48 +8,9 @@ import {
   type SaveProfileOptions,
 } from '@openhands/agent-sdk-ts';
 
-export type HostLlmProfileStoreOptions = LLMProfileStoreOptions & {
-  /** When true, allow inline secrets (apiKey/headers) to be returned or persisted. */
+export type HostLlmProfileSaveOptions = LLMProfileStoreOptions & {
+  /** When true, allow inline secrets (apiKey/headers) to be persisted to disk. */
   includeSecrets?: boolean;
-};
-
-const expandHomeDir = (value: string): string => {
-  if (value === '~') return os.homedir();
-  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
-  return value;
-};
-
-const resolveRootDir = (options: LLMProfileStoreOptions = {}): string => {
-  const rootDir = options.rootDir ?? DEFAULT_LLM_PROFILES_DIR;
-  return path.resolve(expandHomeDir(rootDir));
-};
-
-const assertValidProfileId = (profileId: string): void => {
-  if (!profileId.trim()) {
-    throw new LLMProfileValidationError('Profile id must be a non-empty string');
-  }
-  if (profileId !== profileId.trim()) {
-    throw new LLMProfileValidationError('Profile id must not have leading/trailing whitespace');
-  }
-  if (profileId.includes('/') || profileId.includes('\\')) {
-    throw new LLMProfileValidationError('Profile id must not contain path separators');
-  }
-  if (!/^[a-zA-Z0-9._-]+$/.test(profileId)) {
-    throw new LLMProfileValidationError('Profile id contains invalid characters');
-  }
-};
-
-const getProfilePath = (profileId: string, rootDir: string): string => {
-  assertValidProfileId(profileId);
-  const normalizedRootDir = path.resolve(rootDir);
-  const candidate = path.resolve(normalizedRootDir, `${profileId}.json`);
-  const rootWithSep = normalizedRootDir.endsWith(path.sep)
-    ? normalizedRootDir
-    : `${normalizedRootDir}${path.sep}`;
-  if (!candidate.startsWith(rootWithSep)) {
-    throw new LLMProfileValidationError('Profile id resolves outside the profile root directory');
-  }
-  return candidate;
 };
 
 const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
@@ -72,7 +28,7 @@ const toSdkStoreOptions = (options: LLMProfileStoreOptions = {}): LLMProfileStor
   options.rootDir ? { rootDir: options.rootDir } : {}
 );
 
-const toSdkSaveOptions = (options: HostLlmProfileStoreOptions = {}): SaveProfileOptions => {
+const toSdkSaveOptions = (options: HostLlmProfileSaveOptions = {}): SaveProfileOptions => {
   const includeSecrets = options.includeSecrets ?? false;
   return options.rootDir ? { rootDir: options.rootDir, includeSecrets } : { includeSecrets };
 };
@@ -82,33 +38,17 @@ export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] =>
 
 export const loadProfile = (
   profileId: string,
-  options: HostLlmProfileStoreOptions = {},
+  options: LLMProfileStoreOptions = {},
 ): { profileId: string; config: LLMConfiguration } => {
   const profile = loadSdkProfile(profileId, toSdkStoreOptions(options));
-  const config = options.includeSecrets ? profile.config : stripSecrets(profile.config);
-  return { profileId: profile.profileId, config };
+  return { profileId: profile.profileId, config: stripSecrets(profile.config) };
 };
 
 export const saveProfile = (
   profileId: string,
   payload: unknown,
-  options: HostLlmProfileStoreOptions = {},
+  options: HostLlmProfileSaveOptions = {},
 ): void => {
   const config = validateProfile(payload);
   saveSdkProfile(profileId, config, toSdkSaveOptions(options));
 };
-
-export const deleteProfile = async (profileId: string, options: LLMProfileStoreOptions = {}): Promise<void> => {
-  const rootDir = resolveRootDir(options);
-  const filePath = getProfilePath(profileId, rootDir);
-  try {
-    await fs.unlink(filePath);
-  } catch (err) {
-    const code = err && typeof err === 'object' && 'code' in err ? String((err as { code?: unknown }).code) : '';
-    if (code === 'ENOENT') {
-      throw new LLMProfileValidationError(`Profile '${profileId}' not found`);
-    }
-    throw err;
-  }
-};
-

--- a/src/webview/host/llmProfilesStore.ts
+++ b/src/webview/host/llmProfilesStore.ts
@@ -1,0 +1,114 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  DEFAULT_LLM_PROFILES_DIR,
+  LLMProfileValidationError,
+  listProfiles as listSdkProfiles,
+  loadProfile as loadSdkProfile,
+  saveProfile as saveSdkProfile,
+  validateProfile,
+  type LLMConfiguration,
+  type LLMProfileStoreOptions,
+  type SaveProfileOptions,
+} from '@openhands/agent-sdk-ts';
+
+export type HostLlmProfileStoreOptions = LLMProfileStoreOptions & {
+  /** When true, allow inline secrets (apiKey/headers) to be returned or persisted. */
+  includeSecrets?: boolean;
+};
+
+const expandHomeDir = (value: string): string => {
+  if (value === '~') return os.homedir();
+  if (value.startsWith('~/')) return path.join(os.homedir(), value.slice(2));
+  return value;
+};
+
+const resolveRootDir = (options: LLMProfileStoreOptions = {}): string => {
+  const rootDir = options.rootDir ?? DEFAULT_LLM_PROFILES_DIR;
+  return path.resolve(expandHomeDir(rootDir));
+};
+
+const assertValidProfileId = (profileId: string): void => {
+  if (!profileId.trim()) {
+    throw new LLMProfileValidationError('Profile id must be a non-empty string');
+  }
+  if (profileId !== profileId.trim()) {
+    throw new LLMProfileValidationError('Profile id must not have leading/trailing whitespace');
+  }
+  if (profileId.includes('/') || profileId.includes('\\')) {
+    throw new LLMProfileValidationError('Profile id must not contain path separators');
+  }
+  if (!/^[a-zA-Z0-9._-]+$/.test(profileId)) {
+    throw new LLMProfileValidationError('Profile id contains invalid characters');
+  }
+};
+
+const getProfilePath = (profileId: string, rootDir: string): string => {
+  assertValidProfileId(profileId);
+  const normalizedRootDir = path.resolve(rootDir);
+  const candidate = path.resolve(normalizedRootDir, `${profileId}.json`);
+  const rootWithSep = normalizedRootDir.endsWith(path.sep)
+    ? normalizedRootDir
+    : `${normalizedRootDir}${path.sep}`;
+  if (!candidate.startsWith(rootWithSep)) {
+    throw new LLMProfileValidationError('Profile id resolves outside the profile root directory');
+  }
+  return candidate;
+};
+
+const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
+  const sanitized: LLMConfiguration = { ...config };
+  if (typeof sanitized.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(sanitized.apiKey)) {
+    delete sanitized.apiKey;
+  }
+  // Headers can plausibly contain auth material (Authorization, x-api-key, etc.).
+  // In "no secrets" mode, be conservative and do not send/persist headers.
+  delete sanitized.headers;
+  return sanitized;
+};
+
+const toSdkStoreOptions = (options: LLMProfileStoreOptions = {}): LLMProfileStoreOptions => (
+  options.rootDir ? { rootDir: options.rootDir } : {}
+);
+
+const toSdkSaveOptions = (options: HostLlmProfileStoreOptions = {}): SaveProfileOptions => {
+  const includeSecrets = options.includeSecrets ?? false;
+  return options.rootDir ? { rootDir: options.rootDir, includeSecrets } : { includeSecrets };
+};
+
+export const listProfiles = (options: LLMProfileStoreOptions = {}): string[] =>
+  listSdkProfiles(toSdkStoreOptions(options));
+
+export const loadProfile = (
+  profileId: string,
+  options: HostLlmProfileStoreOptions = {},
+): { profileId: string; config: LLMConfiguration } => {
+  const profile = loadSdkProfile(profileId, toSdkStoreOptions(options));
+  const config = options.includeSecrets ? profile.config : stripSecrets(profile.config);
+  return { profileId: profile.profileId, config };
+};
+
+export const saveProfile = (
+  profileId: string,
+  payload: unknown,
+  options: HostLlmProfileStoreOptions = {},
+): void => {
+  const config = validateProfile(payload);
+  saveSdkProfile(profileId, config, toSdkSaveOptions(options));
+};
+
+export const deleteProfile = async (profileId: string, options: LLMProfileStoreOptions = {}): Promise<void> => {
+  const rootDir = resolveRootDir(options);
+  const filePath = getProfilePath(profileId, rootDir);
+  try {
+    await fs.unlink(filePath);
+  } catch (err) {
+    const code = err && typeof err === 'object' && 'code' in err ? String((err as { code?: unknown }).code) : '';
+    if (code === 'ENOENT') {
+      throw new LLMProfileValidationError(`Profile '${profileId}' not found`);
+    }
+    throw err;
+  }
+};
+


### PR DESCRIPTION
Fixes oh-tab-ftn.

Adds extension-host profile persistence for `~/.openhands/llm-profiles` and wires it to the webview via request/response message types.

Included:
- Host store helper: `src/webview/host/llmProfilesStore.ts` (list/load/save)
- Webview message contracts: `src/shared/webviewMessages.ts`
- Host message handler wiring: `src/webview/host/createWebviewMessageHandler.ts`
- Unit tests for list/load/save (temp root dir): `src/__tests__/llmProfilesStore.test.ts`

Notes:
- v1 has no delete support.
- Profiles returned to the webview always strip inline secrets and headers.
- Profiles saved to disk omit secrets by default.

Tests:
- `npm test`
