### PR TITLE
oh-tab-49bv: Honor 0 limits in fileDiffSummarizer

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
@@ -82,6 +82,42 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
     expect(llm.requests).toHaveLength(0);
   });
 
+  it('honors explicit maxSummaryChars=0 (skips summarization)', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('should not be called');
+
+    const summary = await summarizeFileChangesWithGeminiFlash(
+      {
+        kind: 'contents',
+        filePath: 'src/example.ts',
+        oldContent: 'const a = 1;\n',
+        newContent: 'const a = 2;\n',
+      },
+      { secrets, llmClient: llm, maxPromptChars: 10_000, maxSummaryChars: 0 }
+    );
+
+    expect(summary).toBeUndefined();
+    expect(llm.requests).toHaveLength(0);
+  });
+
+  it('honors explicit maxPromptChars=0 (skips summarization)', async () => {
+    const secrets = new SecretRegistry();
+    const llm = new RecordingLLM('should not be called');
+
+    const summary = await summarizeFileChangesWithGeminiFlash(
+      {
+        kind: 'contents',
+        filePath: 'src/example.ts',
+        oldContent: 'const a = 1;\n',
+        newContent: 'const a = 2;\n',
+      },
+      { secrets, llmClient: llm, maxPromptChars: 0, maxSummaryChars: 10 }
+    );
+
+    expect(summary).toBeUndefined();
+    expect(llm.requests).toHaveLength(0);
+  });
+
   it('never returns more than maxSummaryChars', async () => {
     const secrets = new SecretRegistry();
     const llm = new RecordingLLM('abcdefghij');

--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -23,8 +23,9 @@ const DEFAULT_MAX_PROMPT_CHARS = 4_000;
 const DEFAULT_MAX_SUMMARY_CHARS = 1_000;
 const CLIP_MARKER = '<diff clipped>';
 
-const toNonNegativeInt = (value: unknown): number => {
-  if (typeof value !== 'number' || !Number.isFinite(value)) return 0;
+const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {
+  if (value === undefined) return defaultValue;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
   return Math.max(0, Math.trunc(value));
 };
 
@@ -138,8 +139,9 @@ export async function summarizeFileChangesWithGeminiFlash(
   input: FileChangeInput,
   options: SummarizeFileChangesOptions
 ): Promise<string | undefined> {
-  const maxPromptChars = toNonNegativeInt(options.maxPromptChars) || DEFAULT_MAX_PROMPT_CHARS;
-  const maxSummaryChars = toNonNegativeInt(options.maxSummaryChars) || DEFAULT_MAX_SUMMARY_CHARS;
+  const maxPromptChars = resolveNonNegativeIntOption(options.maxPromptChars, DEFAULT_MAX_PROMPT_CHARS);
+  const maxSummaryChars = resolveNonNegativeIntOption(options.maxSummaryChars, DEFAULT_MAX_SUMMARY_CHARS);
+  if (maxPromptChars <= 0 || maxSummaryChars <= 0) return undefined;
 
   const { oldContent, newContent } =
     input.kind === 'git_refs'
@@ -184,7 +186,6 @@ export async function summarizeFileChangesWithGeminiFlash(
   const summary = maskSecrets(text, options.secrets).trim();
   if (!summary) return undefined;
   if (summary.length <= maxSummaryChars) return summary;
-  if (maxSummaryChars <= 0) return undefined;
   if (maxSummaryChars === 1) return '…';
   return summary.slice(0, maxSummaryChars - 1) + '…';
 }


### PR DESCRIPTION
Implements oh-tab-49bv.

- fileDiffSummarizer now honors explicit 0 values for maxPromptChars/maxSummaryChars (align with terminalObservationSummarizer option semantics).
- maxPromptChars<=0 or maxSummaryChars<=0 returns undefined and makes no LLM requests.
- Adds unit coverage for both 0 cases.

Checks:
- npm test
- npm run typecheck
- npm run lint
- npm run e2e