### PR TITLE
oh-tab-7ybl: Persist Servers list across reload

### DIFF
--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -4,28 +4,40 @@ import type { SettingsAdapter } from './SettingsAdapter';
 export class VscodeSettingsAdapter implements SettingsAdapter {
   constructor(private context: vscode.ExtensionContext) {}
 
+  private getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    return workspaceFolder
+      ? vscode.workspace.getConfiguration(undefined, workspaceFolder.uri)
+      : vscode.workspace.getConfiguration();
+  }
+
   get<T = unknown>(key: string, defaultValue?: T): T | undefined {
-    const cfg = vscode.workspace.getConfiguration();
+    const cfg = this.getWorkspaceConfiguration();
     return defaultValue !== undefined
       ? cfg.get<T>(key, defaultValue)
       : cfg.get<T>(key);
   }
 
   getExplicit<T = unknown>(key: string): T | undefined {
-    const inspected = vscode.workspace.getConfiguration().inspect<T>(key);
+    const inspected = this.getWorkspaceConfiguration().inspect<T>(key);
     if (!inspected) return undefined;
     // Prefer workspace folder override, then workspace, then global
     return (inspected.workspaceFolderValue as T) ?? (inspected.workspaceValue as T) ?? (inspected.globalValue as T) ?? undefined;
   }
 
   async update<T = unknown>(key: string, value: T, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
-    const hasWorkspace = !!vscode.workspace.workspaceFolders?.length;
+    const hasWorkspaceFolder = !!vscode.workspace.workspaceFolders?.length;
     const effectiveTarget =
-      target === 'workspace' && hasWorkspace
-        ? vscode.ConfigurationTarget.Workspace
+      target === 'workspace' && hasWorkspaceFolder
+        ? vscode.ConfigurationTarget.WorkspaceFolder
         : vscode.ConfigurationTarget.Global;
 
-    await vscode.workspace.getConfiguration().update(key, value, effectiveTarget);
+    const cfg =
+      effectiveTarget === vscode.ConfigurationTarget.WorkspaceFolder
+        ? this.getWorkspaceConfiguration()
+        : vscode.workspace.getConfiguration();
+
+    await cfg.update(key, value, effectiveTarget);
   }
 
   async getSecret(key: string): Promise<string | undefined> {

--- a/src/settings/__tests__/VscodeSettingsAdapter.test.ts
+++ b/src/settings/__tests__/VscodeSettingsAdapter.test.ts
@@ -155,7 +155,7 @@ describe('VscodeSettingsAdapter', () => {
       expect(mockConfiguration.update).toHaveBeenCalledWith(
         key,
         value,
-        vscode.ConfigurationTarget.Workspace
+        vscode.ConfigurationTarget.WorkspaceFolder
       );
     });
 
@@ -202,7 +202,7 @@ describe('VscodeSettingsAdapter', () => {
       expect(mockConfiguration.update).toHaveBeenCalledWith(
         key,
         value,
-        vscode.ConfigurationTarget.Workspace
+        vscode.ConfigurationTarget.WorkspaceFolder
       );
     });
   });

--- a/src/webview/host/__tests__/createWebviewMessageHandler.serversPersist.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.serversPersist.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { createWebviewMessageHandler } from '../createWebviewMessageHandler';
+
+describe('createWebviewMessageHandler (servers persistence)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode as any).__resetMocks();
+  });
+
+  it('persists add/remove server changes to workspace folder settings', async () => {
+    const globalValues = new Map<string, unknown>();
+    const workspaceValues = new Map<string, unknown>();
+    const workspaceFolderValues = new Map<string, unknown>();
+
+    // Simulate VS Code precedence: workspace-folder overrides workspace overrides global.
+    const cfg = {
+      get: vi.fn((key: string, defaultValue?: unknown) => {
+        if (workspaceFolderValues.has(key)) return workspaceFolderValues.get(key);
+        if (workspaceValues.has(key)) return workspaceValues.get(key);
+        if (globalValues.has(key)) return globalValues.get(key);
+        return defaultValue;
+      }),
+      inspect: vi.fn((key: string) => ({
+        globalValue: globalValues.get(key),
+        workspaceValue: workspaceValues.get(key),
+        workspaceFolderValue: workspaceFolderValues.get(key),
+      })),
+      update: vi.fn(async (key: string, value: unknown, target: number) => {
+        if (target === (vscode.ConfigurationTarget as any).Global) {
+          globalValues.set(key, value);
+        } else if (target === (vscode.ConfigurationTarget as any).Workspace) {
+          workspaceValues.set(key, value);
+        } else if (target === (vscode.ConfigurationTarget as any).WorkspaceFolder) {
+          workspaceFolderValues.set(key, value);
+        } else {
+          throw new Error(`Unexpected configuration target: ${String(target)}`);
+        }
+      }),
+    };
+
+    (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
+
+    workspaceFolderValues.set('openhands.servers', [{ url: 'http://old.example:3000', label: 'Old' }]);
+    workspaceFolderValues.set('openhands.serverUrl', 'http://old.example:3000');
+
+    const context = {
+      secrets: {
+        get: vi.fn(async () => undefined),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      },
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    const hostPostMessage = vi.fn(async () => true);
+
+    const handler = createWebviewMessageHandler({
+      context,
+      host: { postMessage: hostPostMessage },
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp/openhands-conversations',
+      setWebviewReadyState: () => undefined,
+      setLastKnownLlmLabel: () => undefined,
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => undefined,
+      onRenderedEventsResponse: () => undefined,
+      onUiStateResponse: () => undefined,
+      onHalStateResponse: () => undefined,
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => undefined,
+    });
+
+    await handler({ type: 'addServer', server: { url: 'http://new.example:3000', label: 'New' } });
+    await handler({ type: 'removeServer', url: 'http://old.example:3000' });
+
+    expect(workspaceFolderValues.get('openhands.servers')).toEqual([{ url: 'http://new.example:3000', label: 'New' }]);
+    expect(workspaceFolderValues.get('openhands.serverUrl')).toBe('');
+  });
+});
+


### PR DESCRIPTION
Fixes oh-tab-7ybl.

Problem: Server add/remove UI updates could appear to work, but the persisted settings would be written to the wrong configuration target in multi-root (workspace-folder overrides stay unchanged), so a window reload would revert to the previous servers list.

Fix:
- Treat the first workspace folder as the settings scope and persist workspace-scoped updates to `vscode.ConfigurationTarget.WorkspaceFolder`.
- Add a unit test that simulates workspace-folder precedence and verifies add/remove updates persist.

Tests:
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved settings configuration handling across different scopes for better scope-aware behavior.
  * Enhanced server configuration persistence in workspace folder settings.

* **Tests**
  * Updated tests to reflect refined configuration target selection.
  * Added test coverage for server persistence in workspace settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->