### PR TITLE
[oh-tab-r158] gemini-flash summarize terminal observations

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { SecretRegistry } from '../SecretRegistry';
+import { summarizeTerminalObservationWithGeminiFlash } from '../terminalObservationSummarizer';
+
+class RecordingLLM implements LLMClient {
+  readonly requests: ChatCompletionRequest[] = [];
+
+  constructor(private readonly reply: string) {}
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
+    yield { type: 'text', text: this.reply };
+    yield { type: 'finish' };
+  }
+}
+
+class ThrowingLLM implements LLMClient {
+  async *streamChat(): AsyncGenerator<LLMStreamChunk> {
+    yield { type: 'finish' };
+    throw new Error('network disabled');
+  }
+}
+
+describe('summarizeTerminalObservationWithGeminiFlash', () => {
+  it('masks registered secrets in the prompt and output', async () => {
+    const secrets = new SecretRegistry();
+    secrets.set('GITHUB_TOKEN', 'supersecretvalue');
+
+    const llm = new RecordingLLM('Printed supersecretvalue.');
+
+    const summary = await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'echo supersecretvalue', exitCode: 0, stdout: 'supersecretvalue\n', stderr: '' },
+      { secrets, llmClient: llm, maxPromptChars: 10_000 }
+    );
+
+    expect(summary).toBe('Printed ***.');
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text).toContain('Command: echo ***');
+      expect(prompt.text).not.toContain('supersecretvalue\n');
+      expect(prompt.text).toContain('***');
+    }
+  });
+
+  it('falls back to deterministic summary when gemini fails', async () => {
+    const secrets = new SecretRegistry();
+    const summary = await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'git status', exitCode: 2, stdout: '', stderr: 'fatal: not a git repository' },
+      { secrets, llmClient: new ThrowingLLM() }
+    );
+
+    expect(summary).toBe('Done (exit code 2).');
+  });
+
+  it('returns Done when exit code is 0 and gemini returns empty', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('   ');
+    const summary = await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'pwd', exitCode: 0, stdout: '/tmp\n', stderr: '' },
+      { secrets, llmClient: llm }
+    );
+
+    expect(summary).toBe('Done.');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -97,4 +97,21 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     expect(summary).toBe('abcd…');
     expect(summary.length).toBe(5);
   });
+
+  it('honors maxOutputChars=0 (does not include stdout in prompt)', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('OK');
+    await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'echo', exitCode: 0, stdout: 'from-stdout\n', stderr: '' },
+      { secrets, llmClient: llm, maxOutputChars: 0, maxPromptChars: 10_000 }
+    );
+
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text).not.toContain('from-stdout');
+      expect(prompt.text).toContain('(empty)');
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -45,6 +45,26 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     }
   });
 
+  it('masks registered secrets even when short', async () => {
+    const secrets = new SecretRegistry();
+    secrets.set('SHORT_SECRET', 'abc');
+
+    const llm = new RecordingLLM('Printed abc.');
+    const summary = await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'echo abc', exitCode: 0, stdout: 'abc\n', stderr: '' },
+      { secrets, llmClient: llm, maxPromptChars: 10_000 }
+    );
+
+    expect(summary).toBe('Printed ***.');
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text).not.toContain('abc');
+      expect(prompt.text).toContain('***');
+    }
+  });
+
   it('falls back to deterministic summary when gemini fails', async () => {
     const secrets = new SecretRegistry();
     const summary = await summarizeTerminalObservationWithGeminiFlash(
@@ -64,5 +84,17 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     );
 
     expect(summary).toBe('Done.');
+  });
+
+  it('never returns more than maxSummaryChars', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('abcdefghij');
+    const summary = await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'echo hello', exitCode: 0, stdout: 'hello\n', stderr: '' },
+      { secrets, llmClient: llm, maxSummaryChars: 5 }
+    );
+
+    expect(summary).toBe('abcd…');
+    expect(summary.length).toBe(5);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/index.ts
@@ -7,3 +7,4 @@ export * from './AgentOrchestrator';
 export * from './persistence';
 export * from './ConversationStats';
 export * from './fileDiffSummarizer';
