### PR TITLE
[oh-tab-flri] Persist servers globally + normalize URLs

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -124,7 +124,16 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
   };
 
   // Diagnostics command for E2E tests and troubleshooting
-  const getServerUrl = () => vscode.workspace.getConfiguration().get<string>('openhands.serverUrl') ?? '';
+  const getServerUrl = () => {
+    const inspected = vscode.workspace.getConfiguration().inspect<string>('openhands.serverUrl');
+    return typeof inspected?.globalValue === 'string' ? inspected.globalValue : '';
+  };
+
+  const getServers = () => {
+    const inspected = vscode.workspace.getConfiguration().inspect<OpenHandsSettings['servers']>('openhands.servers');
+    return inspected?.globalValue ?? [];
+  };
+
   const diag = vscode.commands.registerCommand('openhands._diagnostics', () => {
     const chatView = deps.getChatView();
     const terminal = deps.getTerminal();
@@ -153,8 +162,45 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
       status: deps.getConversation()?.getStatus(),
       mode: deps.getConversationMode(),
       serverUrl: getServerUrl(),
+      servers: getServers(),
       terminal: terminalInfo,
     };
+  });
+
+  // Internal: deterministic server config commands for E2E + debugging.
+  const serversGet = vscode.commands.registerCommand('openhands._serversGet', async () => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    const settings = await settingsMgr.get();
+    return { serverUrl: settings.serverUrl ?? '', servers: settings.servers ?? [] };
+  });
+
+  const serversSet = vscode.commands.registerCommand('openhands._serversSet', async (raw: unknown) => {
+    const payload = raw as { serverUrl?: unknown; servers?: unknown } | undefined;
+    const serverUrl = typeof payload?.serverUrl === 'string' ? payload.serverUrl : '';
+    const servers: OpenHandsSettings['servers'] = Array.isArray(payload?.servers)
+      ? payload.servers.flatMap((s) => {
+          if (typeof s === 'string') {
+            const trimmed = s.trim();
+            return trimmed ? [{ url: trimmed }] : [];
+          }
+          if (typeof s !== 'object' || s === null) return [];
+          const record = s as Record<string, unknown>;
+          const url = typeof record.url === 'string' ? record.url.trim() : '';
+          if (!url) return [];
+          const label = typeof record.label === 'string' ? record.label.trim() : undefined;
+          return [{ url, label: label || undefined }];
+        })
+      : [];
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    await settingsMgr.update({ serverUrl, servers }, 'global');
+    const updated = await settingsMgr.get();
+    return { serverUrl: updated.serverUrl ?? '', servers: updated.servers ?? [] };
+  });
+
+  const serversReset = vscode.commands.registerCommand('openhands._serversReset', async () => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    await settingsMgr.update({ serverUrl: '', servers: [] }, 'global');
+    return { ok: true };
   });
 
   // Internal: return the last error event from the buffered backlog (for E2E + debugging).
@@ -525,6 +571,9 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
 
   return [
     diag,
+    serversGet,
+    serversSet,
+    serversReset,
     queryLastError,
     queryBacklogSummary,
     sendTestEvent,

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,5 +1,6 @@
 import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, ConversationSettings, ConfirmationSettings } from './SettingsAdapter';
 import type { ElevenLabsMode } from '../shared/halTypes';
