### PR TITLE
oh-tab-totj: fix clipTextMiddle tiny max

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
@@ -99,4 +99,26 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
     expect(summary).toBe('abcd…');
     expect(summary?.length).toBe(5);
   });
+
+  it('respects maxPromptChars for tiny limits', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('OK');
+
+    await summarizeFileChangesWithGeminiFlash(
+      {
+        kind: 'contents',
+        filePath: 'src/example.ts',
+        oldContent: 'old\n',
+        newContent: 'new\n',
+      },
+      { secrets, llmClient: llm, maxPromptChars: 1 }
+    );
+
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text.length).toBeLessThanOrEqual(1);
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
@@ -121,4 +121,28 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
       expect(prompt.text.length).toBeLessThanOrEqual(1);
     }
   });
+
+  it('respects maxPromptChars when only the clip marker fits', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('OK');
+    const maxPromptChars = '<diff clipped>'.length + 2;
+
+    await summarizeFileChangesWithGeminiFlash(
+      {
+        kind: 'contents',
+        filePath: 'src/example.ts',
+        oldContent: 'old\n',
+        newContent: 'new\n',
+      },
+      { secrets, llmClient: llm, maxPromptChars }
+    );
+
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text).toContain('<diff clipped>');
+      expect(prompt.text.length).toBeLessThanOrEqual(maxPromptChars);
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -114,4 +114,21 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
       expect(prompt.text).toContain('(empty)');
     }
   });
+
+  it('respects maxPromptChars for tiny limits', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('OK');
+
+    await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'echo hello', exitCode: 0, stdout: 'hello\n', stderr: '' },
+      { secrets, llmClient: llm, maxPromptChars: 1 }
+    );
+
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text.length).toBeLessThanOrEqual(1);
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -131,4 +131,23 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
       expect(prompt.text.length).toBeLessThanOrEqual(1);
     }
   });
+
+  it('respects maxPromptChars when only the clip marker fits', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('OK');
+    const maxPromptChars = '<output clipped>'.length + 2;
+
+    await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'echo hello', exitCode: 0, stdout: 'hello\n', stderr: '' },
+      { secrets, llmClient: llm, maxPromptChars }
+    );
+
+    expect(llm.requests).toHaveLength(1);
+    const prompt = llm.requests[0].messages[0].content[0];
+    expect(prompt.type).toBe('text');
+    if (prompt.type === 'text') {
+      expect(prompt.text).toContain('<output clipped>');
+      expect(prompt.text.length).toBeLessThanOrEqual(maxPromptChars);
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -34,8 +34,11 @@ const clipTextMiddle = (text: string, maxChars: number): string => {
   const markerBudget = CLIP_MARKER.length + 2;
   if (maxChars < markerBudget) return text.slice(0, maxChars);
   const available = maxChars - markerBudget;
-  const half = Math.max(0, Math.floor(available / 2));
-  return `${text.slice(0, half)}\n${CLIP_MARKER}\n${text.slice(-half)}`;
+  const headLen = Math.ceil(available / 2);
+  const tailLen = Math.floor(available / 2);
+  const head = text.slice(0, headLen);
+  const tail = tailLen === 0 ? '' : text.slice(-tailLen);
+  return `${head}\n${CLIP_MARKER}\n${tail}`;
 };
 
 const getLineCount = (text: string): number => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -31,7 +31,9 @@ const toNonNegativeInt = (value: unknown): number => {
 const clipTextMiddle = (text: string, maxChars: number): string => {
   if (maxChars <= 0) return '';
   if (text.length <= maxChars) return text;
-  const available = maxChars - CLIP_MARKER.length - 2;
+  const markerBudget = CLIP_MARKER.length + 2;
+  if (maxChars < markerBudget) return text.slice(0, maxChars);
+  const available = maxChars - markerBudget;
   const half = Math.max(0, Math.floor(available / 2));
   return `${text.slice(0, half)}\n${CLIP_MARKER}\n${text.slice(-half)}`;
 };

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -36,8 +36,11 @@ const clipTextMiddle = (text: string, maxChars: number): string => {
   const markerBudget = CLIP_MARKER.length + 2;
   if (maxChars < markerBudget) return text.slice(0, maxChars);
   const available = maxChars - markerBudget;
-  const half = Math.max(0, Math.floor(available / 2));
-  return `${text.slice(0, half)}\n${CLIP_MARKER}\n${text.slice(-half)}`;
+  const headLen = Math.ceil(available / 2);
+  const tailLen = Math.floor(available / 2);
+  const head = text.slice(0, headLen);
+  const tail = tailLen === 0 ? '' : text.slice(-tailLen);
+  return `${head}\n${CLIP_MARKER}\n${tail}`;
 };
 
 const maskSecrets = (text: string, secrets: SecretRegistry): string => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -33,7 +33,9 @@ const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): numb
 const clipTextMiddle = (text: string, maxChars: number): string => {
   if (maxChars <= 0) return '';
   if (text.length <= maxChars) return text;
-  const available = maxChars - CLIP_MARKER.length - 2;
+  const markerBudget = CLIP_MARKER.length + 2;
+  if (maxChars < markerBudget) return text.slice(0, maxChars);
+  const available = maxChars - markerBudget;
   const half = Math.max(0, Math.floor(available / 2));
   return `${text.slice(0, half)}\n${CLIP_MARKER}\n${text.slice(-half)}`;
 };


### PR DESCRIPTION
Implements Beads `oh-tab-totj`.

Fix:
- `clipTextMiddle(text, maxChars)` now guarantees output length `<= maxChars` for tiny limits by falling back to `text.slice(0, maxChars)` when the clip marker can’t fit.

Coverage:
- Adds unit tests asserting the prompt respects `maxPromptChars=1` for both summarizers.

Local checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`