+export * from './terminalObservationSummarizer';

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -1,0 +1,120 @@
+import type { ChatCompletionRequest, LLMClient } from '../llm';
+import { LLMFactory } from '../llm';
+import type { SecretRegistry } from './SecretRegistry';
+
+export interface TerminalObservationInput {
+  command: string;
+  exitCode: number | string | null | undefined;
+  stdout?: string | null;
+  stderr?: string | null;
+  timedOut?: boolean;
+  wasTruncated?: boolean;
+}
+
+export interface SummarizeTerminalObservationOptions {
+  secrets: SecretRegistry;
+  llmClient?: LLMClient;
+  maxOutputChars?: number;
+  maxPromptChars?: number;
+  maxSummaryChars?: number;
+}
+
+const DEFAULT_MAX_OUTPUT_CHARS = 4_000;
+const DEFAULT_MAX_PROMPT_CHARS = 6_000;
+const DEFAULT_MAX_SUMMARY_CHARS = 1_000;
+const CLIP_MARKER = '<output clipped>';
+
+const toNonNegativeInt = (value: unknown): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+  return Math.max(0, Math.trunc(value));
+};
+
+const clipTextMiddle = (text: string, maxChars: number): string => {
+  if (maxChars <= 0) return '';
+  if (text.length <= maxChars) return text;
+  const available = maxChars - CLIP_MARKER.length - 2;
+  const half = Math.max(0, Math.floor(available / 2));
+  return `${text.slice(0, half)}\n${CLIP_MARKER}\n${text.slice(-half)}`;
+};
+
+const maskSecrets = (text: string, secrets: SecretRegistry): string => {
+  let masked = text;
+  const values = secrets
+    .getRegisteredValues()
+    .map((value) => value.trim())
+    .filter((value) => value.length >= 8)
+    .sort((a, b) => b.length - a.length);
+  for (const value of values) {
+    masked = masked.replaceAll(value, '***');
+  }
+  return masked;
+};
+
+const summarizeExitCodeFallback = (exitCode: TerminalObservationInput['exitCode']): string => {
+  const normalized =
+    typeof exitCode === 'number' ? exitCode.toString() : typeof exitCode === 'string' && exitCode.trim() ? exitCode.trim() : 'unknown';
+  return normalized === '0' ? 'Done.' : `Done (exit code ${normalized}).`;
+};
+
+const getGeminiFlashClient = async (secrets: SecretRegistry): Promise<LLMClient> => {
+  const factory = new LLMFactory(
+    {
+      profileId: 'gemini-flash',
+      model: 'gemini-flash',
+      usageId: 'terminal-observation-summarizer',
+      temperature: 0.2,
+      maxOutputTokens: 256,
+    },
+    { secrets }
+  );
+  return factory.createClient();
+};
+
+export async function summarizeTerminalObservationWithGeminiFlash(
+  input: TerminalObservationInput,
+  options: SummarizeTerminalObservationOptions
+): Promise<string> {
+  const maxOutputChars = toNonNegativeInt(options.maxOutputChars) || DEFAULT_MAX_OUTPUT_CHARS;
+  const maxPromptChars = toNonNegativeInt(options.maxPromptChars) || DEFAULT_MAX_PROMPT_CHARS;
+  const maxSummaryChars = toNonNegativeInt(options.maxSummaryChars) || DEFAULT_MAX_SUMMARY_CHARS;
+
+  const fallback = summarizeExitCodeFallback(input.exitCode);
+  const stdout = typeof input.stdout === 'string' ? input.stdout.trimEnd() : '';
+  const stderr = typeof input.stderr === 'string' ? input.stderr.trimEnd() : '';
+  const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
+
+  const redactedOutput = clipTextMiddle(maskSecrets(output, options.secrets), maxOutputChars);
+  const prompt = [
+    'Write a concise (1–3 sentence) summary of a terminal command execution performed by an autonomous coding agent.',
+    '- Focus on the action taken and key outcome.',
+    '- Do not include secrets or long output excerpts.',
+    '',
+    `Command: ${input.command || '(empty)'}`,
+    `Exit code: ${input.exitCode ?? 'unknown'}`,
+    `Timed out: ${input.timedOut ? 'yes' : 'no'}`,
+    `Output truncated: ${input.wasTruncated ? 'yes' : 'no'}`,
+    '',
+    'Output (redacted + clipped):',
+    redactedOutput || '(empty)',
+  ].join('\n');
+
+  const safePrompt = clipTextMiddle(maskSecrets(prompt, options.secrets), maxPromptChars);
+  const request: ChatCompletionRequest = {
+    systemPrompt: 'You summarize terminal tool results for an IDE UI.',
+    messages: [{ role: 'user', content: [{ type: 'text', text: safePrompt }] }],
+  };
+
+  try {
+    const client = options.llmClient ?? (await getGeminiFlashClient(options.secrets));
+    let text = '';
+    for await (const chunk of client.streamChat(request)) {
+      if (chunk.type === 'text') text += chunk.text;
+    }
+    const summary = maskSecrets(text, options.secrets).trim();
+    if (!summary) return fallback;
+    return summary.length > maxSummaryChars ? summary.slice(0, maxSummaryChars) + '…' : summary;
+  } catch {
+    return fallback;
+  }
+}
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -42,7 +42,7 @@ const maskSecrets = (text: string, secrets: SecretRegistry): string => {
   const values = secrets
     .getRegisteredValues()
     .map((value) => value.trim())
-    .filter((value) => value.length >= 8)
+    .filter((value) => value.length > 0)
     .sort((a, b) => b.length - a.length);
   for (const value of values) {
     masked = masked.replaceAll(value, '***');
@@ -112,9 +112,10 @@ export async function summarizeTerminalObservationWithGeminiFlash(
     }
     const summary = maskSecrets(text, options.secrets).trim();
     if (!summary) return fallback;
-    return summary.length > maxSummaryChars ? summary.slice(0, maxSummaryChars) + '…' : summary;
+    if (summary.length <= maxSummaryChars) return summary;
+    if (maxSummaryChars === 1) return '…';
+    return summary.slice(0, maxSummaryChars - 1) + '…';
   } catch {
     return fallback;
   }
 }
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -24,8 +24,9 @@ const DEFAULT_MAX_PROMPT_CHARS = 6_000;
 const DEFAULT_MAX_SUMMARY_CHARS = 1_000;
 const CLIP_MARKER = '<output clipped>';
 
