### PR TITLE
oh-tab-ujic: Detect context-limit errors and maxInputTokens

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/contextLimit.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/contextLimit.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest } from '../types';
+import { estimateRequestTokens, isContextLimitError, wouldExceedMaxInputTokens } from '../contextLimit';
+
+describe('isContextLimitError', () => {
+  it('detects OpenAI context-length errors', () => {
+    expect(isContextLimitError('openai', new Error('LLM request failed (400): {"error":{"code":"context_length_exceeded"}}'))).toBe(true);
+    expect(
+      isContextLimitError(
+        'openai',
+        new Error("LLM request failed (400): This model's maximum context length is 8192 tokens, however you requested 9000 tokens."),
+      ),
+    ).toBe(true);
+    expect(isContextLimitError('openai', new Error('LLM request failed (401): invalid_api_key'))).toBe(false);
+  });
+
+  it('detects Anthropic prompt-too-long errors', () => {
+    expect(
+      isContextLimitError(
+        'anthropic',
+        new Error('Anthropic request failed (400): {"type":"error","error":{"message":"prompt is too long"}}'),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects Gemini token-limit errors', () => {
+    expect(
+      isContextLimitError(
+        'gemini',
+        new Error('LLM request failed (HTTP 400): {"error":{"message":"The input token count is 200000, which exceeds the maximum number of tokens"}}'),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('estimateRequestTokens / wouldExceedMaxInputTokens', () => {
+  const baseRequest: ChatCompletionRequest = {
+    systemPrompt: 'You are a helpful assistant.',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'Hi' }] }],
+  };
+
+  it('estimates prompt tokens using a conservative heuristic', () => {
+    const request: ChatCompletionRequest = {
+      ...baseRequest,
+      systemPrompt: 'x'.repeat(4000),
+    };
+    expect(estimateRequestTokens(request)).toBeGreaterThanOrEqual(1000);
+  });
+
+  it('returns true when estimated tokens exceed maxInputTokens', () => {
+    const request: ChatCompletionRequest = {
+      ...baseRequest,
+      systemPrompt: 'x'.repeat(4000),
+    };
+    expect(wouldExceedMaxInputTokens({ request, maxInputTokens: 900 })).toBe(true);
+    expect(wouldExceedMaxInputTokens({ request, maxInputTokens: 2000 })).toBe(false);
+  });
+
+  it('includes tool definitions in the estimate (best-effort)', () => {
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'Short.',
+      messages: [],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'test_tool',
+            description: 'x'.repeat(4000),
+            parameters: { type: 'object', properties: { a: { type: 'string' } } },
+          },
+        },
+      ],
+    };
+
+    expect(wouldExceedMaxInputTokens({ request, maxInputTokens: 200 })).toBe(true);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/contextLimit.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/contextLimit.ts
@@ -1,0 +1,122 @@
+import type { ChatCompletionRequest, LLMProvider } from './types';
+import { reduceTextContent } from './types';
+
+const normalizeErrorText = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+const containsAny = (haystack: string, needles: string[]): boolean =>
+  needles.some((needle) => haystack.includes(needle));
+
+/**
+ * Best-effort classifier for "context window / token limit exceeded" errors.
+ *
+ * This intentionally errs on the side of false negatives (to avoid triggering
+ * condensation on unrelated failures).
+ */
+export const isContextLimitError = (provider: LLMProvider | undefined, error: unknown): boolean => {
+  const text = normalizeErrorText(error).toLowerCase();
+  if (!text) return false;
+
+  // Provider-specific hints first (most reliable).
+  switch (provider) {
+    case 'openai':
+    case 'openrouter':
+    case 'litellm_proxy': {
+      return containsAny(text, [
+        'context_length_exceeded',
+        'maximum context length',
+        "this model's maximum context length",
+        'too many tokens',
+        'reduce the length of the messages',
+        'tokens in the prompt',
+      ]);
+    }
+    case 'anthropic': {
+      return containsAny(text, [
+        'prompt is too long',
+        'prompt too long',
+        'context length exceeded',
+        'max_tokens',
+        'tokens exceeded',
+      ]);
+    }
+    case 'gemini': {
+      return containsAny(text, [
+        'prompttokencount',
+        'candidatestokencount',
+        'exceeds the maximum',
+        'maximum number of tokens',
+        'input token',
+        'token limit',
+        'context length',
+        'resource_exhausted',
+      ]);
+    }
+    default:
+      break;
+  }
+
+  // Generic fallback heuristics.
+  return containsAny(text, [
+    'context_length_exceeded',
+    'maximum context length',
+    'prompt is too long',
+    'token limit',
+    'exceeds the maximum number of tokens',
+    'reduce the length',
+  ]);
+};
+
+const estimateTokens = (text: string): number => {
+  const chars = text.trim().length;
+  if (chars <= 0) return 0;
+  // ~4 chars/token heuristic (conservative).
+  return Math.ceil(chars / 4);
+};
+
+export const estimateRequestTokens = (request: ChatCompletionRequest): number => {
+  const parts: string[] = [];
+  parts.push(request.systemPrompt);
+
+  for (const message of request.messages) {
+    parts.push(message.role);
+    if (message.name) parts.push(message.name);
+    if (message.tool_call_id) parts.push(message.tool_call_id);
+    parts.push(reduceTextContent(message));
+    if (message.role === 'assistant' && message.tool_calls?.length) {
+      try {
+        parts.push(JSON.stringify(message.tool_calls));
+      } catch {
+        // ignore stringify failures
+      }
+    }
+  }
+
+  if (request.tools?.length) {
+    try {
+      parts.push(JSON.stringify(request.tools));
+    } catch {
+      // ignore stringify failures
+    }
+  }
+
+  return estimateTokens(parts.join('\n'));
+};
+
+export const wouldExceedMaxInputTokens = (params: {
+  request: ChatCompletionRequest;
+  maxInputTokens: number | null | undefined;
+}): boolean => {
+  const raw = params.maxInputTokens;
+  const maxTokens = typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : undefined;
+  if (!maxTokens || maxTokens <= 0) return false;
+  return estimateRequestTokens(params.request) > maxTokens;
+};
+

--- a/packages/agent-sdk-ts/src/sdk/llm/contextLimit.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/contextLimit.ts
@@ -43,7 +43,6 @@ export const isContextLimitError = (provider: LLMProvider | undefined, error: un
         'prompt is too long',
         'prompt too long',
         'context length exceeded',
-        'max_tokens',
         'tokens exceeded',
       ]);
     }
@@ -56,7 +55,6 @@ export const isContextLimitError = (provider: LLMProvider | undefined, error: un
         'input token',
         'token limit',
         'context length',
-        'resource_exhausted',
       ]);
     }
     default:
@@ -119,4 +117,3 @@ export const wouldExceedMaxInputTokens = (params: {
   if (!maxTokens || maxTokens <= 0) return false;
   return estimateRequestTokens(params.request) > maxTokens;
 };
-

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -9,3 +9,4 @@ export * from './provider';
 export * from './metrics';
 export * from './registry';
 export * from './profiles';
+export * from './contextLimit';


### PR DESCRIPTION
Bead: oh-tab-ujic

- Add shared helpers to classify context/token-limit errors across providers (OpenAI chat/responses, Anthropic, Gemini).
- Add maxInputTokens threshold helper based on conservative token estimation.
- Unit tests cover provider error strings + maxInputTokens behavior.

Local: `npm test -w @openhands/agent-sdk-ts`
