### PR TITLE
oh-tab-er9r: Move @ Add context button to row start

### DIFF
--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -225,6 +225,13 @@ export function InputArea({
 
         {/* Accessory buttons row */}
         <div className="flex items-center gap-2 mt-3">
+          <AccessoryButton
+            label="Add context"
+            displayLabel="@"
+            onClick={onOpenContext}
+            badge={contextCount > 0 ? contextCount : undefined}
+          />
+
           <LlmProfileSelector
             profileId={llmProfileId}
             profiles={llmProfiles}
@@ -232,13 +239,6 @@ export function InputArea({
             onSelect={onSelectLlmProfileId}
             onOpenCreate={onOpenLlmProfilesCreate}
             onOpenEdit={onOpenLlmProfilesEdit}
-          />
-
-          <AccessoryButton
-            icon="mention"
-            label="Add context"
-            onClick={onOpenContext}
-            badge={contextCount > 0 ? contextCount : undefined}
           />
 
           <AccessoryButton
@@ -333,8 +333,9 @@ export function InputArea({
 }
 
 interface AccessoryButtonProps {
-  icon: string;
   label: string;
+  displayLabel?: string;
+  icon?: string;
   onClick: () => void;
   badge?: number;
   comingSoon?: boolean;
@@ -515,7 +516,7 @@ function LlmProfileSelector({
   );
 }
 
-function AccessoryButton({ icon, label, onClick, badge, comingSoon }: AccessoryButtonProps) {
+function AccessoryButton({ icon, label, displayLabel, onClick, badge, comingSoon }: AccessoryButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -535,8 +536,8 @@ function AccessoryButton({ icon, label, onClick, badge, comingSoon }: AccessoryB
       aria-label={label}
       title={label}
     >
-      <span className={`codicon codicon-${icon}`} />
-      <span>{label}</span>
+      {icon && <span className={`codicon codicon-${icon}`} />}
+      <span>{displayLabel ?? label}</span>
 
       {badge !== undefined && badge > 0 && (
         <span className="absolute -top-1.5 -right-1.5 h-4 min-w-4 px-1 rounded-full bg-gradient-to-b from-brand-400 to-brand-600 text-white text-[10px] font-semibold flex items-center justify-center shadow-glow-sm">


### PR DESCRIPTION
Implements oh-tab-er9r.

- Move the Add context control to the leftmost position in the accessory row (before LLM Profile selector).
- Shrink visible label to '@' while keeping tooltip + aria-label as 'Add context'.

Tests:
- npx vitest run src/webview-src/__tests__/App.render.test.tsx src/webview-src/__tests__/actions.test.tsx src/webview-src/__tests__/App.advanced.test.tsx
- npm test
- npm run typecheck
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Redesigned the context button in the input area with a "@" display label and badge indicator for added contexts.
  * Improved button component to provide more flexible rendering with optional icons and customizable display labels for better UI adaptability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->