+import { normalizeServerUrl } from '../shared/serverUrls';
 
 export interface SavedServer {
   url: string;
@@ -138,34 +139,111 @@ const clampUnitInterval = (value: number | null | undefined, defaultValue: numbe
   return Math.min(1, Math.max(0, value));
 };
 
-const normalizeSavedServer = (value: unknown): SavedServer | null => {
-  if (!value || typeof value !== 'object') return null;
-  const candidate = value as Partial<Record<keyof SavedServer, unknown>>;
-  const url = normalizeNonEmptyString(typeof candidate.url === 'string' ? candidate.url : undefined);
-  if (!url) return null;
-  const label = normalizeNonEmptyString(typeof candidate.label === 'string' ? candidate.label : undefined);
-  return label ? { url, label } : { url };
-};
+const normalizeSavedServers = (value: unknown, defaultValue: SavedServer[]): { servers: SavedServer[]; changed: boolean; dropped: number } => {
+  if (!Array.isArray(value)) return { servers: defaultValue, changed: true, dropped: 0 };
 
-const normalizeSavedServers = (value: unknown, defaultValue: SavedServer[]): SavedServer[] => {
-  if (!Array.isArray(value)) return defaultValue;
-  return value
-    .map(normalizeSavedServer)
-    .filter((server): server is SavedServer => server !== null);
+  const byUrl = new Map<string, SavedServer>();
+  let changed = false;
+  let dropped = 0;
+
+  for (const entry of value) {
+    if (!entry || typeof entry !== 'object') {
+      changed = true;
+      dropped += 1;
+      continue;
+    }
+
+    const candidate = entry as Partial<Record<keyof SavedServer, unknown>>;
+    const rawUrl = normalizeNonEmptyString(typeof candidate.url === 'string' ? candidate.url : undefined);
+    if (!rawUrl) {
+      changed = true;
+      dropped += 1;
+      continue;
+    }
+
+    const normalizedUrl = normalizeServerUrl(rawUrl);
+    if (!normalizedUrl.ok) {
+      changed = true;
+      dropped += 1;
+      continue;
+    }
+
+    const label = normalizeNonEmptyString(typeof candidate.label === 'string' ? candidate.label : undefined);
+    if (normalizedUrl.url !== rawUrl) changed = true;
+
+    const existing = byUrl.get(normalizedUrl.url);
+    if (existing) {
+      // Deduplicate by canonical URL; preserve an existing label, but upgrade if we encounter one later.
+      if (!existing.label && label) {
+        byUrl.set(normalizedUrl.url, { ...existing, label });
+        changed = true;
+      } else {
+        changed = true;
+      }
+      continue;
+    }
+
+    byUrl.set(normalizedUrl.url, label ? { url: normalizedUrl.url, label } : { url: normalizedUrl.url });
+  }
+
+  return { servers: Array.from(byUrl.values()), changed, dropped };
 };
 
 export class SettingsManager {
+  private serverNormalizationWarnings: string[] = [];
+
   constructor(private adapter: SettingsAdapter) {}
 
+  drainServerNormalizationWarnings(): string[] {
+    const warnings = this.serverNormalizationWarnings;
+    this.serverNormalizationWarnings = [];
+    return warnings;
+  }
+
   async get(): Promise<OpenHandsSettings> {
-    const serverUrl = normalizeNonEmptyString(
-      this.adapter.get<string | null>('openhands.serverUrl', DEFAULTS.serverUrl) ?? DEFAULTS.serverUrl
-    );
+    const warnings: string[] = [];
+
+    const rawServerUrl = this.adapter.get<string | null>('openhands.serverUrl', DEFAULTS.serverUrl) ?? DEFAULTS.serverUrl;
+    const trimmedServerUrl = normalizeNonEmptyString(rawServerUrl);
+    let serverUrl: string | undefined;
+    let serverUrlChanged = false;
+
+    if (trimmedServerUrl) {
+      const normalized = normalizeServerUrl(trimmedServerUrl);
+      if (normalized.ok) {
+        serverUrl = normalized.url;
+        if (serverUrl !== trimmedServerUrl) serverUrlChanged = true;
+      } else {
+        warnings.push(`Invalid server URL: ${normalized.error}`);
+        serverUrlChanged = true;
+      }
+    }
+
+    const rawServers = this.adapter.get<unknown>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers;
+    const serversResult = normalizeSavedServers(rawServers, DEFAULTS.servers);
+    let servers = serversResult.servers;
+    let serversChanged = serversResult.changed;
+
+    if (serversResult.dropped > 0) {
+      warnings.push(`Dropped ${serversResult.dropped} invalid saved server entr${serversResult.dropped === 1 ? 'y' : 'ies'}.`);
+    }
+
+    // If serverUrl is set, always ensure it appears in the servers list (even if manually configured in settings).
+    if (serverUrl && !servers.some((s) => s.url === serverUrl)) {
+      servers = [...servers, { url: serverUrl }];
+      serversChanged = true;
+    }
+
+    if (serverUrlChanged || serversChanged) {
+      this.serverNormalizationWarnings = warnings;
+      try {
+        await this.update({ serverUrl: serverUrl ?? '', servers }, 'global');
+      } catch {
+        // Best effort: still return normalized values even if persistence fails.
+      }
+    }
+
     const isRemote = !!serverUrl;
-    const servers = normalizeSavedServers(
-      this.adapter.get<unknown>('openhands.servers', DEFAULTS.servers) ?? DEFAULTS.servers,
-      DEFAULTS.servers
-    );
     const explicitBaseUrl = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.baseUrl'));
     const explicitProvider = normalizeLlmProvider(this.adapter.getExplicit<string>('openhands.llm.provider'));
     const provider = isRemote ? explicitProvider : explicitProvider ?? (explicitBaseUrl ? undefined : DEFAULTS.llm.provider);
@@ -267,11 +345,11 @@ export class SettingsManager {
     const ops: Promise<void>[] = [];
 
     if (partial.serverUrl !== undefined) {
-      ops.push(this.adapter.update('openhands.serverUrl', partial.serverUrl ?? '', target));
+      ops.push(this.adapter.update('openhands.serverUrl', partial.serverUrl ?? '', 'global'));
     }
 
     if (partial.servers !== undefined) {
-      ops.push(this.adapter.update('openhands.servers', partial.servers, target));
+      ops.push(this.adapter.update('openhands.servers', partial.servers, 'global'));
     }
 
     if (partial.llm) {

--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -4,6 +4,10 @@ import type { SettingsAdapter } from './SettingsAdapter';
 export class VscodeSettingsAdapter implements SettingsAdapter {
   constructor(private context: vscode.ExtensionContext) {}
 
+  private isGlobalOnlyKey(key: string): boolean {
+    return key === 'openhands.serverUrl' || key === 'openhands.servers';
+  }
+
   private getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {
     const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
     return workspaceFolder
@@ -12,6 +16,11 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
   }
 
   get<T = unknown>(key: string, defaultValue?: T): T | undefined {
+    if (this.isGlobalOnlyKey(key)) {
+      const inspected = vscode.workspace.getConfiguration().inspect<T>(key);
+      const globalValue = inspected?.globalValue;
+      return globalValue !== undefined ? globalValue : defaultValue;
+    }
     const cfg = this.getWorkspaceConfiguration();
     return defaultValue !== undefined
       ? cfg.get<T>(key, defaultValue)
@@ -19,13 +28,21 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
   }
 
   getExplicit<T = unknown>(key: string): T | undefined {
+    if (this.isGlobalOnlyKey(key)) {
+      const inspected = vscode.workspace.getConfiguration().inspect<T>(key);
+      return inspected?.globalValue ?? undefined;
+    }
     const inspected = this.getWorkspaceConfiguration().inspect<T>(key);
     if (!inspected) return undefined;
     // Prefer workspace folder override, then workspace, then global
-    return (inspected.workspaceFolderValue as T) ?? (inspected.workspaceValue as T) ?? (inspected.globalValue as T) ?? undefined;
+    return inspected.workspaceFolderValue ?? inspected.workspaceValue ?? inspected.globalValue ?? undefined;
   }
 
   async update<T = unknown>(key: string, value: T, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
+    if (this.isGlobalOnlyKey(key)) {
+      await vscode.workspace.getConfiguration().update(key, value, vscode.ConfigurationTarget.Global);
+      return;
+    }
     const hasWorkspaceFolder = !!vscode.workspace.workspaceFolders?.length;
     const effectiveTarget =
       target === 'workspace' && hasWorkspaceFolder

--- a/src/shared/serverUrls.ts
+++ b/src/shared/serverUrls.ts
@@ -1,0 +1,42 @@
+export type NormalizeServerUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; error: string };
+
+const HAS_EXPLICIT_SCHEME = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
+  const trimmed = typeof raw === 'string' ? raw.trim() : '';
+  if (!trimmed) {
+    return { ok: false, error: 'Server URL is required' };
+  }
+
+  let candidate = trimmed;
+  if (/^https?:/i.test(candidate) && !/^https?:\/\//i.test(candidate)) {
+    candidate = candidate.replace(/^https?:/i, (match) => `${match}//`);
+  } else if (!HAS_EXPLICIT_SCHEME.test(candidate)) {
+    candidate = `http://${candidate}`;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return { ok: false, error: 'Invalid URL format' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, error: 'Only http(s) URLs are supported' };
+  }
+
+  if (!parsed.hostname) {
+    return { ok: false, error: 'Invalid URL (missing hostname)' };
+  }
+
+  parsed.hash = '';
+  parsed.search = '';
+
+  const canonical =
+    parsed.pathname === '/' ? parsed.origin : parsed.toString();
+  return { ok: true, url: canonical };
+}
+

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
+import { normalizeServerUrl } from '../../shared/serverUrls';
 
 // Re-export for convenience - canonical definition is in SettingsManager
 export interface SavedServer {
@@ -56,22 +57,21 @@ export function ServerSelector({
     const trimmedUrl = newUrl.trim();
     if (!trimmedUrl) return;
 
-    // Validate URL format
-    try {
-      new URL(trimmedUrl);
-    } catch {
-      setUrlError('Invalid URL format');
+    const normalized = normalizeServerUrl(trimmedUrl);
+    if (!normalized.ok) {
+      setUrlError(normalized.error);
       return;
     }
+    const canonicalUrl = normalized.url;
 
     // Check for duplicates
-    if (servers.some(s => s.url === trimmedUrl)) {
+    if (servers.some(s => s.url === canonicalUrl)) {
       setUrlError('Server already exists');
       return;
     }
 
     setUrlError(null);
-    onAddServer({ url: trimmedUrl, label: newLabel.trim() || undefined });
+    onAddServer({ url: canonicalUrl, label: newLabel.trim() || undefined });
     setNewUrl('');
     setNewLabel('');
     setShowAddForm(false);

--- a/src/webview/host/__tests__/createWebviewMessageHandler.serversPersist.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.serversPersist.test.ts
@@ -8,7 +8,7 @@ describe('createWebviewMessageHandler (servers persistence)', () => {
     (vscode as any).__resetMocks();
   });
 
-  it('persists add/remove server changes to workspace folder settings', async () => {
+  it('persists add/remove server changes to global settings', async () => {
     const globalValues = new Map<string, unknown>();
     const workspaceValues = new Map<string, unknown>();
     const workspaceFolderValues = new Map<string, unknown>();
@@ -41,8 +41,8 @@ describe('createWebviewMessageHandler (servers persistence)', () => {
 
     (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
 
-    workspaceFolderValues.set('openhands.servers', [{ url: 'http://old.example:3000', label: 'Old' }]);
-    workspaceFolderValues.set('openhands.serverUrl', 'http://old.example:3000');
+    globalValues.set('openhands.servers', [{ url: 'http://old.example:3000', label: 'Old' }]);
+    globalValues.set('openhands.serverUrl', 'http://old.example:3000');
 
     const context = {
       secrets: {
@@ -77,8 +77,76 @@ describe('createWebviewMessageHandler (servers persistence)', () => {
     await handler({ type: 'addServer', server: { url: 'http://new.example:3000', label: 'New' } });
     await handler({ type: 'removeServer', url: 'http://old.example:3000' });
 
-    expect(workspaceFolderValues.get('openhands.servers')).toEqual([{ url: 'http://new.example:3000', label: 'New' }]);
-    expect(workspaceFolderValues.get('openhands.serverUrl')).toBe('');
+    expect(globalValues.get('openhands.servers')).toEqual([{ url: 'http://new.example:3000', label: 'New' }]);
+    expect(globalValues.get('openhands.serverUrl')).toBe('');
+  });
+
+  it('normalizes server URLs on add/select', async () => {
+    const globalValues = new Map<string, unknown>();
+    const workspaceValues = new Map<string, unknown>();
+    const workspaceFolderValues = new Map<string, unknown>();
+
+    const cfg = {
+      get: vi.fn((key: string, defaultValue?: unknown) => {
+        if (workspaceFolderValues.has(key)) return workspaceFolderValues.get(key);
+        if (workspaceValues.has(key)) return workspaceValues.get(key);
+        if (globalValues.has(key)) return globalValues.get(key);
+        return defaultValue;
+      }),
+      inspect: vi.fn((key: string) => ({
+        globalValue: globalValues.get(key),
+        workspaceValue: workspaceValues.get(key),
+        workspaceFolderValue: workspaceFolderValues.get(key),
+      })),
+      update: vi.fn(async (key: string, value: unknown, target: number) => {
+        if (target === (vscode.ConfigurationTarget as any).Global) {
+          globalValues.set(key, value);
+        } else if (target === (vscode.ConfigurationTarget as any).Workspace) {
+          workspaceValues.set(key, value);
+        } else if (target === (vscode.ConfigurationTarget as any).WorkspaceFolder) {
+          workspaceFolderValues.set(key, value);
+        } else {
+          throw new Error(`Unexpected configuration target: ${String(target)}`);
+        }
+      }),
+    };
+
+    (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
+
+    const context = {
+      secrets: {
+        get: vi.fn(async () => undefined),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      },
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    const hostPostMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context,
+      host: { postMessage: hostPostMessage },
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp/openhands-conversations',
+      setWebviewReadyState: () => undefined,
+      setLastKnownLlmLabel: () => undefined,
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => undefined,
+      onRenderedEventsResponse: () => undefined,
+      onUiStateResponse: () => undefined,
+      onHalStateResponse: () => undefined,
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => undefined,
+    });
+
+    await handler({ type: 'addServer', server: { url: 'localhost:3000' } });
+    expect(globalValues.get('openhands.servers')).toEqual([{ url: 'http://localhost:3000' }]);
+
+    await handler({ type: 'selectServer', url: 'http:localhost:3000' });
+    expect(globalValues.get('openhands.serverUrl')).toBe('http://localhost:3000');
+    expect(globalValues.get('openhands.servers')).toEqual([{ url: 'http://localhost:3000' }]);
   });
 });
-

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -13,6 +13,7 @@ import { getHalDialogueLinesForMode } from '../../shared/halScript';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
 import { MAX_PASTED_IMAGE_BYTES } from '../../shared/pasteLimits';
+import { normalizeServerUrl } from '../../shared/serverUrls';
 import type { HostToWebviewMessage, WebviewToHostMessage } from '../../shared/webviewMessages';
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
 import { getConversationHistoryList } from './conversationHistory';
@@ -117,6 +118,16 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
   let elevenlabsTtsGate: TtsConversationGate | null = null;
 
+  const postStatusError = (message: string): void => {
+    void host.postMessage({
+      type: 'statusMessage',
+      level: 'error',
+      message,
+      autoDismiss: true,
+      autoDismissDelay: 6000,
+    });
+  };
+
   const validateProfileId = (profileId: string): void => {
     try {
       assertValidProfileId(profileId);
@@ -211,6 +222,10 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         deps.setWebviewReadyState(message.conversationId, message.lastSeenSeq);
 
         const initSettings = await settingsMgr.get();
+        const serverWarnings = settingsMgr.drainServerNormalizationWarnings();
+        for (const warning of serverWarnings) {
+          postStatusError(warning);
+        }
         deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(initSettings));
 
         void host.postMessage({
@@ -604,17 +619,22 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'selectServer': {
-        const url = message.url;
+        const rawUrl = typeof message.url === 'string' ? message.url.trim() : '';
+        const url = rawUrl ? normalizeServerUrl(rawUrl) : { ok: true as const, url: '' };
+        if (!url.ok) {
+          postStatusError(url.error);
+          break;
+        }
         const currentSettings = await settingsMgr.get();
 
-        const serverExists = currentSettings.servers.some((s) => s.url === url);
-        if (!serverExists && url) {
+        const serverExists = currentSettings.servers.some((s) => s.url === url.url);
+        if (!serverExists && url.url) {
           await settingsMgr.update({
-            servers: [...currentSettings.servers, { url }],
-            serverUrl: url,
+            servers: [...currentSettings.servers, { url: url.url }],
+            serverUrl: url.url,
           });
         } else {
-          await settingsMgr.update({ serverUrl: url });
+          await settingsMgr.update({ serverUrl: url.url });
         }
 
         const updated = await settingsMgr.get();
@@ -629,10 +649,19 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         const server = message.server;
         if (!server?.url) break;
 
+        const normalized = normalizeServerUrl(server.url);
+        if (!normalized.ok) {
+          postStatusError(normalized.error);
+          break;
+        }
+
+        const label = typeof server.label === 'string' ? server.label.trim() : '';
+        const canonicalServer = label ? { url: normalized.url, label } : { url: normalized.url };
+
         const currentSettings = await settingsMgr.get();
-        const exists = currentSettings.servers.some((s) => s.url === server.url);
+        const exists = currentSettings.servers.some((s) => s.url === normalized.url);
         if (!exists) {
-          const newServers = [...currentSettings.servers, server];
+          const newServers = [...currentSettings.servers, canonicalServer];
           await settingsMgr.update({ servers: newServers });
           void host.postMessage({
             type: 'serverListUpdated',
@@ -643,8 +672,15 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'removeServer': {
-        const url = message.url;
-        if (!url) break;
+        const rawUrl = typeof message.url === 'string' ? message.url.trim() : '';
+        if (!rawUrl) break;
+
+        const normalized = normalizeServerUrl(rawUrl);
+        if (!normalized.ok) {
+          postStatusError(normalized.error);
+          break;
+        }
+        const url = normalized.url;
 
         const currentSettings = await settingsMgr.get();
         const newServers = currentSettings.servers.filter((s) => s.url !== url);


### PR DESCRIPTION
- Treat `openhands.serverUrl` and `openhands.servers` as global-only settings (prevents workspace overrides).
- Normalize/validate server URLs (auto-add scheme, fix common typos, canonicalize).
- Migrate + dedupe existing saved servers on load; surface warnings to the webview.
- Add internal diagnostics commands for deterministic E2E.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced server configuration management with automatic URL normalization and validation.

* **Bug Fixes**
  * Improved server URL handling to accept and standardize various URL formats.
  * Fixed server settings persistence to use global configuration consistently.
  * Added validation to detect and handle invalid server URLs with clear error messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->