### PR TITLE
[oh-tab-waqy] Use composedPath for outside-click detection

### DIFF
--- a/src/webview-src/__tests__/useCloseOnEscapeAndOutsideClick.test.tsx
+++ b/src/webview-src/__tests__/useCloseOnEscapeAndOutsideClick.test.tsx
@@ -1,0 +1,48 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { useRef, useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useCloseOnEscapeAndOutsideClick } from '../components/useCloseOnEscapeAndOutsideClick';
+
+function PopoverTargetRemovalRepro({ onClose }: { onClose: () => void }) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [showButton, setShowButton] = useState(true);
+
+  useCloseOnEscapeAndOutsideClick({
+    isOpen: true,
+    onClose: () => onClose(),
+    ref: popoverRef,
+    delay: 100,
+  });
+
+  return (
+    <div ref={popoverRef}>
+      {showButton && (
+        <button type="button" onClick={() => setShowButton(false)}>
+          Remove Target
+        </button>
+      )}
+    </div>
+  );
+}
+
+describe('useCloseOnEscapeAndOutsideClick', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not treat an inside click as outside when the click target is removed before the document handler runs', () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+
+    render(<PopoverTargetRemovalRepro onClose={onClose} />);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Target' }));
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -181,8 +181,7 @@ export function ServerSelector({
                     )}
                   </button>
                   <button
-                    onClick={(e) => {
-                      e.stopPropagation();
+                    onClick={() => {
                       onRemoveServer(server.url);
                     }}
                     className="p-1 rounded hover:bg-red-500/20 hover:text-red-400 opacity-50 hover:opacity-100 transition-all"
@@ -245,8 +244,7 @@ export function ServerSelector({
         ) : (
           <button
             type="button"
-            onClick={(e) => {
-              e.stopPropagation();
+            onClick={() => {
               setShowAddForm(true);
             }}
             className="w-full px-4 py-3 text-sm text-left hover:bg-white/5 transition-colors flex items-center gap-2"

--- a/src/webview-src/components/useCloseOnEscapeAndOutsideClick.ts
+++ b/src/webview-src/components/useCloseOnEscapeAndOutsideClick.ts
@@ -19,9 +19,15 @@ export function useCloseOnEscapeAndOutsideClick(
 
     const handleClickOutside = (e: MouseEvent) => {
       const el = ref.current;
-      if (el && !el.contains(e.target as Node)) {
-        onClose('outside');
-      }
+      if (!el) return;
+
+      const path = e.composedPath?.();
+      if (Array.isArray(path) && path.includes(el)) return;
+
+      const target = e.target;
+      if (target instanceof Node && el.contains(target)) return;
+
+      onClose('outside');
     };
 
     const timer = window.setTimeout(() => {


### PR DESCRIPTION
Implements `oh-tab-waqy`.

- `useCloseOnEscapeAndOutsideClick`: prefer `MouseEvent.composedPath()` over `el.contains(e.target)` so clicks don’t mis-detect as “outside” when the clicked node is removed by a React re-render.
- Removes the `stopPropagation()` workarounds in `ServerSelector` (they’re no longer needed).

Tests:
- `npx vitest run src/webview-src/__tests__/ServerSelector.test.tsx`
- `npx vitest run src/webview-src/__tests__/App.advanced.test.tsx`