### PR TITLE
oh-tab-s1kr: Expand System Prompt skills/tools

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -157,6 +157,13 @@ describe('Agent-SDK event rendering', () => {
 
   it('renders SystemPromptEvent', async () => {
     render(<App />);
+    postToWindow({
+      type: 'skillsList',
+      skills: [
+        { label: 'react-skill', path: '/skills/react-skill.md' },
+        { label: 'typescript-skill', path: '/skills/typescript-skill.md' },
+      ],
+    });
     const ev = {
       kind: 'SystemPromptEvent',
       source: 'agent' as const,
@@ -167,7 +174,18 @@ describe('Agent-SDK event rendering', () => {
     const toggle = await screen.findByRole('button', { name: /Show system prompt/i });
     fireEvent.click(toggle);
     expect(await screen.findByText(/You are a helpful AI assistant designed for testing/)).toBeInTheDocument();
-    expect(await screen.findByText(/3 tools available/)).toBeInTheDocument();
+
+    const skillsRow = await screen.findByRole('button', { name: /2 skills loaded/i });
+    const toolsRow = await screen.findByRole('button', { name: /3 tools available/i });
+
+    fireEvent.click(skillsRow);
+    expect(await screen.findByText('react-skill')).toBeInTheDocument();
+    expect(await screen.findByText('typescript-skill')).toBeInTheDocument();
+
+    fireEvent.click(toolsRow);
+    expect(await screen.findByText('bash')).toBeInTheDocument();
+    expect(await screen.findByText('read')).toBeInTheDocument();
+    expect(await screen.findByText('write')).toBeInTheDocument();
   });
 
   it('renders ActionEvent', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -152,8 +152,16 @@ type PendingLlmProfilesRequest =
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.
  */
-function EventBlock({ event, index }: { event: Event; index: number }) {
-  if (isSystemPromptEvent(event)) return <SystemPromptEventBlock event={event} index={index} />;
+function EventBlock({
+  event,
+  index,
+  skills,
+}: {
+  event: Event;
+  index: number;
+  skills: { label: string; path: string }[];
+}) {
+  if (isSystemPromptEvent(event)) return <SystemPromptEventBlock event={event} index={index} skills={skills} />;
   if (isActionEvent(event)) return <ActionEventBlock event={event} index={index} />;
   if (isObservationEvent(event)) return <ObservationEventBlock event={event} index={index} />;
   if (isUserRejectObservation(event)) return <UserRejectBlock event={event} index={index} />;
@@ -1369,7 +1377,7 @@ export function App() {
         ) : (
           <>
             {events.map((ev, index) => (
-              <EventBlock key={ev.id} event={ev.event} index={index} />
+              <EventBlock key={ev.id} event={ev.event} index={index} skills={skills} />
             ))}
             {streamingContent !== null && (
               <StreamingMessageBlock content={streamingContent} />

--- a/src/webview-src/components/eventBlocks/SystemPromptEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/SystemPromptEventBlock.tsx
@@ -2,12 +2,61 @@ import { useState } from 'react';
 import type { SystemPromptEvent } from '@openhands/agent-sdk-ts';
 import { EventContainer, SYSTEM_ACCENT_COLOR, withAlpha } from './shared';
 
+type LoadedSkill = { label: string; path: string };
+
+const getNonEmptyString = (value: unknown): string | null => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const getToolDisplayName = (tool: Record<string, unknown>, index: number): string => {
+  const direct = getNonEmptyString(tool.name);
+  if (direct) return direct;
+
+  const functionField = tool.function;
+  if (functionField && typeof functionField === 'object') {
+    const name = getNonEmptyString((functionField as Record<string, unknown>).name);
+    if (name) return name;
+  }
+
+  return `tool_${index + 1}`;
+};
+
 /**
  * Renders system prompt - expandable view of initial agent instructions.
  */
-export function SystemPromptEventBlock({ event, index }: { event: SystemPromptEvent; index?: number }) {
+export function SystemPromptEventBlock({
+  event,
+  index,
+  skills,
+}: {
+  event: SystemPromptEvent;
+  index?: number;
+  skills?: LoadedSkill[];
+}) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const [skillsExpanded, setSkillsExpanded] = useState(false);
+  const [toolsExpanded, setToolsExpanded] = useState(false);
   const toggleLabel = isExpanded ? 'Hide system prompt' : 'Show system prompt';
+  const toolNames = Array.isArray(event.tools)
+    ? event.tools
+      .filter((tool): tool is Record<string, unknown> => tool !== null && typeof tool === 'object')
+      .map(getToolDisplayName)
+    : [];
+
+  const skillNames = Array.isArray(skills)
+    ? skills
+      .map((skill) => getNonEmptyString(skill.label))
+      .filter((label): label is string => label !== null)
+    : [];
+
+  const idSuffix =
+    typeof event.id === 'string' && event.id.trim().length > 0
+      ? event.id.trim()
+      : `idx-${index ?? 0}`;
+  const skillsListId = `system-prompt-skills-${idSuffix}`;
+  const toolsListId = `system-prompt-tools-${idSuffix}`;
 
   return (
     <EventContainer accentColor={SYSTEM_ACCENT_COLOR} bgOpacity={0.03} index={index}>
@@ -20,7 +69,16 @@ export function SystemPromptEventBlock({ event, index }: { event: SystemPromptEv
         </div>
         <div className="font-semibold text-sm text-stone-200">System Prompt</div>
         <button
-          onClick={() => setIsExpanded(!isExpanded)}
+          onClick={() =>
+            setIsExpanded((prev) => {
+              const next = !prev;
+              if (!next) {
+                setSkillsExpanded(false);
+                setToolsExpanded(false);
+              }
+              return next;
+            })
+          }
           className="ml-auto text-xs text-stone-400 hover:text-stone-300 transition-colors flex items-center gap-1.5 px-2 py-1 rounded-md hover:bg-white/[0.05]"
           aria-label={toggleLabel}
           title={toggleLabel}
@@ -34,15 +92,79 @@ export function SystemPromptEventBlock({ event, index }: { event: SystemPromptEv
           <div className="whitespace-pre-wrap text-sm leading-relaxed text-stone-300 font-mono bg-black/20 rounded-lg p-3 border border-white/[0.04]">
             {event.system_prompt.text}
           </div>
-          {event.tools && event.tools.length > 0 && (
-            <div className="mt-3 pt-3 border-t border-white/[0.06] text-xs text-stone-400 flex items-center gap-2">
+          <div className="mt-3 pt-3 border-t border-white/[0.06] text-xs text-stone-400 space-y-2">
+            <button
+              type="button"
+              onClick={() => setSkillsExpanded((prev) => !prev)}
+              className="w-full flex items-center gap-2 px-2 py-1 rounded-md hover:bg-white/[0.05] hover:text-stone-300 transition-colors"
+              aria-label={`${skillNames.length} skills loaded`}
+              aria-expanded={skillsExpanded}
+              aria-controls={skillsListId}
+              title={skillsExpanded ? 'Hide skills' : 'Show skills'}
+            >
+              <span className="codicon codicon-mortar-board" style={{ color: SYSTEM_ACCENT_COLOR }} />
+              <span>{skillNames.length} skills loaded</span>
+              <span className={`ml-auto codicon codicon-chevron-${skillsExpanded ? 'up' : 'down'} text-[10px] opacity-70`} />
+            </button>
+            {skillsExpanded && (
+              <div
+                id={skillsListId}
+                role="region"
+                aria-label="Loaded skills"
+                className="ml-7 bg-black/20 rounded-lg border border-white/[0.04] max-h-40 overflow-auto"
+              >
+                {skillNames.length > 0 ? (
+                  skillNames.map((name, idx) => (
+                    <div
+                      key={`${name}:${idx}`}
+                      className="px-3 py-1.5 text-xs text-stone-300 border-b border-white/[0.04] last:border-b-0"
+                    >
+                      {name}
+                    </div>
+                  ))
+                ) : (
+                  <div className="px-3 py-2 text-xs opacity-70">No skills loaded</div>
+                )}
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={() => setToolsExpanded((prev) => !prev)}
+              className="w-full flex items-center gap-2 px-2 py-1 rounded-md hover:bg-white/[0.05] hover:text-stone-300 transition-colors"
+              aria-label={`${toolNames.length} tools available`}
+              aria-expanded={toolsExpanded}
+              aria-controls={toolsListId}
+              title={toolsExpanded ? 'Hide tools' : 'Show tools'}
+            >
               <span className="codicon codicon-tools" style={{ color: SYSTEM_ACCENT_COLOR }} />
-              <span>{event.tools.length} tools available</span>
-            </div>
-          )}
+              <span>{toolNames.length} tools available</span>
+              <span className={`ml-auto codicon codicon-chevron-${toolsExpanded ? 'up' : 'down'} text-[10px] opacity-70`} />
+            </button>
+            {toolsExpanded && (
+              <div
+                id={toolsListId}
+                role="region"
+                aria-label="Available tools"
+                className="ml-7 bg-black/20 rounded-lg border border-white/[0.04] max-h-40 overflow-auto"
+              >
+                {toolNames.length > 0 ? (
+                  toolNames.map((name, idx) => (
+                    <div
+                      key={`${name}:${idx}`}
+                      className="px-3 py-1.5 text-xs text-stone-300 border-b border-white/[0.04] last:border-b-0"
+                    >
+                      {name}
+                    </div>
+                  ))
+                ) : (
+                  <div className="px-3 py-2 text-xs opacity-70">No tools available</div>
+                )}
+              </div>
+            )}
+          </div>
         </>
       )}
     </EventContainer>
   );
 }
-


### PR DESCRIPTION
Implements oh-tab-s1kr.

- Expanded System Prompt block now shows clickable summary rows for skills + tools counts.
- Each row toggles a scrollable list of names (UI-only).

Tests:
- npm test
- npm run typecheck
- npm run lint