### PR TITLE
oh-tab-t2fk: icon-only new conversation button

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -523,7 +523,7 @@ describe('App - Advanced Test Coverage', () => {
 
       expect(input.value).toBe('Some text');
 
-      const newChatBtn = screen.getByLabelText('New');
+      const newChatBtn = screen.getByLabelText('Start new conversation');
       await userEvent.click(newChatBtn);
 
       expect(input.value).toBe('');

--- a/src/webview-src/__tests__/App.render.test.tsx
+++ b/src/webview-src/__tests__/App.render.test.tsx
@@ -18,7 +18,7 @@ describe('App render', () => {
     render(<App />);
     expect(screen.getByText('OpenHands')).toBeInTheDocument();
     expect(screen.getByPlaceholderText('Ask OpenHands anything...')).toBeInTheDocument();
-    expect(screen.getByLabelText('New')).toBeInTheDocument();
+    expect(screen.getByLabelText('Start new conversation')).toBeInTheDocument();
     expect(screen.getByLabelText('Add context')).toBeInTheDocument();
   });
 

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -65,47 +65,6 @@ function StatusIndicator({ status }: { status: 'online' | 'offline' | 'connectin
   );
 }
 
-function HeaderButton({
-  icon,
-  label,
-  onClick,
-  disabled = false,
-  variant = 'default',
-}: {
-  icon: string;
-  label: string;
-  onClick: () => void;
-  disabled?: boolean;
-  variant?: 'default' | 'primary';
-}) {
-  const baseClasses = `
-    relative inline-flex items-center justify-center
-    h-9 px-3.5 rounded-lg
-    text-sm font-medium
-    transition-all duration-200
-    focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
-    disabled:opacity-40 disabled:cursor-not-allowed
-  `;
-
-  const variantClasses = variant === 'primary'
-    ? 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:shadow-glow-sm hover:border-brand-500/40'
-    : 'bg-white/[0.04] text-stone-300 border border-white/[0.06] hover:bg-white/[0.08] hover:border-white/[0.1]';
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={`${baseClasses} ${variantClasses}`}
-      aria-label={label}
-      title={label}
-    >
-      <span className={`codicon codicon-${icon} mr-2 text-sm`} />
-      <span>{label}</span>
-    </button>
-  );
-}
-
 function IconButton({
   icon,
   label,
@@ -244,12 +203,7 @@ export function Header({
 
         {/* Right side - Actions */}
         <div className="flex items-center gap-2">
-          <HeaderButton
-            icon="add"
-            label="New"
-            onClick={onNewConversation}
-            variant="primary"
-          />
+          <IconButton icon="add" label="Start new conversation" onClick={onNewConversation} />
 
           <div className="w-px h-6 bg-white/[0.08]" />
 


### PR DESCRIPTION
Implements bead `oh-tab-t2fk`.

- Replace header "New" button with an icon-only + button (codicon add)
- Tooltip/aria-label: "Start new conversation"
- Update webview tests that asserted the old "New" label

Local checks: `npm test`, `npm run typecheck`, `npm run lint`.
