### PR TITLE
oh-tab-hvrf: Show missing API key banner

### DIFF
--- a/src/webview-src/__tests__/App.missingApiKey.test.tsx
+++ b/src/webview-src/__tests__/App.missingApiKey.test.tsx
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { App } from '../components/App';
+import { postToWindow } from './testUtils';
+
+describe('App - missing LLM API key', () => {
+  const mockApi = { postMessage: vi.fn() };
+
+  beforeEach(() => {
+    // @ts-expect-error mock VS Code API
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows a transient status banner for missing_llm_api_key conversation errors', async () => {
+    render(<App />);
+
+    postToWindow({
+      type: 'event',
+      event: {
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        code: 'missing_llm_api_key',
+        detail: 'Missing API key for LLM provider',
+      },
+    });
+
+    expect(await screen.findByText('Missing API key. Set it in LLM Profiles.')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status-row')).toHaveTextContent('Missing API key. Set it in LLM Profiles.');
+    });
+  });
+});
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -520,6 +520,8 @@ export function App() {
     } else if (isAgentErrorEvent(event)) {
       showStatusMessage('error', event.error);
       clearSubmissionState();
+    } else if (isConversationErrorEvent(event) && event.code === 'missing_llm_api_key') {
+      showStatusMessage('error', 'Missing API key. Set it in LLM Profiles.', { autoDismiss: true, autoDismissDelay: 8000 });
     } else if (isPauseEvent(event)) {
       showStatusMessage('warn', 'Conversation paused');
     }


### PR DESCRIPTION
Fixes oh-tab-hvrf.

When the agent emits a ConversationErrorEvent with code=missing_llm_api_key, the webview now shows a transient bottom status banner (in addition to the normal event rendering).

Tests:
- npm test
- npm run typecheck
- npm run lint
- npm run e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing API key scenarios with a dismissible banner notification that displays "Missing API key. Set it in LLM Profiles." and automatically dismisses after 8 seconds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->