### PR TITLE
oh-tab-uad0: Hide conversation id subtitle

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -369,9 +369,10 @@ describe('App - Advanced Test Coverage', () => {
       // Conversation started clears the events but doesn't show a toast
       // The implementation comment says: "No toast: UI clears and restored/started messages will render naturally"
       await waitFor(() => {
-        // Verify the conversation ID is shown in the header
-        expect(screen.getByText(/conv-123/i)).toBeInTheDocument();
+        expect(screen.getByText('OpenHands')).toBeInTheDocument();
       });
+
+      expect(screen.queryByText(/conv-123/i)).not.toBeInTheDocument();
     });
 
     it('handles conversation ID updates without crashing', async () => {
@@ -381,12 +382,11 @@ describe('App - Advanced Test Coverage', () => {
       postToWindow({ type: 'conversationStarted', conversationId: 'test-conversation-id-123' });
 
       // The component should handle the conversation ID without crashing
-      // The conversation ID is shown in the header (first 8 chars)
       await waitFor(() => {
-        expect(screen.getByText(/test-con/i)).toBeInTheDocument();
+        expect(screen.getByText('OpenHands')).toBeInTheDocument();
       });
 
-      expect(screen.getByText('OpenHands')).toBeInTheDocument();
+      expect(screen.queryByText(/test-con/i)).not.toBeInTheDocument();
     });
 
     it('shows error banner on error message', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1378,7 +1378,6 @@ export function App() {
       <Header
         status={status}
         mode={mode}
-        conversationId={conversationId}
         currentServerUrl={currentServerUrl}
         servers={servers}
         totals={conversationTotals}

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -4,7 +4,6 @@ import { ServerSelector, getServerDisplayLabel, type SavedServer } from './Serve
 interface HeaderProps {
   status: 'online' | 'offline' | 'connecting';
   mode: 'local' | 'remote';
-  conversationId?: string;
   currentServerUrl?: string;
   servers: SavedServer[];
   totals: {
@@ -110,7 +109,6 @@ function IconButton({
 export function Header({
   status,
   mode,
-  conversationId,
   currentServerUrl,
   servers,
   totals,
@@ -157,11 +155,6 @@ export function Header({
             </div>
             <div>
               <div className="font-semibold text-base leading-tight text-stone-100">OpenHands</div>
-              {conversationId && (
-                <div className="text-xs text-stone-500 font-mono leading-tight">
-                  {conversationId.slice(0, 8)}
-                </div>
-              )}
             </div>
           </div>
 


### PR DESCRIPTION
Fixes oh-tab-uad0.

- Remove the conversation id subtitle under the OpenHands header.

Tests:
- `npm test`
