### PR TITLE
oh-tab-0i36: collapsible Advanced settings

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -114,4 +114,38 @@ describe('LLM Profiles view', () => {
 
     expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
   });
+
+  it('supports a collapsible Advanced settings section', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Show advanced settings' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('API Version')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
+    expect(await screen.findByText('API Version')).toBeInTheDocument();
+
+    const topPInput = screen.getByPlaceholderText('1');
+    fireEvent.change(topPInput, { target: { value: 'abc' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide advanced settings' }));
+    expect(screen.queryByText('API Version')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByRole('button', { name: 'Hide advanced settings' })).toBeInTheDocument();
+    expect(await screen.findByText('Must be a valid number')).toBeInTheDocument();
+  });
 });

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -54,6 +54,19 @@ const EMPTY_FORM: ProfileFormState = {
   outputCostPerToken: '',
 };
 
+const ADVANCED_FIELD_KEYS: Array<keyof ProfileFormState> = [
+  'apiVersion',
+  'temperature',
+  'topP',
+  'topK',
+  'maxInputTokens',
+  'maxOutputTokens',
+  'reasoningEffort',
+  'reasoningSummary',
+  'inputCostPerToken',
+  'outputCostPerToken',
+];
+
 const toFormState = (profileId: string, config: LLMConfiguration): ProfileFormState => {
   const strOrEmpty = (v: unknown): string => (typeof v === 'string' ? v : '');
   const numOrEmpty = (v: unknown): string => (typeof v === 'number' && Number.isFinite(v) ? String(v) : '');
@@ -313,8 +326,10 @@ export function LlmProfilesView(props: {
   const [apiKeyInput, setApiKeyInput] = useState('');
   const [apiKeySaving, setApiKeySaving] = useState(false);
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
+  const [isAdvancedOpen, setIsAdvancedOpen] = useState(false);
 
   const sortedProfiles = useMemo(() => [...profiles].sort((a, b) => a.localeCompare(b)), [profiles]);
+  const advancedErrorCount = useMemo(() => ADVANCED_FIELD_KEYS.reduce((count, key) => (errors[key] ? count + 1 : count), 0), [errors]);
 
   const refreshApiKeyStatus = useCallback(async (profileId: string) => {
     if (activeProfileIdRef.current !== profileId) return;
@@ -361,6 +376,7 @@ export function LlmProfilesView(props: {
     setApiKeyInput('');
     setApiKeySaving(false);
     setApiKeyError(null);
+    setIsAdvancedOpen(false);
   }, []);
 
   const startEdit = useCallback(async (profileId: string) => {
@@ -373,6 +389,7 @@ export function LlmProfilesView(props: {
     setApiKeyError(null);
     setShowApiKeyEditor(false);
     setApiKeyInput('');
+    setIsAdvancedOpen(false);
     setLoadingProfile(true);
     try {
       const config = await loadProfile(profileId);
@@ -404,7 +421,11 @@ export function LlmProfilesView(props: {
     setSaveAttempted(true);
     const nextErrors = validateForm(mode, form);
     setErrors(nextErrors);
-    if (Object.keys(nextErrors).length > 0) return;
+    if (Object.keys(nextErrors).length > 0) {
+      const hasAdvancedErrors = ADVANCED_FIELD_KEYS.some((key) => Boolean(nextErrors[key]));
+      if (hasAdvancedErrors) setIsAdvancedOpen(true);
+      return;
+    }
 
     const profileId = form.name.trim();
     const config = buildProfileConfig(form);
@@ -784,18 +805,6 @@ export function LlmProfilesView(props: {
                   </div>
 
                   <div>
-                    <FieldLabel label="API Version" />
-                    <div className="mt-2">
-                      <InputField
-                        value={form.apiVersion}
-                        onChange={(v) => update('apiVersion', v)}
-                        placeholder="optional"
-                      />
-                      <FieldError message={errors.apiVersion} />
-                    </div>
-                  </div>
-
-                  <div>
                     <FieldLabel label="OpenAI API mode" />
                     <div className="mt-2">
                       <SelectField
@@ -810,9 +819,7 @@ export function LlmProfilesView(props: {
                       <FieldError message={errors.openaiApiMode} />
                     </div>
                   </div>
-                </div>
 
-                <div className="grid grid-cols-3 gap-4">
                   <div>
                     <FieldLabel label="Timeout (seconds)" />
                     <div className="mt-2">
@@ -820,92 +827,132 @@ export function LlmProfilesView(props: {
                       <FieldError message={errors.timeoutSeconds} />
                     </div>
                   </div>
-                  <div>
-                    <FieldLabel label="Temperature" />
-                    <div className="mt-2">
-                      <InputField value={form.temperature} onChange={(v) => update('temperature', v)} placeholder="0.2" />
-                      <FieldError message={errors.temperature} />
-                    </div>
-                  </div>
-                  <div>
-                    <FieldLabel label="Top P" />
-                    <div className="mt-2">
-                      <InputField value={form.topP} onChange={(v) => update('topP', v)} placeholder="1" />
-                      <FieldError message={errors.topP} />
-                    </div>
-                  </div>
-                  <div>
-                    <FieldLabel label="Top K" />
-                    <div className="mt-2">
-                      <InputField value={form.topK} onChange={(v) => update('topK', v)} placeholder="optional" />
-                      <FieldError message={errors.topK} />
-                    </div>
-                  </div>
-                  <div>
-                    <FieldLabel label="Max input tokens" />
-                    <div className="mt-2">
-                      <InputField value={form.maxInputTokens} onChange={(v) => update('maxInputTokens', v)} placeholder="optional" />
-                      <FieldError message={errors.maxInputTokens} />
-                    </div>
-                  </div>
-                  <div>
-                    <FieldLabel label="Max output tokens" />
-                    <div className="mt-2">
-                      <InputField value={form.maxOutputTokens} onChange={(v) => update('maxOutputTokens', v)} placeholder="optional" />
-                      <FieldError message={errors.maxOutputTokens} />
-                    </div>
-                  </div>
                 </div>
 
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <FieldLabel label="Reasoning effort" />
-                    <div className="mt-2">
-                      <SelectField
-                        value={form.reasoningEffort}
-                        onChange={(v) => update('reasoningEffort', v as ProfileFormState['reasoningEffort'])}
-                      >
-                        <option value="">default</option>
-                        <option value="none">none</option>
-                        <option value="low">low</option>
-                        <option value="medium">medium</option>
-                        <option value="high">high</option>
-                      </SelectField>
-                      <FieldError message={errors.reasoningEffort} />
+                <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                  <button
+                    type="button"
+                    onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
+                    className="w-full flex items-center justify-between gap-3 text-left"
+                    aria-label={isAdvancedOpen ? 'Hide advanced settings' : 'Show advanced settings'}
+                    title={isAdvancedOpen ? 'Hide advanced settings' : 'Show advanced settings'}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="codicon codicon-settings text-stone-400" />
+                      <span className="text-sm font-medium text-stone-200">Advanced settings</span>
+                      {advancedErrorCount > 0 && !isAdvancedOpen && (
+                        <span className="ml-1 text-[11px] px-2 py-0.5 rounded-full bg-red-500/10 text-red-200 border border-red-500/20">
+                          {advancedErrorCount} issue{advancedErrorCount === 1 ? '' : 's'}
+                        </span>
+                      )}
                     </div>
-                  </div>
-                  <div>
-                    <FieldLabel label="Reasoning summary" />
-                    <div className="mt-2">
-                      <SelectField
-                        value={form.reasoningSummary}
-                        onChange={(v) => update('reasoningSummary', v as ProfileFormState['reasoningSummary'])}
-                      >
-                        <option value="">default</option>
-                        <option value="auto">auto</option>
-                        <option value="concise">concise</option>
-                        <option value="detailed">detailed</option>
-                      </SelectField>
-                      <FieldError message={errors.reasoningSummary} />
-                    </div>
-                  </div>
-                </div>
+                    <span className={`codicon codicon-chevron-${isAdvancedOpen ? 'up' : 'down'} text-[10px] text-stone-400`} />
+                  </button>
 
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <FieldLabel label="Input cost per token" />
-                    <div className="mt-2">
-                      <InputField value={form.inputCostPerToken} onChange={(v) => update('inputCostPerToken', v)} placeholder="optional" />
-                      <FieldError message={errors.inputCostPerToken} />
+                  {isAdvancedOpen && (
+                    <div className="mt-4 space-y-6">
+                      <div>
+                        <FieldLabel label="API Version" />
+                        <div className="mt-2">
+                          <InputField
+                            value={form.apiVersion}
+                            onChange={(v) => update('apiVersion', v)}
+                            placeholder="optional"
+                          />
+                          <FieldError message={errors.apiVersion} />
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-3 gap-4">
+                        <div>
+                          <FieldLabel label="Temperature" />
+                          <div className="mt-2">
+                            <InputField value={form.temperature} onChange={(v) => update('temperature', v)} placeholder="0.2" />
+                            <FieldError message={errors.temperature} />
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel label="Top P" />
+                          <div className="mt-2">
+                            <InputField value={form.topP} onChange={(v) => update('topP', v)} placeholder="1" />
+                            <FieldError message={errors.topP} />
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel label="Top K" />
+                          <div className="mt-2">
+                            <InputField value={form.topK} onChange={(v) => update('topK', v)} placeholder="optional" />
+                            <FieldError message={errors.topK} />
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel label="Max input tokens" />
+                          <div className="mt-2">
+                            <InputField value={form.maxInputTokens} onChange={(v) => update('maxInputTokens', v)} placeholder="optional" />
+                            <FieldError message={errors.maxInputTokens} />
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel label="Max output tokens" />
+                          <div className="mt-2">
+                            <InputField value={form.maxOutputTokens} onChange={(v) => update('maxOutputTokens', v)} placeholder="optional" />
+                            <FieldError message={errors.maxOutputTokens} />
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <FieldLabel label="Reasoning effort" />
+                          <div className="mt-2">
+                            <SelectField
+                              value={form.reasoningEffort}
+                              onChange={(v) => update('reasoningEffort', v as ProfileFormState['reasoningEffort'])}
+                            >
+                              <option value="">default</option>
+                              <option value="none">none</option>
+                              <option value="low">low</option>
+                              <option value="medium">medium</option>
+                              <option value="high">high</option>
+                            </SelectField>
+                            <FieldError message={errors.reasoningEffort} />
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel label="Reasoning summary" />
+                          <div className="mt-2">
+                            <SelectField
+                              value={form.reasoningSummary}
+                              onChange={(v) => update('reasoningSummary', v as ProfileFormState['reasoningSummary'])}
+                            >
+                              <option value="">default</option>
+                              <option value="auto">auto</option>
+                              <option value="concise">concise</option>
+                              <option value="detailed">detailed</option>
+                            </SelectField>
+                            <FieldError message={errors.reasoningSummary} />
+                          </div>
+                        </div>
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <FieldLabel label="Input cost per token" />
+                          <div className="mt-2">
+                            <InputField value={form.inputCostPerToken} onChange={(v) => update('inputCostPerToken', v)} placeholder="optional" />
+                            <FieldError message={errors.inputCostPerToken} />
+                          </div>
+                        </div>
+                        <div>
+                          <FieldLabel label="Output cost per token" />
+                          <div className="mt-2">
+                            <InputField value={form.outputCostPerToken} onChange={(v) => update('outputCostPerToken', v)} placeholder="optional" />
+                            <FieldError message={errors.outputCostPerToken} />
+                          </div>
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                  <div>
-                    <FieldLabel label="Output cost per token" />
-                    <div className="mt-2">
-                      <InputField value={form.outputCostPerToken} onChange={(v) => update('outputCostPerToken', v)} placeholder="optional" />
-                      <FieldError message={errors.outputCostPerToken} />
-                    </div>
-                  </div>
+                  )}
                 </div>
               </div>
             )}

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -330,6 +330,8 @@ export function LlmProfilesView(props: {
 
   const sortedProfiles = useMemo(() => [...profiles].sort((a, b) => a.localeCompare(b)), [profiles]);
   const advancedErrorCount = useMemo(() => ADVANCED_FIELD_KEYS.reduce((count, key) => (errors[key] ? count + 1 : count), 0), [errors]);
+  const advancedSettingsLabelId = 'llmProfilesAdvancedSettingsLabel';
+  const advancedSettingsPanelId = 'llmProfilesAdvancedSettingsPanel';
 
   const refreshApiKeyStatus = useCallback(async (profileId: string) => {
     if (activeProfileIdRef.current !== profileId) return;
@@ -832,14 +834,16 @@ export function LlmProfilesView(props: {
                 <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
                   <button
                     type="button"
-                    onClick={() => setIsAdvancedOpen(!isAdvancedOpen)}
+                    onClick={() => setIsAdvancedOpen((prev) => !prev)}
                     className="w-full flex items-center justify-between gap-3 text-left"
                     aria-label={isAdvancedOpen ? 'Hide advanced settings' : 'Show advanced settings'}
+                    aria-expanded={isAdvancedOpen}
+                    aria-controls={advancedSettingsPanelId}
                     title={isAdvancedOpen ? 'Hide advanced settings' : 'Show advanced settings'}
                   >
                     <div className="flex items-center gap-2">
                       <span className="codicon codicon-settings text-stone-400" />
-                      <span className="text-sm font-medium text-stone-200">Advanced settings</span>
+                      <span id={advancedSettingsLabelId} className="text-sm font-medium text-stone-200">Advanced settings</span>
                       {advancedErrorCount > 0 && !isAdvancedOpen && (
                         <span className="ml-1 text-[11px] px-2 py-0.5 rounded-full bg-red-500/10 text-red-200 border border-red-500/20">
                           {advancedErrorCount} issue{advancedErrorCount === 1 ? '' : 's'}
@@ -850,7 +854,12 @@ export function LlmProfilesView(props: {
                   </button>
 
                   {isAdvancedOpen && (
-                    <div className="mt-4 space-y-6">
+                    <div
+                      id={advancedSettingsPanelId}
+                      role="region"
+                      aria-labelledby={advancedSettingsLabelId}
+                      className="mt-4 space-y-6"
+                    >
                       <div>
                         <FieldLabel label="API Version" />
                         <div className="mt-2">


### PR DESCRIPTION
Implements bead `oh-tab-0i36`.

- Adds a collapsible **Advanced settings** section in `LlmProfilesView` (default collapsed)
- Moves API version / sampling / tokens / reasoning / cost fields into Advanced
- Auto-expands Advanced on Save when validation errors are inside it (and shows a small issue count badge when collapsed)
- Adds a webview test covering toggle + auto-expand-on-error

Local checks: `npm test`, `npm run typecheck`, `npm run lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a collapsible Advanced settings section in LLM Profiles that users can toggle to show/hide advanced configuration options. A notification badge displays when validation errors exist in advanced fields. The section automatically expands if errors are detected upon save.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->