### PR TITLE
oh-tab-dbum: Close LLM profile dropdown on selection

### DIFF
--- a/src/webview-src/__tests__/LlmProfileDropdown.test.tsx
+++ b/src/webview-src/__tests__/LlmProfileDropdown.test.tsx
@@ -46,7 +46,7 @@ describe('LLM profile dropdown', () => {
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
   });
 
-  it('shows an edit icon for the selected profile while open', async () => {
+  it('closes on selection and shows the selected profile when reopened', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -64,6 +64,12 @@ describe('LLM profile dropdown', () => {
 
     const selection = getLastPostedOfType('setLlmProfileId');
     expect(selection.profileId).toBe('claude_4');
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText('Edit selected profile gpt-5')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByLabelText('LLM profile'));
 
     expect(await screen.findByLabelText('Edit selected profile claude_4')).toBeInTheDocument();
     expect(screen.queryByLabelText('Edit selected profile gpt-5')).not.toBeInTheDocument();
@@ -113,4 +119,3 @@ describe('LLM profile dropdown', () => {
     expect(await screen.findByText('Edit profile')).toBeInTheDocument();
   });
 });
-

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -375,6 +375,7 @@ function LlmProfileSelector({
 
   const handleSelect = (next: string | null) => {
     onSelect(next);
+    setIsOpen(false);
   };
 
   const isSelected = (candidate: string | null) => candidate === profileId;


### PR DESCRIPTION
Fixes the Profiles dropdown UX in the Conversation toolbar:\n\n- Selecting a profile now closes the dropdown (prevents the check/gear decorations from visibly changing while the menu is still open).\n- Updated the dropdown unit test to assert close-on-select + correct selection after reopen.\n\nTests:\n- npx vitest run src/webview-src/__tests__/LlmProfileDropdown.test.tsx\n- npx vitest run src/webview-src/__tests__/App.toolbar.test.tsx\n