### PR TITLE
oh-tab-6adp: Show effective profile LLM in error details

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1083,7 +1083,7 @@ export class Agent extends EventEmitter {
           const profileModel = toOptionalNonEmptyString(profile.config.model);
           const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
           const effectiveProfileProvider =
-            profile.config.provider ?? detectProviderFromBaseUrl(configuredBaseUrl ?? profileBaseUrl);
+            profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
           contextParts.push(`llm.effectiveProvider=${effectiveProfileProvider}`);
           contextParts.push(`llm.effectiveModel=${profileModel ?? '(unset)'}`);
         } catch {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -6,7 +6,7 @@ import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
 import type { ChatCompletionRequest, LLMClient, LLMToolDefinition } from '../llm';
-import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMFactory } from '../llm';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMFactory, loadProfile } from '../llm';
 import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
 import {
   isActionEvent,
@@ -1054,6 +1054,7 @@ export class Agent extends EventEmitter {
     const message = options?.message ?? stringifyErrorWithCause(error);
     const code = options?.code ?? classifyConversationErrorCode(message);
     const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
+    const profileId = toOptionalNonEmptyString(this.options.settings?.llm?.profileId);
     const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
     const configuredProvider = this.options.settings?.llm?.provider ?? undefined;
     const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
@@ -1073,6 +1074,23 @@ export class Agent extends EventEmitter {
       `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
       `llm.apiKey=${apiKeyStatus}`,
     ];
+    if (profileId) {
+      contextParts.push(`llm.profileId=${profileId}`);
+
+      if (isSafeProfileId(profileId)) {
+        try {
+          const profile = loadProfile(profileId);
+          const profileModel = toOptionalNonEmptyString(profile.config.model);
+          const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
+          const effectiveProfileProvider =
+            profile.config.provider ?? detectProviderFromBaseUrl(configuredBaseUrl ?? profileBaseUrl);
+          contextParts.push(`llm.effectiveProvider=${effectiveProfileProvider}`);
+          contextParts.push(`llm.effectiveModel=${profileModel ?? '(unset)'}`);
+        } catch {
+          // best-effort: profile may be missing or unreadable
+        }
+      }
+    }
     if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
 
     const detail = `${message} (${contextParts.join(', ')})`;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
@@ -154,4 +154,53 @@ describe('Agent profile api key selection', () => {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   });
+
+  it('includes effective provider/model in ConversationErrorEvent detail when profileId is set', async () => {
+    const tmpHome = makeTempDir('agent-profile-error-detail-');
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      process.env.HOME = tmpHome;
+      process.env.USERPROFILE = tmpHome;
+      vi.resetModules();
+
+      const [{ saveProfile }, { Agent }] = await Promise.all([
+        import('../../llm'),
+        import('../Agent'),
+      ]);
+
+      saveProfile('p1', {
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet',
+      });
+
+      const agent = new Agent({
+        workspaceRoot: tmpHome,
+        settings: {
+          // Raw settings are misleading when profileId is set; detail should include effective profile values.
+          llm: { profileId: 'p1', provider: 'openai', model: 'gpt-4o-mini' },
+          secrets: {},
+        } as any,
+      });
+
+      let error: unknown;
+      try {
+        await (agent as any).createLlmClientFromSettings();
+      } catch (err) {
+        error = err;
+      }
+      expect(error).toBeTruthy();
+
+      const event = (agent as any).toConversationErrorEvent(error) as { kind?: string; detail?: string };
+      expect(event.kind).toBe('ConversationErrorEvent');
+      expect(event.detail).toContain('llm.profileId=p1');
+      expect(event.detail).toContain('llm.effectiveProvider=anthropic');
+      expect(event.detail).toContain('llm.effectiveModel=claude-3-5-sonnet');
+    } finally {
+      process.env.HOME = originalHome;
+      process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
Fixes oh-tab-6adp.

When `settings.llm.profileId` is set, `ConversationErrorEvent.detail` previously only reflected the raw `openhands.llm.*` settings fields, which can be misleading. This adds `llm.profileId` and best-effort `llm.effectiveProvider/llm.effectiveModel` resolved from the profile config.

Tests:
- Adds a unit test covering missing-key with a selected profile, asserting the effective provider/model appear in `detail`.

Verification:
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced profile-based LLM configuration support to the Agent SDK. When a profile ID is configured, effective LLM provider and model details are now automatically included in error reports for enhanced debugging and error diagnostics.

* **Tests**
  * Added test coverage verifying profile-based LLM information is correctly included in error event details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->