-const toNonNegativeInt = (value: unknown): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {
+  if (value === undefined) return defaultValue;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
   return Math.max(0, Math.trunc(value));
 };
 
@@ -70,15 +71,22 @@ const getGeminiFlashClient = async (secrets: SecretRegistry): Promise<LLMClient>
   return factory.createClient();
 };
 
+const truncateSummary = (text: string, maxChars: number): string => {
+  if (maxChars <= 0) return '';
+  if (text.length <= maxChars) return text;
+  if (maxChars === 1) return '…';
+  return text.slice(0, maxChars - 1) + '…';
+};
+
 export async function summarizeTerminalObservationWithGeminiFlash(
   input: TerminalObservationInput,
   options: SummarizeTerminalObservationOptions
 ): Promise<string> {
-  const maxOutputChars = toNonNegativeInt(options.maxOutputChars) || DEFAULT_MAX_OUTPUT_CHARS;
-  const maxPromptChars = toNonNegativeInt(options.maxPromptChars) || DEFAULT_MAX_PROMPT_CHARS;
-  const maxSummaryChars = toNonNegativeInt(options.maxSummaryChars) || DEFAULT_MAX_SUMMARY_CHARS;
+  const maxOutputChars = resolveNonNegativeIntOption(options.maxOutputChars, DEFAULT_MAX_OUTPUT_CHARS);
+  const maxPromptChars = resolveNonNegativeIntOption(options.maxPromptChars, DEFAULT_MAX_PROMPT_CHARS);
+  const maxSummaryChars = resolveNonNegativeIntOption(options.maxSummaryChars, DEFAULT_MAX_SUMMARY_CHARS);
 
-  const fallback = summarizeExitCodeFallback(input.exitCode);
+  const fallback = truncateSummary(summarizeExitCodeFallback(input.exitCode), maxSummaryChars);
   const stdout = typeof input.stdout === 'string' ? input.stdout.trimEnd() : '';
   const stderr = typeof input.stderr === 'string' ? input.stderr.trimEnd() : '';
   const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
@@ -112,9 +120,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
     }
     const summary = maskSecrets(text, options.secrets).trim();
     if (!summary) return fallback;
-    if (summary.length <= maxSummaryChars) return summary;
-    if (maxSummaryChars === 1) return '…';
-    return summary.slice(0, maxSummaryChars - 1) + '…';
+    return truncateSummary(summary, maxSummaryChars);
   } catch {
     return fallback;
   }


### PR DESCRIPTION
Adds a core helper for summarizing terminal tool observations via the `gemini-flash` profile.

- `summarizeTerminalObservationWithGeminiFlash()` returns a 1–3 sentence summary when Gemini is available.
- Fallback on error/empty: deterministic `Done.` / `Done (exit code …).` (parity with current UI).
- Unit tests use injected `LLMClient` (no network).

Bead: oh-tab-r158

Tests: `npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts`
