### PR TITLE
oh-tab-zqq4: Show basename for file links

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -300,7 +300,7 @@ describe('Agent-SDK event rendering', () => {
       source: 'environment' as const,
       observation: {
         command: 'str_replace',
-        path: '/tmp/README.md',
+        path: '/tmp/nested/README.md',
         prev_exist: true,
         old_content: 'old content',
         new_content: 'new content',
@@ -311,13 +311,16 @@ describe('Agent-SDK event rendering', () => {
     } as any;
 
     postToWindow({ type: 'event', event: observationEvent });
-    const button = await screen.findByRole('button', { name: 'View diff for /tmp/README.md' });
+    const button = await screen.findByRole('button', { name: 'View diff for /tmp/nested/README.md' });
+    expect(button).toHaveTextContent('README.md');
+    expect(button).not.toHaveTextContent('/tmp/nested/README.md');
+    expect(button).toHaveAttribute('title', 'View diff for /tmp/nested/README.md');
     fireEvent.click(button);
 
     expect(mockApi.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'openWorkspaceDiff',
-        path: '/tmp/README.md',
+        path: '/tmp/nested/README.md',
         oldContent: 'old content',
         newContent: 'new content',
         preferGitHead: true,

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -213,6 +213,13 @@ function InlineFileReference({ path }: { path?: string }) {
   if (!path) {
     return <span className="font-mono text-xs text-stone-400">this path</span>;
   }
+
+  const trimmedPath = path.replace(/[\\/]+$/, '');
+  const normalizedPath = trimmedPath.replaceAll('\\', '/');
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+  const basename = lastSlashIndex >= 0 ? normalizedPath.slice(lastSlashIndex + 1) : normalizedPath;
+  const label = basename || normalizedPath || path;
+
   return (
     <button
       type="button"
@@ -222,7 +229,7 @@ function InlineFileReference({ path }: { path?: string }) {
       title={`Open ${path}`}
     >
       <span className="codicon codicon-file text-brand-400/70" />
-      <span className="truncate max-w-[16rem]">{path}</span>
+      <span className="truncate max-w-[16rem]">{label}</span>
       <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
     </button>
   );
@@ -239,6 +246,12 @@ function InlineFileDiffReference({ path, oldContent, newContent }: { path?: stri
     return <span className="font-mono text-xs text-stone-400">this path</span>;
   }
 
+  const trimmedPath = path.replace(/[\\/]+$/, '');
+  const normalizedPath = trimmedPath.replaceAll('\\', '/');
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+  const basename = lastSlashIndex >= 0 ? normalizedPath.slice(lastSlashIndex + 1) : normalizedPath;
+  const label = basename || normalizedPath || path;
+
   const oldText = normalizeDiffContent(oldContent);
   const newText = normalizeDiffContent(newContent);
   if (oldText === undefined || newText === undefined) {
@@ -254,7 +267,7 @@ function InlineFileDiffReference({ path, oldContent, newContent }: { path?: stri
       title={`View diff for ${path}`}
     >
       <span className="codicon codicon-diff text-brand-400/70" />
-      <span className="truncate max-w-[16rem]">{path}</span>
+      <span className="truncate max-w-[16rem]">{label}</span>
       <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
     </button>
   );


### PR DESCRIPTION
Bead: oh-tab-zqq4

- File editor Tool Result links now display only the basename (filename).
- Tooltip/title still shows the full path.
- Clicking behavior unchanged.

Local: npx vitest run src/webview-src/__tests__/event.rendering.test.tsx
