### PR TITLE
oh-tab-6dcu: Invalidate SecretRegistry cache from Profiles UI

### DIFF
--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { saveProfile as saveSdkProfile } from '@openhands/agent-sdk-ts';
+import { saveProfile as saveSdkProfile, SecretRegistry } from '@openhands/agent-sdk-ts';
 import { createWebviewMessageHandler } from '../webview/host/createWebviewMessageHandler';
 
 describe('LLM profile host CRUD (llm-profiles store)', () => {
@@ -21,14 +21,21 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
 
   const createHandler = () => {
     const postMessage = vi.fn(async () => true);
+    const secretValues = new Map<string, string>();
     const secrets = {
-      get: vi.fn(async () => undefined),
-      store: vi.fn(async () => {}),
-      delete: vi.fn(async () => {}),
+      get: vi.fn(async (key: string) => secretValues.get(key)),
+      store: vi.fn(async (key: string, value: string) => {
+        secretValues.set(key, value);
+      }),
+      delete: vi.fn(async (key: string) => {
+        secretValues.delete(key);
+      }),
     };
+    const secretRegistry = new SecretRegistry(secrets as any, null);
     const handler = createWebviewMessageHandler({
       context: { globalStorageUri: { fsPath: tmpDir }, secrets } as any,
       host: { postMessage },
+      secretRegistry,
       getConversation: () => undefined,
       getConversationMode: () => 'local',
       getConversationStoreRoot: () => undefined,
@@ -46,7 +53,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       fileLog: () => {},
     });
 
-    return { handler, postMessage, secrets };
+    return { handler, postMessage, secrets, secretRegistry };
   };
 
   it('lists profiles from the configured root dir', async () => {
@@ -121,10 +128,27 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     expect(content).not.toContain('Authorization');
   });
 
+  it('clearing a profile API key invalidates the SecretRegistry cache', async () => {
+    const { handler, secrets, secretRegistry } = createHandler();
+    const key = 'openhands.llmProfileApiKey.a';
+
+    await secrets.store(key, 'sk-test');
+    await expect(secretRegistry.get(key)).resolves.toBe('sk-test');
+
+    await handler({ type: 'llmProfileApiKeySetRequest', requestId: 'req1', profileId: 'a', apiKey: '' });
+
+    await expect(secretRegistry.get(key)).resolves.toBeUndefined();
+  });
+
   it('deletes profiles and clears stored API keys', async () => {
     saveSdkProfile('a', { model: 'gpt-5-mini' }, { rootDir: tmpDir, includeSecrets: false });
 
-    const { handler, postMessage, secrets } = createHandler();
+    const { handler, postMessage, secrets, secretRegistry } = createHandler();
+    const key = 'openhands.llmProfileApiKey.a';
+
+    await secrets.store(key, 'sk-test');
+    await expect(secretRegistry.get(key)).resolves.toBe('sk-test');
+
     await handler({ type: 'llmProfileDeleteRequest', requestId: 'req1', profileId: 'a' });
 
     expect(postMessage).toHaveBeenCalledWith({
@@ -133,7 +157,8 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       ok: true,
       profileId: 'a',
     });
-    expect(secrets.delete).toHaveBeenCalledWith('openhands.llmProfileApiKey.a');
+    expect(secrets.delete).toHaveBeenCalledWith(key);
+    await expect(secretRegistry.get(key)).resolves.toBeUndefined();
     await expect(fs.stat(path.join(tmpDir, 'a.json'))).rejects.toThrow();
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -375,6 +375,7 @@ export function activate(context: vscode.ExtensionContext) {
       createWebviewMessageHandler({
         context,
         host: { postMessage: (message) => view.webview.postMessage(message) },
+        secretRegistry,
         getConversation: () => conversation,
         getConversationMode: () => conversationMode,
         getConversationStoreRoot: () => conversationStoreRoot,

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import * as childProcess from 'child_process';
-import { assertValidProfileId, LLMProfileValidationError } from '@openhands/agent-sdk-ts';
+import { assertValidProfileId, LLMProfileValidationError, type SecretRegistry } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -49,6 +49,7 @@ async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8
 export type CreateWebviewMessageHandlerDeps = {
   context: vscode.ExtensionContext;
   host: WebviewHost;
+  secretRegistry?: SecretRegistry;
 
   getConversation: () => import('@openhands/agent-sdk-ts').ConversationInstance | undefined;
   getConversationMode: () => 'local' | 'remote';
@@ -480,7 +481,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         try {
           llmProfilesStore.deleteProfile(profileId, llmProfileStoreOptions());
-          await context.secrets.delete(getProfileApiKeySecretKey(profileId));
+          const key = getProfileApiKeySecretKey(profileId);
+          await context.secrets.delete(key);
+          deps.secretRegistry?.set(key, undefined);
           void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: true, profileId });
 
           const before = await settingsMgr.get();
@@ -556,8 +559,10 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           const key = getProfileApiKeySecretKey(profileId);
           if (!apiKey) {
             await context.secrets.delete(key);
+            deps.secretRegistry?.set(key, undefined);
           } else {
             await context.secrets.store(key, apiKey);
+            deps.secretRegistry?.set(key, apiKey);
           }
           void host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: true, profileId });
         } catch (err) {


### PR DESCRIPTION
Fixes oh-tab-6dcu.

Profiles UI updates VS Code SecretStorage for per-profile API keys, but the running local agent reads from an in-memory SecretRegistry cache. If a key was previously cached, clearing/deleting it in the Profiles UI could leave the cached value still usable until reload.

Changes:
- Keep SecretRegistry in sync on `llmProfileApiKeySetRequest` and `llmProfileDeleteRequest`.
- Add unit coverage for the cache-invalidation scenario.

Verification:
- `npm run typecheck`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API key and secret management throughout LLM profile operations. API keys are now properly synchronized with the internal secret registry, and secrets are correctly cleared when profiles are deleted or API keys are modified. This ensures consistent cache state and prevents stale secrets from remaining in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->