### PR TITLE
[oh-tab-am0j] Esc closes context picker and focuses input

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -163,6 +163,56 @@ describe('App toolbar interactions', () => {
     expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
   });
 
+  it('closes the context picker on Esc and returns focus to the input', async () => {
+    render(<App />);
+    const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+    expect(input).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
+      }));
+    });
+
+    fireEvent.change(input, { target: { value: '@' } });
+    input.setSelectionRange(1, 1);
+    fireEvent.select(input);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'workspaceFiles', files: ['src/index.ts', 'README.md'] }
+      }));
+    });
+
+    expect(await screen.findByPlaceholderText('Search files...')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('src/index.ts'));
+
+    await waitFor(() => {
+      expect(input.value).toContain('@src/index.ts');
+    });
+
+    // Blur input (user clicked elsewhere)
+    input.blur();
+
+    // Clicking back into the input near the mention re-opens the picker.
+    input.setSelectionRange(input.value.length, input.value.length);
+    input.focus();
+    fireEvent.select(input);
+
+    const searchInput = await screen.findByPlaceholderText('Search files...');
+    fireEvent.keyDown(searchInput, { key: 'Escape' });
+
+    expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(input.value.length);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+
   it('requests skills and opens selected skill file', async () => {
     render(<App />);
     fireEvent.click(screen.getAllByLabelText('Skills')[0]);

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -230,6 +230,7 @@ export function App() {
   const [selectedContextFiles, setSelectedContextFiles] = useState<string[]>([]);
   const [isMentionActive, setIsMentionActive] = useState(false);
   const mentionStartRef = useRef<number | null>(null);
+  const suppressMentionOnceRef = useRef(false);
 
   // Skills state
   const [showSkillsPopover, setShowSkillsPopover] = useState(false);
@@ -1048,6 +1049,14 @@ export function App() {
     const before = text.slice(0, caret);
     const at = before.lastIndexOf('@');
 
+    // If we intentionally closed the picker (e.g. Esc), avoid reopening immediately on the focus/selection event.
+    if (suppressMentionOnceRef.current) {
+      suppressMentionOnceRef.current = false;
+      if (at !== -1 && !/\s/.test(before.slice(at + 1))) {
+        return;
+      }
+    }
+
     // Clear mention if no @ or whitespace after @
     if (at === -1 || /\s/.test(before.slice(at + 1))) {
       if (isMentionActive) {
@@ -1163,6 +1172,33 @@ export function App() {
       return willBeOpen;
     });
   }, [postMessage]);
+
+  const focusInputAtEnd = useCallback(() => {
+    const textarea = document.getElementById('openhands-chat-input') as HTMLTextAreaElement | null;
+    if (!textarea) return;
+    textarea.focus();
+    const pos = textarea.value.length;
+    try {
+      textarea.setSelectionRange(pos, pos);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  const handleCloseContextPicker = useCallback((reason: 'escape' | 'outside') => {
+    setShowContextPicker(false);
+
+    if (reason !== 'escape') {
+      return;
+    }
+
+    // When Esc closes the picker, return focus to the input and prevent the mention logic from reopening it.
+    setIsMentionActive(false);
+    setContextQuery('');
+    mentionStartRef.current = null;
+    suppressMentionOnceRef.current = true;
+    focusInputAtEnd();
+  }, [focusInputAtEnd]);
 
   // Attachments handlers
   const handleOpenAttachments = useCallback(() => {
@@ -1424,7 +1460,7 @@ export function App() {
         {showContextPicker && (
           <ContextPicker
             isOpen
-            onClose={() => setShowContextPicker(false)}
+            onClose={handleCloseContextPicker}
             files={workspaceFiles}
             selectedFiles={selectedContextFiles}
             onToggleFile={handleToggleContextFile}
@@ -1434,14 +1470,14 @@ export function App() {
         )}
 
         {/* Skills popover */}
-        {showSkillsPopover && (
-          <SkillsPopover
-            isOpen
-            onClose={() => setShowSkillsPopover(false)}
-            skills={skills}
-            onOpenSkill={handleOpenSkill}
-          />
-        )}
+      {showSkillsPopover && (
+        <SkillsPopover
+          isOpen
+          onClose={() => setShowSkillsPopover(false)}
+          skills={skills}
+          onOpenSkill={handleOpenSkill}
+        />
+      )}
       </div>
 
       {/* LLM Profiles view (slide-over panel) */}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState, useEffect } from 'react';
-import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
+import { useCloseOnEscapeAndOutsideClick, type CloseReason } from './useCloseOnEscapeAndOutsideClick';
 
 interface InputAreaProps {
   value: string;
@@ -535,7 +535,7 @@ function AccessoryButton({ icon, label, onClick, badge, comingSoon }: AccessoryB
 {/* Context Picker Popover */}
 interface ContextPickerProps {
   isOpen: boolean;
-  onClose: () => void;
+  onClose: (reason: CloseReason) => void;
   files: string[];
   selectedFiles: string[];
   onToggleFile: (file: string) => void;
@@ -588,7 +588,7 @@ export function ContextPicker({
 
     if (e.key === 'Escape') {
       e.preventDefault();
-      onClose();
+      onClose('escape');
     }
   };
 
@@ -683,7 +683,7 @@ interface Skill {
 
 interface SkillsPopoverProps {
   isOpen: boolean;
-  onClose: () => void;
+  onClose: (reason: CloseReason) => void;
   skills: Skill[];
   onOpenSkill: (path: string) => void;
 }
@@ -731,7 +731,7 @@ export function SkillsPopover({
 
     if (e.key === 'Escape') {
       e.preventDefault();
-      onClose();
+      onClose('escape');
     }
   };
 

--- a/src/webview-src/components/useCloseOnEscapeAndOutsideClick.ts
+++ b/src/webview-src/components/useCloseOnEscapeAndOutsideClick.ts
@@ -1,8 +1,10 @@
 import { useEffect } from 'react';
 import type { RefObject } from 'react';
 
+export type CloseReason = 'escape' | 'outside';
+
 export function useCloseOnEscapeAndOutsideClick(
-  opts: { isOpen: boolean; onClose: () => void; ref: RefObject<HTMLElement | null>; delay?: number }
+  opts: { isOpen: boolean; onClose: (reason: CloseReason) => void; ref: RefObject<HTMLElement | null>; delay?: number }
 ) {
   const { isOpen, onClose, ref, delay = 100 } = opts;
 
@@ -11,14 +13,14 @@ export function useCloseOnEscapeAndOutsideClick(
 
     const handleEscape = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
-        onClose();
+        onClose('escape');
       }
     };
 
     const handleClickOutside = (e: MouseEvent) => {
       const el = ref.current;
       if (el && !el.contains(e.target as Node)) {
-        onClose();
+        onClose('outside');
       }
     };
 


### PR DESCRIPTION
Fixes Bead `oh-tab-am0j`.

Behavior:
- Esc closes the context picker and returns focus to the chat input.
- Caret moves to the end of the current input value.
- Prevents the mention logic from immediately reopening the picker on that focus/selection event.

Changes:
- `useCloseOnEscapeAndOutsideClick` now distinguishes close reasons (`escape` vs `outside`).
- App wires Esc-close to focus the input.
- Adds a mention-flow regression test.

Tests:
- `npm test`
