### PR TITLE
oh-tab-ii7l: Unit test provider key fallback for profileId

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { ConversationStats } from '../runtime/ConversationStats';
+import { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMFactory, LLMRegistry, TrackedLLMClient, saveProfile } from '../llm';
 
 const makeTempDir = (prefix: string) => fs.mkdtempSync(path.join(os.tmpdir(), prefix));
@@ -63,5 +64,49 @@ describe('LLMFactory profile selection', () => {
     expect(tracked.modelName).toBe('gpt-5-mini');
     expect(tracked.label).toBe('gpt-5-mini');
     expect(stats.usageToLabels.default).toBe('gpt-5-mini');
+  });
+
+  it('falls back to provider env key when profileId key is missing', async () => {
+    const dir = makeTempDir('llm-profile-selection-keys-');
+    const originalLlmApiKey = process.env.LLM_API_KEY;
+    delete process.env.LLM_API_KEY;
+    try {
+      saveProfile(
+        'p1',
+        {
+          provider: 'anthropic',
+          model: 'claude-sonnet-4-20250514',
+          profileName: 'Sonnet Profile',
+        },
+        { rootDir: dir },
+      );
+
+      const secrets = new SecretRegistry();
+      secrets.set('ANTHROPIC_API_KEY', 'sk-anthropic');
+
+      const factory = new LLMFactory(
+        {
+          provider: 'openai',
+          model: 'IGNORED',
+          profileId: 'p1',
+          usageId: 'default',
+        },
+        {
+          secrets,
+          preferredApiKeys: ['openhands.llmProfileApiKey.p1'],
+          profileStoreOptions: { rootDir: dir },
+        },
+      );
+
+      const client = await factory.createClient();
+      expect(client).toBeInstanceOf(TrackedLLMClient);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+      if (originalLlmApiKey === undefined) {
+        delete process.env.LLM_API_KEY;
+      } else {
+        process.env.LLM_API_KEY = originalLlmApiKey;
+      }
+    }
   });
 });


### PR DESCRIPTION
Adds a unit test covering the regression where selecting a profileId (preferredApiKeys contains only the per-profile key) must still fall back to the provider’s default env key name (e.g. ANTHROPIC_API_KEY).

This guards against E2E failures like llmSwitching step 8 (sonnet-45) when global cross-provider fallback is disabled.

Tests:
- npm test -w @openhands/agent-sdk-ts
