### PR TITLE
oh-tab-c1dt: Make diff right pane editable

### DIFF
--- a/src/webview/host/__tests__/diffDocuments.test.ts
+++ b/src/webview/host/__tests__/diffDocuments.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { showWorkspaceDiff } from '../diffDocuments';
+
+describe('showWorkspaceDiff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode as any).__resetMocks();
+
+    (vscode.Uri.parse as any).mockImplementation((raw: string) => {
+      const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(raw);
+      const scheme = (match?.[1] ?? 'file').toLowerCase();
+      return { scheme, fsPath: raw, toString: () => raw } as unknown as vscode.Uri;
+    });
+
+    (vscode.Uri.file as any).mockImplementation((fsPath: string) => {
+      return { scheme: 'file', fsPath, toString: () => `file:${fsPath}` } as unknown as vscode.Uri;
+    });
+  });
+
+  it('opens vscode.diff with a real file on the right-hand side', async () => {
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+
+    await showWorkspaceDiff({
+      context,
+      filePath: 'README.md',
+      oldContent: 'old',
+      newContent: 'new',
+    });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalled();
+    const call = (vscode.commands.executeCommand as any).mock.calls.find((args: unknown[]) => args[0] === 'vscode.diff');
+    expect(call).toBeTruthy();
+
+    const [, beforeUri, afterUri] = call;
+    expect(beforeUri.scheme).toBe('openhands-diff');
+    expect(afterUri.scheme).toBe('file');
+    expect(afterUri.fsPath).toBe('/test/workspace/README.md');
+  });
+});
+

--- a/src/webview/host/diffDocuments.ts
+++ b/src/webview/host/diffDocuments.ts
@@ -51,11 +51,10 @@ export async function showWorkspaceDiff(args: {
 }): Promise<void> {
   ensureDiffProviderRegistered(args.context);
 
-  const { displayPath } = resolveWorkspaceFilePath(args.filePath);
-  const { beforeUri, afterUri } = createDiffUris(displayPath);
+  const { resolvedPath, displayPath } = resolveWorkspaceFilePath(args.filePath);
+  const { beforeUri } = createDiffUris(displayPath);
+  const afterUri = vscode.Uri.file(resolvedPath);
   storeDiffDocument(beforeUri, args.oldContent);
-  storeDiffDocument(afterUri, args.newContent);
 
   await vscode.commands.executeCommand('vscode.diff', beforeUri, afterUri, `Diff: ${displayPath}`, { preview: false });
 }
-


### PR DESCRIPTION
Fixes oh-tab-c1dt.

When opening workspace diffs from the webview, the diff editor used two `openhands-diff:` virtual documents (read-only). This changes the right-hand side to the real workspace file URI so the user can edit/save directly from the diff view.

Changes:
- `src/webview/host/diffDocuments.ts`: right pane uses `vscode.Uri.file(resolvedPath)`; left pane stays virtual.
- `src/webview/host/__tests__/diffDocuments.test.ts`: asserts `vscode.diff` is invoked with a file URI on the right.

Verification:
- `npx vitest run src/webview/host/__tests__/diffDocuments.test.ts`
