### PR TITLE
oh-tab-k9qw: Max output tokens control

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -149,6 +149,65 @@ describe('LLM Profiles view', () => {
     expect(await screen.findByText('Must be a valid number')).toBeInTheDocument();
   });
 
+  it('syncs Max output tokens slider with numeric input', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show advanced settings' }));
+
+    const slider = await screen.findByRole('slider', { name: 'Max output tokens' });
+    const input = await screen.findByRole('spinbutton', { name: 'Max output tokens' });
+    expect(slider).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: '2048' } });
+
+    await waitFor(() => {
+      expect(slider).not.toBeDisabled();
+      expect(slider).toHaveValue('2048');
+    });
+
+    fireEvent.change(slider, { target: { value: '4096' } });
+
+    await waitFor(() => {
+      expect(input).toHaveValue(4096);
+    });
+  });
+
+  it('validates Max output tokens range', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Show advanced settings' }));
+
+    const input = await screen.findByRole('spinbutton', { name: 'Max output tokens' });
+
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText('Must be >= 1')).toBeInTheDocument();
+
+    fireEvent.change(input, { target: { value: '70000' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(await screen.findByText('Must be <= 65536')).toBeInTheDocument();
+  });
+
   it('offers header icon actions for create/edit (delete disabled)', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -164,8 +164,8 @@ describe('LLM Profiles view', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Show advanced settings' }));
 
-    const slider = await screen.findByRole('slider', { name: 'Max output tokens' });
-    const input = await screen.findByRole('spinbutton', { name: 'Max output tokens' });
+    const slider = await screen.findByRole('slider', { name: 'Max output tokens (slider)' });
+    const input = await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' });
     expect(slider).toBeDisabled();
 
     fireEvent.change(input, { target: { value: '2048' } });
@@ -197,7 +197,7 @@ describe('LLM Profiles view', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Show advanced settings' }));
 
-    const input = await screen.findByRole('spinbutton', { name: 'Max output tokens' });
+    const input = await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' });
 
     fireEvent.change(input, { target: { value: '0' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -95,6 +95,10 @@ const PROVIDER_API_KEY_URLS: Partial<Record<Provider, string>> = {
   gemini: 'https://aistudio.google.com/app/apikey',
 };
 
+const MIN_OUTPUT_TOKENS = 1;
+const MAX_OUTPUT_TOKENS_SLIDER_MAX = 65536;
+const MAX_OUTPUT_TOKENS_SLIDER_STEP = 256;
+
 const postMessage = (message: WebviewToHostMessage) => {
   const api = getVscodeApi();
   api.postMessage(message);
@@ -211,7 +215,15 @@ const validateForm = (mode: ProfileFormMode, form: ProfileFormState): FieldError
   if (maxInputTokens.error) errors.maxInputTokens = maxInputTokens.error;
 
   const maxOutputTokens = parseOptionalInt(form.maxOutputTokens);
-  if (maxOutputTokens.error) errors.maxOutputTokens = maxOutputTokens.error;
+  if (maxOutputTokens.error) {
+    errors.maxOutputTokens = maxOutputTokens.error;
+  } else if (maxOutputTokens.value !== null) {
+    if (maxOutputTokens.value < MIN_OUTPUT_TOKENS) {
+      errors.maxOutputTokens = `Must be >= ${MIN_OUTPUT_TOKENS}`;
+    } else if (maxOutputTokens.value > MAX_OUTPUT_TOKENS_SLIDER_MAX) {
+      errors.maxOutputTokens = `Must be <= ${MAX_OUTPUT_TOKENS_SLIDER_MAX}`;
+    }
+  }
 
   const inputCost = parseOptionalNumber(form.inputCostPerToken);
   if (inputCost.error) errors.inputCostPerToken = inputCost.error;
@@ -280,6 +292,7 @@ function InputField(props: {
   placeholder?: string;
   disabled?: boolean;
   type?: string;
+  ariaLabel?: string;
 }) {
   return (
     <input
@@ -288,6 +301,7 @@ function InputField(props: {
       placeholder={props.placeholder}
       disabled={props.disabled}
       type={props.type ?? 'text'}
+      aria-label={props.ariaLabel}
       className={`
         w-full px-3 py-2 rounded-lg
         bg-white/[0.03] border border-white/[0.06]
@@ -553,6 +567,14 @@ export function LlmProfilesView(props: {
   const missingStoredApiKey = canEditApiKey && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasKey;
   const missingDraftApiKey = mode === 'create' && saveAttempted && providerRequiresApiKey && !apiKeyInput.trim();
   const showMissingApiKeyWarning = providerRequiresApiKey && (missingStoredApiKey || missingDraftApiKey);
+  const maxOutputTokensSlider = (() => {
+    const parsed = parseOptionalInt(form.maxOutputTokens);
+    const value = parsed.value;
+    if (value === null || value < MIN_OUTPUT_TOKENS || value > MAX_OUTPUT_TOKENS_SLIDER_MAX) {
+      return { disabled: true, value: MIN_OUTPUT_TOKENS };
+    }
+    return { disabled: false, value };
+  })();
 
   const apiKeyStatusLabel = (() => {
     if (!canEditApiKey) return '—';
@@ -1102,7 +1124,30 @@ export function LlmProfilesView(props: {
                         <div>
                           <FieldLabel label="Max output tokens" />
                           <div className="mt-2">
-                            <InputField value={form.maxOutputTokens} onChange={(v) => update('maxOutputTokens', v)} placeholder="optional" />
+                            <div className="space-y-2">
+                              <InputField
+                                value={form.maxOutputTokens}
+                                onChange={(v) => update('maxOutputTokens', v)}
+                                placeholder="optional"
+                                type="number"
+                                ariaLabel="Max output tokens"
+                              />
+                              <input
+                                type="range"
+                                min={MIN_OUTPUT_TOKENS}
+                                max={MAX_OUTPUT_TOKENS_SLIDER_MAX}
+                                step={MAX_OUTPUT_TOKENS_SLIDER_STEP}
+                                value={maxOutputTokensSlider.value}
+                                onChange={(e) => update('maxOutputTokens', e.target.value)}
+                                disabled={maxOutputTokensSlider.disabled}
+                                aria-label="Max output tokens"
+                                className="w-full accent-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                              />
+                              <div className="flex items-center justify-between text-[11px] text-stone-500">
+                                <span>{MIN_OUTPUT_TOKENS}</span>
+                                <span>{MAX_OUTPUT_TOKENS_SLIDER_MAX.toLocaleString()}</span>
+                              </div>
+                            </div>
                             <FieldError message={errors.maxOutputTokens} />
                           </div>
                         </div>

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -1130,7 +1130,7 @@ export function LlmProfilesView(props: {
                                 onChange={(v) => update('maxOutputTokens', v)}
                                 placeholder="optional"
                                 type="number"
-                                ariaLabel="Max output tokens"
+                                ariaLabel="Max output tokens (numeric input)"
                               />
                               <input
                                 type="range"
@@ -1140,7 +1140,7 @@ export function LlmProfilesView(props: {
                                 value={maxOutputTokensSlider.value}
                                 onChange={(e) => update('maxOutputTokens', e.target.value)}
                                 disabled={maxOutputTokensSlider.disabled}
-                                aria-label="Max output tokens"
+                                aria-label="Max output tokens (slider)"
                                 className="w-full accent-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
                               />
                               <div className="flex items-center justify-between text-[11px] text-stone-500">


### PR DESCRIPTION
Implements oh-tab-k9qw.

- Profiles view: Max output tokens uses a slider + numeric input (synced).
- Range validation: unset or 1..65536.
- Unit tests: slider sync + range validation.

Local checks: npm test, npm run typecheck, npm run lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a range slider control for Max output tokens, allowing visual adjustment alongside numeric input
  * Added input validation with defined constraints for Max output tokens (minimum: 1, maximum: 65536)

* **Improvements**
  * Enhanced accessibility with improved aria-labeling for form inputs

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->