### PR TITLE
oh-tab-yzw: LLM Profiles UI + per-profile API keys

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -19,6 +19,10 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileLoadResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: false; profileId: string; error: string }
+  | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: true; profileId: string; hasKey: boolean }
+  | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: false; profileId: string; error: string }
+  | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
+  | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
   | { type: 'elevenlabsSettings'; elevenlabs: OpenHandsSettings['elevenlabs'] }
   | {
@@ -67,6 +71,8 @@ export type WebviewToHostMessage =
   | { type: 'llmProfilesListRequest'; requestId: string }
   | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string }
   | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown }
+  | { type: 'llmProfileApiKeyStatusRequest'; requestId: string; profileId: string }
+  | { type: 'llmProfileApiKeySetRequest'; requestId: string; profileId: string; apiKey: string }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }
   | { type: 'removeServer'; url: string }

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App } from '../components/App';
+import { postToWindow } from './testUtils';
+
+const mockApi = { postMessage: vi.fn() };
+
+const getLastPostedOfType = (type: string): any | null => {
+  const calls = mockApi.postMessage.mock.calls.map((call) => call[0]);
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const candidate = calls[i];
+    if (candidate?.type === type) return candidate;
+  }
+  return null;
+};
+
+describe('LLM Profiles view', () => {
+  beforeEach(() => {
+    // @ts-expect-error mock VS Code API
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('supports per-profile API key configuration', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    expect(typeof listRequest.requestId).toBe('string');
+
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+
+    const profileButton = await screen.findByLabelText('Edit profile gpt-5');
+    fireEvent.click(profileButton);
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    expect(typeof loadRequest.requestId).toBe('string');
+
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: { model: 'gpt-5', provider: 'openai' },
+    });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+    });
+
+    expect(await screen.findByText('Not set')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Set key…' }));
+
+    const apiKeyInput = await screen.findByPlaceholderText('(hidden)');
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();
+    });
+
+    const setRequest = getLastPostedOfType('llmProfileApiKeySetRequest');
+    expect(setRequest.profileId).toBe('gpt-5');
+    expect(setRequest.apiKey).toBe('sk-test');
+
+    postToWindow({
+      type: 'llmProfileApiKeySetResponse',
+      requestId: setRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+    });
+
+    await waitFor(() => {
+      const latest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+      expect(latest).toBeTruthy();
+      expect(latest.requestId).not.toBe(statusRequest.requestId);
+    });
+
+    const statusRequest2 = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest2.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: true,
+    });
+
+    expect(await screen.findByText('Set')).toBeInTheDocument();
+
+    expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
+  });
+});

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -13,6 +13,7 @@ import {
   isConversationStateUpdateEvent,
   type Event,
   type ActionEvent,
+  type LLMConfiguration,
 } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
 import { normalizeHalUserName } from '../../shared/halScript';
@@ -30,6 +31,7 @@ import { InputArea, ContextPicker, SkillsPopover } from './InputArea';
 import { ConfirmationPrompt } from './ConfirmationPrompt';
 import { StatusBanner } from './StatusBanner';
 import { HistoryView } from './HistoryView';
