### PR TITLE
oh-tab-a4dt: Remove llmModel from status payload

### DIFF
--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -42,7 +42,6 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
       status: s,
       mode: deps.getConversationMode(),
       llmProfileLabel: deps.getLastKnownLlmLabel(),
-      llmModel: deps.getLastKnownLlmLabel(),
     });
   });
 

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -458,7 +458,6 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
       status: deps.getConversation()?.getStatus() ?? 'offline',
       mode: deps.getConversationMode(),
       llmProfileLabel: label,
-      llmModel: label,
     });
     await broadcastLlmProfilesUpdated();
     return { ok: true, profileId: updated.llm.profileId ?? null };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -664,7 +664,6 @@ export function activate(context: vscode.ExtensionContext) {
         status: conversation?.getStatus() ?? 'offline',
         mode: conversationMode,
         llmProfileLabel: lastKnownLlmLabel,
-        llmModel: lastKnownLlmLabel,
       } satisfies HostToWebviewMessage);
     }
   }

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -8,7 +8,6 @@ export type HostToWebviewMessage =
     status: string;
     mode: 'local' | 'remote';
     llmProfileLabel?: string | null;
-    llmModel?: string | null;
   }
   | { type: 'error'; error: string }
   | { type: 'statusMessage'; level: 'info' | 'warn' | 'error'; message: string; autoDismiss?: boolean; autoDismissDelay?: number }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -588,7 +588,6 @@ export function App() {
         serverUrl?: string | null;
         mode?: 'local' | 'remote';
         llmProfileLabel?: string | null;
-        llmModel?: string | null;
         profiles?: string[];
         activeProfileId?: string | null;
         profileId?: unknown;
@@ -617,7 +616,7 @@ export function App() {
             if (payload.mode === 'local' || payload.mode === 'remote') {
               setMode(payload.mode);
             }
-            const label = payload.llmProfileLabel !== undefined ? payload.llmProfileLabel : payload.llmModel;
+            const label = payload.llmProfileLabel;
             if (typeof label === 'string' || label === null) {
               setLlmProfileLabel(label);
             }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -193,7 +193,6 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           status: conversation?.getStatus() ?? 'offline',
           mode: deps.getConversationMode(),
           llmProfileLabel: deps.getLastKnownLlmLabel(),
-          llmModel: deps.getLastKnownLlmLabel(),
         });
 
         void host.postMessage({
@@ -412,7 +411,6 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           status: conversation?.getStatus() ?? 'offline',
           mode: deps.getConversationMode(),
           llmProfileLabel: deps.getLastKnownLlmLabel(),
-          llmModel: deps.getLastKnownLlmLabel(),
         });
 
         void host.postMessage({


### PR DESCRIPTION
Fixes oh-tab-a4dt.

Removes redundant `llmModel` from Host→Webview `type: "status"` messages (we already have `llmProfileLabel`, and the webview prefers that).

Tests:
- npm test
- npm run typecheck
- npm run lint
- npm run e2e
