### PR TITLE
oh-tab-cpt1: Duplicate profile action

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -238,6 +238,7 @@ describe('LLM Profiles view', () => {
 
     const nameInput = await screen.findByPlaceholderText('e.g. gpt-5');
     expect(nameInput).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Duplicate profile' })).not.toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
@@ -245,7 +246,65 @@ describe('LLM Profiles view', () => {
       expect(screen.getByPlaceholderText('e.g. gpt-5')).not.toBeDisabled();
     });
     expect(screen.getByRole('button', { name: 'Edit profile' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Duplicate profile' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
+  });
+
+  it('duplicates an existing profile into a new create form', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+
+    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: {
+        model: 'gpt-5',
+        provider: 'openai',
+        baseUrl: 'https://example.com/v1',
+        maxOutputTokens: 2048,
+      },
+    });
+
+    const nameInput = await screen.findByPlaceholderText('e.g. gpt-5');
+    expect(nameInput).toBeDisabled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Duplicate profile' }));
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('e.g. gpt-5')).not.toBeDisabled();
+    });
+
+    const nameInput2 = screen.getByPlaceholderText('e.g. gpt-5');
+    expect(nameInput2).toHaveValue('');
+    expect(screen.getByPlaceholderText('e.g. gpt-5, claude-4-sonnet, gemini-2.5-pro')).toHaveValue('gpt-5');
+
+    const baseUrlToggle = screen.getByRole('checkbox', { name: 'Use custom base URL' });
+    expect(baseUrlToggle).toBeChecked();
+    expect(screen.getByPlaceholderText('https://api.openai.com/v1')).toHaveValue('https://example.com/v1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
+    expect(await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' })).toHaveValue(2048);
+
+    const apiKeyInput = await screen.findByPlaceholderText('(hidden)');
+    expect(apiKeyInput).toHaveValue('');
   });
 
   it('shows an inline missing API key warning and blocks save in create mode', async () => {

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -630,7 +630,7 @@ export function LlmProfilesView(props: {
       return;
     }
 
-    editorScrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+    editorScrollRef.current?.scrollTo?.({ top: 0, behavior: 'smooth' });
     requestAnimationFrame(() => {
       const firstFocusable = panelRef.current?.querySelector<HTMLElement>(
         'select:not([disabled]), input:not([disabled]), textarea:not([disabled])'
@@ -638,6 +638,30 @@ export function LlmProfilesView(props: {
       firstFocusable?.focus();
     });
   }, [mode, selectedProfileId, startEdit]);
+
+  const handleDuplicateProfile = useCallback(() => {
+    if (mode !== 'edit') return;
+
+    const source = form;
+    activeProfileIdRef.current = null;
+    setMode('create');
+    setSelectedProfileId(null);
+    setForm({ ...source, name: '' });
+    setErrors({});
+    setSaveAttempted(false);
+    setTopError(null);
+    setApiKeyStatus({ state: 'unknown' });
+    setShowApiKeyEditor(false);
+    setApiKeyInput('');
+    setApiKeySaving(false);
+    setApiKeyError(null);
+    setUseCustomBaseUrl(Boolean(source.baseUrl.trim()));
+
+    editorScrollRef.current?.scrollTo?.({ top: 0, behavior: 'smooth' });
+    requestAnimationFrame(() => {
+      panelRef.current?.querySelector<HTMLInputElement>('input[placeholder="e.g. gpt-5"]')?.focus();
+    });
+  }, [form, mode]);
 
   if (!isOpen) return null;
 
@@ -679,6 +703,16 @@ export function LlmProfilesView(props: {
               title="Edit profile"
             >
               <span className="codicon codicon-edit" />
+            </button>
+            <button
+              type="button"
+              onClick={handleDuplicateProfile}
+              disabled={mode !== 'edit' || !selectedProfileId || loadingProfile}
+              className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+              aria-label="Duplicate profile"
+              title="Duplicate profile"
+            >
+              <span className="codicon codicon-copy" />
             </button>
             <button
               type="button"


### PR DESCRIPTION
Implements oh-tab-cpt1.

- Adds a header "Duplicate profile" action while editing an existing profile.
- Duplicating copies all editable fields into create mode, clears the Name field, and does not copy the API key.
- Includes unit tests covering the duplicate flow.

Local checks: npm test, npm run typecheck, npm run lint.