+import { LlmProfilesView } from './LlmProfilesView';
 import { isHalDecision, type HalPhase } from '../../shared/halTypes';
 import { HalOverlay } from './HalOverlay';
 import {
@@ -76,6 +78,8 @@ const INITIAL_CONVERSATION_TOTALS: ConversationTotals = {
   costIsKnown: false,
 };
 
+const LLM_PROFILES_REQUEST_TIMEOUT_MS = 15_000;
+
 const computeConversationTotalsFromStats = (value: unknown): ConversationTotals | null => {
   const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
     !!candidate && typeof candidate === 'object';
@@ -112,6 +116,38 @@ const computeConversationTotalsFromStats = (value: unknown): ConversationTotals 
 
   return { contextTokens, totalTokens, totalCost, costIsKnown };
 };
+
+type PendingLlmProfilesRequest =
+  | {
+    kind: 'list';
+    resolve: (profiles: string[]) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }
+  | {
+    kind: 'load';
+    resolve: (profile: LLMConfiguration) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }
+  | {
+    kind: 'save';
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }
+  | {
+    kind: 'apiKeyStatus';
+    resolve: (hasKey: boolean) => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }
+  | {
+    kind: 'apiKeySet';
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  };
 
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.
@@ -184,6 +220,7 @@ export function App() {
   const { statusBanner, setStatusBanner, showStatusMessage } = useStatusMessages({ message: 'Initializing…', level: 'info' });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
+  const [showLlmProfiles, setShowLlmProfiles] = useState(false);
 
   // Context picker state
   const [showContextPicker, setShowContextPicker] = useState(false);
@@ -231,6 +268,72 @@ export function App() {
     const api = getVscodeApi();
     api.postMessage(msg);
   }, []);
+
+  const llmProfilesRequestSeqRef = useRef(1);
+  const pendingLlmProfilesRequestsRef = useRef<Map<string, PendingLlmProfilesRequest>>(new Map());
+
+  const createLlmProfilesRequestId = (kind: string): string =>
+    `llmProfiles:${kind}:${llmProfilesRequestSeqRef.current++}`;
+
+  const listLlmProfiles = useCallback(async (): Promise<string[]> => {
+    const requestId = createLlmProfilesRequestId('list');
+    return await new Promise<string[]>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingLlmProfilesRequestsRef.current.delete(requestId);
+        reject(new Error('Timed out listing LLM profiles'));
+      }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
+      pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'list', resolve, reject, timeout });
+      postMessage({ type: 'llmProfilesListRequest', requestId });
+    });
+  }, [postMessage]);
+
+  const loadLlmProfile = useCallback(async (profileId: string): Promise<LLMConfiguration> => {
+    const requestId = createLlmProfilesRequestId('load');
+    return await new Promise<LLMConfiguration>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingLlmProfilesRequestsRef.current.delete(requestId);
+        reject(new Error('Timed out loading LLM profile'));
+      }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
+      pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'load', resolve, reject, timeout });
+      postMessage({ type: 'llmProfileLoadRequest', requestId, profileId });
+    });
+  }, [postMessage]);
+
+  const saveLlmProfile = useCallback(async (profileId: string, profile: LLMConfiguration): Promise<void> => {
+    const requestId = createLlmProfilesRequestId('save');
+    return await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingLlmProfilesRequestsRef.current.delete(requestId);
+        reject(new Error('Timed out saving LLM profile'));
+      }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
+      pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'save', resolve, reject, timeout });
+      postMessage({ type: 'llmProfileSaveRequest', requestId, profileId, profile });
+    });
+  }, [postMessage]);
+
+  const getLlmProfileApiKeyStatus = useCallback(async (profileId: string): Promise<boolean> => {
+    const requestId = createLlmProfilesRequestId('apiKeyStatus');
+    return await new Promise<boolean>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingLlmProfilesRequestsRef.current.delete(requestId);
+        reject(new Error('Timed out fetching LLM profile API key status'));
+      }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
+      pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'apiKeyStatus', resolve, reject, timeout });
+      postMessage({ type: 'llmProfileApiKeyStatusRequest', requestId, profileId });
+    });
+  }, [postMessage]);
+
+  const setLlmProfileApiKey = useCallback(async (profileId: string, apiKey: string): Promise<void> => {
+    const requestId = createLlmProfilesRequestId('apiKeySet');
+    return await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingLlmProfilesRequestsRef.current.delete(requestId);
+        reject(new Error('Timed out setting LLM profile API key'));
+      }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
+      pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'apiKeySet', resolve, reject, timeout });
+      postMessage({ type: 'llmProfileApiKeySetRequest', requestId, profileId, apiKey });
+    });
+  }, [postMessage]);
 
   const { inlineImages, setInlineImages, handlePasteImageFiles, handleRemoveInlineImage } = useInlineImageAttachments({
     showStatusMessage,
@@ -470,6 +573,7 @@ export function App() {
       const payload = event.data as {
         type?: string;
         requestId?: string;
+        ok?: unknown;
         status?: 'online' | 'offline' | 'connecting';
         serverUrl?: string | null;
         mode?: 'local' | 'remote';
@@ -477,6 +581,9 @@ export function App() {
         llmModel?: string | null;
         profiles?: string[];
         activeProfileId?: string | null;
+        profileId?: unknown;
+        profile?: unknown;
+        hasKey?: unknown;
         elevenlabs?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
         seq?: unknown;
@@ -549,6 +656,81 @@ export function App() {
           if (typeof payload.activeProfileId === 'string' || payload.activeProfileId === null) {
             setLlmProfileId(payload.activeProfileId);
           }
+          break;
+        }
+        case 'llmProfilesListResponse': {
+          const requestId = payload.requestId;
+          if (typeof requestId !== 'string') break;
+          const pending = pendingLlmProfilesRequestsRef.current.get(requestId);
+          if (!pending || pending.kind !== 'list') break;
+          pendingLlmProfilesRequestsRef.current.delete(requestId);
+          clearTimeout(pending.timeout);
+          if (payload.ok === true && Array.isArray(payload.profiles)) {
+            pending.resolve(payload.profiles.filter((id): id is string => typeof id === 'string' && id.trim().length > 0));
+            break;
+          }
+          const reason = typeof payload.error === 'string' ? payload.error : 'Failed to list LLM profiles';
+          pending.reject(new Error(reason));
+          break;
+        }
+        case 'llmProfileLoadResponse': {
+          const requestId = payload.requestId;
+          if (typeof requestId !== 'string') break;
+          const pending = pendingLlmProfilesRequestsRef.current.get(requestId);
+          if (!pending || pending.kind !== 'load') break;
+          pendingLlmProfilesRequestsRef.current.delete(requestId);
+          clearTimeout(pending.timeout);
+          if (payload.ok === true && payload.profile && typeof payload.profile === 'object') {
+            pending.resolve(payload.profile as LLMConfiguration);
+            break;
+          }
+          const reason = typeof payload.error === 'string' ? payload.error : 'Failed to load LLM profile';
+          pending.reject(new Error(reason));
+          break;
+        }
+        case 'llmProfileSaveResponse': {
+          const requestId = payload.requestId;
+          if (typeof requestId !== 'string') break;
+          const pending = pendingLlmProfilesRequestsRef.current.get(requestId);
+          if (!pending || pending.kind !== 'save') break;
+          pendingLlmProfilesRequestsRef.current.delete(requestId);
+          clearTimeout(pending.timeout);
+          if (payload.ok === true) {
+            pending.resolve();
+            break;
+          }
+          const reason = typeof payload.error === 'string' ? payload.error : 'Failed to save LLM profile';
+          pending.reject(new Error(reason));
+          break;
+        }
+        case 'llmProfileApiKeyStatusResponse': {
+          const requestId = payload.requestId;
+          if (typeof requestId !== 'string') break;
+          const pending = pendingLlmProfilesRequestsRef.current.get(requestId);
+          if (!pending || pending.kind !== 'apiKeyStatus') break;
+          pendingLlmProfilesRequestsRef.current.delete(requestId);
+          clearTimeout(pending.timeout);
+          if (payload.ok === true && typeof payload.hasKey === 'boolean') {
+            pending.resolve(payload.hasKey);
+            break;
+          }
+          const reason = typeof payload.error === 'string' ? payload.error : 'Failed to fetch LLM profile API key status';
+          pending.reject(new Error(reason));
+          break;
+        }
+        case 'llmProfileApiKeySetResponse': {
+          const requestId = payload.requestId;
+          if (typeof requestId !== 'string') break;
+          const pending = pendingLlmProfilesRequestsRef.current.get(requestId);
+          if (!pending || pending.kind !== 'apiKeySet') break;
+          pendingLlmProfilesRequestsRef.current.delete(requestId);
+          clearTimeout(pending.timeout);
+          if (payload.ok === true) {
+            pending.resolve();
+            break;
+          }
+          const reason = typeof payload.error === 'string' ? payload.error : 'Failed to set LLM profile API key';
+          pending.reject(new Error(reason));
           break;
         }
         case 'configUpdated':
@@ -903,6 +1085,10 @@ export function App() {
     postMessage({ type: 'requestHistory' });
   }, [postMessage]);
 
+  const handleOpenLlmProfiles = useCallback(() => {
+    setShowLlmProfiles(true);
+  }, []);
+
   const handleOpenSettings = useCallback(() => {
     postMessage({ type: 'openSettingsPage' });
   }, [postMessage]);
@@ -1087,6 +1273,7 @@ export function App() {
         currentServerUrl={currentServerUrl}
         servers={servers}
         totals={conversationTotals}
+        onOpenProfiles={handleOpenLlmProfiles}
         onNewConversation={handleStartNewConversation}
         onOpenHistory={handleOpenHistory}
         onOpenSettings={handleOpenSettings}
@@ -1223,6 +1410,17 @@ export function App() {
           />
         )}
       </div>
+
+      {/* LLM Profiles view (slide-over panel) */}
+      <LlmProfilesView
+        isOpen={showLlmProfiles}
+        onClose={() => setShowLlmProfiles(false)}
+        listProfiles={listLlmProfiles}
+        loadProfile={loadLlmProfile}
+        saveProfile={saveLlmProfile}
+        getApiKeyStatus={getLlmProfileApiKeyStatus}
+        setApiKey={setLlmProfileApiKey}
+      />
 
       {/* History view (slide-over panel) */}
       <HistoryView

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -12,6 +12,7 @@ interface HeaderProps {
     totalCost: number;
     costIsKnown: boolean;
   };
+  onOpenProfiles: () => void;
   onNewConversation: () => void;
   onOpenHistory: () => void;
   onOpenSettings: () => void;
@@ -154,6 +155,7 @@ export function Header({
   currentServerUrl,
   servers,
   totals,
+  onOpenProfiles,
   onNewConversation,
   onOpenHistory,
   onOpenSettings,
@@ -255,6 +257,12 @@ export function Header({
             icon="history"
             label="History"
             onClick={onOpenHistory}
+          />
+
+          <IconButton
+            icon="symbol-parameter"
+            label="LLM Profiles"
+            onClick={onOpenProfiles}
           />
 
           <IconButton

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -311,6 +311,7 @@ export function LlmProfilesView(props: {
   const sortedProfiles = useMemo(() => [...profiles].sort((a, b) => a.localeCompare(b)), [profiles]);
 
   const refreshApiKeyStatus = useCallback(async (profileId: string) => {
+    if (activeProfileIdRef.current !== profileId) return;
     setApiKeyStatus({ state: 'loading' });
     try {
       const hasKey = await getApiKeyStatus(profileId);
@@ -369,13 +370,19 @@ export function LlmProfilesView(props: {
     setLoadingProfile(true);
     try {
       const config = await loadProfile(profileId);
+      if (activeProfileIdRef.current !== profileId) return;
       setForm(toFormState(profileId, config));
     } catch (err) {
+      if (activeProfileIdRef.current !== profileId) return;
       setTopError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoadingProfile(false);
+      if (activeProfileIdRef.current === profileId) {
+        setLoadingProfile(false);
+      }
     }
-    void refreshApiKeyStatus(profileId);
+    if (activeProfileIdRef.current === profileId) {
+      void refreshApiKeyStatus(profileId);
+    }
   }, [loadProfile, refreshApiKeyStatus]);
 
   const handleSave = useCallback(async () => {

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -1,0 +1,895 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import type { LLMConfiguration } from '@openhands/agent-sdk-ts';
+import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
+
+type ProfileFormMode = 'create' | 'edit';
+
+type ProfileFormState = {
+  name: string;
+  provider: '' | 'openai' | 'anthropic' | 'openrouter' | 'litellm_proxy' | 'gemini';
+  model: string;
+  baseUrl: string;
+  apiVersion: string;
+  openaiApiMode: 'auto' | 'chat_completions' | 'responses';
+  timeoutSeconds: string;
+  temperature: string;
+  topP: string;
+  topK: string;
+  maxInputTokens: string;
+  maxOutputTokens: string;
+  reasoningEffort: '' | 'none' | 'low' | 'medium' | 'high';
+  reasoningSummary: '' | 'auto' | 'concise' | 'detailed';
+  inputCostPerToken: string;
+  outputCostPerToken: string;
+};
+
+type FieldErrors = Partial<Record<keyof ProfileFormState, string>>;
+
+type ApiKeyStatus =
+  | { state: 'unknown' }
+  | { state: 'loading' }
+  | { state: 'ready'; hasKey: boolean }
+  | { state: 'error'; error: string };
+
+const EMPTY_FORM: ProfileFormState = {
+  name: '',
+  provider: '',
+  model: '',
+  baseUrl: '',
+  apiVersion: '',
+  openaiApiMode: 'auto',
+  timeoutSeconds: '',
+  temperature: '',
+  topP: '',
+  topK: '',
+  maxInputTokens: '',
+  maxOutputTokens: '',
+  reasoningEffort: '',
+  reasoningSummary: '',
+  inputCostPerToken: '',
+  outputCostPerToken: '',
+};
+
+const toFormState = (profileId: string, config: LLMConfiguration): ProfileFormState => {
+  const strOrEmpty = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const numOrEmpty = (v: unknown): string => (typeof v === 'number' && Number.isFinite(v) ? String(v) : '');
+  const nullableStr = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const nullableNum = (v: unknown): string => (typeof v === 'number' && Number.isFinite(v) ? String(v) : '');
+  const provider = config.provider;
+  const openaiApiMode = provider === 'openai' && config.openaiApiMode
+    ? config.openaiApiMode
+    : 'auto';
+
+  return {
+    ...EMPTY_FORM,
+    name: profileId,
+    provider: provider === 'openai' || provider === 'anthropic' || provider === 'openrouter' || provider === 'litellm_proxy' || provider === 'gemini'
+      ? provider
+      : '',
+    model: strOrEmpty(config.model),
+    baseUrl: nullableStr(config.baseUrl),
+    apiVersion: nullableStr(config.apiVersion),
+    openaiApiMode,
+    timeoutSeconds: nullableNum(config.timeoutSeconds),
+    temperature: nullableNum(config.temperature),
+    topP: nullableNum(config.topP),
+    topK: nullableNum(config.topK),
+    maxInputTokens: nullableNum(config.maxInputTokens),
+    maxOutputTokens: nullableNum(config.maxOutputTokens),
+    reasoningEffort: config.reasoningEffort === null || config.reasoningEffort === undefined
+      ? ''
+      : (config.reasoningEffort === 'none' || config.reasoningEffort === 'low' || config.reasoningEffort === 'medium' || config.reasoningEffort === 'high')
+        ? config.reasoningEffort
+        : '',
+    reasoningSummary: config.reasoningSummary === null || config.reasoningSummary === undefined
+      ? ''
+      : (config.reasoningSummary === 'auto' || config.reasoningSummary === 'concise' || config.reasoningSummary === 'detailed')
+        ? config.reasoningSummary
+        : '',
+    inputCostPerToken: numOrEmpty(config.inputCostPerToken),
+    outputCostPerToken: numOrEmpty(config.outputCostPerToken),
+  };
+};
+
+const validateProfileId = (value: string): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) return 'Name is required';
+  if (trimmed !== value) return 'Name must not have leading/trailing whitespace';
+  if (trimmed.includes('/') || trimmed.includes('\\')) return 'Name must not contain path separators';
+  if (/\s/.test(trimmed)) return 'Name must not contain spaces';
+  if (!/^[a-zA-Z0-9._-]+$/.test(trimmed)) return 'Name contains invalid characters';
+  return null;
+};
+
+const parseOptionalNumber = (raw: string): { value: number | null; error?: string } => {
+  const trimmed = raw.trim();
+  if (!trimmed) return { value: null };
+  const num = Number(trimmed);
+  if (!Number.isFinite(num)) return { value: null, error: 'Must be a valid number' };
+  if (num < 0) return { value: null, error: 'Must be >= 0' };
+  return { value: num };
+};
+
+const parseOptionalInt = (raw: string): { value: number | null; error?: string } => {
+  const base = parseOptionalNumber(raw);
+  if (base.error || base.value === null) return base;
+  if (!Number.isInteger(base.value)) return { value: null, error: 'Must be an integer' };
+  return base;
+};
+
+const validateForm = (mode: ProfileFormMode, form: ProfileFormState): FieldErrors => {
+  const errors: FieldErrors = {};
+
+  const nameErr = validateProfileId(form.name);
+  if (nameErr) errors.name = nameErr;
+
+  const model = form.model.trim();
+  if (!model) errors.model = 'Model is required';
+
+  if (form.baseUrl.trim()) {
+    try {
+      const url = new URL(form.baseUrl.trim());
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        errors.baseUrl = 'Base URL must start with http:// or https://';
+      }
+    } catch {
+      errors.baseUrl = 'Base URL must be a valid URL';
+    }
+  }
+
+  if (form.provider !== 'openai' && form.openaiApiMode !== 'auto') {
+    errors.openaiApiMode = 'OpenAI API mode only applies to the OpenAI provider';
+  }
+
+  const timeout = parseOptionalNumber(form.timeoutSeconds);
+  if (timeout.error) errors.timeoutSeconds = timeout.error;
+
+  const temperature = parseOptionalNumber(form.temperature);
+  if (temperature.error) errors.temperature = temperature.error;
+
+  const topP = parseOptionalNumber(form.topP);
+  if (topP.error) errors.topP = topP.error;
+
+  const topK = parseOptionalInt(form.topK);
+  if (topK.error) errors.topK = topK.error;
+
+  const maxInputTokens = parseOptionalInt(form.maxInputTokens);
+  if (maxInputTokens.error) errors.maxInputTokens = maxInputTokens.error;
+
+  const maxOutputTokens = parseOptionalInt(form.maxOutputTokens);
+  if (maxOutputTokens.error) errors.maxOutputTokens = maxOutputTokens.error;
+
+  const inputCost = parseOptionalNumber(form.inputCostPerToken);
+  if (inputCost.error) errors.inputCostPerToken = inputCost.error;
+
+  const outputCost = parseOptionalNumber(form.outputCostPerToken);
+  if (outputCost.error) errors.outputCostPerToken = outputCost.error;
+
+  return errors;
+};
+
+const buildProfileConfig = (form: ProfileFormState): LLMConfiguration => {
+  const optionalStringOrNull = (raw: string): string | null => {
+    const trimmed = raw.trim();
+    return trimmed ? trimmed : null;
+  };
+
+  const timeoutSeconds = parseOptionalNumber(form.timeoutSeconds).value;
+  const temperature = parseOptionalNumber(form.temperature).value;
+  const topP = parseOptionalNumber(form.topP).value;
+  const topK = parseOptionalInt(form.topK).value;
+  const maxInputTokens = parseOptionalInt(form.maxInputTokens).value;
+  const maxOutputTokens = parseOptionalInt(form.maxOutputTokens).value;
+  const inputCostPerToken = parseOptionalNumber(form.inputCostPerToken).value;
+  const outputCostPerToken = parseOptionalNumber(form.outputCostPerToken).value;
+
+  const provider = form.provider || undefined;
+  const openaiApiMode = provider === 'openai'
+    ? (form.openaiApiMode === 'auto' ? null : form.openaiApiMode)
+    : null;
+
+  return {
+    provider,
+    model: form.model.trim(),
+    baseUrl: optionalStringOrNull(form.baseUrl),
+    apiVersion: optionalStringOrNull(form.apiVersion),
+    openaiApiMode,
+    timeoutSeconds,
+    temperature,
+    topP,
+    topK,
+    maxInputTokens,
+    maxOutputTokens,
+    reasoningEffort: form.reasoningEffort ? form.reasoningEffort : null,
+    reasoningSummary: form.reasoningSummary ? form.reasoningSummary : null,
+    inputCostPerToken,
+    outputCostPerToken,
+  };
+};
+
+function FieldLabel({ label, required }: { label: string; required?: boolean }) {
+  return (
+    <div className="text-xs font-medium text-stone-300">
+      {label}{required ? <span className="text-red-400"> *</span> : null}
+    </div>
+  );
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <div className="text-xs text-red-400 mt-1">{message}</div>;
+}
+
+function InputField(props: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  type?: string;
+}) {
+  return (
+    <input
+      value={props.value}
+      onChange={(e) => props.onChange(e.target.value)}
+      placeholder={props.placeholder}
+      disabled={props.disabled}
+      type={props.type ?? 'text'}
+      className={`
+        w-full px-3 py-2 rounded-lg
+        bg-white/[0.03] border border-white/[0.06]
+        text-stone-200 placeholder:text-stone-600
+        focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+        disabled:opacity-50 disabled:cursor-not-allowed
+      `}
+    />
+  );
+}
+
+function SelectField(props: {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <select
+      value={props.value}
+      onChange={(e) => props.onChange(e.target.value)}
+      disabled={props.disabled}
+      className={`
+        w-full px-3 py-2 rounded-lg
+        bg-white/[0.03] border border-white/[0.06]
+        text-stone-200
+        focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+        disabled:opacity-50 disabled:cursor-not-allowed
+      `}
+    >
+      {props.children}
+    </select>
+  );
+}
+
+export function LlmProfilesView(props: {
+  isOpen: boolean;
+  onClose: () => void;
+  listProfiles: () => Promise<string[]>;
+  loadProfile: (profileId: string) => Promise<LLMConfiguration>;
+  saveProfile: (profileId: string, profile: LLMConfiguration) => Promise<void>;
+  getApiKeyStatus: (profileId: string) => Promise<boolean>;
+  setApiKey: (profileId: string, apiKey: string) => Promise<void>;
+}) {
+  const {
+    isOpen,
+    onClose,
+    listProfiles,
+    loadProfile,
+    saveProfile,
+    getApiKeyStatus,
+    setApiKey,
+  } = props;
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: panelRef, delay: 100 });
+
+  const activeProfileIdRef = useRef<string | null>(null);
+  const [profiles, setProfiles] = useState<string[]>([]);
+  const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
+  const [mode, setMode] = useState<ProfileFormMode>('create');
+  const [form, setForm] = useState<ProfileFormState>(EMPTY_FORM);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [saveAttempted, setSaveAttempted] = useState(false);
+  const [loadingList, setLoadingList] = useState(false);
+  const [loadingProfile, setLoadingProfile] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [topError, setTopError] = useState<string | null>(null);
+  const [apiKeyStatus, setApiKeyStatus] = useState<ApiKeyStatus>({ state: 'unknown' });
+  const [showApiKeyEditor, setShowApiKeyEditor] = useState(false);
+  const [apiKeyInput, setApiKeyInput] = useState('');
+  const [apiKeySaving, setApiKeySaving] = useState(false);
+  const [apiKeyError, setApiKeyError] = useState<string | null>(null);
+
+  const sortedProfiles = useMemo(() => [...profiles].sort((a, b) => a.localeCompare(b)), [profiles]);
+
+  const refreshApiKeyStatus = useCallback(async (profileId: string) => {
+    setApiKeyStatus({ state: 'loading' });
+    try {
+      const hasKey = await getApiKeyStatus(profileId);
+      if (activeProfileIdRef.current !== profileId) return;
+      setApiKeyStatus({ state: 'ready', hasKey });
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      if (activeProfileIdRef.current !== profileId) return;
+      setApiKeyStatus({ state: 'error', error: reason });
+    }
+  }, [getApiKeyStatus]);
+
+  const refreshProfiles = useCallback(async () => {
+    setLoadingList(true);
+    setTopError(null);
+    try {
+      const next = await listProfiles();
+      setProfiles(next);
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingList(false);
+    }
+  }, [listProfiles]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    void refreshProfiles();
+  }, [isOpen, refreshProfiles]);
+
+  const startCreate = useCallback(() => {
+    activeProfileIdRef.current = null;
+    setMode('create');
+    setSelectedProfileId(null);
+    setForm(EMPTY_FORM);
+    setErrors({});
+    setSaveAttempted(false);
+    setTopError(null);
+    setApiKeyStatus({ state: 'unknown' });
+    setShowApiKeyEditor(false);
+    setApiKeyInput('');
+    setApiKeySaving(false);
+    setApiKeyError(null);
+  }, []);
+
+  const startEdit = useCallback(async (profileId: string) => {
+    activeProfileIdRef.current = profileId;
+    setMode('edit');
+    setSelectedProfileId(profileId);
+    setErrors({});
+    setSaveAttempted(false);
+    setTopError(null);
+    setApiKeyError(null);
+    setShowApiKeyEditor(false);
+    setApiKeyInput('');
+    setLoadingProfile(true);
+    try {
+      const config = await loadProfile(profileId);
+      setForm(toFormState(profileId, config));
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoadingProfile(false);
+    }
+    void refreshApiKeyStatus(profileId);
+  }, [loadProfile, refreshApiKeyStatus]);
+
+  const handleSave = useCallback(async () => {
+    setSaveAttempted(true);
+    const nextErrors = validateForm(mode, form);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    const profileId = form.name.trim();
+    const config = buildProfileConfig(form);
+
+    setSaving(true);
+    setTopError(null);
+    try {
+      await saveProfile(profileId, config);
+      await refreshProfiles();
+      activeProfileIdRef.current = profileId;
+      setMode('edit');
+      setSelectedProfileId(profileId);
+      void refreshApiKeyStatus(profileId);
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [form, mode, refreshApiKeyStatus, refreshProfiles, saveProfile]);
+
+  const update = <K extends keyof ProfileFormState>(key: K, value: ProfileFormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+    if (saveAttempted) {
+      setErrors((prev) => {
+        if (!prev[key]) return prev;
+        const next = { ...prev };
+        delete next[key];
+        return next;
+      });
+    }
+  };
+
+  const selectedIsActive = (candidate: string) => candidate === selectedProfileId;
+  const canEditApiKey = mode === 'edit' && !!selectedProfileId && !loadingProfile;
+
+  const apiKeyStatusLabel = (() => {
+    if (!canEditApiKey) return '—';
+    if (apiKeyStatus.state === 'loading') return 'Checking…';
+    if (apiKeyStatus.state === 'ready') return apiKeyStatus.hasKey ? 'Set' : 'Not set';
+    if (apiKeyStatus.state === 'error') return 'Error';
+    return '—';
+  })();
+
+  const handleSetApiKey = useCallback(async () => {
+    if (!selectedProfileId) return;
+    const profileId = selectedProfileId;
+    setApiKeySaving(true);
+    setApiKeyError(null);
+    try {
+      const trimmed = apiKeyInput.trim();
+      if (!trimmed) {
+        setApiKeyError('API key is required');
+        return;
+      }
+      await setApiKey(profileId, trimmed);
+      setApiKeyInput('');
+      setShowApiKeyEditor(false);
+      setApiKeyStatus({ state: 'ready', hasKey: true });
+      void refreshApiKeyStatus(profileId);
+    } catch (err) {
+      setApiKeyError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApiKeySaving(false);
+    }
+  }, [apiKeyInput, refreshApiKeyStatus, selectedProfileId, setApiKey]);
+
+  const handleClearApiKey = useCallback(async () => {
+    if (!selectedProfileId) return;
+    const profileId = selectedProfileId;
+    setApiKeySaving(true);
+    setApiKeyError(null);
+    try {
+      await setApiKey(profileId, '');
+      setApiKeyStatus({ state: 'ready', hasKey: false });
+      void refreshApiKeyStatus(profileId);
+    } catch (err) {
+      setApiKeyError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApiKeySaving(false);
+    }
+  }, [refreshApiKeyStatus, selectedProfileId, setApiKey]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className="relative ml-auto w-full max-w-5xl h-full bg-[var(--vscode-editor-background)] border-l border-white/[0.08] shadow-2xl flex flex-col animate-slide-in-right"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.08]">
+          <div className="flex items-center gap-2">
+            <span className="codicon codicon-symbol-parameter text-brand-400" />
+            <h2 className="text-lg font-semibold text-stone-100">LLM Profiles</h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
+            aria-label="Close profiles view"
+            title="Close"
+          >
+            <span className="codicon codicon-close" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-hidden flex">
+          {/* Left: list */}
+          <div className="w-64 border-r border-white/[0.08] flex flex-col">
+            <div className="p-4 border-b border-white/[0.06] flex items-center gap-2">
+              <button
+                type="button"
+                onClick={startCreate}
+                className="flex-1 inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40 transition-all"
+              >
+                <span className="codicon codicon-add" />
+                New profile
+              </button>
+            </div>
+
+            <div className="flex-1 overflow-y-auto p-3 space-y-1">
+              {loadingList ? (
+                <div className="text-sm text-stone-500 px-2 py-2">Loading profiles…</div>
+              ) : sortedProfiles.length === 0 ? (
+                <div className="px-2 py-3">
+                  <div className="text-sm text-stone-300 mb-1">No profiles found</div>
+                  <div className="text-xs text-stone-500">Create one to get started.</div>
+                </div>
+              ) : (
+                sortedProfiles.map((id) => (
+                  <button
+                    key={id}
+                    type="button"
+                    onClick={() => { void startEdit(id); }}
+                    className={`
+                      w-full text-left px-3 py-2 rounded-lg
+                      text-sm font-mono
+                      transition-colors
+                      border
+                      ${selectedIsActive(id)
+                        ? 'bg-brand-500/15 border-brand-500/25 text-brand-200'
+                        : 'bg-white/[0.02] border-white/[0.04] text-stone-300 hover:bg-white/[0.05] hover:border-white/[0.08]'}
+                    `}
+                    aria-label={`Edit profile ${id}`}
+                    title={id}
+                  >
+                    {id}
+                  </button>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Right: editor */}
+          <div className="flex-1 overflow-y-auto p-6">
+            {topError && (
+              <div className="mb-4 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+                {topError}
+              </div>
+            )}
+
+            <div className="flex items-start justify-between gap-4 mb-6">
+              <div>
+                <div className="text-sm text-stone-500">
+                  {mode === 'create' ? 'Create a new profile' : 'Edit profile'}
+                </div>
+                <div className="text-lg font-semibold text-stone-100 mt-1">
+                  {mode === 'create' ? (form.name.trim() ? form.name.trim() : 'New profile') : (selectedProfileId ?? '—')}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => { void handleSave(); }}
+                disabled={saving || loadingProfile}
+                className={`
+                  inline-flex items-center gap-2 px-4 py-2 rounded-lg
+                  text-sm font-medium
+                  transition-all
+                  border
+                  ${saving || loadingProfile
+                    ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
+                    : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
+                `}
+              >
+                <span className={`codicon codicon-${saving ? 'loading' : 'save'} ${saving ? 'animate-spin' : ''}`} />
+                {saving ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+
+            {loadingProfile ? (
+              <div className="text-sm text-stone-500">Loading profile…</div>
+            ) : (
+              <div className="space-y-6">
+                <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <div className="text-sm font-medium text-stone-200">API key</div>
+                      <div className="text-xs text-stone-500 mt-0.5">
+                        Stored in VS Code Secret Storage. Not saved to disk.
+                      </div>
+                    </div>
+
+                    {canEditApiKey ? (
+                      <div className="flex items-center gap-2">
+                        <div className="text-xs text-stone-400">{apiKeyStatusLabel}</div>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setApiKeyError(null);
+                            setShowApiKeyEditor(true);
+                          }}
+                          disabled={apiKeySaving}
+                          className={`
+                            inline-flex items-center gap-2 px-3 py-1.5 rounded-lg
+                            text-xs font-medium
+                            transition-all
+                            border
+                            ${apiKeySaving
+                              ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
+                              : 'bg-white/[0.04] text-stone-300 border-white/[0.06] hover:bg-white/[0.08] hover:border-white/[0.1]'}
+                          `}
+                        >
+                          <span className="codicon codicon-key" />
+                          Set key…
+                        </button>
+                        {apiKeyStatus.state === 'ready' && apiKeyStatus.hasKey && (
+                          <button
+                            type="button"
+                            onClick={() => { void handleClearApiKey(); }}
+                            disabled={apiKeySaving}
+                            className={`
+                              inline-flex items-center gap-2 px-3 py-1.5 rounded-lg
+                              text-xs font-medium
+                              transition-all
+                              border
+                              ${apiKeySaving
+                                ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
+                                : 'bg-red-500/10 text-red-200 border-red-500/20 hover:bg-red-500/15 hover:border-red-500/30'}
+                            `}
+                          >
+                            <span className="codicon codicon-trash" />
+                            Clear
+                          </button>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="text-xs text-stone-500">Save profile to set a key.</div>
+                    )}
+                  </div>
+
+                  {canEditApiKey && apiKeyStatus.state === 'error' && (
+                    <div className="mt-2 text-xs text-red-400">{apiKeyStatus.error}</div>
+                  )}
+                  {canEditApiKey && apiKeyError && (
+                    <div className="mt-2 text-xs text-red-400">{apiKeyError}</div>
+                  )}
+
+                  {canEditApiKey && showApiKeyEditor && (
+                    <div className="mt-3">
+                      <FieldLabel label="New API key" required />
+                      <div className="mt-2">
+                        <InputField
+                          value={apiKeyInput}
+                          onChange={setApiKeyInput}
+                          placeholder="(hidden)"
+                          type="password"
+                        />
+                      </div>
+                      <div className="mt-3 flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => { void handleSetApiKey(); }}
+                          disabled={apiKeySaving}
+                          className={`
+                            inline-flex items-center gap-2 px-3 py-2 rounded-lg
+                            text-xs font-medium
+                            transition-all
+                            border
+                            ${apiKeySaving
+                              ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
+                              : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
+                          `}
+                        >
+                          <span className={`codicon codicon-${apiKeySaving ? 'loading' : 'save'} ${apiKeySaving ? 'animate-spin' : ''}`} />
+                          Save key
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setShowApiKeyEditor(false);
+                            setApiKeyInput('');
+                            setApiKeyError(null);
+                          }}
+                          disabled={apiKeySaving}
+                          className={`
+                            inline-flex items-center gap-2 px-3 py-2 rounded-lg
+                            text-xs font-medium
+                            transition-all
+                            border
+                            ${apiKeySaving
+                              ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
+                              : 'bg-white/[0.04] text-stone-300 border-white/[0.06] hover:bg-white/[0.08] hover:border-white/[0.1]'}
+                          `}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <FieldLabel label="Name" required />
+                    <div className="mt-2">
+                      <InputField
+                        value={form.name}
+                        onChange={(v) => update('name', v)}
+                        placeholder="e.g. gpt-5"
+                        disabled={mode === 'edit'}
+                      />
+                      <FieldError message={errors.name} />
+                    </div>
+                  </div>
+
+                  <div>
+                    <FieldLabel label="Provider" />
+                    <div className="mt-2">
+                      <SelectField
+                        value={form.provider}
+                        onChange={(v) => update('provider', v as ProfileFormState['provider'])}
+                      >
+                        <option value="">Select…</option>
+                        <option value="openai">openai</option>
+                        <option value="anthropic">anthropic</option>
+                        <option value="openrouter">openrouter</option>
+                        <option value="litellm_proxy">litellm_proxy</option>
+                        <option value="gemini">gemini</option>
+                      </SelectField>
+                      <FieldError message={errors.provider} />
+                    </div>
+                  </div>
+
+                  <div className="col-span-2">
+                    <FieldLabel label="Model" required />
+                    <div className="mt-2">
+                      <InputField
+                        value={form.model}
+                        onChange={(v) => update('model', v)}
+                        placeholder="e.g. gpt-5, claude-4-sonnet, gemini-2.5-pro"
+                      />
+                      <FieldError message={errors.model} />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="col-span-2">
+                    <FieldLabel label="Base URL" />
+                    <div className="mt-2">
+                      <InputField
+                        value={form.baseUrl}
+                        onChange={(v) => update('baseUrl', v)}
+                        placeholder="https://api.openai.com/v1"
+                      />
+                      <FieldError message={errors.baseUrl} />
+                    </div>
+                  </div>
+
+                  <div>
+                    <FieldLabel label="API Version" />
+                    <div className="mt-2">
+                      <InputField
+                        value={form.apiVersion}
+                        onChange={(v) => update('apiVersion', v)}
+                        placeholder="optional"
+                      />
+                      <FieldError message={errors.apiVersion} />
+                    </div>
+                  </div>
+
+                  <div>
+                    <FieldLabel label="OpenAI API mode" />
+                    <div className="mt-2">
+                      <SelectField
+                        value={form.openaiApiMode}
+                        onChange={(v) => update('openaiApiMode', v as ProfileFormState['openaiApiMode'])}
+                        disabled={form.provider !== 'openai'}
+                      >
+                        <option value="auto">auto</option>
+                        <option value="chat_completions">chat_completions</option>
+                        <option value="responses">responses</option>
+                      </SelectField>
+                      <FieldError message={errors.openaiApiMode} />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-3 gap-4">
+                  <div>
+                    <FieldLabel label="Timeout (seconds)" />
+                    <div className="mt-2">
+                      <InputField value={form.timeoutSeconds} onChange={(v) => update('timeoutSeconds', v)} placeholder="60" />
+                      <FieldError message={errors.timeoutSeconds} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Temperature" />
+                    <div className="mt-2">
+                      <InputField value={form.temperature} onChange={(v) => update('temperature', v)} placeholder="0.2" />
+                      <FieldError message={errors.temperature} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Top P" />
+                    <div className="mt-2">
+                      <InputField value={form.topP} onChange={(v) => update('topP', v)} placeholder="1" />
+                      <FieldError message={errors.topP} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Top K" />
+                    <div className="mt-2">
+                      <InputField value={form.topK} onChange={(v) => update('topK', v)} placeholder="optional" />
+                      <FieldError message={errors.topK} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Max input tokens" />
+                    <div className="mt-2">
+                      <InputField value={form.maxInputTokens} onChange={(v) => update('maxInputTokens', v)} placeholder="optional" />
+                      <FieldError message={errors.maxInputTokens} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Max output tokens" />
+                    <div className="mt-2">
+                      <InputField value={form.maxOutputTokens} onChange={(v) => update('maxOutputTokens', v)} placeholder="optional" />
+                      <FieldError message={errors.maxOutputTokens} />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <FieldLabel label="Reasoning effort" />
+                    <div className="mt-2">
+                      <SelectField
+                        value={form.reasoningEffort}
+                        onChange={(v) => update('reasoningEffort', v as ProfileFormState['reasoningEffort'])}
+                      >
+                        <option value="">default</option>
+                        <option value="none">none</option>
+                        <option value="low">low</option>
+                        <option value="medium">medium</option>
+                        <option value="high">high</option>
+                      </SelectField>
+                      <FieldError message={errors.reasoningEffort} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Reasoning summary" />
+                    <div className="mt-2">
+                      <SelectField
+                        value={form.reasoningSummary}
+                        onChange={(v) => update('reasoningSummary', v as ProfileFormState['reasoningSummary'])}
+                      >
+                        <option value="">default</option>
+                        <option value="auto">auto</option>
+                        <option value="concise">concise</option>
+                        <option value="detailed">detailed</option>
+                      </SelectField>
+                      <FieldError message={errors.reasoningSummary} />
+                    </div>
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <FieldLabel label="Input cost per token" />
+                    <div className="mt-2">
+                      <InputField value={form.inputCostPerToken} onChange={(v) => update('inputCostPerToken', v)} placeholder="optional" />
+                      <FieldError message={errors.inputCostPerToken} />
+                    </div>
+                  </div>
+                  <div>
+                    <FieldLabel label="Output cost per token" />
+                    <div className="mt-2">
+                      <InputField value={form.outputCostPerToken} onChange={(v) => update('outputCostPerToken', v)} placeholder="optional" />
+                      <FieldError message={errors.outputCostPerToken} />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -100,6 +100,26 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
   let elevenlabsTtsGate: TtsConversationGate | null = null;
 
+  const validateProfileId = (profileId: string): void => {
+    if (!profileId.trim()) {
+      throw new Error('Profile id must be a non-empty string');
+    }
+    if (profileId !== profileId.trim()) {
+      throw new Error('Profile id must not have leading/trailing whitespace');
+    }
+    if (profileId.includes('/') || profileId.includes('\\')) {
+      throw new Error('Profile id must not contain path separators');
+    }
+    if (!/^[a-zA-Z0-9._-]+$/.test(profileId)) {
+      throw new Error('Profile id contains invalid characters');
+    }
+  };
+
+  const getProfileApiKeySecretKey = (profileId: string): string => {
+    validateProfileId(profileId);
+    return `openhands.llmProfileApiKey.${profileId}`;
+  };
+
   const getElevenlabsTtsGate = (): TtsConversationGate => {
     if (elevenlabsTtsGate) return elevenlabsTtsGate;
     const baseDir = context.globalStorageUri?.fsPath || path.join(os.tmpdir(), 'oh-tab-global-storage');
@@ -422,6 +442,47 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: false, profileId, error: reason });
+        }
+        break;
+      }
+      case 'llmProfileApiKeyStatusRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        if (!requestId || !profileId) break;
+
+        try {
+          const key = getProfileApiKeySecretKey(profileId);
+          const stored = await context.secrets.get(key);
+          void host.postMessage({
+            type: 'llmProfileApiKeyStatusResponse',
+            requestId,
+            ok: true,
+            profileId,
+            hasKey: typeof stored === 'string' && stored.trim().length > 0,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfileApiKeyStatusResponse', requestId, ok: false, profileId, error: reason });
+        }
+        break;
+      }
+      case 'llmProfileApiKeySetRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        const apiKey = typeof message.apiKey === 'string' ? message.apiKey.trim() : '';
+        if (!requestId || !profileId) break;
+
+        try {
+          const key = getProfileApiKeySecretKey(profileId);
+          if (!apiKey) {
+            await context.secrets.delete(key);
+          } else {
+            await context.secrets.store(key, apiKey);
+          }
+          void host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: true, profileId });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: false, profileId, error: reason });
         }
         break;
       }


### PR DESCRIPTION
Implements the LLM Profiles slide-over editor in the webview, including per-profile API key status + set/clear stored in VS Code SecretStorage (never written to disk).

Key changes
- Webview UI: `LlmProfilesView` (list + create/edit form) + header entry point.
- Host/webview messaging: API key status/set request/response plumbing.
- Tests: `src/webview-src/__tests__/LlmProfilesView.test.tsx` covers the API key flow.

Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced LLM Profiles panel for managing and configuring AI model profiles with support for different providers and settings
  * Added API key management functionality within the profiles interface
  * Added new LLM Profiles button in the header for quick access to profile management

* **Tests**
  * Added comprehensive test coverage for LLM Profiles end-to-end workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->