### PR TITLE
oh-tab-n1tl: summarize file edit tool results

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -26,6 +26,7 @@ import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
+import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
 import { SYSTEM_PROMPT } from './systemPrompt';
 
 export type AgentRunInput = string | Message;
@@ -1213,22 +1214,23 @@ export class Agent extends EventEmitter {
     try {
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
       const result = await tool.execute(validated, context);
+      const enrichedResult = await this.maybeAttachFileDiffSummary(toolCall, result);
 
       if (toolCall.function.name === 'terminal') {
-        this.emitTerminalEvents(toolCall, result);
+        this.emitTerminalEvents(toolCall, enrichedResult);
       }
 
       const observation = {
         kind: 'ObservationEvent',
         source: 'environment',
-        observation: deepTruncate(this.maskSecretsInUnknown(result)) as Record<string, unknown>,
+        observation: deepTruncate(this.maskSecretsInUnknown(enrichedResult)) as Record<string, unknown>,
         tool_name: toolCall.function.name,
         tool_call_id: toolCall.id,
         action_id: actionEvent.id ?? randomUUID(),
       } as Event;
       this.events.push(observation);
 
-      const formatted = this.formatToolMessageText(toolCall, result);
+      const formatted = this.formatToolMessageText(toolCall, enrichedResult);
       const masked = this.maskSecretsInText(formatted);
       const clipped = truncateToolMessage(masked);
 
@@ -1244,7 +1246,7 @@ export class Agent extends EventEmitter {
       };
       this.events.push(toolMessage);
 
-      await this.maybeSummarizeToolCall(toolCall, result);
+      await this.maybeSummarizeToolCall(toolCall, enrichedResult);
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_execute', toolName: tool.name });
       if (classified.classification === 'agent') {
@@ -1257,6 +1259,43 @@ export class Agent extends EventEmitter {
         message: classified.message,
         ...(classified.code ? { code: classified.code } : {}),
       });
+    }
+  }
+
+  private async maybeAttachFileDiffSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
+    if (toolCall.function.name !== 'file_editor') return result;
+    if (!this.summarizeToolCallsEnabled) return result;
+    if (this.toolSummarizerFailed) return result;
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
+
+    const record = result as Record<string, unknown>;
+    const command = toOptionalNonEmptyString(record.command);
+    if (command !== 'insert' && command !== 'str_replace') return result;
+
+    if (typeof record.summary === 'string' && record.summary.trim()) return result;
+
+    const filePath = toOptionalNonEmptyString(record.path);
+    const oldContent = record.old_content;
+    const newContent = record.new_content;
+    const oldText = typeof oldContent === 'string' ? oldContent : oldContent === null ? '' : undefined;
+    const newText = typeof newContent === 'string' ? newContent : newContent === null ? '' : undefined;
+    if (!filePath || oldText === undefined || newText === undefined) return result;
+
+    try {
+      const llmClient = await this.getToolSummarizerClient();
+      const summary = await summarizeFileChangesWithGeminiFlash(
+        { kind: 'contents', filePath, oldContent: oldText, newContent: newText },
+        { secrets: this.secrets, llmClient },
+      );
+      if (!summary) return result;
+
+      return { ...record, summary };
+    } catch (error) {
+      this.toolSummarizerFailed = true;
+      if (this.debug) {
+        console.warn('[Agent] File diff summarization failed; disabling for this session:', error);
+      }
+      return result;
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import type { OpenHandsSettings } from '../../types/settings';
+import type { ToolDefinition } from '../../types/tools';
+import { isObservationEvent } from '../../types';
+
+class ToolCallLLM implements LLMClient {
+  private callIndex = 0;
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void request;
+    if (this.callIndex++ === 0) {
+      yield { type: 'text', text: 'Editing file' };
+      yield {
+        type: 'tool_call_delta',
+        id: 'call_file_editor',
+        name: 'file_editor',
+        arguments: '{"command":"str_replace","path":"README.md","old_str":"old","new_str":"new"}',
+      };
+      yield { type: 'finish' };
+      return;
+    }
+
+    yield { type: 'text', text: 'Done' };
+    yield { type: 'finish' };
+  }
+}
+
+class SummaryLLM implements LLMClient {
+  constructor(private readonly summary: string) {}
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void request;
+    yield { type: 'text', text: this.summary };
+    yield { type: 'finish' };
+  }
+}
+
+const workspaceRoots: string[] = [];
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-file-diff-summary-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('Agent file diff summaries (optional)', () => {
+  it('attaches a summary to file_editor edit observations when enabled', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: { summarizeToolCalls: true },
+      conversation: { maxIterations: 3 },
+      confirmation: {},
+      secrets: {},
+    };
+    const log = new EventLog();
+    const llm = new ToolCallLLM();
+    const summarizer = new SummaryLLM('Replaced old with new.');
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'file_editor',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: 'str_replace',
+        path: 'README.md',
+        prev_exist: true,
+        old_content: 'old',
+        new_content: 'new',
+      }),
+    };
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      toolSummarizerClient: summarizer,
+      tools: [tool],
+    });
+
+    await agent.run('hi');
+
+    const observation = log
+      .list()
+      .find((event) => isObservationEvent(event) && event.tool_name === 'file_editor');
+
+    expect(observation).toBeTruthy();
+    expect((observation as any).observation.summary).toBe('Replaced old with new.');
+  });
+});

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -330,6 +330,32 @@ describe('Agent-SDK event rendering', () => {
     fireEvent.click(toggle);
     expect(await screen.findByText(/SECRET FILE CONTENT/)).toBeInTheDocument();
   });
