### PR TITLE
[oh-tab-rszp] Gold focus accents in History/Skills

### DIFF
--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -109,7 +109,7 @@ function ConversationItem({
           transition-all duration-200
           border
           hover:bg-white/[0.04]
-          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 focus:border-brand-500/25
           ${isActive
             ? 'bg-brand-500/10 border-brand-500/25 hover:bg-brand-500/15'
             : 'bg-white/[0.02] border-white/[0.04] hover:border-white/[0.08]'}
@@ -323,7 +323,7 @@ export function HistoryView({
                 }
               }}
               placeholder="Search history…"
-              className="w-full pl-9 pr-9 py-2 rounded-lg bg-white/[0.03] border border-white/[0.06] text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0"
+              className="w-full pl-9 pr-9 py-2 rounded-lg bg-white/[0.03] border border-white/[0.06] text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 focus:border-brand-500/25"
               aria-label="Search conversation history"
             />
             {hasAnyQuery && (

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -783,7 +783,7 @@ export function SkillsPopover({
           placeholder="Search skills..."
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
-          className="mt-2 w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-violet-500/40 focus:border-violet-500/30"
+          className="mt-2 w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500/30"
           autoFocus
         />
       </div>
@@ -813,7 +813,7 @@ export function SkillsPopover({
                   flex items-center gap-2
                   group
                   ${isActive
-                    ? 'bg-white/[0.06] text-stone-200 border border-white/[0.16]'
+                    ? 'bg-brand-500/10 text-stone-200 border border-brand-500/25'
                     : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300 border border-transparent'
                   }
                 `}


### PR DESCRIPTION
Fixes `oh-tab-rszp` by aligning History/Skills focus/selection accents to OpenHands gold.

- History: search input now uses a gold focus border (in addition to the existing ring).
- History: conversation rows use a gold focus border for keyboard focus.
- Skills popover: search input focus ring/border now uses OpenHands gold (was violet).
- Skills popover: active item border now uses OpenHands gold.

Local checks: `npm test`, `npm run typecheck`, `npm run lint`.
