### PR TITLE
oh-tab-sqnl: show Gemini terminal summaries

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -353,18 +353,43 @@ describe('Agent-SDK event rendering', () => {
         command: 'ls -la',
         exit_code: 0,
         stdout: 'README.md',
+        summary: 'Listed the working directory contents and printed README.md.',
       },
       tool_name: 'terminal',
       tool_call_id: 'call_terminal_action',
       action_id: 'action_terminal_action',
     } as any;
     postToWindow({ type: 'event', event: observationEvent });
-    expect(await screen.findByText(/Done\./i)).toBeInTheDocument();
+    expect(await screen.findByText(/Listed the working directory contents/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Done\./i)).toBeNull();
     expect(screen.getAllByText(/ls -la/)).toHaveLength(1);
 
     const toggle = await screen.findByRole('button', { name: /Show tool result/i });
     fireEvent.click(toggle);
-    expect(await screen.findByText(/README\.md/)).toBeInTheDocument();
+    expect(await screen.findByText(/"stdout": "README\.md"/)).toBeInTheDocument();
+  });
+
+  it('falls back to Done for terminal observations without summary', async () => {
+    render(<App />);
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        command: 'echo hello',
+        exit_code: 0,
+        stdout: 'hello',
+      },
+      tool_name: 'terminal',
+      tool_call_id: 'call_terminal_fallback',
+      action_id: 'action_terminal_fallback',
+    } as any;
+
+    postToWindow({ type: 'event', event: observationEvent });
+    expect(await screen.findByText(/Done\./i)).toBeInTheDocument();
+
+    const toggle = await screen.findByRole('button', { name: /Show tool result/i });
+    fireEvent.click(toggle);
+    expect(await screen.findByText(/hello/)).toBeInTheDocument();
   });
 
 

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -398,7 +398,14 @@ export function TerminalObservationSummary({
 }): React.ReactElement | null {
   const exitCodeNumber = getNumber(observation.exit_code);
   const exitCodeText = exitCodeNumber !== undefined ? exitCodeNumber.toString() : getString(observation.exit_code) ?? 'unknown';
-  const summaryText = exitCodeText === '0' ? 'Done.' : `Done (exit code ${exitCodeText}).`;
+  const metadata = observation.metadata;
+  const metadataSummary =
+    metadata && typeof metadata === 'object' && 'summary' in metadata
+      ? getString((metadata as Record<string, unknown>).summary)
+      : undefined;
+  const geminiSummary = getString(observation.summary) ?? metadataSummary;
+  const trimmedGeminiSummary = geminiSummary?.trim() ? geminiSummary.trim() : undefined;
+  const summaryText = trimmedGeminiSummary ?? (exitCodeText === '0' ? 'Done.' : `Done (exit code ${exitCodeText}).`);
   const toggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';
   return (
     <div className="text-sm leading-relaxed">


### PR DESCRIPTION
Implements Beads `oh-tab-sqnl`.

- Terminal Tool Result summary shows `observation.summary` (Gemini) when present (also checks `observation.metadata.summary`).
- Keeps existing expand/collapse to reveal raw JSON.
- Falls back to deterministic "Done" message when no summary is available.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
