### PR TITLE
[oh-tab-bu9c] Prefer per-profile API key in local mode

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1002,9 +1002,7 @@ export class Agent extends EventEmitter {
     const configuredApiKeyIsReference =
       typeof configuredApiKey === 'string' && /^[A-Z0-9_]+$/.test(configuredApiKey);
     const configuredApiKeyInline = configuredApiKeyIsReference ? undefined : configuredApiKey;
-    if (configuredApiKeyInline) {
-      this.secrets.set('openhands.llmApiKey', configuredApiKeyInline);
-    }
+    this.secrets.set('openhands.llmApiKey', configuredApiKeyInline);
 
     const preferredApiKeys = (() => {
       if (!profileId || !isSafeProfileId(profileId)) return undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -97,6 +97,13 @@ function toOptionalNonEmptyString(value: unknown): string | undefined {
   return trimmed ? trimmed : undefined;
 }
 
+function isSafeProfileId(profileId: string): boolean {
+  if (!profileId.trim()) return false;
+  if (profileId !== profileId.trim()) return false;
+  if (profileId.includes('/') || profileId.includes('\\')) return false;
+  return /^[a-zA-Z0-9._-]+$/.test(profileId);
+}
+
 function truncateToolMessage(text: string, maxChars = TOOL_MESSAGE_MAX_CHARS): string {
   if (text.length <= maxChars) return text;
   const available = maxChars - TOOL_MESSAGE_CLIP_MARKER.length - 2;
@@ -990,6 +997,24 @@ export class Agent extends EventEmitter {
     const effectiveUsageId = profileId && (!configuredUsageId || configuredUsageId === 'default-llm')
       ? profileId
       : configuredUsageId;
+
+    const configuredApiKey = toOptionalNonEmptyString(s.secrets?.llmApiKey);
+    const configuredApiKeyIsReference =
+      typeof configuredApiKey === 'string' && /^[A-Z0-9_]+$/.test(configuredApiKey);
+    const configuredApiKeyInline = configuredApiKeyIsReference ? undefined : configuredApiKey;
+    if (configuredApiKeyInline) {
+      this.secrets.set('openhands.llmApiKey', configuredApiKeyInline);
+    }
+
+    const preferredApiKeys = (() => {
+      if (!profileId || !isSafeProfileId(profileId)) return undefined;
+      const keys: string[] = [`openhands.llmProfileApiKey.${profileId}`];
+      if (configuredApiKeyIsReference && configuredApiKey) {
+        keys.push(configuredApiKey);
+      }
+      return keys;
+    })();
+
     const config = {
       profileId,
       provider: s.llm.provider ?? undefined,
@@ -997,7 +1022,7 @@ export class Agent extends EventEmitter {
       openaiApiMode: s.llm.openaiApiMode ?? undefined,
       usageId: effectiveUsageId,
       baseUrl: s.llm.baseUrl ?? undefined,
-      apiKey: s.secrets?.llmApiKey ?? undefined,
+      apiKey: profileId ? undefined : configuredApiKey,
       apiVersion: s.llm.apiVersion ?? undefined,
       timeoutSeconds: s.llm.timeout ?? undefined,
       temperature: s.llm.temperature ?? undefined,
@@ -1012,6 +1037,7 @@ export class Agent extends EventEmitter {
     };
     const factory = new LLMFactory(config, {
       secrets: this.secrets,
+      preferredApiKeys,
       registry: this.registry,
       onMetricsUpdate: (usageId, metrics) => {
         if (!this.conversationStats) return;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
@@ -1,0 +1,157 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+const makeTempDir = (prefix: string) => fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+
+describe('Agent profile api key selection', () => {
+  it('prefers per-profile key over global key when profileId is set', async () => {
+    const tmpHome = makeTempDir('agent-profile-key-');
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      process.env.HOME = tmpHome;
+      process.env.USERPROFILE = tmpHome;
+      vi.resetModules();
+
+      const [{ saveProfile }, { Agent }, { SecretRegistry }] = await Promise.all([
+        import('../../llm'),
+        import('../Agent'),
+        import('../SecretRegistry'),
+      ]);
+
+      saveProfile('p1', {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        openaiApiMode: 'responses',
+        baseUrl: 'http://example.invalid/v1',
+      });
+
+      const secrets = new SecretRegistry();
+      secrets.set('openhands.llmProfileApiKey.p1', 'sk-profile');
+
+      let authorization: string | undefined;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_url: unknown, init?: { headers?: unknown }) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        authorization = headers?.Authorization ?? headers?.authorization;
+        return new Response(
+          JSON.stringify({
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'ok' }],
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }) as typeof globalThis.fetch;
+
+      try {
+        const agent = new Agent({
+          workspaceRoot: tmpHome,
+          secrets,
+          settings: {
+            llm: { profileId: 'p1' },
+            secrets: { llmApiKey: 'sk-global' },
+          } as any,
+        });
+
+        const client = await (agent as any).createLlmClientFromSettings();
+        for await (const _ of client.streamChat({
+          systemPrompt: 'test',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        } as any)) {
+          void _;
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      expect(authorization).toBe('Bearer sk-profile');
+    } finally {
+      process.env.HOME = originalHome;
+      process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to global key when profile key is absent', async () => {
+    const tmpHome = makeTempDir('agent-profile-key-fallback-');
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      process.env.HOME = tmpHome;
+      process.env.USERPROFILE = tmpHome;
+      vi.resetModules();
+
+      const [{ saveProfile }, { Agent }, { SecretRegistry }] = await Promise.all([
+        import('../../llm'),
+        import('../Agent'),
+        import('../SecretRegistry'),
+      ]);
+
+      saveProfile('p1', {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        openaiApiMode: 'responses',
+        baseUrl: 'http://example.invalid/v1',
+      });
+
+      const secrets = new SecretRegistry();
+
+      let authorization: string | undefined;
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (_url: unknown, init?: { headers?: unknown }) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        authorization = headers?.Authorization ?? headers?.authorization;
+        return new Response(
+          JSON.stringify({
+            output: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'ok' }],
+              },
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 },
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        );
+      }) as typeof globalThis.fetch;
+
+      try {
+        const agent = new Agent({
+          workspaceRoot: tmpHome,
+          secrets,
+          settings: {
+            llm: { profileId: 'p1' },
+            secrets: { llmApiKey: 'sk-global' },
+          } as any,
+        });
+
+        const client = await (agent as any).createLlmClientFromSettings();
+        for await (const _ of client.streamChat({
+          systemPrompt: 'test',
+          messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+        } as any)) {
+          void _;
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+
+      expect(authorization).toBe('Bearer sk-global');
+    } finally {
+      process.env.HOME = originalHome;
+      process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Fixes Bead `oh-tab-bu9c`.

When an LLM profile is selected (`llm.profileId` set), prefer the per-profile API key stored in VS Code SecretStorage under `openhands.llmProfileApiKey.<profileId>` before falling back to the global key and env keys.

Changes:
- `Agent.createLlmClientFromSettings()`: when `profileId` is set, do not pass `config.apiKey` (which always won); instead pass `preferredApiKeys` with the profile-specific secret key first.
- If `settings.secrets.llmApiKey` is an inline key (not a reference like `OPENAI_API_KEY`), register it in the SecretRegistry as `openhands.llmApiKey` so it remains in the fallback chain.
- Unit tests cover profile-key override and global fallback.

Tests:
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced API key management with support for profile-based configuration, allowing different API keys per profile with automatic fallback to global settings
  * Added validation to ensure profile identifiers meet security requirements

* **Tests**
  * Introduced test coverage for profile-specific API key selection and global fallback scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->