### PR TITLE
[oh-tab-262f] Internal profile _commands + E2E suite

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -3,10 +3,12 @@ import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsMan
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from '../shared/halTeleport';
 import { DEFAULT_HAL_STATE } from '../shared/halDefaults';
+import { resolveConfiguredLlmLabel } from '../shared/llmProfiles';
 import { safeStringify } from '../shared/safeStringify';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
+import * as llmProfilesStore from '../webview/host/llmProfilesStore';
 import type { ConversationInstance, SecretRegistry, Event } from '@openhands/agent-sdk-ts';
 
 export type RenderedEventsInfo = {
@@ -106,6 +108,12 @@ function createPendingResponse<T>(
 }
 
 export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDeps): vscode.Disposable[] {
+  const postToWebview = async (message: HostToWebviewMessage): Promise<boolean> => {
+    const chatView = deps.getChatView();
+    if (!chatView || !deps.getChatWebviewReady()) return false;
+    return chatView.webview.postMessage(message);
+  };
+
   // Diagnostics command for E2E tests and troubleshooting
   const getServerUrl = () => vscode.workspace.getConfiguration().get<string>('openhands.serverUrl') ?? '';
   const diag = vscode.commands.registerCommand('openhands._diagnostics', () => {
@@ -283,13 +291,6 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
   );
 
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
-    const postToWebview = (message: HostToWebviewMessage) => {
-      const chatView = deps.getChatView();
-      if (!chatView || !deps.getChatWebviewReady()) return false;
-      void chatView.webview.postMessage(message);
-      return true;
-    };
-
     try {
       const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
       const settings = await settingsMgr.get();
@@ -298,7 +299,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
       if (!firstServerUrl) {
         const message = 'No server available';
         deps.getOutputChannel()?.appendLine(`[hal.teleport] ${message}`);
-        const posted = postToWebview({ type: 'halTeleportUnavailable', error: message });
+        const posted = await postToWebview({ type: 'halTeleportUnavailable', error: message });
         if (!posted) {
           void vscode.window.showErrorMessage(message);
         }
@@ -351,11 +352,118 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     } catch (err) {
       const reason = deps.renderError(err);
       deps.getOutputChannel()?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
-      const posted = postToWebview({ type: 'halTeleportFailed', error: reason });
+      const posted = await postToWebview({ type: 'halTeleportFailed', error: reason });
       if (!posted) {
         void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
       }
     }
+  });
+
+  const getProfileApiKeySecretKey = (profileId: string): string => `openhands.llmProfileApiKey.${profileId}`;
+
+  const broadcastLlmProfilesUpdated = async (): Promise<void> => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    const settings = await settingsMgr.get();
+    await postToWebview({
+      type: 'llmProfilesUpdated',
+      profiles: llmProfilesStore.listProfiles(),
+      activeProfileId: settings.llm.profileId ?? null,
+    });
+  };
+
+  const openProfilesView = vscode.commands.registerCommand('openhands._openProfilesView', async (raw: unknown) => {
+    await vscode.commands.executeCommand('openhands.open');
+    await deps.ensureConversationAndConnection({ uiJustCreated: true });
+
+    const mode = (raw as { mode?: unknown } | undefined)?.mode;
+    const profileIdRaw = (raw as { profileId?: unknown } | undefined)?.profileId;
+    const payload: Record<string, unknown> = {};
+    if (mode === 'create' || mode === 'edit') payload.mode = mode;
+    if (typeof profileIdRaw === 'string') payload.profileId = profileIdRaw;
+
+    return await vscode.commands.executeCommand('openhands._webviewAction', { action: 'openLlmProfilesView', payload });
+  });
+
+  const createProfile = vscode.commands.registerCommand('openhands._createProfile', async (raw: unknown) => {
+    const profileId = typeof (raw as { profileId?: unknown } | undefined)?.profileId === 'string'
+      ? ((raw as { profileId: string }).profileId).trim()
+      : '';
+    if (!profileId) throw new Error('profileId is required');
+    const profile = (raw as { profile?: unknown } | undefined)?.profile;
+    if (profile === undefined) throw new Error('profile is required');
+
+    const existing = llmProfilesStore.listProfiles();
+    if (existing.includes(profileId)) throw new Error(`Profile '${profileId}' already exists`);
+
+    llmProfilesStore.saveProfile(profileId, profile);
+    await broadcastLlmProfilesUpdated();
+    return { ok: true, profileId };
+  });
+
+  const updateProfile = vscode.commands.registerCommand('openhands._updateProfile', async (raw: unknown) => {
+    const profileId = typeof (raw as { profileId?: unknown } | undefined)?.profileId === 'string'
+      ? ((raw as { profileId: string }).profileId).trim()
+      : '';
+    if (!profileId) throw new Error('profileId is required');
+    const profile = (raw as { profile?: unknown } | undefined)?.profile;
+    const patch = (raw as { patch?: unknown } | undefined)?.patch;
+
+    const existing = llmProfilesStore.listProfiles();
+    if (!existing.includes(profileId)) throw new Error(`Profile '${profileId}' not found`);
+
+    if (profile !== undefined) {
+      llmProfilesStore.saveProfile(profileId, profile);
+      await broadcastLlmProfilesUpdated();
+      return { ok: true, profileId };
+    }
+
+    if (!patch || typeof patch !== 'object') throw new Error('patch must be an object');
+    const current = llmProfilesStore.loadProfile(profileId).config;
+    const next = { ...current, ...(patch as Record<string, unknown>) };
+    llmProfilesStore.saveProfile(profileId, next);
+    await broadcastLlmProfilesUpdated();
+    return { ok: true, profileId };
+  });
+
+  const selectProfile = vscode.commands.registerCommand('openhands._selectProfile', async (raw: unknown) => {
+    const profileIdRaw = (raw as { profileId?: unknown } | undefined)?.profileId ?? raw;
+    if (profileIdRaw !== null && typeof profileIdRaw !== 'string') {
+      throw new Error('profileId must be a string or null');
+    }
+    const profileId = typeof profileIdRaw === 'string' ? profileIdRaw.trim() : '';
+
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    await settingsMgr.update({ llm: { profileId } }, 'global');
+    await deps.ensureConversationAndConnection();
+
+    const updated = await settingsMgr.get();
+    const label = resolveConfiguredLlmLabel(updated);
+    await postToWebview({
+      type: 'status',
+      status: deps.getConversation()?.getStatus() ?? 'offline',
+      mode: deps.getConversationMode(),
+      llmProfileLabel: label,
+      llmModel: label,
+    });
+    await broadcastLlmProfilesUpdated();
+    return { ok: true, profileId: updated.llm.profileId ?? null };
+  });
+
+  const setProfileApiKey = vscode.commands.registerCommand('openhands._setProfileApiKey', async (raw: unknown) => {
+    const profileId = typeof (raw as { profileId?: unknown } | undefined)?.profileId === 'string'
+      ? ((raw as { profileId: string }).profileId).trim()
+      : '';
+    if (!profileId) throw new Error('profileId is required');
+    const apiKeyRaw = (raw as { apiKey?: unknown } | undefined)?.apiKey;
+    const apiKey = typeof apiKeyRaw === 'string' ? apiKeyRaw.trim() : '';
+
+    const key = getProfileApiKeySecretKey(profileId);
+    if (!apiKey) {
+      await deps.context.secrets.delete(key);
+      return { ok: true, profileId, hasKey: false };
+    }
+    await deps.context.secrets.store(key, apiKey);
+    return { ok: true, profileId, hasKey: true };
   });
 
   return [
@@ -368,6 +476,10 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     queryHalState,
     webviewAction,
     teleportToRemoteRuntime,
+    openProfilesView,
+    createProfile,
+    updateProfile,
+    selectProfile,
+    setProfileApiKey,
   ];
 }
