### PR TITLE
Support deleting LLM profiles (oh-tab-97l0)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import type { LLMConfiguration } from '../llm';
-import { DEFAULT_LLM_PROFILE_IDS, LLMProfileValidationError, ensureDefaultProfiles, listProfiles, loadProfile, saveProfile, validateProfile } from '../llm';
+import { DEFAULT_LLM_PROFILE_IDS, LLMProfileValidationError, deleteProfile, ensureDefaultProfiles, listProfiles, loadProfile, saveProfile, validateProfile } from '../llm';
 
 const makeTempDir = () => fs.mkdtempSync(path.join(os.tmpdir(), 'llm-profiles-'));
 
@@ -108,6 +108,20 @@ describe('LLM profiles', () => {
         LLMProfileValidationError,
       );
       expect(() => loadProfile('../evil', { rootDir: dir })).toThrow(LLMProfileValidationError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('deletes profiles from disk', () => {
+    const dir = makeTempDir();
+    try {
+      saveProfile('a', { provider: 'openai', model: 'gpt-5' }, { rootDir: dir });
+      expect(listProfiles({ rootDir: dir })).toEqual(['a']);
+
+      deleteProfile('a', { rootDir: dir });
+      expect(listProfiles({ rootDir: dir })).toEqual([]);
+      expect(() => loadProfile('a', { rootDir: dir })).toThrow(LLMProfileValidationError);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -329,6 +329,20 @@ export const saveProfile = (
   }
 };
 
+/**
+ * Deletes an LLM profile stored on disk.
+ *
+ * Note: this does not remove any out-of-band secrets (API keys) stored elsewhere.
+ */
+export const deleteProfile = (profileId: string, options: LLMProfileStoreOptions = {}): void => {
+  const rootDir = resolveRootDir(options);
+  const filePath = getProfilePath(profileId, rootDir);
+  if (!fs.existsSync(filePath)) {
+    throw new LLMProfileValidationError(`Profile '${profileId}' not found`);
+  }
+  fs.unlinkSync(filePath);
+};
+
 export const DEFAULT_LLM_PROFILE_IDS = [
   'gemini-flash',
   'gpt-5',

--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -21,8 +21,13 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
 
   const createHandler = () => {
     const postMessage = vi.fn(async () => true);
+    const secrets = {
+      get: vi.fn(async () => undefined),
+      store: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    };
     const handler = createWebviewMessageHandler({
-      context: { globalStorageUri: { fsPath: tmpDir } } as any,
+      context: { globalStorageUri: { fsPath: tmpDir }, secrets } as any,
       host: { postMessage },
       getConversation: () => undefined,
       getConversationMode: () => 'local',
@@ -41,7 +46,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       fileLog: () => {},
     });
 
-    return { handler, postMessage };
+    return { handler, postMessage, secrets };
   };
 
   it('lists profiles from the configured root dir', async () => {
@@ -114,5 +119,21 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     const content = await fs.readFile(path.join(tmpDir, 'saved.json'), 'utf8');
     expect(content).not.toContain('sk-test-inline');
     expect(content).not.toContain('Authorization');
+  });
+
+  it('deletes profiles and clears stored API keys', async () => {
+    saveSdkProfile('a', { model: 'gpt-5-mini' }, { rootDir: tmpDir, includeSecrets: false });
+
+    const { handler, postMessage, secrets } = createHandler();
+    await handler({ type: 'llmProfileDeleteRequest', requestId: 'req1', profileId: 'a' });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'llmProfileDeleteResponse',
+      requestId: 'req1',
+      ok: true,
+      profileId: 'a',
+    });
+    expect(secrets.delete).toHaveBeenCalledWith('openhands.llmProfileApiKey.a');
+    await expect(fs.stat(path.join(tmpDir, 'a.json'))).rejects.toThrow();
   });
 });

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -18,6 +18,8 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileLoadResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: false; profileId: string; error: string }
+  | { type: 'llmProfileDeleteResponse'; requestId: string; ok: true; profileId: string }
+  | { type: 'llmProfileDeleteResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: true; profileId: string; hasKey: boolean }
   | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
@@ -70,6 +72,7 @@ export type WebviewToHostMessage =
   | { type: 'llmProfilesListRequest'; requestId: string }
   | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string }
   | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown }
+  | { type: 'llmProfileDeleteRequest'; requestId: string; profileId: string }
   | { type: 'llmProfileApiKeyStatusRequest'; requestId: string; profileId: string }
   | { type: 'llmProfileApiKeySetRequest'; requestId: string; profileId: string; apiKey: string }
   | { type: 'selectServer'; url: string }

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -208,7 +208,7 @@ describe('LLM Profiles view', () => {
     expect(await screen.findByText('Must be <= 65536')).toBeInTheDocument();
   });
 
