### PR TITLE
[oh-tab-lhn2] Webview header totals row

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -30,6 +30,60 @@ describe('App toolbar interactions', () => {
     });
   });
 
+  it('shows and updates conversation totals from stats events', async () => {
+    render(<App />);
+
+    const totalsRow = await screen.findByTestId('header-totals-row');
+    expect(totalsRow).toHaveTextContent('Context:');
+    expect(totalsRow).toHaveTextContent('Total cost:');
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'event',
+          event: {
+            kind: 'ConversationStateUpdateEvent',
+            key: 'stats',
+            value: {
+              usage_to_metrics: {
+                default: {
+                  accumulated_cost: 0.0123,
+                  accumulated_token_usage: { prompt_tokens: 10, completion_tokens: 5 },
+                },
+              },
+            },
+          },
+        },
+      }));
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 10 tokens');
+    expect(totalsRow).toHaveTextContent('Total cost: $0.0123');
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'event',
+          event: {
+            kind: 'ConversationStateUpdateEvent',
+            key: 'stats',
+            value: {
+              usage_to_metrics: {
+                default: {
+                  accumulated_cost: 0,
+                  accumulated_token_usage: { prompt_tokens: 12, completion_tokens: 0 },
+                },
+              },
+            },
+          },
+        },
+      }));
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 12 tokens');
+    expect(totalsRow).toHaveTextContent('Total cost: —');
+  });
+
   it('shows the configured LLM profile in the input row', async () => {
     render(<App />);
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -62,6 +62,57 @@ type ConversationsList = Array<{
   messageCount?: number;
 }>;
 
+type ConversationTotals = {
+  contextTokens: number;
+  totalTokens: number;
+  totalCost: number;
+  costIsKnown: boolean;
+};
+
+const INITIAL_CONVERSATION_TOTALS: ConversationTotals = {
+  contextTokens: 0,
+  totalTokens: 0,
+  totalCost: 0,
+  costIsKnown: false,
+};
+
+const computeConversationTotalsFromStats = (value: unknown): ConversationTotals | null => {
+  const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
+    !!candidate && typeof candidate === 'object';
+  const asFiniteNumber = (raw: unknown): number | null => {
+    const num = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+    return Number.isFinite(num) ? num : null;
+  };
+
+  if (!isRecord(value)) return null;
+  const usageToMetricsRaw = value.usage_to_metrics ?? value.usageToMetrics ?? value.service_to_metrics ?? value.serviceToMetrics;
+  if (!isRecord(usageToMetricsRaw)) return null;
+
+  let contextTokens = 0;
+  let completionTokens = 0;
+  let totalCost = 0;
+
+  for (const metricRaw of Object.values(usageToMetricsRaw)) {
+    if (!isRecord(metricRaw)) continue;
+    const costRaw = metricRaw.accumulatedCost ?? metricRaw.accumulated_cost;
+    const cost = asFiniteNumber(costRaw);
+    if (cost !== null && cost > 0) totalCost += cost;
+
+    const usageRaw = metricRaw.accumulatedTokenUsage ?? metricRaw.accumulated_token_usage;
+    if (!isRecord(usageRaw)) continue;
+    const prompt = asFiniteNumber(usageRaw.promptTokens ?? usageRaw.prompt_tokens);
+    if (prompt !== null && prompt > 0) contextTokens += prompt;
+    const completion = asFiniteNumber(usageRaw.completionTokens ?? usageRaw.completion_tokens);
+    if (completion !== null && completion > 0) completionTokens += completion;
+  }
+
+  const totalTokens = contextTokens + completionTokens;
+  // Best-effort: treat cost as "known" only once we have non-zero usage + non-zero cost.
+  const costIsKnown = totalTokens > 0 && totalCost > 0;
+
+  return { contextTokens, totalTokens, totalCost, costIsKnown };
+};
+
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.
  */
@@ -119,6 +170,7 @@ export function App() {
   const [agentStatus, setAgentStatus] = useState<string | undefined>(undefined);
   const [pendingActions, setPendingActions] = useState<ActionEvent[]>([]);
   const [streamingContent, setStreamingContent] = useState<string | null>(null);
+  const [conversationTotals, setConversationTotals] = useState<ConversationTotals>(INITIAL_CONVERSATION_TOTALS);
   const eventId = useRef(1);
 
   // Input state
@@ -296,6 +348,23 @@ export function App() {
         showStatusMessage('warn', 'Agent is waiting for confirmation');
       }
       lastAgentStatusRef.current = event.agent_status;
+    }
+
+    if (event.key === 'stats') {
+      const totals = computeConversationTotalsFromStats(event.value);
+      if (totals) {
+        setConversationTotals((prev) => {
+          if (
+            prev.contextTokens === totals.contextTokens
+            && prev.totalTokens === totals.totalTokens
+            && prev.totalCost === totals.totalCost
+            && prev.costIsKnown === totals.costIsKnown
+          ) {
+            return prev;
+          }
+          return totals;
+        });
+      }
     }
 
     return true;
@@ -519,6 +588,7 @@ export function App() {
               agentStatusRef.current = undefined;
               setAgentStatus(undefined);
               setStreamingContent(null);
+              setConversationTotals(INITIAL_CONVERSATION_TOTALS);
               eventId.current = 1;
               const api = getVscodeApi();
               api.setState?.({});
@@ -819,6 +889,7 @@ export function App() {
     setPendingActions([]);
     setAgentStatus(undefined);
     setStreamingContent(null);
+    setConversationTotals(INITIAL_CONVERSATION_TOTALS);
     eventId.current = 1;
     setInput('');
     setSelectedContextFiles([]);
@@ -1015,6 +1086,7 @@ export function App() {
         conversationId={conversationId}
         currentServerUrl={currentServerUrl}
         servers={servers}
+        totals={conversationTotals}
         onNewConversation={handleStartNewConversation}
         onOpenHistory={handleOpenHistory}
         onOpenSettings={handleOpenSettings}

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -7,6 +7,11 @@ interface HeaderProps {
   conversationId?: string;
   currentServerUrl?: string;
   servers: SavedServer[];
+  totals: {
+    contextTokens: number;
+    totalCost: number;
+    costIsKnown: boolean;
+  };
   onNewConversation: () => void;
   onOpenHistory: () => void;
   onOpenSettings: () => void;
@@ -148,6 +153,7 @@ export function Header({
   conversationId,
   currentServerUrl,
   servers,
+  totals,
   onNewConversation,
   onOpenHistory,
   onOpenSettings,
@@ -158,6 +164,11 @@ export function Header({
   onSwitchToLocal,
 }: HeaderProps) {
   const [showServerSelector, setShowServerSelector] = useState(false);
+  const formatInt = (value: number) => Math.max(0, Math.trunc(value)).toLocaleString();
+  const formatCost = (value: number) => {
+    const clamped = Number.isFinite(value) ? Math.max(0, value) : 0;
+    return `$${clamped.toFixed(4)}`;
+  };
 
   // Get display name using shared helper for consistency
   const getServerDisplayName = () => {
@@ -267,6 +278,24 @@ export function Header({
               <span>Connecting...</span>
             </div>
           )}
+        </div>
+      </div>
+
+      <div
+        className="px-4 pb-2 text-xs text-stone-500 flex items-center justify-between gap-4"
+        data-testid="header-totals-row"
+      >
+        <div className="flex items-center gap-1.5">
+          <span>Context:</span>{' '}
+          <span className="font-mono text-stone-300">{formatInt(totals.contextTokens)}</span>{' '}
+          <span>tokens</span>
+        </div>
+
+        <div className="flex items-center gap-1.5">
+          <span>Total cost:</span>{' '}
+          <span className="font-mono text-stone-300">
+            {totals.costIsKnown ? formatCost(totals.totalCost) : '—'}
+          </span>
         </div>
       </div>
     </header>


### PR DESCRIPTION
Adds a small totals row under the header actions.

- Context tokens are computed from ConversationStateUpdateEvent key=stats across all usage buckets.
- Total cost is shown when non-zero cost is available; otherwise shows —.
- Includes unit test coverage for stats-driven updates.

Bead: oh-tab-lhn2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added conversation usage statistics display in the header, showing context tokens and total cost information. The UI now reflects real-time updates when conversation stats change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->