### PR TITLE
[oh-tab-i2ma] Provider API key fallback for profiles

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -20,7 +20,16 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileDeleteResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileDeleteResponse'; requestId: string; ok: false; profileId: string; error: string }
-  | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: true; profileId: string; hasKey: boolean }
+  | {
+    type: 'llmProfileApiKeyStatusResponse';
+    requestId: string;
+    ok: true;
+    profileId: string;
+    hasKey: boolean;
+    hasProfileKey: boolean;
+    hasProviderKey: boolean;
+    providerKeyName?: string;
+  }
   | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: false; profileId: string; error: string }

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -26,9 +26,9 @@ describe('LLM Profiles view', () => {
     cleanup();
   });
 
-    it('supports per-profile API key configuration', async () => {
-      render(<App />);
-      mockApi.postMessage.mockClear();
+  it('supports per-profile API key configuration', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
 
     fireEvent.click(screen.getByLabelText('LLM Profiles'));
 
@@ -63,28 +63,28 @@ describe('LLM Profiles view', () => {
       expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
     });
 
-      const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-      postToWindow({
-        type: 'llmProfileApiKeyStatusResponse',
-        requestId: statusRequest.requestId,
-        ok: true,
-        profileId: 'gpt-5',
-        hasKey: false,
-        hasProfileKey: false,
-        hasProviderKey: false,
-        providerKeyName: 'OPENAI_API_KEY',
-      });
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+      hasProfileKey: false,
+      hasProviderKey: false,
+      providerKeyName: 'OPENAI_API_KEY',
+    });
 
-      expect(await screen.findByText('Missing')).toBeInTheDocument();
+    expect(await screen.findByText('Missing')).toBeInTheDocument();
 
-      fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
 
-      const apiKeyInput = await screen.findByLabelText('API key override');
-      fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
+    const apiKeyInput = await screen.findByLabelText('API key override');
+    fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
 
-      await waitFor(() => {
-        expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();
     });
 
     const setRequest = getLastPostedOfType('llmProfileApiKeySetRequest');
@@ -104,22 +104,22 @@ describe('LLM Profiles view', () => {
       expect(latest.requestId).not.toBe(statusRequest.requestId);
     });
 
-      const statusRequest2 = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-      postToWindow({
-        type: 'llmProfileApiKeyStatusResponse',
-        requestId: statusRequest2.requestId,
-        ok: true,
-        profileId: 'gpt-5',
-        hasKey: true,
-        hasProfileKey: true,
-        hasProviderKey: false,
-        providerKeyName: 'OPENAI_API_KEY',
-      });
-
-      expect(await screen.findByText('Override set')).toBeInTheDocument();
-
-      expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
+    const statusRequest2 = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest2.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: true,
+      hasProfileKey: true,
+      hasProviderKey: false,
+      providerKeyName: 'OPENAI_API_KEY',
     });