-  it('offers header icon actions for create/edit (delete disabled)', async () => {
+  it('offers header icon actions for create/edit/duplicate/delete', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -239,6 +239,7 @@ describe('LLM Profiles view', () => {
     const nameInput = await screen.findByLabelText('Name');
     expect(nameInput).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Duplicate profile' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Delete profile' })).not.toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: 'Create profile' }));
 
@@ -305,6 +306,65 @@ describe('LLM Profiles view', () => {
 
     const apiKeyInput = await screen.findByLabelText('API key');
     expect(apiKeyInput).toHaveValue('');
+  });
+
+  it('deletes an existing profile and returns to create mode', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+
+    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: { model: 'gpt-5', provider: 'openai' },
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Delete profile' }));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileDeleteRequest')).toBeTruthy();
+    });
+
+    const deleteRequest = getLastPostedOfType('llmProfileDeleteRequest');
+    expect(deleteRequest.profileId).toBe('gpt-5');
+
+    postToWindow({
+      type: 'llmProfileDeleteResponse',
+      requestId: deleteRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+    });
+
+    await waitFor(() => {
+      const latest = getLastPostedOfType('llmProfilesListRequest');
+      expect(latest).toBeTruthy();
+      expect(latest.requestId).not.toBe(listRequest.requestId);
+    });
+
+    const listRequest2 = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest2.requestId, ok: true, profiles: [] });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('e.g. gpt-5')).not.toBeDisabled();
+    });
+    expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
   });
 
   it('shows an inline missing API key warning and blocks save in create mode', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -137,6 +137,12 @@ type PendingLlmProfilesRequest =
     timeout: ReturnType<typeof setTimeout>;
   }
   | {
+    kind: 'delete';
+    resolve: () => void;
+    reject: (error: Error) => void;
+    timeout: ReturnType<typeof setTimeout>;
+  }
+  | {
     kind: 'apiKeyStatus';
     resolve: (hasKey: boolean) => void;
     reject: (error: Error) => void;
@@ -318,6 +324,18 @@ export function App() {
       }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
       pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'save', resolve, reject, timeout });
       postMessage({ type: 'llmProfileSaveRequest', requestId, profileId, profile });
+    });
+  }, [postMessage]);
+
+  const deleteLlmProfile = useCallback(async (profileId: string): Promise<void> => {
+    const requestId = createLlmProfilesRequestId('delete');
+    return await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        pendingLlmProfilesRequestsRef.current.delete(requestId);
+        reject(new Error('Timed out deleting LLM profile'));
+      }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
+      pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'delete', resolve, reject, timeout });
+      postMessage({ type: 'llmProfileDeleteRequest', requestId, profileId });
     });
   }, [postMessage]);
 
@@ -711,6 +729,21 @@ export function App() {
             break;
           }
           const reason = typeof payload.error === 'string' ? payload.error : 'Failed to save LLM profile';
+          pending.reject(new Error(reason));
+          break;
+        }
+        case 'llmProfileDeleteResponse': {
+          const requestId = payload.requestId;
+          if (typeof requestId !== 'string') break;
+          const pending = pendingLlmProfilesRequestsRef.current.get(requestId);
+          if (!pending || pending.kind !== 'delete') break;
+          pendingLlmProfilesRequestsRef.current.delete(requestId);
+          clearTimeout(pending.timeout);
+          if (payload.ok === true) {
+            pending.resolve();
+            break;
+          }
+          const reason = typeof payload.error === 'string' ? payload.error : 'Failed to delete LLM profile';
           pending.reject(new Error(reason));
           break;
         }
