### PR TITLE
[oh-tab-2u19] File edit Observations diff prefers HEAD

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -62,7 +62,7 @@ export type WebviewToHostMessage =
   | { type: 'openSkill'; path: string }
   | { type: 'openWorkspaceFile'; path: string }
   | { type: 'openMarkdownLink'; href: string }
-  | { type: 'openWorkspaceDiff'; path: string; oldContent: string; newContent: string }
+  | { type: 'openWorkspaceDiff'; path: string; oldContent: string; newContent: string; preferGitHead?: boolean }
   | { type: 'requestHistory' }
   | { type: 'restoreConversation'; id: string }
   | { type: 'deleteConversation'; id: string }

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -302,6 +302,7 @@ describe('Agent-SDK event rendering', () => {
         path: '/tmp/README.md',
         oldContent: 'old content',
         newContent: 'new content',
+        preferGitHead: true,
       })
     );
   });

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -60,8 +60,14 @@ export const openWorkspaceFile = (path: string) => {
   postMessage({ type: 'openWorkspaceFile', path });
 };
 
-export const openWorkspaceDiff = (path: string, oldContent: string, newContent: string) => {
-  postMessage({ type: 'openWorkspaceDiff', path, oldContent, newContent });
+export const openWorkspaceDiff = (path: string, oldContent: string, newContent: string, options?: { preferGitHead?: boolean }) => {
+  postMessage({
+    type: 'openWorkspaceDiff',
+    path,
+    oldContent,
+    newContent,
+    ...(options?.preferGitHead ? { preferGitHead: true } : {}),
+  });
 };
 
 export const openMarkdownLink = (href: string) => {
@@ -242,7 +248,7 @@ function InlineFileDiffReference({ path, oldContent, newContent }: { path?: stri
   return (
     <button
       type="button"
-      onClick={() => openWorkspaceDiff(path, oldText, newText)}
+      onClick={() => openWorkspaceDiff(path, oldText, newText, { preferGitHead: true })}
       className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.06] hover:border-white/[0.1] text-xs font-mono text-brand-300 align-middle max-w-full transition-all duration-150 group"
       aria-label={`View diff for ${path}`}
       title={`View diff for ${path}`}
@@ -478,4 +484,3 @@ export function EventContainer({
     </div>
   );
 }
-

--- a/src/webview/host/__tests__/gitHeadDiff.test.ts
+++ b/src/webview/host/__tests__/gitHeadDiff.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveGitHeadDiffContents } from '../gitHeadDiff';
+
+describe('resolveGitHeadDiffContents', () => {
+  it('prefers git HEAD ↔ working tree when available', async () => {
+    const execFileText = vi.fn(async (_command: string, args: string[], _cwd?: string) => {
+      if (args[0] === 'rev-parse') return '/repo\n';
+      if (args[0] === 'show') return 'HEAD CONTENT';
+      throw new Error(`unexpected git args: ${args.join(' ')}`);
+    });
+    const readFileText = vi.fn(async () => 'WORKING CONTENT');
+
+    const result = await resolveGitHeadDiffContents({
+      workspaceRoot: '/repo',
+      resolvedPath: '/repo/README.md',
+      fallbackOldContent: 'FALLBACK OLD',
+      fallbackNewContent: 'FALLBACK NEW',
+      execFileText,
+      readFileText,
+    });
+
+    expect(result).toEqual({ oldContent: 'HEAD CONTENT', newContent: 'WORKING CONTENT', source: 'git_head' });
+  });
+
+  it('falls back to provided diff when git show fails', async () => {
+    const execFileText = vi.fn(async (_command: string, args: string[], _cwd?: string) => {
+      if (args[0] === 'rev-parse') return '/repo\n';
+      if (args[0] === 'show') throw new Error('no such path');
+      throw new Error(`unexpected git args: ${args.join(' ')}`);
+    });
+    const readFileText = vi.fn(async () => 'WORKING CONTENT');
+
+    const result = await resolveGitHeadDiffContents({
+      workspaceRoot: '/repo',
+      resolvedPath: '/repo/README.md',
+      fallbackOldContent: 'FALLBACK OLD',
+      fallbackNewContent: 'FALLBACK NEW',
+      execFileText,
+      readFileText,
+    });
+
+    expect(result).toEqual({ oldContent: 'FALLBACK OLD', newContent: 'FALLBACK NEW', source: 'fallback' });
+  });
+
+  it('falls back when the path is outside the git root', async () => {
+    const execFileText = vi.fn(async (_command: string, args: string[], _cwd?: string) => {
+      if (args[0] === 'rev-parse') return '/repo\n';
+      throw new Error(`unexpected git args: ${args.join(' ')}`);
+    });
+    const readFileText = vi.fn(async () => 'WORKING CONTENT');
+
+    const result = await resolveGitHeadDiffContents({
+      workspaceRoot: '/repo',
+      resolvedPath: '/other/README.md',
+      fallbackOldContent: 'FALLBACK OLD',
+      fallbackNewContent: 'FALLBACK NEW',
+      execFileText,
+      readFileText,
+    });
+
+    expect(result).toEqual({ oldContent: 'FALLBACK OLD', newContent: 'FALLBACK NEW', source: 'fallback' });
+  });
+
+  it('falls back when workspaceRoot is unknown', async () => {
+    const execFileText = vi.fn();
+    const readFileText = vi.fn();
+
+    const result = await resolveGitHeadDiffContents({
+      workspaceRoot: undefined,
+      resolvedPath: '/repo/README.md',
+      fallbackOldContent: 'FALLBACK OLD',
+      fallbackNewContent: 'FALLBACK NEW',
+      execFileText,
+      readFileText,
+    });
+
+    expect(result).toEqual({ oldContent: 'FALLBACK OLD', newContent: 'FALLBACK NEW', source: 'fallback' });
+    expect(execFileText).not.toHaveBeenCalled();
+    expect(readFileText).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
+import * as childProcess from 'child_process';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -15,6 +16,7 @@ import type { HostToWebviewMessage, WebviewToHostMessage } from '../../shared/we
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
 import { getConversationHistoryList } from './conversationHistory';
 import { showWorkspaceDiff } from './diffDocuments';
+import { resolveGitHeadDiffContents } from './gitHeadDiff';
 import * as llmProfilesStore from './llmProfilesStore';
 import { listSkillFiles } from './skills';
 import { listWorkspaceFiles } from './workspaceFiles';
@@ -23,6 +25,19 @@ import { resolveWorkspaceFilePath } from './workspacePaths';
 export type WebviewHost = {
   postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
 };
+
+function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(command, args, { cwd }, (err, stdout, stderr) => {
+      if (err) {
+        const message = typeof stderr === 'string' && stderr.trim().length > 0 ? stderr.trim() : err.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve(typeof stdout === 'string' ? stdout : String(stdout));
+    });
+  });
+}
 
 async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
   const filePath = getPastedImagePath(baseDir, imageId);
@@ -309,7 +324,25 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           break;
         }
         try {
-          await showWorkspaceDiff({ context, filePath: p, oldContent: message.oldContent, newContent: message.newContent });
+          let oldContent = message.oldContent;
+          let newContent = message.newContent;
+
+          if (message.preferGitHead === true) {
+            const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+            const { resolvedPath } = resolveWorkspaceFilePath(p);
+            const resolved = await resolveGitHeadDiffContents({
+              workspaceRoot: wsRoot,
+              resolvedPath,
+              fallbackOldContent: oldContent,
+              fallbackNewContent: newContent,
+              execFileText,
+              readFileText: (filePath) => fs.readFile(filePath, 'utf8'),
+            });
+            oldContent = resolved.oldContent;
+            newContent = resolved.newContent;
+          }
+
+          await showWorkspaceDiff({ context, filePath: p, oldContent, newContent });
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           void vscode.window.showErrorMessage(`Failed to open diff: ${reason}`);

--- a/src/webview/host/gitHeadDiff.ts
+++ b/src/webview/host/gitHeadDiff.ts
@@ -1,0 +1,61 @@
+import * as path from 'path';
+
+export type DiffContentsSource = 'git_head' | 'fallback';
+
+export type DiffContents = {
+  oldContent: string;
+  newContent: string;
+  source: DiffContentsSource;
+};
+
+export type ResolveGitHeadDiffContentsArgs = {
+  workspaceRoot: string | undefined;
+  resolvedPath: string;
+  fallbackOldContent: string;
+  fallbackNewContent: string;
+  execFileText: (command: string, args: string[], cwd?: string) => Promise<string>;
+  readFileText: (filePath: string) => Promise<string>;
+};
+
+export async function resolveGitHeadDiffContents(args: ResolveGitHeadDiffContentsArgs): Promise<DiffContents> {
+  const fallback = (): DiffContents => ({
+    oldContent: args.fallbackOldContent,
+    newContent: args.fallbackNewContent,
+    source: 'fallback',
+  });
+
+  if (!args.workspaceRoot) return fallback();
+
+  let gitRoot = '';
+  try {
+    gitRoot = (await args.execFileText('git', ['rev-parse', '--show-toplevel'], args.workspaceRoot)).trim();
+  } catch {
+    return fallback();
+  }
+  if (!gitRoot) return fallback();
+
+  const relativePath = path.relative(gitRoot, args.resolvedPath);
+  if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return fallback();
+  }
+
+  const gitPath = relativePath.split(path.sep).join('/');
+
+  let oldContent: string;
+  let newContent: string;
+
+  try {
+    oldContent = await args.execFileText('git', ['show', `HEAD:${gitPath}`], gitRoot);
+  } catch {
+    return fallback();
+  }
+
+  try {
+    newContent = await args.readFileText(args.resolvedPath);
+  } catch {
+    return fallback();
+  }
+
+  return { oldContent, newContent, source: 'git_head' };
+}
+


### PR DESCRIPTION
Implements `oh-tab-2u19`.

- FileEditor edit Observations “View diff” now prefers **git HEAD ↔ current working tree**.
- Falls back to the tool-provided `old_content` ↔ `new_content` diff when HEAD cannot be resolved (untracked/outside repo/no git).
- Adds unit tests for host diff selection + updates webview rendering test.
