### PR TITLE
oh-tab-gjr1: Hide Total cost when unknown

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -35,7 +35,7 @@ describe('App toolbar interactions', () => {
 
     const totalsRow = await screen.findByTestId('header-totals-row');
     expect(totalsRow).toHaveTextContent('Context:');
-    expect(totalsRow).toHaveTextContent('Total cost:');
+    expect(totalsRow).not.toHaveTextContent('Total cost:');
 
     await act(async () => {
       window.dispatchEvent(new MessageEvent('message', {
@@ -81,7 +81,8 @@ describe('App toolbar interactions', () => {
     });
 
     expect(totalsRow).toHaveTextContent('Context: 12 tokens');
-    expect(totalsRow).toHaveTextContent('Total cost: —');
+    expect(totalsRow).not.toHaveTextContent('Total cost:');
+    expect(totalsRow).not.toHaveTextContent('—');
   });
 
   it('shows the configured LLM profile in the input row', async () => {

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -253,12 +253,14 @@ export function Header({
           <span>tokens</span>
         </div>
 
-        <div className="flex items-center gap-1.5">
-          <span>Total cost:</span>{' '}
-          <span className="font-mono text-stone-300">
-            {totals.costIsKnown ? formatCost(totals.totalCost) : '—'}
-          </span>
-        </div>
+        {totals.costIsKnown && (
+          <div className="flex items-center gap-1.5">
+            <span>Total cost:</span>{' '}
+            <span className="font-mono text-stone-300">
+              {formatCost(totals.totalCost)}
+            </span>
+          </div>
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
Fixes oh-tab-gjr1.

- Hide the `Total cost` field entirely when `costIsKnown=false`.
- Keep Context tokens visible.

Tests:
- `npm test`
