### PR TITLE
oh-tab-bw8p: Provider docs link

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -148,4 +148,40 @@ describe('LLM Profiles view', () => {
     expect(await screen.findByRole('button', { name: 'Hide advanced settings' })).toBeInTheDocument();
     expect(await screen.findByText('Must be a valid number')).toBeInTheDocument();
   });
+
+  it('offers a Provider docs link based on the selected provider', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
+
+    const providerSelect = screen.getAllByRole('combobox').find((candidate) => (
+      candidate.querySelector('option[value="openai"]') !== null
+    ));
+    if (!providerSelect) throw new Error('Failed to find provider select');
+
+    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Provider docs' }));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('openMarkdownLink')).toBeTruthy();
+    });
+
+    expect(getLastPostedOfType('openMarkdownLink')?.href).toBe('https://platform.openai.com/docs');
+
+    fireEvent.change(providerSelect, { target: { value: 'openrouter' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Provider docs' }));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('openMarkdownLink')?.href).toBe('https://openrouter.ai/docs');
+    });
+  });
 });

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { LLMConfiguration } from '@openhands/agent-sdk-ts';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
+import { getVscodeApi } from '../shared/vscodeApi';
+import type { WebviewToHostMessage } from '../../shared/webviewMessages';
 
 type ProfileFormMode = 'create' | 'edit';
 
@@ -66,6 +68,25 @@ const ADVANCED_FIELD_KEYS: Array<keyof ProfileFormState> = [
   'inputCostPerToken',
   'outputCostPerToken',
 ];
+
+type Provider = Exclude<ProfileFormState['provider'], ''>;
+
+const PROVIDER_DOCS_URLS: Record<Provider, string> = {
+  openai: 'https://platform.openai.com/docs',
+  anthropic: 'https://docs.anthropic.com/en/docs',
+  openrouter: 'https://openrouter.ai/docs',
+  litellm_proxy: 'https://docs.litellm.ai/docs',
+  gemini: 'https://ai.google.dev/gemini-api/docs',
+};
+
+const postMessage = (message: WebviewToHostMessage) => {
+  const api = getVscodeApi();
+  api.postMessage(message);
+};
+
+const openMarkdownLink = (href: string) => {
+  postMessage({ type: 'openMarkdownLink', href });
+};
 
 const toFormState = (profileId: string, config: LLMConfiguration): ProfileFormState => {
   const strOrEmpty = (v: unknown): string => (typeof v === 'string' ? v : '');
@@ -462,6 +483,7 @@ export function LlmProfilesView(props: {
 
   const selectedIsActive = (candidate: string) => candidate === selectedProfileId;
   const canEditApiKey = mode === 'edit' && !!selectedProfileId && !loadingProfile;
+  const providerDocsUrl = form.provider ? PROVIDER_DOCS_URLS[form.provider] : null;
 
   const apiKeyStatusLabel = (() => {
     if (!canEditApiKey) return '—';
@@ -763,7 +785,20 @@ export function LlmProfilesView(props: {
                   </div>
 
                   <div>
-                    <FieldLabel label="Provider" />
+                    <div className="flex items-center justify-between gap-2">
+                      <FieldLabel label="Provider" />
+                      {providerDocsUrl && (
+                        <button
+                          type="button"
+                          onClick={() => openMarkdownLink(providerDocsUrl)}
+                          className="text-xs text-brand-300 underline decoration-white/20 hover:decoration-white/40 hover:text-brand-200 transition-colors"
+                          aria-label="Provider docs"
+                          title="Open provider docs"
+                        >
+                          Provider docs <span className="codicon codicon-link-external text-[11px]" />
+                        </button>
+                      )}
+                    </div>
                     <div className="mt-2">
                       <SelectField
                         value={form.provider}


### PR DESCRIPTION
Implements bead `oh-tab-bw8p` by adding a "Provider docs" action next to the Provider selector in the LLM Profiles view.

- Uses existing `openMarkdownLink` host handler (http(s) allowlist) to open docs in browser
- Adds unit test covering provider->URL mapping (OpenAI + OpenRouter)

Checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run e2e`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Provider docs" button to LLM Profiles view, providing quick access to documentation for supported providers including OpenAI, Anthropic, OpenRouter, Litellm proxy, and Gemini.

* **Tests**
  * Added test verifying provider documentation links update correctly when switching between providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->