### PR TITLE
[oh-tab-wenm] Add Server opens form immediately

### DIFF
--- a/src/webview-src/__tests__/ServerSelector.test.tsx
+++ b/src/webview-src/__tests__/ServerSelector.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { ServerSelector } from '../components/ServerSelector';
+
+describe('ServerSelector', () => {
+  it('shows the add-server form immediately without closing the dropdown', () => {
+    const onClose = vi.fn();
+
+    render(
+      <ServerSelector
+        isOpen
+        onClose={onClose}
+        servers={[]}
+        currentServerUrl={undefined}
+        mode="remote"
+        onSelectServer={() => {}}
+        onAddServer={() => {}}
+        onRemoveServer={() => {}}
+        onSwitchToLocal={() => {}}
+      />
+    );
+
+    const addButton = screen.getByRole('button', { name: 'Add Server' });
+    fireEvent.click(addButton);
+
+    expect(onClose).not.toHaveBeenCalled();
+    const urlInput = screen.getByPlaceholderText('https://server-url...');
+    expect(urlInput).toHaveFocus();
+  });
+});

--- a/src/webview-src/__tests__/ServerSelector.test.tsx
+++ b/src/webview-src/__tests__/ServerSelector.test.tsx
@@ -1,9 +1,14 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ServerSelector } from '../components/ServerSelector';
 
 describe('ServerSelector', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('shows the add-server form immediately without closing the dropdown', () => {
+    vi.useFakeTimers();
     const onClose = vi.fn();
 
     render(
@@ -19,6 +24,10 @@ describe('ServerSelector', () => {
         onSwitchToLocal={() => {}}
       />
     );
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
 
     const addButton = screen.getByRole('button', { name: 'Add Server' });
     fireEvent.click(addButton);

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -246,7 +246,6 @@ export function ServerSelector({
           <button
             type="button"
             onClick={(e) => {
-              e.preventDefault();
               e.stopPropagation();
               setShowAddForm(true);
             }}

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -244,7 +244,12 @@ export function ServerSelector({
           </div>
         ) : (
           <button
-            onClick={() => setShowAddForm(true)}
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              setShowAddForm(true);
+            }}
             className="w-full px-4 py-3 text-sm text-left hover:bg-white/5 transition-colors flex items-center gap-2"
           >
             <span className="codicon codicon-add" />


### PR DESCRIPTION
Fixes `oh-tab-wenm`.

- Clicking “Add Server” now stops propagation so the server dropdown doesn’t close as a side-effect.
- Adds a small webview unit test to lock in the behavior + focus.

Local `npm test` is green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Add Server" button event handling to ensure the add-server form opens reliably.

* **Tests**
  * Added unit test for ServerSelector component to verify add-server functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->