### PR TITLE
oh-tab-3rs6: Empty Git HEAD diff fallback

### DIFF
--- a/src/webview/host/__tests__/createWebviewMessageHandler.openWorkspaceDiff.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.openWorkspaceDiff.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../diffDocuments', () => ({
+  showWorkspaceDiff: vi.fn(async () => {}),
+}));
+
+vi.mock('../gitHeadDiff', () => ({
+  resolveGitHeadDiffContents: vi.fn(async (args: any) => ({
+    oldContent: args.fallbackOldContent,
+    newContent: args.fallbackNewContent,
+    source: 'fallback',
+  })),
+}));
+
+import * as vscode from 'vscode';
+import { createWebviewMessageHandler } from '../createWebviewMessageHandler';
+import { showWorkspaceDiff } from '../diffDocuments';
+import { resolveGitHeadDiffContents } from '../gitHeadDiff';
+
+describe('createWebviewMessageHandler(openWorkspaceDiff)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode as any).__resetMocks?.();
+  });
+
+  it('uses an empty fallback before-content when preferGitHead is enabled', async () => {
+    const handler = createWebviewMessageHandler({
+      context: { subscriptions: [] } as any,
+      host: { postMessage: vi.fn(async () => true) },
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp',
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    await handler({
+      type: 'openWorkspaceDiff',
+      path: 'README.md',
+      oldContent: 'OLD CONTENT',
+      newContent: 'NEW CONTENT',
+      preferGitHead: true,
+    });
+
+    expect(resolveGitHeadDiffContents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fallbackOldContent: '',
+        fallbackNewContent: 'NEW CONTENT',
+      }),
+    );
+
+    expect(showWorkspaceDiff).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: 'README.md',
+        oldContent: '',
+        newContent: 'NEW CONTENT',
+      }),
+    );
+  });
+});
+

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -330,7 +330,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
             const resolved = await resolveGitHeadDiffContents({
               workspaceRoot: wsRoot,
               resolvedPath,
-              fallbackOldContent: oldContent,
+              fallbackOldContent: '',
               fallbackNewContent: newContent,
               execFileText,
               readFileText: (filePath) => fs.readFile(filePath, 'utf8'),


### PR DESCRIPTION
Implements the remaining fallback behavior for `oh-tab-3rs6`.

- When opening a file-edit diff with `preferGitHead=true` and `git show HEAD:<path>` fails, the left pane fallback is now empty (instead of using the per-step oldContent).
- Adds a unit test to lock in the behavior.

Test:
- `npx vitest run src/webview/host/__tests__/createWebviewMessageHandler.openWorkspaceDiff.test.ts`
