### PR TITLE
oh-tab-snd4: Fix missing API key after profile delete

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/credentials.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/credentials.ts
@@ -2,11 +2,6 @@ import { SecretRegistry } from '../runtime/SecretRegistry';
 
 const FALLBACK_KEY_ORDER = [
   'openhands.llmApiKey',
-  'OPENAI_API_KEY',
-  'OPENROUTER_API_KEY',
-  'LITELLM_API_KEY',
-  'ANTHROPIC_API_KEY',
-  'GEMINI_API_KEY',
   'LLM_API_KEY',
 ];
 

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -74,11 +74,19 @@ export class LLMFactory {
       typeof config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(config.apiKey)
         ? config.apiKey
         : undefined;
+    const defaultApiKeyName = this.getDefaultApiKeyName(provider);
+    const preferredApiKeys = config.apiKey ?? this.preferredKeys;
+    const apiKeyLookup = (() => {
+      if (Array.isArray(preferredApiKeys)) {
+        const keys = [...preferredApiKeys];
+        if (!keys.includes(defaultApiKeyName)) keys.push(defaultApiKeyName);
+        return keys;
+      }
+      return preferredApiKeys ?? defaultApiKeyName;
+    })();
     const apiKey =
       inlineApiKey ??
-      (await this.credentialProvider.getApiKey(
-        config.apiKey ?? this.preferredKeys ?? this.getDefaultApiKeyName(provider),
-      ));
+      (await this.credentialProvider.getApiKey(apiKeyLookup));
     if (!apiKey) {
       throw new Error('Missing API key for LLM provider');
     }

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -439,6 +439,34 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     return { ok: true, profileId };
   });
 
+  const deleteProfile = vscode.commands.registerCommand('openhands._deleteProfile', async (raw: unknown) => {
+    const profileId = typeof (raw as { profileId?: unknown } | undefined)?.profileId === 'string'
+      ? ((raw as { profileId: string }).profileId).trim()
+      : '';
+    if (!profileId) throw new Error('profileId is required');
+
+    const existing = llmProfilesStore.listProfiles();
+    if (!existing.includes(profileId)) throw new Error(`Profile '${profileId}' not found`);
+
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    const before = await settingsMgr.get();
+    const activeProfileId = before.llm.profileId ?? null;
+
+    llmProfilesStore.deleteProfile(profileId);
+    const apiKeySecretKey = getProfileApiKeySecretKey(profileId);
+    await deps.context.secrets.delete(apiKeySecretKey);
+    deps.secretRegistry.set(apiKeySecretKey, undefined);
+
+    const clearedSelection = activeProfileId === profileId;
+    if (clearedSelection) {
+      await settingsMgr.update({ llm: { profileId: '' } }, 'global');
+      await deps.ensureConversationAndConnection();
+    }
+
+    await broadcastLlmProfilesUpdated();
+    return { ok: true, profileId, clearedSelection };
+  });
+
   const selectProfile = vscode.commands.registerCommand('openhands._selectProfile', async (raw: unknown) => {
     const nestedProfileId = (raw as { profileId?: unknown } | undefined)?.profileId;
     const profileIdRaw = nestedProfileId === undefined ? raw : nestedProfileId;
@@ -474,9 +502,11 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     const key = getProfileApiKeySecretKey(profileId);
     if (!apiKey) {
       await deps.context.secrets.delete(key);
+      deps.secretRegistry.set(key, undefined);
       return { ok: true, profileId, hasKey: false };
     }
     await deps.context.secrets.store(key, apiKey);
+    deps.secretRegistry.set(key, apiKey);
     return { ok: true, profileId, hasKey: true };
   });
 
@@ -506,6 +536,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     openProfilesView,
     createProfile,
     updateProfile,
+    deleteProfile,
     selectProfile,
     setProfileApiKey,
     injectTerminalEvent,

--- a/tests/e2e/llmProfiles.test.ts
+++ b/tests/e2e/llmProfiles.test.ts
@@ -36,7 +36,7 @@ describe('OpenHands-Tab LLM Profiles E2E', function () {
         TEST_NAME: 'llmProfiles',
         HOME: userDataDir,
         USERPROFILE: userDataDir,
-        OPENAI_API_KEY: 'e2e-openai-key',
+        OPENAI_API_KEY: '',
         ANTHROPIC_API_KEY: 'e2e-anthropic-key',
       }
     });
