### PR TITLE
oh-tab-h0k9/oh-tab-vjfg: profile dropdown edit + new profile entry

### DIFF
--- a/src/webview-src/__tests__/LlmProfileDropdown.test.tsx
+++ b/src/webview-src/__tests__/LlmProfileDropdown.test.tsx
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App } from '../components/App';
+import { postToWindow } from './testUtils';
+
+const mockApi = { postMessage: vi.fn() };
+
+const getLastPostedOfType = (type: string): any | null => {
+  const calls = mockApi.postMessage.mock.calls.map((call) => call[0]);
+  for (let i = calls.length - 1; i >= 0; i--) {
+    const candidate = calls[i];
+    if (candidate?.type === type) return candidate;
+  }
+  return null;
+};
+
+describe('LLM profile dropdown', () => {
+  beforeEach(() => {
+    // @ts-expect-error mock VS Code API
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('includes a New profile… option that opens the Profiles view in create mode', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    postToWindow({ type: 'llmProfilesUpdated', profiles: ['gpt-5'], activeProfileId: 'gpt-5' });
+
+    fireEvent.click(screen.getByLabelText('LLM profile'));
+    fireEvent.click(await screen.findByLabelText('New profile…'));
+
+    await screen.findByText('LLM Profiles');
+    expect(screen.getByText('Create a new profile')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+  });
+
+  it('shows an edit icon for the selected profile while open', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    postToWindow({ type: 'llmProfilesUpdated', profiles: ['gpt-5', 'claude_4'], activeProfileId: 'gpt-5' });
+
+    fireEvent.click(screen.getByLabelText('LLM profile'));
+
+    expect(await screen.findByLabelText('Edit selected profile gpt-5')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Select profile claude_4'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('setLlmProfileId')).toBeTruthy();
+    });
+
+    const selection = getLastPostedOfType('setLlmProfileId');
+    expect(selection.profileId).toBe('claude_4');
+
+    expect(await screen.findByLabelText('Edit selected profile claude_4')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Edit selected profile gpt-5')).not.toBeInTheDocument();
+  });
+
+  it('opens the Profiles view focused on the selected profile for editing', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    postToWindow({ type: 'llmProfilesUpdated', profiles: ['gpt-5'], activeProfileId: 'gpt-5' });
+
+    fireEvent.click(screen.getByLabelText('LLM profile'));
+    fireEvent.click(await screen.findByLabelText('Edit selected profile gpt-5'));
+
+    await screen.findByText('LLM Profiles');
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: { model: 'gpt-5', provider: 'openai' },
+    });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+    });
+
+    expect(await screen.findByText('Edit profile')).toBeInTheDocument();
+  });
+});
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -31,7 +31,7 @@ import { InputArea, ContextPicker, SkillsPopover } from './InputArea';
 import { ConfirmationPrompt } from './ConfirmationPrompt';
 import { StatusBanner } from './StatusBanner';
 import { HistoryView } from './HistoryView';
