### PR TITLE
[oh-tab-593e] OpenAI Responses: round-trip encrypted_content exactly

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.orchestrator.test.ts
@@ -313,6 +313,46 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     ))).toBe(true);
   });
 
+  it('round-trips encrypted_content exactly (store=false)', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient(baseConfig, 'test-key');
+    const orchestrator = new AgentOrchestrator(client);
+
+    const encryptedContent = 'encrypted\n';
+    await orchestrator.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'previous answer' }],
+          responses_reasoning_item: { id: 'rs_1', summary: ['short summary'], encrypted_content: encryptedContent },
+        },
+        { role: 'user', content: [{ type: 'text', text: 'follow up' }] },
+      ],
+      tools: [{ type: 'function', function: { name: 'ping' } }],
+    });
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    const reasoningItem = Array.isArray(body?.input)
+      ? body.input.find((item: { type?: unknown; id?: unknown }) => item.type === 'reasoning' && item.id === 'rs_1')
+      : undefined;
+
+    expect(reasoningItem?.encrypted_content).toBe(encryptedContent);
+  });
+
   it('includes reasoning summary in Responses request body when configured', async () => {
     const payload = {
       output: [

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -114,8 +114,9 @@ const toResponsesReasoningInputItem = (reasoning: ResponsesReasoningItem): Respo
   // In stateless mode (store=false) we can only safely re-send reasoning items if the response included
   // `encrypted_content` (requested via include: ['reasoning.encrypted_content']). Otherwise OpenAI treats
   // the `rs_*` id as a server-stored reference and returns 404 when store=false.
-  const encrypted = typeof reasoning.encrypted_content === 'string' ? reasoning.encrypted_content.trim() : '';
-  if (!encrypted) return undefined;
+  // IMPORTANT: `encrypted_content` must be round-tripped exactly as received (opaque blob).
+  const encrypted = reasoning.encrypted_content;
+  if (typeof encrypted !== 'string' || encrypted.length === 0) return undefined;
 
   const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text' as const, text }));
   return {

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -116,7 +116,7 @@ const toResponsesReasoningInputItem = (reasoning: ResponsesReasoningItem): Respo
   // the `rs_*` id as a server-stored reference and returns 404 when store=false.
   // IMPORTANT: `encrypted_content` must be round-tripped exactly as received (opaque blob).
   const encrypted = reasoning.encrypted_content;
-  if (typeof encrypted !== 'string' || encrypted.length === 0) return undefined;
+  if (typeof encrypted !== 'string' || encrypted.trim().length === 0) return undefined;
 
   const summary = (reasoning.summary ?? []).map((text) => ({ type: 'summary_text' as const, text }));
   return {


### PR DESCRIPTION
Fixes `oh-tab-593e`.

- Preserve `ResponsesReasoningItem.encrypted_content` exactly when re-sending reasoning items in stateless `store=false` mode (it’s an opaque blob and must be round-tripped verbatim).
- Adds a unit test asserting we don’t mutate `encrypted_content` (e.g. by trimming).

Context:
- See `scripts/openai-responses-store-false-404-rs-item-not-found.log` and `scripts/test-openai-responses-reasoning.mjs` for repro/expected behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of encrypted content in reasoning items to preserve exact values without modification
* **Tests**
  * Added tests to verify encrypted content is correctly preserved in request payloads

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->