### PR TITLE
oh-tab-1oh: bucket metrics per LLM profile switch

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -84,8 +84,25 @@ describe('ConversationStats', () => {
     // Ensure we don't double-count if we register again (though registerLlm is usually called once per client init)
     // But if we did:
     newStats.registerLlm({ llm: { usageId: 'persistent', metrics: m2 } });
-    // Should not merge again because _restored_usage_ids prevents it
+    // Should not merge again because it's the same live metrics object
     expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(7);
+  });
+
+  it('preserves accumulated metrics when replacing the metrics object multiple times', () => {
+    const stats = new ConversationStats();
+    const m1 = makeMetrics(2);
+    stats.registerLlm({ llm: { usageId: 'switchy', metrics: m1 } });
+
+    const m2 = new Metrics('m');
+    stats.registerLlm({ llm: { usageId: 'switchy', metrics: m2 } });
+    expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(2);
+
+    m2.addTokenUsage({ promptTokens: 3, completionTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, contextWindow: 0, responseId: 'more' });
+    expect(m2.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(5);
+
+    const m3 = new Metrics('m');
+    stats.registerLlm({ llm: { usageId: 'switchy', metrics: m3 } });
+    expect(m3.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(5);
   });
 
   it('combines accumulated cost across usage ids (best-effort)', () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import type { Event } from '../types';
+import { saveProfile } from '../llm';
 
 let wsInstances: MockWS[] = [];
 
@@ -70,6 +74,8 @@ const baseSettings = {
   confirmation: { policy: 'never' as const },
   secrets: {},
 };
+
+const makeTempDir = (prefix: string) => fs.mkdtempSync(path.join(os.tmpdir(), prefix));
 
 describe('RemoteConversation', () => {
   beforeEach(() => {
@@ -174,6 +180,44 @@ describe('RemoteConversation', () => {
     conversation.disconnect();
     expect(id).toBe('conv-1');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives usage_id from profileId when usageId is default-llm', async () => {
+    const dir = makeTempDir('remote-conversation-profiles-');
+    try {
+      saveProfile('p1', { provider: 'openai', model: 'gpt-5-mini' }, { rootDir: dir });
+
+      let capturedReq: any = null;
+      const fetchMock = vi.fn(async (url: string, init?: any) => {
+        expect(url).toContain('/api/conversations');
+        capturedReq = JSON.parse(init?.body ?? '{}');
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ id: 'conv-1' }),
+          text: async () => '',
+        } as any;
+      });
+      (globalThis as any).fetch = fetchMock;
+
+      const { RemoteConversation } = await import('../conversation/RemoteConversation');
+      const conversation = new RemoteConversation({
+        serverUrl: 'http://localhost:3000',
+        settings: {
+          ...baseSettings,
+          llm: { profileId: 'p1', usageId: 'default-llm' },
+        } as any,
+        profileStoreOptions: { rootDir: dir },
+      });
+
+      const id = await conversation.startNewConversation();
+      conversation.disconnect();
+
+      expect(id).toBe('conv-1');
+      expect(capturedReq?.agent?.llm?.usage_id).toBe('p1');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('omits invalid secret values when starting a new conversation', async () => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -170,7 +170,10 @@ export class RemoteConversation extends EventEmitter {
       const profileBaseUrl = toOptionalString(profileConfig?.baseUrl);
       const profileApiVersion = toOptionalString(profileConfig?.apiVersion);
 
-      const effectiveUsageId = usageId ?? profileUsageId;
+      const derivedUsageId = profileId && (!usageId || usageId === 'default-llm')
+        ? profileId
+        : undefined;
+      const effectiveUsageId = derivedUsageId ?? usageId ?? profileUsageId;
       const effectiveModel = profileModel ?? model;
       const effectiveBaseUrl = baseUrl ?? profileBaseUrl;
       const effectiveApiVersion = apiVersion ?? profileApiVersion;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -986,12 +986,16 @@ export class Agent extends EventEmitter {
     if (!profileId && !model) {
       return Promise.reject(new Error('LLM model is not configured'));
     }
+    const configuredUsageId = toOptionalNonEmptyString(s.llm?.usageId);
+    const effectiveUsageId = profileId && (!configuredUsageId || configuredUsageId === 'default-llm')
+      ? profileId
+      : configuredUsageId;
     const config = {
       profileId,
       provider: s.llm.provider ?? undefined,
       model: model ?? '',
       openaiApiMode: s.llm.openaiApiMode ?? undefined,
-      usageId: s.llm.usageId ?? undefined,
+      usageId: effectiveUsageId,
       baseUrl: s.llm.baseUrl ?? undefined,
       apiKey: s.secrets?.llmApiKey ?? undefined,
       apiVersion: s.llm.apiVersion ?? undefined,

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -58,12 +58,13 @@ export class ConversationStats {
   registerLlm(event: { llm: { usageId: string; metrics: Metrics; label?: string } }): void {
     const llm = event.llm;
     const usageId = llm.usageId;
-    if (usageId in this.usageToMetrics && !this.restoredUsageIds.has(usageId)) {
-      // restore existing metrics into llm
-      llm.metrics.merge(this.usageToMetrics[usageId]);
+    const existing = this.usageToMetrics[usageId];
+    if (existing && existing !== llm.metrics) {
+      // Preserve accumulated metrics when the client is rebuilt for the same usageId (e.g. profile switching).
+      llm.metrics.merge(existing);
       this.restoredUsageIds.add(usageId);
     }
-    // Ensure we track the live metrics object
+    // Ensure we track the live metrics object.
     this.usageToMetrics[usageId] = llm.metrics;
     if (llm.label) {
       this.usageToLabels[usageId] = llm.label;


### PR DESCRIPTION
Fixes `oh-tab-1oh` by making LLM profile switches produce separate metrics buckets.

Behavior
- When `llm.profileId` is set and `llm.usageId` is unset/`default-llm`, we derive `usageId = profileId`.
- ConversationStats now preserves accumulated metrics when the same usageId is re-registered (e.g. switching back/forth).
- Remote conversation start payload derives `llm.usage_id` from `profileId` under the same conditions.

Tests
- Adds coverage for repeated metrics-object replacement and remote payload derivation.

Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved LLM configuration to correctly derive usage identifiers from profile settings when defaults are used.
  * Fixed metrics accumulation when reapplying LLM configurations with matching identifiers.

* **Tests**
  * Added test coverage for LLM profile-based configuration handling.
  * Added test validation for metrics state preservation across configuration updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->