-import { LlmProfilesView } from './LlmProfilesView';
+import { LlmProfilesView, type LlmProfilesViewOpenRequest } from './LlmProfilesView';
 import { isHalDecision, type HalPhase } from '../../shared/halTypes';
 import { HalOverlay } from './HalOverlay';
 import {
@@ -221,6 +221,7 @@ export function App() {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [showHistory, setShowHistory] = useState(false);
   const [showLlmProfiles, setShowLlmProfiles] = useState(false);
+  const [llmProfilesOpenRequest, setLlmProfilesOpenRequest] = useState<LlmProfilesViewOpenRequest | null>(null);
 
   // Context picker state
   const [showContextPicker, setShowContextPicker] = useState(false);
@@ -1086,6 +1087,17 @@ export function App() {
   }, [postMessage]);
 
   const handleOpenLlmProfiles = useCallback(() => {
+    setLlmProfilesOpenRequest(null);
+    setShowLlmProfiles(true);
+  }, []);
+
+  const handleOpenLlmProfilesCreate = useCallback(() => {
+    setLlmProfilesOpenRequest({ mode: 'create' });
+    setShowLlmProfiles(true);
+  }, []);
+
+  const handleOpenLlmProfilesEdit = useCallback((profileId: string) => {
+    setLlmProfilesOpenRequest({ mode: 'edit', profileId });
     setShowLlmProfiles(true);
   }, []);
 
@@ -1373,6 +1385,8 @@ export function App() {
           llmProfiles={llmProfiles}
           llmProfileLabel={llmProfileLabel}
           onSelectLlmProfileId={handleSelectLlmProfileId}
+          onOpenLlmProfilesCreate={handleOpenLlmProfilesCreate}
+          onOpenLlmProfilesEdit={handleOpenLlmProfilesEdit}
           onOpenContext={handleOpenContext}
           contextCount={selectedContextFiles.length}
           onOpenSkills={handleOpenSkills}
@@ -1415,6 +1429,7 @@ export function App() {
       <LlmProfilesView
         isOpen={showLlmProfiles}
         onClose={() => setShowLlmProfiles(false)}
+        openRequest={llmProfilesOpenRequest}
         listProfiles={listLlmProfiles}
         loadProfile={loadLlmProfile}
         saveProfile={saveLlmProfile}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -12,6 +12,8 @@ interface InputAreaProps {
   llmProfiles: string[];
   llmProfileLabel?: string | null;
   onSelectLlmProfileId: (profileId: string | null) => void;
+  onOpenLlmProfilesCreate?: () => void;
+  onOpenLlmProfilesEdit?: (profileId: string) => void;
   // Context picker
   onOpenContext: () => void;
   contextCount?: number;
@@ -43,6 +45,8 @@ export function InputArea({
   llmProfiles,
   llmProfileLabel,
   onSelectLlmProfileId,
+  onOpenLlmProfilesCreate,
+  onOpenLlmProfilesEdit,
   onOpenContext,
   contextCount = 0,
   onOpenSkills,
@@ -198,6 +202,8 @@ export function InputArea({
             profiles={llmProfiles}
             fallbackLabel={llmProfileLabel}
             onSelect={onSelectLlmProfileId}
+            onOpenCreate={onOpenLlmProfilesCreate}
+            onOpenEdit={onOpenLlmProfilesEdit}
           />
 
           <AccessoryButton
@@ -320,9 +326,18 @@ interface LlmProfileSelectorProps {
   profiles: string[];
   fallbackLabel?: string | null;
   onSelect: (profileId: string | null) => void;
+  onOpenCreate?: () => void;
+  onOpenEdit?: (profileId: string) => void;
 }
 
-function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: LlmProfileSelectorProps) {
+function LlmProfileSelector({
+  profileId,
+  profiles,
+  fallbackLabel,
+  onSelect,
+  onOpenCreate,
+  onOpenEdit,
+}: LlmProfileSelectorProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
 
@@ -340,7 +355,6 @@ function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: Ll
 
   const handleSelect = (next: string | null) => {
     onSelect(next);
-    setIsOpen(false);
   };
 
   const isSelected = (candidate: string | null) => candidate === profileId;
@@ -406,10 +420,8 @@ function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: Ll
               sanitizedProfiles.map((id) => {
                 const selected = isSelected(id);
                 return (
-                  <button
+                  <div
                     key={id}
-                    type="button"
-                    onClick={() => handleSelect(id)}
                     role="option"
                     aria-selected={selected}
                     className={`
@@ -421,13 +433,62 @@ function LlmProfileSelector({ profileId, profiles, fallbackLabel, onSelect }: Ll
                       ${selected ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
                     `}
                   >
-                    <span className="codicon codicon-symbol-misc" />
-                    <span className="flex-1 font-mono truncate">{id}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(id)}
+                      className="flex-1 flex items-center gap-2 text-left min-w-0"
+                      aria-label={`Select profile ${id}`}
+                      title={`Select profile ${id}`}
+                    >
+                      <span className="codicon codicon-symbol-misc" />
+                      <span className="flex-1 font-mono truncate">{id}</span>
+                    </button>
+
+                    {selected && onOpenEdit && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setIsOpen(false);
+                          onOpenEdit(id);
+                        }}
+                        className="h-7 w-7 rounded-md bg-white/[0.03] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:border-white/[0.1] transition-all flex items-center justify-center"
+                        aria-label={`Edit selected profile ${id}`}
+                        title={`Edit profile ${id}`}
+                      >
+                        <span className="codicon codicon-settings-gear text-[13px]" />
+                      </button>
+                    )}
+
                     {selected && <span className="codicon codicon-check text-brand-400" />}
-                  </button>
+                  </div>
                 );
               })
             )}
+
+            <div className="my-1 border-t border-white/10" />
+
+            <button
+              type="button"
+              onClick={() => {
+                if (!onOpenCreate) return;
+                setIsOpen(false);
+                onOpenCreate();
+              }}
+              className={`
+                w-full text-left px-3 py-2 rounded-lg
+                text-sm
+                transition-colors duration-150
+                hover:bg-white/10
+                flex items-center gap-2
+                ${onOpenCreate ? 'text-stone-300' : 'text-stone-500 cursor-not-allowed'}
+              `}
+              disabled={!onOpenCreate}
+              aria-label="New profile…"
+              title="New profile…"
+            >
+              <span className="codicon codicon-add" />
+              <span className="flex-1">New profile…</span>
+            </button>
           </div>
         </div>
       )}

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -4,6 +4,10 @@ import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideCli
 
 type ProfileFormMode = 'create' | 'edit';
 
+export type LlmProfilesViewOpenRequest =
+  | { mode: 'create' }
+  | { mode: 'edit'; profileId: string };
+
 type ProfileFormState = {
   name: string;
   provider: '' | 'openai' | 'anthropic' | 'openrouter' | 'litellm_proxy' | 'gemini';
@@ -272,6 +276,7 @@ function SelectField(props: {
 export function LlmProfilesView(props: {
   isOpen: boolean;
   onClose: () => void;
+  openRequest?: LlmProfilesViewOpenRequest | null;
   listProfiles: () => Promise<string[]>;
   loadProfile: (profileId: string) => Promise<LLMConfiguration>;
   saveProfile: (profileId: string, profile: LLMConfiguration) => Promise<void>;
@@ -281,6 +286,7 @@ export function LlmProfilesView(props: {
   const {
     isOpen,
     onClose,
+    openRequest,
     listProfiles,
     loadProfile,
     saveProfile,
@@ -384,6 +390,15 @@ export function LlmProfilesView(props: {
       void refreshApiKeyStatus(profileId);
     }
   }, [loadProfile, refreshApiKeyStatus]);
+
+  useEffect(() => {
+    if (!isOpen || !openRequest) return;
+    if (openRequest.mode === 'create') {
+      startCreate();
+      return;
+    }
+    void startEdit(openRequest.profileId);
+  }, [isOpen, openRequest, startCreate, startEdit]);
 
   const handleSave = useCallback(async () => {
     setSaveAttempted(true);


### PR DESCRIPTION
Implements:
- oh-tab-h0k9: show edit icon on selected profile row (in open dropdown) to open Profiles view focused on that profile.
- oh-tab-vjfg: add "New profile…" dropdown option to open Profiles view in create mode.

Notes:
- Dropdown stays open on selection changes; edit icon follows the selected row.

Tests:
- npm test
- npm run typecheck
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "New profile…" option to the LLM profile dropdown for creating profiles
  * Introduced edit functionality for existing profiles with inline edit controls
  * Enhanced LLM profiles panel to open in create or edit modes based on user action
  * Improved profile selection workflow with updated dropdown behavior

* **Tests**
  * Added comprehensive test suite for LLM profile dropdown UI including profile creation, editing, and API key status flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->