### PR TITLE
oh-tab-fm7z: Dedupe profileId validation

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -45,7 +45,7 @@ const resolveRootDir = (options: LLMProfileStoreOptions = {}): string => {
   return path.resolve(expandHomeDir(rootDir));
 };
 
-const assertValidProfileId = (profileId: string): void => {
+export const assertValidProfileId = (profileId: string): void => {
   if (!profileId.trim()) {
     throw new LLMProfileValidationError('Profile id must be a non-empty string');
   }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import * as childProcess from 'child_process';
+import { assertValidProfileId, LLMProfileValidationError } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -116,17 +117,13 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   let elevenlabsTtsGate: TtsConversationGate | null = null;
 
   const validateProfileId = (profileId: string): void => {
-    if (!profileId.trim()) {
-      throw new Error('Profile id must be a non-empty string');
-    }
-    if (profileId !== profileId.trim()) {
-      throw new Error('Profile id must not have leading/trailing whitespace');
-    }
-    if (profileId.includes('/') || profileId.includes('\\')) {
-      throw new Error('Profile id must not contain path separators');
-    }
-    if (!/^[a-zA-Z0-9._-]+$/.test(profileId)) {
-      throw new Error('Profile id contains invalid characters');
+    try {
+      assertValidProfileId(profileId);
+    } catch (err) {
+      if (err instanceof LLMProfileValidationError) {
+        throw new Error(err.message);
+      }
+      throw err;
     }
   };
 


### PR DESCRIPTION
Implements oh-tab-fm7z.

- Export assertValidProfileId from @openhands/agent-sdk-ts.
- Use it from the extension host instead of duplicating validation logic (preserve error messages by mapping LLMProfileValidationError -> Error).

Checks:
- npm test
- npm run typecheck
- npm run lint
- npm run e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated profile ID validation logic to a centralized library function, improving consistency and error handling across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->