### PR TITLE
[oh-tab-egu0] agent-sdk-ts: compute cost from token usage

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -8,6 +8,24 @@ function makeMetrics(token: number): Metrics {
   return m;
 }
 
+function makePricedMetrics(params: {
+  promptTokens: number;
+  completionTokens: number;
+  inputCostPerToken: number;
+  outputCostPerToken: number;
+}): Metrics {
+  const m = new Metrics('m', { inputCostPerToken: params.inputCostPerToken, outputCostPerToken: params.outputCostPerToken });
+  m.addTokenUsage({
+    promptTokens: params.promptTokens,
+    completionTokens: params.completionTokens,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    contextWindow: 0,
+    responseId: `${params.promptTokens}:${params.completionTokens}`,
+  });
+  return m;
+}
+
 describe('ConversationStats', () => {
   it('registers llm metrics and combines', () => {
     const stats = new ConversationStats();
@@ -68,5 +86,25 @@ describe('ConversationStats', () => {
     newStats.registerLlm({ llm: { usageId: 'persistent', metrics: m2 } });
     // Should not merge again because _restored_usage_ids prevents it
     expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(7);
+  });
+
+  it('combines accumulated cost across usage ids (best-effort)', () => {
+    const stats = new ConversationStats();
+    stats.registerLlm({
+      llm: {
+        usageId: 'a',
+        metrics: makePricedMetrics({ promptTokens: 10, completionTokens: 5, inputCostPerToken: 0.001, outputCostPerToken: 0.002 }),
+      },
+    });
+    stats.registerLlm({
+      llm: {
+        usageId: 'b',
+        metrics: makePricedMetrics({ promptTokens: 2, completionTokens: 3, inputCostPerToken: 0.001, outputCostPerToken: 0.002 }),
+      },
+    });
+
+    const combined = stats.getCombinedMetrics().getSnapshot();
+    // (10+2)*0.001 + (5+3)*0.002 = 0.012 + 0.016 = 0.028
+    expect(combined.accumulatedCost).toBeCloseTo(0.028);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
@@ -60,4 +60,29 @@ describe('Metrics', () => {
     const snap = m.getSnapshot();
     expect(snap.accumulatedCost).toBeCloseTo(0.07);
   });
+
+  it('computes cost from token usage when cost rates are configured', () => {
+    const m = new Metrics('priced-model', { inputCostPerToken: 0.001, outputCostPerToken: 0.002 });
+    m.addTokenUsage({
+      promptTokens: 100,
+      completionTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      contextWindow: 0,
+      responseId: 'r1',
+    });
+
+    expect(m.accumulatedCost).toBeCloseTo(0.2);
+
+    m.addTokenUsage({
+      promptTokens: 10,
+      completionTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      contextWindow: 0,
+      responseId: 'r2',
+    });
+
+    expect(m.accumulatedCost).toBeCloseTo(0.21);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
@@ -85,4 +85,17 @@ describe('Metrics', () => {
 
     expect(m.accumulatedCost).toBeCloseTo(0.21);
   });
+
+  it('does not compute cost when cost rates are not configured', () => {
+    const m = new Metrics('model-without-rates');
+    m.addTokenUsage({
+      promptTokens: 100,
+      completionTokens: 50,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      contextWindow: 0,
+      responseId: 'r1',
+    });
+    expect(m.accumulatedCost).toBe(0);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -154,7 +154,10 @@ export class LLMFactory {
     }
 
     if (derivedUsageId) {
-      const metrics = new Metrics(config.model);
+      const metrics = new Metrics(config.model, {
+        inputCostPerToken: config.inputCostPerToken ?? null,
+        outputCostPerToken: config.outputCostPerToken ?? null,
+      });
       const tracked = new TrackedLLMClient({
         inner: base,
         usageId: derivedUsageId,

--- a/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
@@ -23,14 +23,27 @@ export type TokenUsage = {
 export class Metrics {
   modelName: string;
   accumulatedCost = 0;
+  inputCostPerToken: number | null = null;
+  outputCostPerToken: number | null = null;
   maxBudgetPerTask: number | null = null;
   costs: Cost[] = [];
   responseLatencies: ResponseLatency[] = [];
   tokenUsages: TokenUsage[] = [];
   accumulatedTokenUsage: TokenUsage | null = null;
 
-  constructor(modelName = 'default') {
+  constructor(
+    modelName = 'default',
+    options: { inputCostPerToken?: number | null; outputCostPerToken?: number | null } = {},
+  ) {
     this.modelName = modelName;
+    const inputCostPerToken = options.inputCostPerToken;
+    this.inputCostPerToken = typeof inputCostPerToken === 'number' && Number.isFinite(inputCostPerToken)
+      ? inputCostPerToken
+      : null;
+    const outputCostPerToken = options.outputCostPerToken;
+    this.outputCostPerToken = typeof outputCostPerToken === 'number' && Number.isFinite(outputCostPerToken)
+      ? outputCostPerToken
+      : null;
   }
 
   static fromJSON(json: unknown): Metrics {
@@ -178,6 +191,7 @@ export class Metrics {
       responseId: String(params.responseId ?? ''),
     };
     this.tokenUsages.push(usage);
+    this.maybeAddCostForTokenUsage(usage);
 
     const add = {
       model: this.modelName,
@@ -205,6 +219,15 @@ export class Metrics {
         perTurnToken: add.perTurnToken,
       };
     }
+  }
+
+  private maybeAddCostForTokenUsage(usage: TokenUsage): void {
+    const inputRate = this.inputCostPerToken;
+    const outputRate = this.outputCostPerToken;
+    // Best-effort: only compute cost when both rates are known.
+    if (typeof inputRate !== 'number' || typeof outputRate !== 'number') return;
+    const cost = usage.promptTokens * inputRate + usage.completionTokens * outputRate;
+    if (cost > 0) this.addCost(cost);
   }
 
   merge(other: Metrics): void {

--- a/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
@@ -35,15 +35,11 @@ export class Metrics {
     modelName = 'default',
     options: { inputCostPerToken?: number | null; outputCostPerToken?: number | null } = {},
   ) {
+    const sanitizeRate = (rate?: number | null) =>
+      typeof rate === 'number' && Number.isFinite(rate) ? rate : null;
     this.modelName = modelName;
-    const inputCostPerToken = options.inputCostPerToken;
-    this.inputCostPerToken = typeof inputCostPerToken === 'number' && Number.isFinite(inputCostPerToken)
-      ? inputCostPerToken
-      : null;
-    const outputCostPerToken = options.outputCostPerToken;
-    this.outputCostPerToken = typeof outputCostPerToken === 'number' && Number.isFinite(outputCostPerToken)
-      ? outputCostPerToken
-      : null;
+    this.inputCostPerToken = sanitizeRate(options.inputCostPerToken);
+    this.outputCostPerToken = sanitizeRate(options.outputCostPerToken);
   }
 
   static fromJSON(json: unknown): Metrics {


### PR DESCRIPTION
Implements best-effort accumulated cost computation from token usage when inputCostPerToken + outputCostPerToken are configured.

- Metrics.addTokenUsage() now updates accumulatedCost when rates are known.
- LLMFactory passes configured cost rates into Metrics for tracked clients.
- Added unit tests for single-usage + combined cost via ConversationStats.getCombinedMetrics().

Bead: oh-tab-egu0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-token cost tracking: configure input/output token rates for models and automatically calculate accumulated costs, including aggregation across multiple interactions.

* **Tests**
  * Added coverage for cost calculation scenarios: per-token rate application, zero-rate behavior, and multi-usage cost aggregation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->