### PR TITLE
oh-tab-6oc5: Inline missing API key warning

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -189,6 +189,93 @@ describe('LLM Profiles view', () => {
     expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
   });
 
+  it('shows an inline missing API key warning and blocks save in create mode', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. gpt-5'), { target: { value: 'gpt-5' } });
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. gpt-5, claude-4-sonnet, gemini-2.5-pro'),
+      { target: { value: 'gpt-5' } }
+    );
+
+    const providerSelect = screen.getAllByRole('combobox').find((candidate) => (
+      candidate.querySelector('option[value="openai"]') !== null
+    ));
+    if (!providerSelect) throw new Error('Failed to find provider select');
+    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
+    expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText('(hidden)'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
+    });
+  });
+
+  it('shows an inline missing API key warning and blocks save in edit mode', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+
+    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: { model: 'gpt-5', provider: 'openai' },
+    });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+    });
+
+    expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
+    expect(await screen.findByPlaceholderText('(hidden)')).toBeInTheDocument();
+  });
+
   it('offers a Provider docs link based on the selected provider', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -227,6 +227,70 @@ describe('LLM Profiles view', () => {
     });
   });
 
+  it('preserves the draft API key when initial key storage fails during create', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
+
+    fireEvent.change(screen.getByPlaceholderText('e.g. gpt-5'), { target: { value: 'gpt-5' } });
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. gpt-5, claude-4-sonnet, gemini-2.5-pro'),
+      { target: { value: 'gpt-5' } }
+    );
+
+    const providerSelect = screen.getAllByRole('combobox').find((candidate) => (
+      candidate.querySelector('option[value="openai"]') !== null
+    ));
+    if (!providerSelect) throw new Error('Failed to find provider select');
+    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+
+    fireEvent.change(await screen.findByPlaceholderText('(hidden)'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
+    });
+
+    const saveRequest = getLastPostedOfType('llmProfileSaveRequest');
+    postToWindow({ type: 'llmProfileSaveResponse', requestId: saveRequest.requestId, ok: true });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();
+    });
+
+    const setRequest = getLastPostedOfType('llmProfileApiKeySetRequest');
+    expect(setRequest.profileId).toBe('gpt-5');
+    expect(setRequest.apiKey).toBe('sk-test');
+    postToWindow({ type: 'llmProfileApiKeySetResponse', requestId: setRequest.requestId, ok: false, error: 'nope' });
+
+    await waitFor(() => {
+      const latest = getLastPostedOfType('llmProfilesListRequest');
+      expect(latest).toBeTruthy();
+      expect(latest.requestId).not.toBe(listRequest.requestId);
+    });
+
+    const listRequest2 = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest2.requestId, ok: true, profiles: ['gpt-5'] });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({ type: 'llmProfileApiKeyStatusResponse', requestId: statusRequest.requestId, ok: true, hasKey: false });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Set key…' }));
+    expect(await screen.findByPlaceholderText('(hidden)')).toHaveValue('sk-test');
+  });
+
   it('shows an inline missing API key warning and blocks save in edit mode', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -503,10 +503,10 @@ export function LlmProfilesView(props: {
       if (mode === 'create' && providerRequiresApiKey) {
         try {
           await setApiKey(profileId, trimmedDraftApiKey);
+          setApiKeyInput('');
         } catch (err) {
           setTopError(err instanceof Error ? err.message : String(err));
         }
-        setApiKeyInput('');
       }
       await refreshProfiles();
       activeProfileIdRef.current = profileId;

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -472,6 +472,27 @@ export function LlmProfilesView(props: {
       return;
     }
 
+    const providerRequiresApiKey = Boolean(form.provider);
+    const trimmedDraftApiKey = apiKeyInput.trim();
+    const canEditApiKeyForSave = mode === 'edit' && !!selectedProfileId && !loadingProfile;
+
+    if (providerRequiresApiKey) {
+      if (mode === 'create') {
+        if (!trimmedDraftApiKey) {
+          requestAnimationFrame(() => {
+            panelRef.current?.querySelector<HTMLInputElement>('input[type="password"]')?.focus();
+          });
+          return;
+        }
+      } else if (canEditApiKeyForSave && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasKey) {
+        setShowApiKeyEditor(true);
+        requestAnimationFrame(() => {
+          panelRef.current?.querySelector<HTMLInputElement>('input[type="password"]')?.focus();
+        });
+        return;
+      }
+    }
+
     const profileId = form.name.trim();
     const config = buildProfileConfig(form);
 
@@ -479,17 +500,37 @@ export function LlmProfilesView(props: {
     setTopError(null);
     try {
       await saveProfile(profileId, config);
+      if (mode === 'create' && providerRequiresApiKey) {
+        try {
+          await setApiKey(profileId, trimmedDraftApiKey);
+        } catch (err) {
+          setTopError(err instanceof Error ? err.message : String(err));
+        }
+        setApiKeyInput('');
+      }
       await refreshProfiles();
       activeProfileIdRef.current = profileId;
       setMode('edit');
       setSelectedProfileId(profileId);
+      setShowApiKeyEditor(false);
       void refreshApiKeyStatus(profileId);
     } catch (err) {
       setTopError(err instanceof Error ? err.message : String(err));
     } finally {
       setSaving(false);
     }
-  }, [form, mode, refreshApiKeyStatus, refreshProfiles, saveProfile]);
+  }, [
+    apiKeyInput,
+    apiKeyStatus,
+    form,
+    loadingProfile,
+    mode,
+    refreshApiKeyStatus,
+    refreshProfiles,
+    saveProfile,
+    selectedProfileId,
+    setApiKey,
+  ]);
 
   const update = <K extends keyof ProfileFormState>(key: K, value: ProfileFormState[K]) => {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -505,9 +546,13 @@ export function LlmProfilesView(props: {
 
   const selectedIsActive = (candidate: string) => candidate === selectedProfileId;
   const canEditApiKey = mode === 'edit' && !!selectedProfileId && !loadingProfile;
+  const providerRequiresApiKey = Boolean(form.provider);
   const providerDocsUrl = form.provider ? PROVIDER_DOCS_URLS[form.provider] : null;
   const providerLabel = form.provider ? PROVIDER_LABELS[form.provider] : null;
   const providerApiKeyUrl = form.provider ? (PROVIDER_API_KEY_URLS[form.provider] ?? null) : null;
+  const missingStoredApiKey = canEditApiKey && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasKey;
+  const missingDraftApiKey = mode === 'create' && saveAttempted && providerRequiresApiKey && !apiKeyInput.trim();
+  const showMissingApiKeyWarning = providerRequiresApiKey && (missingStoredApiKey || missingDraftApiKey);
 
   const apiKeyStatusLabel = (() => {
     if (!canEditApiKey) return '—';
@@ -777,10 +822,34 @@ export function LlmProfilesView(props: {
                           </button>
                         )}
                       </div>
+                    ) : mode === 'create' && providerRequiresApiKey ? (
+                      <div className="text-xs text-stone-400">Required</div>
                     ) : (
-                      <div className="text-xs text-stone-500">Save profile to set a key.</div>
+                      <div className="text-xs text-stone-500">
+                        {mode === 'create' ? 'Select a provider to set a key.' : 'Save profile to set a key.'}
+                      </div>
                     )}
                   </div>
+
+                  {showMissingApiKeyWarning && (
+                    <div className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+                      You must provide a valid API key.
+                    </div>
+                  )}
+
+                  {mode === 'create' && providerRequiresApiKey && (
+                    <div className="mt-3">
+                      <FieldLabel label="API key" required />
+                      <div className="mt-2">
+                        <InputField
+                          value={apiKeyInput}
+                          onChange={setApiKeyInput}
+                          placeholder="(hidden)"
+                          type="password"
+                        />
+                      </div>
+                    </div>
+                  )}
 
                   {canEditApiKey && apiKeyStatus.state === 'error' && (
                     <div className="mt-2 text-xs text-red-400">{apiKeyStatus.error}</div>


### PR DESCRIPTION
Fixes oh-tab-6oc5.

Adds an inline warning near the Provider/API key section when a selected profile lacks a required API key:
- Edit mode: shows banner when SecretStorage has no key; blocks Save until key set (opens key editor on Save).
- Create mode: shows key input when provider selected; blocks Save until key entered; stores key to SecretStorage after profile save.

Tests:
- npm test
- npm run typecheck
- npm run lint
- npm run e2e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added API key validation to prevent saving LLM profiles without required credentials
  * Displays "Required" indicator and clear warnings when an API key is missing
  * Improved user guidance for entering API keys during profile creation and editing
  * Enhanced save flow to prompt for missing API keys before proceeding

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->