@@ -1497,6 +1530,7 @@ export function App() {
         listProfiles={listLlmProfiles}
         loadProfile={loadLlmProfile}
         saveProfile={saveLlmProfile}
+        deleteProfile={deleteLlmProfile}
         getApiKeyStatus={getLlmProfileApiKeyStatus}
         setApiKey={setLlmProfileApiKey}
       />

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -368,6 +368,7 @@ export function LlmProfilesView(props: {
   listProfiles: () => Promise<string[]>;
   loadProfile: (profileId: string) => Promise<LLMConfiguration>;
   saveProfile: (profileId: string, profile: LLMConfiguration) => Promise<void>;
+  deleteProfile: (profileId: string) => Promise<void>;
   getApiKeyStatus: (profileId: string) => Promise<boolean>;
   setApiKey: (profileId: string, apiKey: string) => Promise<void>;
 }) {
@@ -378,6 +379,7 @@ export function LlmProfilesView(props: {
     listProfiles,
     loadProfile,
     saveProfile,
+    deleteProfile,
     getApiKeyStatus,
     setApiKey,
   } = props;
@@ -400,6 +402,7 @@ export function LlmProfilesView(props: {
   const [loadingList, setLoadingList] = useState(false);
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [topError, setTopError] = useState<string | null>(null);
   const [apiKeyStatus, setApiKeyStatus] = useState<ApiKeyStatus>({ state: 'unknown' });
   const [showApiKeyEditor, setShowApiKeyEditor] = useState(false);
@@ -680,6 +683,22 @@ export function LlmProfilesView(props: {
     });
   }, [mode, selectedProfileId, startEdit]);
 
+  const handleDeleteProfile = useCallback(async () => {
+    if (mode !== 'edit' || !selectedProfileId) return;
+    const profileId = selectedProfileId;
+    setDeleting(true);
+    setTopError(null);
+    try {
+      await deleteProfile(profileId);
+      await refreshProfiles();
+      startCreate();
+    } catch (err) {
+      setTopError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleteProfile, mode, refreshProfiles, selectedProfileId, startCreate]);
+
   const handleDuplicateProfile = useCallback(() => {
     if (mode !== 'edit') return;
 
@@ -752,12 +771,13 @@ export function LlmProfilesView(props: {
             </button>
             <button
               type="button"
-              disabled
-              className="h-9 w-9 rounded-lg bg-white/[0.03] border border-white/[0.06] text-stone-500 transition-all flex items-center justify-center cursor-not-allowed"
+              onClick={() => { void handleDeleteProfile(); }}
+              disabled={mode !== 'edit' || !selectedProfileId || loadingProfile || saving || deleting}
+              className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
               aria-label="Delete profile"
-              title="Delete profile (coming soon)"
+              title="Delete profile"
             >
-              <span className="codicon codicon-trash" />
+              <span className={`codicon codicon-${deleting ? 'loading' : 'trash'} ${deleting ? 'animate-spin' : ''}`} />
             </button>
             <button
               type="button"

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -473,6 +473,58 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         }
         break;
       }
+      case 'llmProfileDeleteRequest': {
+        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
+        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
+        if (!requestId || !profileId) break;
+
+        try {
+          llmProfilesStore.deleteProfile(profileId, llmProfileStoreOptions());
+          await context.secrets.delete(getProfileApiKeySecretKey(profileId));
+          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: true, profileId });
+
+          const before = await settingsMgr.get();
+          const activeProfileId = before.llm.profileId ?? null;
+          if (activeProfileId === profileId) {
+            await settingsMgr.update({ llm: { profileId: '' } });
+            void host.postMessage({
+              type: 'statusMessage',
+              level: 'error',
+              message: `Active LLM profile '${profileId}' was deleted; selection cleared.`,
+              autoDismiss: true,
+              autoDismissDelay: 8000,
+            });
+          } else {
+            void host.postMessage({
+              type: 'statusMessage',
+              level: 'info',
+              message: `Deleted profile '${profileId}'.`,
+              autoDismiss: true,
+              autoDismissDelay: 4000,
+            });
+          }
+
+          const updated = await settingsMgr.get();
+          deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(updated));
+
+          void host.postMessage({
+            type: 'status',
+            status: conversation?.getStatus() ?? 'offline',
+            mode: deps.getConversationMode(),
+            llmProfileLabel: deps.getLastKnownLlmLabel(),
+          });
+
+          void host.postMessage({
+            type: 'llmProfilesUpdated',
+            profiles: listAvailableLlmProfiles(),
+            activeProfileId: updated.llm.profileId ?? null,
+          });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: false, profileId, error: reason });
+        }
+        break;
+      }
       case 'llmProfileApiKeyStatusRequest': {
         const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
         const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';

--- a/src/webview/host/llmProfilesStore.ts
+++ b/src/webview/host/llmProfilesStore.ts
@@ -1,4 +1,5 @@
 import {
+  deleteProfile as deleteSdkProfile,
   listProfiles as listSdkProfiles,
   loadProfile as loadSdkProfile,
   saveProfile as saveSdkProfile,
@@ -52,3 +53,6 @@ export const saveProfile = (
   const config = validateProfile(payload);
   saveSdkProfile(profileId, config, toSdkSaveOptions(options));
 };
+
+export const deleteProfile = (profileId: string, options: LLMProfileStoreOptions = {}): void =>
+  deleteSdkProfile(profileId, toSdkStoreOptions(options));


### PR DESCRIPTION
Implements profile deletion end-to-end:\n\n- Adds deleteProfile() in SDK profile store.\n- Wires webview delete action to host handler.\n- Deletes profile file + SecretStorage key; clears active selection if deleted.\n\nTests: npm test, npm run typecheck, npm run lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can delete LLM profiles from the UI; deletion clears stored API keys, unsets the active profile if needed, refreshes the profiles list, and returns to create mode.

* **UI**
  * Delete action enabled in edit mode with loading state and proper enable/disable behavior.

* **Tests**
  * Added automated tests covering profile deletion, API key clearing, and UI flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->