+
+  it('renders Gemini summaries for file_editor edit observations and hides raw payload', async () => {
+    render(<App />);
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        command: 'str_replace',
+        path: '/tmp/README.md',
+        prev_exist: true,
+        old_content: 'SECRET FILE CONTENT',
+        new_content: 'PUBLIC FILE CONTENT',
+        summary: 'Replaced the greeting line in README.md.',
+      },
+      tool_name: 'file_editor',
+      tool_call_id: 'call_file_editor_summary',
+      action_id: 'action_file_editor_summary',
+    } as any;
+
+    postToWindow({ type: 'event', event: observationEvent });
+    expect(await screen.findByText(/Replaced the greeting line/i)).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'View diff for /tmp/README.md' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Show tool result/i })).toBeNull();
+    expect(screen.queryByText(/SECRET FILE CONTENT/)).toBeNull();
+  });
+
   it('renders friendly summaries for terminal events', async () => {
     render(<App />);
     const actionEvent = {

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -7,8 +7,6 @@ import { EventContainer, FileEditorObservationSummary, OBSERVATION_ACCENT_COLOR,
  */
 export function ObservationEventBlock({ event, index }: { event: ObservationEvent; index?: number }) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const observationString = JSON.stringify(event.observation, null, 2);
-  const isTruncated = observationString.length > 2000;
   const isFileEditObservation = (() => {
     if (event.tool_name !== 'file_editor') return false;
     const candidate = (event.observation as Record<string, unknown> | null) ?? null;
@@ -23,6 +21,8 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
       : null;
   const hasSummary = observationSummary !== null;
   const shouldShowRaw = isFileEditObservation ? false : !hasSummary || isExpanded;
+  const observationString = shouldShowRaw ? JSON.stringify(event.observation, null, 2) : '';
+  const isTruncated = shouldShowRaw && observationString.length > 2000;
   const showHeaderToggle = hasSummary && event.tool_name !== 'terminal' && !isFileEditObservation;
   const showFooterToggle = !hasSummary && isTruncated;
   const headerToggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -9,14 +9,21 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
   const [isExpanded, setIsExpanded] = useState(false);
   const observationString = JSON.stringify(event.observation, null, 2);
   const isTruncated = observationString.length > 2000;
+  const isFileEditObservation = (() => {
+    if (event.tool_name !== 'file_editor') return false;
+    const candidate = (event.observation as Record<string, unknown> | null) ?? null;
+    if (!candidate || typeof candidate !== 'object') return false;
+    const command = typeof candidate.command === 'string' ? candidate.command : '';
+    return command === 'insert' || command === 'str_replace';
+  })();
   const observationSummary = event.tool_name === 'file_editor'
     ? <FileEditorObservationSummary observation={event.observation} />
     : event.tool_name === 'terminal'
       ? <TerminalObservationSummary observation={event.observation} isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />
       : null;
   const hasSummary = observationSummary !== null;
-  const shouldShowRaw = !hasSummary || isExpanded;
-  const showHeaderToggle = hasSummary && event.tool_name !== 'terminal';
+  const shouldShowRaw = isFileEditObservation ? false : !hasSummary || isExpanded;
+  const showHeaderToggle = hasSummary && event.tool_name !== 'terminal' && !isFileEditObservation;
   const showFooterToggle = !hasSummary && isTruncated;
   const headerToggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';
   const footerToggleLabel = isExpanded ? 'Show less' : 'Show more';
@@ -73,4 +80,3 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
     </EventContainer>
   );
 }
-

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -336,6 +336,7 @@ export function FileEditorObservationSummary({ observation }: { observation: Jso
   const rawNew = observation.new_content;
   const oldLength = getCharCount(rawOld);
   const newLength = getCharCount(rawNew);
+  const summary = getString(observation.summary)?.trim();
 
   if (!isFileEditorCommand(command)) return null;
 
@@ -365,7 +366,7 @@ export function FileEditorObservationSummary({ observation }: { observation: Jso
       const detail = formatSizeDelta(oldLength, newLength);
       return (
         <div className="text-sm leading-relaxed space-y-1">
-          <p>Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}</p>
+          {summary ? <p>{summary}</p> : <p>Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}</p>}
           <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
           {detail && <p className="text-xs opacity-70">{detail}</p>}
         </div>


### PR DESCRIPTION
Implements Beads `oh-tab-n1tl`.

- Agent (local mode): when `file_editor` runs an edit (`insert`/`str_replace`) and Gemini tool summaries are enabled, attach a short Gemini diff summary as `observation.summary`.
- Webview: for `file_editor` edit Tool Results, show the summary (and diff link) and **do not** expose raw JSON payload toggles.
- Fallback: if no summary is available, keep the existing deterministic summary + diff link.

Local checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File editor tool outputs now automatically generate and display concise summaries of changes
  * Raw file content is hidden by default, improving security and readability

* **Tests**
  * Added integration tests for file-diff summary functionality
  * Added test coverage for summary display in file editor observations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->