+
+    expect(await screen.findByText('Override set')).toBeInTheDocument();
+
+    expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
+  });
 
   it('supports a collapsible Advanced settings section', async () => {
     render(<App />);
@@ -257,7 +257,7 @@ describe('LLM Profiles view', () => {
     expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
   });
 
-    it('duplicates an existing profile into a new create form', async () => {
+  it('duplicates an existing profile into a new create form', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -307,13 +307,13 @@ describe('LLM Profiles view', () => {
     expect(baseUrlToggle).toBeChecked();
     expect(screen.getByLabelText('Base URL')).toHaveValue('https://example.com/v1');
 
-      fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
-      expect(await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' })).toHaveValue(2048);
+    fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
+    expect(await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' })).toHaveValue(2048);
 
-      expect(screen.getByText('Use provider key')).toBeInTheDocument();
-      expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).not.toBeChecked();
-      expect(screen.queryByLabelText('API key override')).toBeNull();
-    });
+    expect(screen.getByText('Use provider key')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).not.toBeChecked();
+    expect(screen.queryByLabelText('API key override')).toBeNull();
+  });
 
   it('deletes an existing profile and returns to create mode', async () => {
     render(<App />);
@@ -374,7 +374,7 @@ describe('LLM Profiles view', () => {
     expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
   });
 
-    it('shows an inline missing API key warning and blocks save in create mode', async () => {
+  it('shows an inline missing API key warning and blocks save in create mode', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -387,25 +387,25 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
 
-      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
-      fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
-      fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
 
-      fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-      expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
-      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
+    expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
+    expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
 
-      fireEvent.change(screen.getByLabelText('API key override'), { target: { value: 'sk-test' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.change(screen.getByLabelText('API key override'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-      await waitFor(() => {
-        expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
     });
   });
 
-    it('preserves the draft API key when initial key storage fails during create', async () => {
+  it('preserves the draft API key when initial key storage fails during create', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -418,13 +418,13 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
 
-      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
-      fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
-      fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
 
-      fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
-      fireEvent.change(await screen.findByLabelText('API key override'), { target: { value: 'sk-test' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
+    fireEvent.change(await screen.findByLabelText('API key override'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
@@ -455,23 +455,23 @@ describe('LLM Profiles view', () => {
       expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
     });
 
-      const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-      postToWindow({
-        type: 'llmProfileApiKeyStatusResponse',
-        requestId: statusRequest.requestId,
-        ok: true,
-        profileId: 'gpt-5',
-        hasKey: false,
-        hasProfileKey: false,
-        hasProviderKey: false,
-        providerKeyName: 'OPENAI_API_KEY',
-      });
-
-      expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).toBeChecked();
-      expect(await screen.findByLabelText('API key override')).toHaveValue('sk-test');
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+      hasProfileKey: false,
+      hasProviderKey: false,
+      providerKeyName: 'OPENAI_API_KEY',
     });
 
-    it('shows an inline missing API key warning and blocks save in edit mode', async () => {
+    expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).toBeChecked();
+    expect(await screen.findByLabelText('API key override')).toHaveValue('sk-test');
+  });
+
+  it('shows an inline missing API key warning and blocks save in edit mode', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -503,26 +503,26 @@ describe('LLM Profiles view', () => {
       expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
     });
 
-      const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-      postToWindow({
-        type: 'llmProfileApiKeyStatusResponse',
-        requestId: statusRequest.requestId,
-        ok: true,
-        profileId: 'gpt-5',
-        hasKey: false,
-        hasProfileKey: false,
-        hasProviderKey: false,
-        providerKeyName: 'OPENAI_API_KEY',
-      });
-
-      fireEvent.click(await screen.findByRole('checkbox', { name: 'Override for this profile' }));
-      expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
-
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
-      expect(await screen.findByLabelText('API key override')).toBeInTheDocument();
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+      hasProfileKey: false,
+      hasProviderKey: false,
+      providerKeyName: 'OPENAI_API_KEY',
     });
+
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Override for this profile' }));
+    expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
+    expect(await screen.findByLabelText('API key override')).toBeInTheDocument();
+  });
 
   it('offers a Provider docs link based on the selected provider', async () => {
     render(<App />);

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -26,9 +26,9 @@ describe('LLM Profiles view', () => {
     cleanup();
   });
 
-  it('supports per-profile API key configuration', async () => {
-    render(<App />);
-    mockApi.postMessage.mockClear();
+    it('supports per-profile API key configuration', async () => {
+      render(<App />);
+      mockApi.postMessage.mockClear();
 
     fireEvent.click(screen.getByLabelText('LLM Profiles'));
 
@@ -63,25 +63,28 @@ describe('LLM Profiles view', () => {
       expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
     });
 
-    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-    postToWindow({
-      type: 'llmProfileApiKeyStatusResponse',
-      requestId: statusRequest.requestId,
-      ok: true,
-      profileId: 'gpt-5',
-      hasKey: false,
-    });
+      const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+      postToWindow({
+        type: 'llmProfileApiKeyStatusResponse',
+        requestId: statusRequest.requestId,
+        ok: true,
+        profileId: 'gpt-5',
+        hasKey: false,
+        hasProfileKey: false,
+        hasProviderKey: false,
+        providerKeyName: 'OPENAI_API_KEY',
+      });
 
-    expect(await screen.findByText('Not set')).toBeInTheDocument();
+      expect(await screen.findByText('Missing')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Set key…' }));
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
 
-    const apiKeyInput = await screen.findByLabelText('New API key');
-    fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
+      const apiKeyInput = await screen.findByLabelText('API key override');
+      fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
 
-    await waitFor(() => {
-      expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();
+      await waitFor(() => {
+        expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();
     });
 
     const setRequest = getLastPostedOfType('llmProfileApiKeySetRequest');
@@ -101,19 +104,22 @@ describe('LLM Profiles view', () => {
       expect(latest.requestId).not.toBe(statusRequest.requestId);
     });
 
-    const statusRequest2 = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-    postToWindow({
-      type: 'llmProfileApiKeyStatusResponse',
-      requestId: statusRequest2.requestId,
-      ok: true,
-      profileId: 'gpt-5',
-      hasKey: true,
+      const statusRequest2 = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+      postToWindow({
+        type: 'llmProfileApiKeyStatusResponse',
+        requestId: statusRequest2.requestId,
+        ok: true,
+        profileId: 'gpt-5',
+        hasKey: true,
+        hasProfileKey: true,
+        hasProviderKey: false,
+        providerKeyName: 'OPENAI_API_KEY',
+      });
+
+      expect(await screen.findByText('Override set')).toBeInTheDocument();
+
+      expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
     });
-
-    expect(await screen.findByText('Set')).toBeInTheDocument();
-
-    expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
-  });
 
   it('supports a collapsible Advanced settings section', async () => {
     render(<App />);
@@ -251,7 +257,7 @@ describe('LLM Profiles view', () => {
     expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
   });
 
-  it('duplicates an existing profile into a new create form', async () => {
+    it('duplicates an existing profile into a new create form', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -301,12 +307,13 @@ describe('LLM Profiles view', () => {
     expect(baseUrlToggle).toBeChecked();
     expect(screen.getByLabelText('Base URL')).toHaveValue('https://example.com/v1');
 
-    fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
-    expect(await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' })).toHaveValue(2048);
+      fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
+      expect(await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' })).toHaveValue(2048);
 
-    const apiKeyInput = await screen.findByLabelText('API key');
-    expect(apiKeyInput).toHaveValue('');
-  });
+      expect(screen.getByText('Use provider key')).toBeInTheDocument();
+      expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).not.toBeChecked();
+      expect(screen.queryByLabelText('API key override')).toBeNull();
+    });
 
   it('deletes an existing profile and returns to create mode', async () => {
     render(<App />);
@@ -367,7 +374,7 @@ describe('LLM Profiles view', () => {
     expect(screen.getByRole('button', { name: 'Delete profile' })).toBeDisabled();
   });
 
-  it('shows an inline missing API key warning and blocks save in create mode', async () => {
+    it('shows an inline missing API key warning and blocks save in create mode', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -380,24 +387,25 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
-    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
+      fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
+      fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
-    expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
+      expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
+      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
 
-    fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'sk-test' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.change(screen.getByLabelText('API key override'), { target: { value: 'sk-test' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-    await waitFor(() => {
-      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
+      await waitFor(() => {
+        expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
     });
   });
 
-  it('preserves the draft API key when initial key storage fails during create', async () => {
+    it('preserves the draft API key when initial key storage fails during create', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -410,12 +418,13 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
 
-    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
-    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+      fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
+      fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
+      fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
 
-    fireEvent.change(await screen.findByLabelText('API key'), { target: { value: 'sk-test' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
+      fireEvent.change(await screen.findByLabelText('API key override'), { target: { value: 'sk-test' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileSaveRequest')).toBeTruthy();
@@ -446,14 +455,23 @@ describe('LLM Profiles view', () => {
       expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
     });
 
-    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-    postToWindow({ type: 'llmProfileApiKeyStatusResponse', requestId: statusRequest.requestId, ok: true, hasKey: false });
+      const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+      postToWindow({
+        type: 'llmProfileApiKeyStatusResponse',
+        requestId: statusRequest.requestId,
+        ok: true,
+        profileId: 'gpt-5',
+        hasKey: false,
+        hasProfileKey: false,
+        hasProviderKey: false,
+        providerKeyName: 'OPENAI_API_KEY',
+      });
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Set key…' }));
-    expect(await screen.findByLabelText('New API key')).toHaveValue('sk-test');
-  });
+      expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).toBeChecked();
+      expect(await screen.findByLabelText('API key override')).toHaveValue('sk-test');
+    });
 
-  it('shows an inline missing API key warning and blocks save in edit mode', async () => {
+    it('shows an inline missing API key warning and blocks save in edit mode', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();
 
@@ -485,22 +503,26 @@ describe('LLM Profiles view', () => {
       expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
     });
 
-    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
-    postToWindow({
-      type: 'llmProfileApiKeyStatusResponse',
-      requestId: statusRequest.requestId,
-      ok: true,
-      profileId: 'gpt-5',
-      hasKey: false,
+      const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+      postToWindow({
+        type: 'llmProfileApiKeyStatusResponse',
+        requestId: statusRequest.requestId,
+        ok: true,
+        profileId: 'gpt-5',
+        hasKey: false,
+        hasProfileKey: false,
+        hasProviderKey: false,
+        providerKeyName: 'OPENAI_API_KEY',
+      });
+
+      fireEvent.click(await screen.findByRole('checkbox', { name: 'Override for this profile' }));
+      expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
+      expect(await screen.findByLabelText('API key override')).toBeInTheDocument();
     });
-
-    expect(await screen.findByText('You must provide a valid API key.')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
-
-    expect(getLastPostedOfType('llmProfileSaveRequest')).toBeNull();
-    expect(await screen.findByLabelText('New API key')).toBeInTheDocument();
-  });
 
   it('offers a Provider docs link based on the selected provider', async () => {
     render(<App />);

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -144,7 +144,7 @@ type PendingLlmProfilesRequest =
   }
   | {
     kind: 'apiKeyStatus';
-    resolve: (hasKey: boolean) => void;
+    resolve: (status: LlmProfileApiKeyStatusInfo) => void;
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   }
@@ -154,6 +154,13 @@ type PendingLlmProfilesRequest =
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   };
+
+type LlmProfileApiKeyStatusInfo = {
+  hasKey: boolean;
+  hasProfileKey: boolean;
+  hasProviderKey: boolean;
+  providerKeyName?: string;
+};
 
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.
@@ -339,9 +346,9 @@ export function App() {
     });
   }, [postMessage]);
 
-  const getLlmProfileApiKeyStatus = useCallback(async (profileId: string): Promise<boolean> => {
+  const getLlmProfileApiKeyStatus = useCallback(async (profileId: string): Promise<LlmProfileApiKeyStatusInfo> => {
     const requestId = createLlmProfilesRequestId('apiKeyStatus');
-    return await new Promise<boolean>((resolve, reject) => {
+    return await new Promise<LlmProfileApiKeyStatusInfo>((resolve, reject) => {
       const timeout = setTimeout(() => {
         pendingLlmProfilesRequestsRef.current.delete(requestId);
         reject(new Error('Timed out fetching LLM profile API key status'));
@@ -613,6 +620,9 @@ export function App() {
         profileId?: unknown;
         profile?: unknown;
         hasKey?: unknown;
+        hasProfileKey?: unknown;
+        hasProviderKey?: unknown;
+        providerKeyName?: unknown;
         elevenlabs?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
         seq?: unknown;
@@ -754,8 +764,28 @@ export function App() {
           if (!pending || pending.kind !== 'apiKeyStatus') break;
           pendingLlmProfilesRequestsRef.current.delete(requestId);
           clearTimeout(pending.timeout);
+          const providerKeyName = typeof payload.providerKeyName === 'string' ? payload.providerKeyName : undefined;
+          if (
+            payload.ok === true &&
+            typeof payload.hasKey === 'boolean' &&
+            typeof payload.hasProfileKey === 'boolean' &&
+            typeof payload.hasProviderKey === 'boolean'
+          ) {
+            pending.resolve({
+              hasKey: payload.hasKey,
+              hasProfileKey: payload.hasProfileKey,
+              hasProviderKey: payload.hasProviderKey,
+              providerKeyName,
+            });
+            break;
+          }
           if (payload.ok === true && typeof payload.hasKey === 'boolean') {
-            pending.resolve(payload.hasKey);
+            pending.resolve({
+              hasKey: payload.hasKey,
+              hasProfileKey: payload.hasKey,
+              hasProviderKey: false,
+              providerKeyName,
+            });
             break;
           }
           const reason = typeof payload.error === 'string' ? payload.error : 'Failed to fetch LLM profile API key status';

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -34,8 +34,15 @@ type FieldErrors = Partial<Record<keyof ProfileFormState, string>>;
 type ApiKeyStatus =
   | { state: 'unknown' }
   | { state: 'loading' }
-  | { state: 'ready'; hasKey: boolean }
+  | { state: 'ready'; hasKey: boolean; hasProfileKey: boolean; hasProviderKey: boolean; providerKeyName?: string }
   | { state: 'error'; error: string };
+
+type LlmProfileApiKeyStatusInfo = {
+  hasKey: boolean;
+  hasProfileKey: boolean;
+  hasProviderKey: boolean;
+  providerKeyName?: string;
+};
 
 const EMPTY_FORM: ProfileFormState = {
   name: '',
@@ -369,7 +376,7 @@ export function LlmProfilesView(props: {
   loadProfile: (profileId: string) => Promise<LLMConfiguration>;
   saveProfile: (profileId: string, profile: LLMConfiguration) => Promise<void>;
   deleteProfile: (profileId: string) => Promise<void>;
-  getApiKeyStatus: (profileId: string) => Promise<boolean>;
+  getApiKeyStatus: (profileId: string) => Promise<LlmProfileApiKeyStatusInfo>;
   setApiKey: (profileId: string, apiKey: string) => Promise<void>;
 }) {
   const {
@@ -405,7 +412,7 @@ export function LlmProfilesView(props: {
   const [deleting, setDeleting] = useState(false);
   const [topError, setTopError] = useState<string | null>(null);
   const [apiKeyStatus, setApiKeyStatus] = useState<ApiKeyStatus>({ state: 'unknown' });
-  const [showApiKeyEditor, setShowApiKeyEditor] = useState(false);
+  const [overrideProfileApiKey, setOverrideProfileApiKey] = useState(false);
   const [apiKeyInput, setApiKeyInput] = useState('');
   const [apiKeySaving, setApiKeySaving] = useState(false);
   const [apiKeyError, setApiKeyError] = useState<string | null>(null);
@@ -421,9 +428,12 @@ export function LlmProfilesView(props: {
     if (activeProfileIdRef.current !== profileId) return;
     setApiKeyStatus({ state: 'loading' });
     try {
-      const hasKey = await getApiKeyStatus(profileId);
+      const status = await getApiKeyStatus(profileId);
       if (activeProfileIdRef.current !== profileId) return;
-      setApiKeyStatus({ state: 'ready', hasKey });
+      setApiKeyStatus({ state: 'ready', ...status });
+      if (status.hasProfileKey) {
+        setOverrideProfileApiKey(true);
+      }
     } catch (err) {
       const reason = err instanceof Error ? err.message : String(err);
       if (activeProfileIdRef.current !== profileId) return;
@@ -468,7 +478,7 @@ export function LlmProfilesView(props: {
     setSaveAttempted(false);
     setTopError(null);
     setApiKeyStatus({ state: 'unknown' });
-    setShowApiKeyEditor(false);
+    setOverrideProfileApiKey(false);
     setApiKeyInput('');
     setApiKeySaving(false);
     setApiKeyError(null);
@@ -537,16 +547,14 @@ export function LlmProfilesView(props: {
     const trimmedDraftApiKey = apiKeyInput.trim();
     const canEditApiKeyForSave = mode === 'edit' && !!selectedProfileId && !loadingProfile;
 
-    if (providerRequiresApiKey) {
-      if (mode === 'create') {
-        if (!trimmedDraftApiKey) {
-          requestAnimationFrame(() => {
-            apiKeyInputRef.current?.focus();
-          });
-          return;
-        }
-      } else if (canEditApiKeyForSave && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasKey) {
-        setShowApiKeyEditor(true);
+    if (providerRequiresApiKey && overrideProfileApiKey) {
+      if (mode === 'create' && !trimmedDraftApiKey) {
+        requestAnimationFrame(() => {
+          apiKeyInputRef.current?.focus();
+        });
+        return;
+      }
+      if (canEditApiKeyForSave && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasProfileKey) {
         requestAnimationFrame(() => {
           apiKeyInputRef.current?.focus();
         });
@@ -561,7 +569,7 @@ export function LlmProfilesView(props: {
     setTopError(null);
     try {
       await saveProfile(profileId, config);
-      if (mode === 'create' && providerRequiresApiKey) {
+      if (mode === 'create' && providerRequiresApiKey && overrideProfileApiKey && trimmedDraftApiKey) {
         try {
           await setApiKey(profileId, trimmedDraftApiKey);
           setApiKeyInput('');
@@ -573,7 +581,6 @@ export function LlmProfilesView(props: {
       activeProfileIdRef.current = profileId;
       setMode('edit');
       setSelectedProfileId(profileId);
-      setShowApiKeyEditor(false);
       void refreshApiKeyStatus(profileId);
     } catch (err) {
       setTopError(err instanceof Error ? err.message : String(err));
@@ -586,6 +593,7 @@ export function LlmProfilesView(props: {
     form,
     loadingProfile,
     mode,
+    overrideProfileApiKey,
     refreshApiKeyStatus,
     refreshProfiles,
     saveProfile,
@@ -611,9 +619,9 @@ export function LlmProfilesView(props: {
   const providerDocsUrl = form.provider ? PROVIDER_DOCS_URLS[form.provider] : null;
   const providerLabel = form.provider ? PROVIDER_LABELS[form.provider] : null;
   const providerApiKeyUrl = form.provider ? (PROVIDER_API_KEY_URLS[form.provider] ?? null) : null;
-  const missingStoredApiKey = canEditApiKey && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasKey;
-  const missingDraftApiKey = mode === 'create' && saveAttempted && providerRequiresApiKey && !apiKeyInput.trim();
-  const showMissingApiKeyWarning = providerRequiresApiKey && (missingStoredApiKey || missingDraftApiKey);
+  const missingStoredApiKey = canEditApiKey && overrideProfileApiKey && apiKeyStatus.state === 'ready' && !apiKeyStatus.hasProfileKey;
+  const missingDraftApiKey = mode === 'create' && saveAttempted && providerRequiresApiKey && overrideProfileApiKey && !apiKeyInput.trim();
+  const showMissingApiKeyWarning = missingStoredApiKey || missingDraftApiKey;
   const maxOutputTokensSlider = (() => {
     const parsed = parseOptionalInt(form.maxOutputTokens);
     const value = parsed.value;
@@ -624,9 +632,14 @@ export function LlmProfilesView(props: {
   })();
 
   const apiKeyStatusLabel = (() => {
-    if (!canEditApiKey) return '—';
+    if (!providerRequiresApiKey) return '—';
+    if (mode === 'create') return overrideProfileApiKey ? (apiKeyInput.trim() ? 'Draft' : 'Not set') : 'Use provider key';
     if (apiKeyStatus.state === 'loading') return 'Checking…';
-    if (apiKeyStatus.state === 'ready') return apiKeyStatus.hasKey ? 'Set' : 'Not set';
+    if (apiKeyStatus.state === 'ready') {
+      if (apiKeyStatus.hasProfileKey) return 'Override set';
+      if (apiKeyStatus.hasProviderKey) return `Using ${apiKeyStatus.providerKeyName ?? 'provider key'}`;
+      return 'Missing';
+    }
     if (apiKeyStatus.state === 'error') return 'Error';
     return '—';
   })();
@@ -644,8 +657,6 @@ export function LlmProfilesView(props: {
       }
       await setApiKey(profileId, trimmed);
       setApiKeyInput('');
-      setShowApiKeyEditor(false);
-      setApiKeyStatus({ state: 'ready', hasKey: true });
       void refreshApiKeyStatus(profileId);
     } catch (err) {
       setApiKeyError(err instanceof Error ? err.message : String(err));
@@ -661,7 +672,6 @@ export function LlmProfilesView(props: {
     setApiKeyError(null);
     try {
       await setApiKey(profileId, '');
-      setApiKeyStatus({ state: 'ready', hasKey: false });
       void refreshApiKeyStatus(profileId);
     } catch (err) {
       setApiKeyError(err instanceof Error ? err.message : String(err));
@@ -669,6 +679,21 @@ export function LlmProfilesView(props: {
       setApiKeySaving(false);
     }
   }, [refreshApiKeyStatus, selectedProfileId, setApiKey]);
+
+  const handleToggleOverrideProfileApiKey = useCallback((next: boolean) => {
+    setOverrideProfileApiKey(next);
+    setApiKeyError(null);
+    setApiKeyInput('');
+    if (!next && mode === 'edit') {
+      void handleClearApiKey();
+      return;
+    }
+    if (next) {
+      requestAnimationFrame(() => {
+        apiKeyInputRef.current?.focus();
+      });
+    }
+  }, [handleClearApiKey, mode]);
 
   const handleHeaderEditClick = useCallback(() => {
     if (!selectedProfileId) return;
@@ -891,55 +916,22 @@ export function LlmProfilesView(props: {
                       )}
                     </div>
 
-                    {canEditApiKey ? (
-                      <div className="flex items-center gap-2">
+                    {providerRequiresApiKey ? (
+                      <div className="flex flex-col items-end gap-2">
                         <div className="text-xs text-stone-400">{apiKeyStatusLabel}</div>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setApiKeyError(null);
-                            setShowApiKeyEditor(true);
-                          }}
-                          disabled={apiKeySaving}
-                          className={`
-                            inline-flex items-center gap-2 px-3 py-1.5 rounded-lg
-                            text-xs font-medium
-                            transition-all
-                            border
-                            ${apiKeySaving
-                              ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
-                              : 'bg-white/[0.04] text-stone-300 border-white/[0.06] hover:bg-white/[0.08] hover:border-white/[0.1]'}
-                          `}
-                        >
-                          <span className="codicon codicon-key" />
-                          Set key…
-                        </button>
-                        {apiKeyStatus.state === 'ready' && apiKeyStatus.hasKey && (
-                          <button
-                            type="button"
-                            onClick={() => { void handleClearApiKey(); }}
-                            disabled={apiKeySaving}
-                            className={`
-                              inline-flex items-center gap-2 px-3 py-1.5 rounded-lg
-                              text-xs font-medium
-                              transition-all
-                              border
-                              ${apiKeySaving
-                                ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
-                                : 'bg-red-500/10 text-red-200 border-red-500/20 hover:bg-red-500/15 hover:border-red-500/30'}
-                            `}
-                          >
-                            <span className="codicon codicon-trash" />
-                            Clear
-                          </button>
-                        )}
+                        <label className="flex items-center gap-2 text-xs text-stone-300 select-none">
+                          <input
+                            type="checkbox"
+                            checked={overrideProfileApiKey}
+                            onChange={(e) => { handleToggleOverrideProfileApiKey(e.target.checked); }}
+                            disabled={apiKeySaving || (mode === 'edit' && !canEditApiKey)}
+                            className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 disabled:opacity-50"
+                          />
+                          Override for this profile
+                        </label>
                       </div>
-                    ) : mode === 'create' && providerRequiresApiKey ? (
-                      <div className="text-xs text-stone-400">Required</div>
                     ) : (
-                      <div className="text-xs text-stone-500">
-                        {mode === 'create' ? 'Select a provider to set a key.' : 'Save profile to set a key.'}
-                      </div>
+                      <div className="text-xs text-stone-500">Select a provider to configure keys.</div>
                     )}
                   </div>
 
@@ -949,9 +941,9 @@ export function LlmProfilesView(props: {
                     </div>
                   )}
 
-                  {mode === 'create' && providerRequiresApiKey && (
+                  {mode === 'create' && providerRequiresApiKey && overrideProfileApiKey && (
                     <div className="mt-3">
-                      <FieldLabel label="API key" required htmlFor="llmProfilesApiKeyCreate" />
+                      <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyCreate" />
                       <div className="mt-2">
                         <InputField
                           ref={apiKeyInputRef}
@@ -972,9 +964,9 @@ export function LlmProfilesView(props: {
                     <div className="mt-2 text-xs text-red-400">{apiKeyError}</div>
                   )}
 
-                  {canEditApiKey && showApiKeyEditor && (
+                  {mode === 'edit' && canEditApiKey && providerRequiresApiKey && overrideProfileApiKey && (
                     <div className="mt-3">
-                      <FieldLabel label="New API key" required htmlFor="llmProfilesApiKeyEdit" />
+                      <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyEdit" />
                       <div className="mt-2">
                         <InputField
                           ref={apiKeyInputRef}
@@ -1002,26 +994,6 @@ export function LlmProfilesView(props: {
                         >
                           <span className={`codicon codicon-${apiKeySaving ? 'loading' : 'save'} ${apiKeySaving ? 'animate-spin' : ''}`} />
                           Save key
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setShowApiKeyEditor(false);
-                            setApiKeyInput('');
-                            setApiKeyError(null);
-                          }}
-                          disabled={apiKeySaving}
-                          className={`
-                            inline-flex items-center gap-2 px-3 py-2 rounded-lg
-                            text-xs font-medium
-                            transition-all
-                            border
-                            ${apiKeySaving
-                              ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
-                              : 'bg-white/[0.04] text-stone-300 border-white/[0.06] hover:bg-white/[0.08] hover:border-white/[0.1]'}
-                          `}
-                        >
-                          Cancel
                         </button>
                       </div>
                     </div>

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -894,111 +894,111 @@ export function LlmProfilesView(props: {
                 <div className="text-sm text-stone-500">Loading profile…</div>
               ) : (
                 <div className="space-y-6">
-                <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <div className="text-sm font-medium text-stone-200">
-                        {providerLabel ? `${providerLabel} API key` : 'API key'}
+                  <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <div className="text-sm font-medium text-stone-200">
+                          {providerLabel ? `${providerLabel} API key` : 'API key'}
+                        </div>
+                        <div className="text-xs text-stone-500 mt-0.5">
+                          API keys are stored securely in VS Code Secret Storage. Not saved to disk.
+                        </div>
+                        {providerLabel && providerApiKeyUrl && (
+                          <button
+                            type="button"
+                            onClick={() => openMarkdownLink(providerApiKeyUrl)}
+                            className="mt-1 text-xs text-brand-300 underline decoration-white/20 hover:decoration-white/40 hover:text-brand-200 transition-colors"
+                            aria-label={`Get ${providerLabel} API Key`}
+                            title={`Get ${providerLabel} API Key`}
+                          >
+                            Get {providerLabel} API Key <span className="codicon codicon-link-external text-[11px]" />
+                          </button>
+                        )}
                       </div>
-                      <div className="text-xs text-stone-500 mt-0.5">
-                        API keys are stored securely in VS Code Secret Storage. Not saved to disk.
-                      </div>
-                      {providerLabel && providerApiKeyUrl && (
-                        <button
-                          type="button"
-                          onClick={() => openMarkdownLink(providerApiKeyUrl)}
-                          className="mt-1 text-xs text-brand-300 underline decoration-white/20 hover:decoration-white/40 hover:text-brand-200 transition-colors"
-                          aria-label={`Get ${providerLabel} API Key`}
-                          title={`Get ${providerLabel} API Key`}
-                        >
-                          Get {providerLabel} API Key <span className="codicon codicon-link-external text-[11px]" />
-                        </button>
+
+                      {providerRequiresApiKey ? (
+                        <div className="flex flex-col items-end gap-2">
+                          <div className="text-xs text-stone-400">{apiKeyStatusLabel}</div>
+                          <label className="flex items-center gap-2 text-xs text-stone-300 select-none">
+                            <input
+                              type="checkbox"
+                              checked={overrideProfileApiKey}
+                              onChange={(e) => { handleToggleOverrideProfileApiKey(e.target.checked); }}
+                              disabled={apiKeySaving || (mode === 'edit' && !canEditApiKey)}
+                              className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 disabled:opacity-50"
+                            />
+                            Override for this profile
+                          </label>
+                        </div>
+                      ) : (
+                        <div className="text-xs text-stone-500">Select a provider to configure keys.</div>
                       )}
                     </div>
 
-                    {providerRequiresApiKey ? (
-                      <div className="flex flex-col items-end gap-2">
-                        <div className="text-xs text-stone-400">{apiKeyStatusLabel}</div>
-                        <label className="flex items-center gap-2 text-xs text-stone-300 select-none">
-                          <input
-                            type="checkbox"
-                            checked={overrideProfileApiKey}
-                            onChange={(e) => { handleToggleOverrideProfileApiKey(e.target.checked); }}
-                            disabled={apiKeySaving || (mode === 'edit' && !canEditApiKey)}
-                            className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 disabled:opacity-50"
-                          />
-                          Override for this profile
-                        </label>
+                    {showMissingApiKeyWarning && (
+                      <div className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
+                        You must provide a valid API key.
                       </div>
-                    ) : (
-                      <div className="text-xs text-stone-500">Select a provider to configure keys.</div>
+                    )}
+
+                    {mode === 'create' && providerRequiresApiKey && overrideProfileApiKey && (
+                      <div className="mt-3">
+                        <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyCreate" />
+                        <div className="mt-2">
+                          <InputField
+                            ref={apiKeyInputRef}
+                            id="llmProfilesApiKeyCreate"
+                            value={apiKeyInput}
+                            onChange={setApiKeyInput}
+                            placeholder="(hidden)"
+                            type="password"
+                          />
+                        </div>
+                      </div>
+                    )}
+
+                    {canEditApiKey && apiKeyStatus.state === 'error' && (
+                      <div className="mt-2 text-xs text-red-400">{apiKeyStatus.error}</div>
+                    )}
+                    {canEditApiKey && apiKeyError && (
+                      <div className="mt-2 text-xs text-red-400">{apiKeyError}</div>
+                    )}
+
+                    {mode === 'edit' && canEditApiKey && providerRequiresApiKey && overrideProfileApiKey && (
+                      <div className="mt-3">
+                        <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyEdit" />
+                        <div className="mt-2">
+                          <InputField
+                            ref={apiKeyInputRef}
+                            id="llmProfilesApiKeyEdit"
+                            value={apiKeyInput}
+                            onChange={setApiKeyInput}
+                            placeholder="(hidden)"
+                            type="password"
+                          />
+                        </div>
+                        <div className="mt-3 flex items-center gap-2">
+                          <button
+                            type="button"
+                            onClick={() => { void handleSetApiKey(); }}
+                            disabled={apiKeySaving}
+                            className={`
+                              inline-flex items-center gap-2 px-3 py-2 rounded-lg
+                              text-xs font-medium
+                              transition-all
+                              border
+                              ${apiKeySaving
+                                ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
+                                : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
+                            `}
+                          >
+                            <span className={`codicon codicon-${apiKeySaving ? 'loading' : 'save'} ${apiKeySaving ? 'animate-spin' : ''}`} />
+                            Save key
+                          </button>
+                        </div>
+                      </div>
                     )}
                   </div>
-
-                  {showMissingApiKeyWarning && (
-                    <div className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-200">
-                      You must provide a valid API key.
-                    </div>
-                  )}
-
-                  {mode === 'create' && providerRequiresApiKey && overrideProfileApiKey && (
-                    <div className="mt-3">
-                      <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyCreate" />
-                      <div className="mt-2">
-                        <InputField
-                          ref={apiKeyInputRef}
-                          id="llmProfilesApiKeyCreate"
-                          value={apiKeyInput}
-                          onChange={setApiKeyInput}
-                          placeholder="(hidden)"
-                          type="password"
-                        />
-                      </div>
-                    </div>
-                  )}
-
-                  {canEditApiKey && apiKeyStatus.state === 'error' && (
-                    <div className="mt-2 text-xs text-red-400">{apiKeyStatus.error}</div>
-                  )}
-                  {canEditApiKey && apiKeyError && (
-                    <div className="mt-2 text-xs text-red-400">{apiKeyError}</div>
-                  )}
-
-                  {mode === 'edit' && canEditApiKey && providerRequiresApiKey && overrideProfileApiKey && (
-                    <div className="mt-3">
-                      <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyEdit" />
-                      <div className="mt-2">
-                        <InputField
-                          ref={apiKeyInputRef}
-                          id="llmProfilesApiKeyEdit"
-                          value={apiKeyInput}
-                          onChange={setApiKeyInput}
-                          placeholder="(hidden)"
-                          type="password"
-                        />
-                      </div>
-                      <div className="mt-3 flex items-center gap-2">
-                        <button
-                          type="button"
-                          onClick={() => { void handleSetApiKey(); }}
-                          disabled={apiKeySaving}
-                          className={`
-                            inline-flex items-center gap-2 px-3 py-2 rounded-lg
-                            text-xs font-medium
-                            transition-all
-                            border
-                            ${apiKeySaving
-                              ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
-                              : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
-                          `}
-                        >
-                          <span className={`codicon codicon-${apiKeySaving ? 'loading' : 'save'} ${apiKeySaving ? 'animate-spin' : ''}`} />
-                          Save key
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
 
                 <div className="grid grid-cols-2 gap-4">
                   <div>

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import * as childProcess from 'child_process';
-import { assertValidProfileId, LLMProfileValidationError, type SecretRegistry } from '@openhands/agent-sdk-ts';
+import { assertValidProfileId, detectProviderFromBaseUrl, LLMProfileValidationError, type LLMProvider, type SecretRegistry } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -131,6 +131,30 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   const getProfileApiKeySecretKey = (profileId: string): string => {
     validateProfileId(profileId);
     return `openhands.llmProfileApiKey.${profileId}`;
+  };
+
+  const getProviderApiKeyName = (provider: LLMProvider): string => {
+    switch (provider) {
+      case 'openrouter':
+        return 'OPENROUTER_API_KEY';
+      case 'litellm_proxy':
+        return 'LITELLM_API_KEY';
+      case 'anthropic':
+        return 'ANTHROPIC_API_KEY';
+      case 'gemini':
+        return 'GEMINI_API_KEY';
+      default:
+        return 'OPENAI_API_KEY';
+    }
+  };
+
+  const hasStoredSecret = async (key: string): Promise<boolean> => {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) return false;
+    const resolved = deps.secretRegistry
+      ? await deps.secretRegistry.get(trimmedKey)
+      : (process.env[trimmedKey] ?? (await context.secrets.get(trimmedKey)));
+    return typeof resolved === 'string' && resolved.trim().length > 0;
   };
 
   const getElevenlabsTtsGate = (): TtsConversationGate => {
@@ -536,12 +560,20 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         try {
           const key = getProfileApiKeySecretKey(profileId);
           const stored = await context.secrets.get(key);
+          const hasProfileKey = typeof stored === 'string' && stored.trim().length > 0;
+          const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
+          const provider = profile.config.provider ?? detectProviderFromBaseUrl(profile.config.baseUrl);
+          const providerKeyName = getProviderApiKeyName(provider);
+          const hasProviderKey = await hasStoredSecret(providerKeyName);
           void host.postMessage({
             type: 'llmProfileApiKeyStatusResponse',
             requestId,
             ok: true,
             profileId,
-            hasKey: typeof stored === 'string' && stored.trim().length > 0,
+            hasKey: hasProfileKey || hasProviderKey,
+            hasProfileKey,
+            hasProviderKey,
+            providerKeyName,
           });
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Implements provider-global API key fallback for LLM profiles.

**Behavior**
- API key resolution: per-profile override (VS Code Secret Storage) → provider-global key → missing-key error.
- LLM Profiles UI defaults to provider key; optional per-profile override via “Override for this profile” + “Save key”.
- API key status now reports `hasProfileKey` / `hasProviderKey` (plus `providerKeyName`).

**Validation**
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-profile API key overrides via an "Override for this profile" toggle.
  * Better handling of provider-supplied keys alongside profile-specific keys; status now reflects both.

* **UI Improvements**
  * "Not set" → "Missing" for clearer status.
  * Field relabeled to "API key override" and updated save/reset flows.
  * Status text shows "Override set" and "Using provider key" where appropriate.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->