-

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -426,7 +426,8 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
   });
 
   const selectProfile = vscode.commands.registerCommand('openhands._selectProfile', async (raw: unknown) => {
-    const profileIdRaw = (raw as { profileId?: unknown } | undefined)?.profileId ?? raw;
+    const nestedProfileId = (raw as { profileId?: unknown } | undefined)?.profileId;
+    const profileIdRaw = nestedProfileId === undefined ? raw : nestedProfileId;
     if (profileIdRaw !== null && typeof profileIdRaw !== 'string') {
       throw new Error('profileId must be a string or null');
     }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -929,6 +929,25 @@ export function App() {
               postMessage({ type: 'setLlmProfileId', profileId });
               break;
             }
+            case 'openLlmProfilesView': {
+              const mode = (rawPayload as { mode?: unknown } | undefined)?.mode;
+              const profileIdRaw = (rawPayload as { profileId?: unknown } | undefined)?.profileId;
+              setShowLlmProfiles(true);
+              if (mode === 'create') {
+                setLlmProfilesOpenRequest({ mode: 'create' });
+                break;
+              }
+              if (mode === 'edit' && typeof profileIdRaw === 'string' && profileIdRaw.trim()) {
+                setLlmProfilesOpenRequest({ mode: 'edit', profileId: profileIdRaw.trim() });
+                break;
+              }
+              setLlmProfilesOpenRequest(null);
+              break;
+            }
+            case 'closeLlmProfilesView':
+              setShowLlmProfiles(false);
+              setLlmProfilesOpenRequest(null);
+              break;
             case 'halApprove':
               handleHalApprove();
               break;

--- a/tests/e2e/llmProfiles.test.ts
+++ b/tests/e2e/llmProfiles.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-profiles-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab LLM Profiles E2E', function () {
+  this.timeout(180000);
+
+  it('creates, updates, and switches LLM profiles', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
+    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'llmProfiles',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+        OPENAI_API_KEY: 'e2e-openai-key',
+        ANTHROPIC_API_KEY: 'e2e-anthropic-key',
+      }
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -54,6 +54,11 @@ export async function run(): Promise<void> {
     return runLlmSwitchingTest();
   }
 
+  if (testName === 'llmProfiles') {
+    const { run: runLlmProfilesTest } = await import('./llmProfiles');
+    return runLlmProfilesTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness

--- a/tests/e2e/suite/llmProfiles.ts
+++ b/tests/e2e/suite/llmProfiles.ts
@@ -101,11 +101,13 @@ export async function run(): Promise<void> {
     await update('openhands.confirmation.policy', 'never');
     await update('openhands.agent.enableSecurityAnalyzer', false);
 
+    const v1BaseUrl = `${mock.baseUrl}/v1`;
+
     // Base LLM config (used when no profile is selected).
     await update('openhands.llm.profileId', '');
     await update('openhands.llm.provider', 'anthropic');
     await update('openhands.llm.model', 'claude-e2e');
-    await update('openhands.llm.baseUrl', mock.baseUrl);
+    await update('openhands.llm.baseUrl', v1BaseUrl);
 
     await vscode.commands.executeCommand('openhands.reconnect');
     await vscode.commands.executeCommand('openhands.startNewConversation');
@@ -116,7 +118,7 @@ export async function run(): Promise<void> {
       profile: {
         provider: 'openai',
         model: 'gpt-4o-mini',
-        baseUrl: mock.baseUrl,
+        baseUrl: v1BaseUrl,
         openaiApiMode: 'chat_completions',
       },
     });
@@ -125,7 +127,7 @@ export async function run(): Promise<void> {
       profile: {
         provider: 'openai',
         model: 'gpt-5-mini',
-        baseUrl: mock.baseUrl,
+        baseUrl: v1BaseUrl,
         openaiApiMode: 'responses',
       },
     });
@@ -178,4 +180,3 @@ export async function run(): Promise<void> {
     await mock.close();
   }
 }
-

--- a/tests/e2e/suite/llmProfiles.ts
+++ b/tests/e2e/suite/llmProfiles.ts
@@ -1,0 +1,181 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import { startMockLlmServer, type MockLlmRequest } from './mockLlmServer';
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+type DiagnosticsInfo = {
+  eventBacklog?: { latestSeq?: number };
+};
+
+type ErrorInfo = { seq?: number } | null;
+
+async function sendAndWaitForRequestPath(options: {
+  text: string;
+  expectedPath: string;
+  timeoutMs?: number;
+  getRequests: () => MockLlmRequest[];
+}): Promise<MockLlmRequest> {
+  const { text, expectedPath, timeoutMs = 45000, getRequests } = options;
+  const beforeReqCount = getRequests().length;
+  const beforeDiag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  const beforeSeq = typeof beforeDiag?.eventBacklog?.latestSeq === 'number' ? beforeDiag.eventBacklog.latestSeq : 0;
+  const beforeError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+  const beforeErrorSeq = typeof beforeError?.seq === 'number' ? beforeError.seq : -1;
+
+  const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text }
+  });
+  if (!send?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+  }
+
+  try {
+    await pollUntil(async () => {
+      const reqs = getRequests();
+      const hasExpected = reqs.slice(beforeReqCount).some((r) => r.path === expectedPath);
+      if (!hasExpected) return false;
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+      const seq = typeof diag?.eventBacklog?.latestSeq === 'number' ? diag.eventBacklog.latestSeq : 0;
+      return seq > beforeSeq;
+    }, timeoutMs, 200);
+  } catch (err) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
+    const recent = getRequests()
+      .slice(beforeReqCount)
+      .map((r) => r.path)
+      .slice(-20);
+    throw new Error(
+      `Timed out waiting for mock request (${expectedPath}).\n` +
+      `- diag: ${JSON.stringify(diag)}\n` +
+      `- lastError: ${JSON.stringify(lastError)}\n` +
+      `- requestsSinceSend: ${recent.join(', ') || '(none)'}\n` +
+      `- original: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+  const afterErrorSeq = typeof afterError?.seq === 'number' ? afterError.seq : -1;
+  if (afterError && afterErrorSeq > beforeErrorSeq) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    throw new Error(
+      `Detected error event(s) after sending message.\n` +
+      `- diag: ${JSON.stringify(diag)}\n` +
+      `- lastError: ${JSON.stringify(afterError)}`,
+    );
+  }
+
+  const last = getRequests()
+    .slice(beforeReqCount)
+    .filter((r) => r.path === expectedPath)
+    .slice(-1)[0];
+  if (!last) {
+    throw new Error(`Expected mock request (${expectedPath}) after send, but none was recorded`);
+  }
+  return last;
+}
+
+export async function run(): Promise<void> {
+  const mock = await startMockLlmServer();
+
+  try {
+    await vscode.commands.executeCommand('openhands.open');
+
+    await pollUntil(async () => {
+      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+    }, 15000);
+
+    const cfg = vscode.workspace.getConfiguration();
+    const update = async (key: string, value: unknown): Promise<void> => {
+      await cfg.update(key, value, vscode.ConfigurationTarget.Global);
+    };
+
+    // Force local mode + short runs for E2E.
+    await update('openhands.serverUrl', '');
+    await update('openhands.conversation.maxIterations', 10);
+    await update('openhands.confirmation.policy', 'never');
+    await update('openhands.agent.enableSecurityAnalyzer', false);
+
+    // Base LLM config (used when no profile is selected).
+    await update('openhands.llm.profileId', '');
+    await update('openhands.llm.provider', 'anthropic');
+    await update('openhands.llm.model', 'claude-e2e');
+    await update('openhands.llm.baseUrl', mock.baseUrl);
+
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+
+    // Create profiles used by this suite.
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: 'e2e-openai-chat',
+      profile: {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        baseUrl: mock.baseUrl,
+        openaiApiMode: 'chat_completions',
+      },
+    });
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: 'e2e-openai-responses',
+      profile: {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        baseUrl: mock.baseUrl,
+        openaiApiMode: 'responses',
+      },
+    });
+
+    // No profile selected: should use the base anthropic config.
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: null });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 1: base (anthropic)',
+      expectedPath: '/v1/messages',
+      getRequests: () => mock.requests,
+    });
+
+    // Select a profile and verify subsequent calls use it.
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: 'e2e-openai-chat' });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 2: profile (openai chat_completions)',
+      expectedPath: '/v1/chat/completions',
+      getRequests: () => mock.requests,
+    });
+
+    // Update profile config and verify it takes effect after re-selecting.
+    await vscode.commands.executeCommand('openhands._updateProfile', {
+      profileId: 'e2e-openai-chat',
+      patch: { openaiApiMode: 'responses', model: 'gpt-5-mini' },
+    });
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: null });
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: 'e2e-openai-chat' });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 3: updated profile (openai responses)',
+      expectedPath: '/v1/responses',
+      getRequests: () => mock.requests,
+    });
+
+    // Switch to a second profile.
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: 'e2e-openai-responses' });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 4: second profile (openai responses)',
+      expectedPath: '/v1/responses',
+      getRequests: () => mock.requests,
+    });
+
+    // Clearing selection returns to base config again.
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: null });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 5: base again (anthropic)',
+      expectedPath: '/v1/messages',
+      getRequests: () => mock.requests,
+    });
+  } finally {
+    await mock.close();
+  }
+}
+


### PR DESCRIPTION
Implements `oh-tab-262f` (E2E + internal commands for LLM Profiles).

**Internal commands**
- `openhands._openProfilesView` (mode: create/edit)
- `openhands._createProfile`
- `openhands._updateProfile`
- `openhands._selectProfile`
- `openhands._setProfileApiKey`

**E2E**
- Adds `tests/e2e/llmProfiles.test.ts` + `tests/e2e/suite/llmProfiles.ts` (create/update/select + fallback-to-base config using the mock LLM server).

Ran locally:
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npx tsc -p tests/e2e/tsconfig.suite.json`
- `npx tsc -p tsconfig.e2e.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM profiles management system: create, update, and switch between multiple LLM model configurations
  * Per-profile API key storage and management
  * Dedicated profiles view interface for managing LLM settings

* **Tests**
  * Added comprehensive end-to-end test suite for LLM profiles functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->