### PR TITLE
oh-tab-9kb6: Gemini helper not Flash-specific

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type { ChatCompletionRequest, LLMClient } from '../llm';
-import { LLMFactory } from '../llm';
+import { getGeminiClient } from './geminiClient';
 import type { SecretRegistry } from './SecretRegistry';
 
 const execFileAsync = promisify(execFile);
@@ -121,20 +121,6 @@ const loadContentsFromGitRefs = async (
   return { oldContent, newContent };
 };
 
-const getGeminiFlashClient = async (secrets: SecretRegistry): Promise<LLMClient> => {
-  const factory = new LLMFactory(
-    {
-      profileId: 'gemini-flash',
-      model: 'gemini-flash',
-      usageId: 'file-diff-summarizer',
-      temperature: 0.2,
-      maxOutputTokens: 256,
-    },
-    { secrets }
-  );
-  return factory.createClient();
-};
-
 export async function summarizeFileChangesWithGeminiFlash(
   input: FileChangeInput,
   options: SummarizeFileChangesOptions
@@ -177,7 +163,14 @@ export async function summarizeFileChangesWithGeminiFlash(
     messages: [{ role: 'user', content: [{ type: 'text', text: safePrompt }] }],
   };
 
-  const client = options.llmClient ?? (await getGeminiFlashClient(options.secrets));
+  const client =
+    options.llmClient ??
+    (await getGeminiClient(options.secrets, {
+      usageId: 'file-diff-summarizer',
+      profileId: 'gemini-flash',
+      model: 'gemini-flash',
+      maxOutputTokens: 256,
+    }));
   let text = '';
   for await (const chunk of client.streamChat(request)) {
     if (chunk.type === 'text') text += chunk.text;

--- a/packages/agent-sdk-ts/src/sdk/runtime/geminiClient.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/geminiClient.ts
@@ -1,0 +1,37 @@
+import type { LLMClient } from '../llm';
+import { LLMFactory } from '../llm';
+import type { SecretRegistry } from './SecretRegistry';
+
+export interface GeminiClientOptions {
+  usageId: string;
+  profileId?: string;
+  model?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+}
+
+const DEFAULT_GEMINI_PROFILE_ID = 'gemini-flash';
+
+/**
+ * Gemini-only helper for creating a Google GenAI client for runtime summarizers.
+ *
+ * Note: This is intentionally *not* a cross-provider helper. It supports multiple
+ * Gemini models (Flash/Pro/etc.) by allowing callers to override `profileId`/`model`.
+ */
+export const getGeminiClient = async (secrets: SecretRegistry, options: GeminiClientOptions): Promise<LLMClient> => {
+  const profileId = options.profileId ?? DEFAULT_GEMINI_PROFILE_ID;
+  const model = options.model ?? profileId;
+
+  const factory = new LLMFactory(
+    {
+      profileId,
+      model,
+      usageId: options.usageId,
+      temperature: options.temperature ?? 0.2,
+      maxOutputTokens: options.maxOutputTokens,
+    },
+    { secrets }
+  );
+
+  return factory.createClient();
+};

--- a/packages/agent-sdk-ts/src/sdk/runtime/gitChangeSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/gitChangeSummarizer.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type { ChatCompletionRequest, LLMClient } from '../llm';
-import { LLMFactory } from '../llm';
+import { getGeminiClient } from './geminiClient';
 import type { SecretRegistry } from './SecretRegistry';
 
 const execFileAsync = promisify(execFile);
@@ -116,20 +116,6 @@ const normalizePathFilters = (repoRoot: string, filters: string[] | undefined): 
     .map((candidate) => normalizeRepoRelativePath(repoRoot, candidate));
 };
 
-const getGeminiFlashClient = async (secrets: SecretRegistry): Promise<LLMClient> => {
-  const factory = new LLMFactory(
-    {
-      profileId: 'gemini-flash',
-      model: 'gemini-flash',
-      usageId: 'git-change-summarizer',
-      temperature: 0.2,
-      maxOutputTokens: 512,
-    },
-    { secrets },
-  );
-  return factory.createClient();
-};
-
 const extractJsonObject = (text: string): string | null => {
   const start = text.indexOf('{');
   const end = text.lastIndexOf('}');
@@ -239,7 +225,14 @@ export async function summarizeGitChangesWithGeminiFlash(
     messages: [{ role: 'user', content: [{ type: 'text', text: safePrompt }] }],
   };
 
-  const client = options.llmClient ?? (await getGeminiFlashClient(options.secrets));
+  const client =
+    options.llmClient ??
+    (await getGeminiClient(options.secrets, {
+      usageId: 'git-change-summarizer',
+      profileId: 'gemini-flash',
+      model: 'gemini-flash',
+      maxOutputTokens: 512,
+    }));
   let text = '';
   for await (const chunk of client.streamChat(request)) {
     if (chunk.type === 'text') text += chunk.text;

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -1,5 +1,5 @@
 import type { ChatCompletionRequest, LLMClient } from '../llm';
-import { LLMFactory } from '../llm';
+import { getGeminiClient } from './geminiClient';
 import type { SecretRegistry } from './SecretRegistry';
 
 export interface TerminalObservationInput {
@@ -62,20 +62,6 @@ const summarizeExitCodeFallback = (exitCode: TerminalObservationInput['exitCode'
   return normalized === '0' ? 'Done.' : `Done (exit code ${normalized}).`;
 };
 
-const getGeminiFlashClient = async (secrets: SecretRegistry): Promise<LLMClient> => {
-  const factory = new LLMFactory(
-    {
-      profileId: 'gemini-flash',
-      model: 'gemini-flash',
-      usageId: 'terminal-observation-summarizer',
-      temperature: 0.2,
-      maxOutputTokens: 256,
-    },
-    { secrets }
-  );
-  return factory.createClient();
-};
-
 const truncateSummary = (text: string, maxChars: number): string => {
   if (maxChars <= 0) return '';
   if (text.length <= maxChars) return text;
@@ -118,7 +104,14 @@ export async function summarizeTerminalObservationWithGeminiFlash(
   };
 
   try {
-    const client = options.llmClient ?? (await getGeminiFlashClient(options.secrets));
+    const client =
+      options.llmClient ??
+      (await getGeminiClient(options.secrets, {
+        usageId: 'terminal-observation-summarizer',
+        profileId: 'gemini-flash',
+        model: 'gemini-flash',
+        maxOutputTokens: 256,
+      }));
     let text = '';
     for await (const chunk of client.streamChat(request)) {
       if (chunk.type === 'text') text += chunk.text;


### PR DESCRIPTION
Bead: oh-tab-9kb6 (GH #400)

- Introduce a shared Gemini-only getGeminiClient() helper (supports model/profile overrides for Flash/Pro/etc.).
- Update runtime summarizers (git/file/terminal) to use the shared helper.
- Default behavior remains Gemini Flash (profileId/model=gemini-flash).

Local: npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal client initialization across AI-powered summarization features through a centralized helper function, improving code maintainability and consistency without affecting public APIs or user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->