@@ -44,4 +44,3 @@ describe('OpenHands-Tab LLM Profiles E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/suite/llmProfiles.ts
+++ b/tests/e2e/suite/llmProfiles.ts
@@ -3,6 +3,12 @@ import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
 
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+type ErrorInfo = { seq?: number; code?: unknown; detail?: unknown; error?: unknown } | null;
+
 export async function run(): Promise<void> {
   const mock = await startMockLlmServer();
 
@@ -37,6 +43,8 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands.startNewConversation');
 
     // Create profiles used by this suite.
+    const openaiProfileKey = 'e2e-profile-openai-key';
+
     await vscode.commands.executeCommand('openhands._createProfile', {
       profileId: 'e2e-openai-chat',
       profile: {
@@ -46,6 +54,10 @@ export async function run(): Promise<void> {
         openaiApiMode: 'chat_completions',
       },
     });
+    await vscode.commands.executeCommand('openhands._setProfileApiKey', {
+      profileId: 'e2e-openai-chat',
+      apiKey: openaiProfileKey,
+    });
     await vscode.commands.executeCommand('openhands._createProfile', {
       profileId: 'e2e-openai-responses',
       profile: {
@@ -54,6 +66,23 @@ export async function run(): Promise<void> {
         baseUrl: v1BaseUrl,
         openaiApiMode: 'responses',
       },
+    });
+    await vscode.commands.executeCommand('openhands._setProfileApiKey', {
+      profileId: 'e2e-openai-responses',
+      apiKey: openaiProfileKey,
+    });
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: 'e2e-openai-delete',
+      profile: {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        baseUrl: v1BaseUrl,
+        openaiApiMode: 'chat_completions',
+      },
+    });
+    await vscode.commands.executeCommand('openhands._setProfileApiKey', {
+      profileId: 'e2e-openai-delete',
+      apiKey: openaiProfileKey,
     });
 
     // No profile selected: should use the base anthropic config.
@@ -99,6 +128,70 @@ export async function run(): Promise<void> {
       text: 'E2E profiles step 5: base again (anthropic)',
       expectedPath: '/v1/messages',
       getRequests: () => mock.requests,
+    });
+
+    const sendAndExpectErrorCode = async (options: { text: string; expectedCode: string; timeoutMs?: number }) => {
+      const { text, expectedCode, timeoutMs = 45000 } = options;
+      const beforeReqCount = mock.requests.length;
+      const beforeError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+      const beforeErrorSeq = typeof beforeError?.seq === 'number' ? beforeError.seq : -1;
+
+      const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+        action: 'sendMessage',
+        payload: { text },
+      });
+      if (!send?.sent) {
+        throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+      }
+
+      await pollUntil(async () => {
+        const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+        const afterSeq = typeof afterError?.seq === 'number' ? afterError.seq : -1;
+        if (!afterError || afterSeq <= beforeErrorSeq) return false;
+        return afterError.code === expectedCode;
+      }, timeoutMs, 200);
+
+      const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+      if (!afterError) throw new Error('Expected an error event after sending message, but none was found');
+      if (afterError.code !== expectedCode) {
+        throw new Error(`Expected error code ${expectedCode} but got ${String(afterError.code)} (${JSON.stringify(afterError)})`);
+      }
+      if (mock.requests.length !== beforeReqCount) {
+        const recent = mock.requests.slice(beforeReqCount).map((r) => ({ method: r.method, path: r.path }));
+        throw new Error(`Expected no mock requests after error, but saw: ${JSON.stringify(recent)}`);
+      }
+      return afterError;
+    };
+
+    // Delete profile: should clear selection + remove stored key.
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: 'e2e-openai-delete' });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 6: delete target profile (openai chat_completions)',
+      expectedPath: '/v1/chat/completions',
+      getRequests: () => mock.requests,
+    });
+
+    await vscode.commands.executeCommand('openhands._deleteProfile', { profileId: 'e2e-openai-delete' });
+    await sendAndWaitForRequestPath({
+      text: 'E2E profiles step 7: after delete uses base config (anthropic)',
+      expectedPath: '/v1/messages',
+      getRequests: () => mock.requests,
+    });
+
+    // Recreate profile without setting a key; selecting it should trigger missing_llm_api_key.
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: 'e2e-openai-delete',
+      profile: {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        baseUrl: v1BaseUrl,
+        openaiApiMode: 'chat_completions',
+      },
+    });
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: 'e2e-openai-delete' });
+    await sendAndExpectErrorCode({
+      text: 'E2E profiles step 8: recreated profile missing key',
+      expectedCode: 'missing_llm_api_key',
     });
   } finally {
     await mock.close();


### PR DESCRIPTION
Fixes e2e coverage for deleting/recreating an LLM profile without a key.

- Scope fallback API keys to generic keys only (prevents OpenAI from silently using ANTHROPIC_API_KEY).
- Clear SecretRegistry cache when setting/deleting per-profile API keys so changes take effect immediately.
- Extend llmProfiles E2E to assert missing_llm_api_key after deleting + recreating a profile without re-setting its key.

Tests:
- npm test
- npm run lint
- E2E: mocha tests/e2e/out/llmProfiles.test.js --timeout 180000

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to delete LLM profiles, which automatically removes the profile and associated API key configurations from storage and updates the application state accordingly.

* **Bug Fixes**
  * Enhanced input validation for profile management operations, including profile selection and creation, to ensure proper error handling and prevent invalid state transitions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->