### PR TITLE
[oh-tab-5odv] Clear stale pending confirmation actions

### DIFF
--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -185,6 +185,81 @@ describe('App - Confirmation Flow', () => {
     });
   });
 
+  it('does not carry stale pending actions across confirmation sessions', async () => {
+    await renderAppAndWaitReady();
+
+    // First confirmation session
+    setWaitingForConfirmation();
+    postToWindow({
+      type: 'event',
+      event: mkAction({
+        tool_call_id: 'call-old',
+        llm_response_id: 'resp-same',
+        thought: [{ type: 'text', text: 'Old pending action' }],
+      }),
+    });
+
+    const firstDialog = await screen.findByRole('dialog');
+    expect(within(firstDialog).getByText('Old pending action')).toBeInTheDocument();
+
+    // Simulate agent moving on (approve accepted, status no longer waiting)
+    postToWindow({
+      type: 'event',
+      event: { kind: 'ConversationStateUpdateEvent', agent_status: 'RUNNING' } as ConversationStateUpdateEvent,
+    });
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+
+    // Second confirmation session (same llm_response_id to ensure we truly cleared)
+    setWaitingForConfirmation();
+    postToWindow({
+      type: 'event',
+      event: mkAction({
+        tool_call_id: 'call-new',
+        llm_response_id: 'resp-same',
+        thought: [{ type: 'text', text: 'New pending action' }],
+      }),
+    });
+
+    const secondDialog = await screen.findByRole('dialog');
+    const scope = within(secondDialog);
+    expect(scope.getByText('New pending action')).toBeInTheDocument();
+    expect(scope.queryByText('Old pending action')).not.toBeInTheDocument();
+  });
+
+  it('replaces pending actions when a new action batch arrives', async () => {
+    await renderAppAndWaitReady();
+    setWaitingForConfirmation();
+
+    postToWindow({
+      type: 'event',
+      event: mkAction({
+        tool_call_id: 'call-old-batch',
+        llm_response_id: 'resp-old-batch',
+        thought: [{ type: 'text', text: 'Old batch action' }],
+      }),
+    });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText('Old batch action')).toBeInTheDocument();
+
+    // New action from a new LLM response should replace (not append)
+    postToWindow({
+      type: 'event',
+      event: mkAction({
+        tool_call_id: 'call-new-batch',
+        llm_response_id: 'resp-new-batch',
+        thought: [{ type: 'text', text: 'New batch action' }],
+      }),
+    });
+
+    await waitFor(() => {
+      const updatedDialog = screen.getByRole('dialog');
+      const scope = within(updatedDialog);
+      expect(scope.getByText('New batch action')).toBeInTheDocument();
+      expect(scope.queryByText('Old batch action')).not.toBeInTheDocument();
+    });
+  });
+
   it('sets isSubmitting=true when approval sent, and resets after 30s timeout', async () => {
     await renderAppAndWaitReady();
     // Spy on setTimeout so we can trigger the scheduled reset callback without relying on fake timers

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -266,6 +266,7 @@ export function App() {
 
   // Conversation refs (used for HAL + event processing without stale closures)
   const pendingActionsRef = useRef<ActionEvent[]>([]);
+  const pendingActionsBatchIdRef = useRef<string | null>(null);
   const agentStatusRef = useRef<string | undefined>(undefined);
   const conversationIdRef = useRef<string | undefined>(undefined);
   const currentServerUrlRef = useRef<string | undefined>(undefined);
@@ -480,10 +481,21 @@ export function App() {
     if (!isConversationStateUpdateEvent(event)) return false;
 
     if (event.agent_status) {
+      const previousStatus = agentStatusRef.current;
       agentStatusRef.current = event.agent_status;
       setAgentStatus(event.agent_status);
       if (event.agent_status === 'WAITING_FOR_CONFIRMATION' && lastAgentStatusRef.current !== 'WAITING_FOR_CONFIRMATION') {
         showStatusMessage('warn', 'Agent is waiting for confirmation');
+      }
+      if (previousStatus === 'WAITING_FOR_CONFIRMATION' && event.agent_status !== 'WAITING_FOR_CONFIRMATION') {
+        pendingActionsRef.current = [];
+        pendingActionsBatchIdRef.current = null;
+        setPendingActions([]);
+        if (submissionTimeoutRef.current) {
+          clearTimeout(submissionTimeoutRef.current);
+          submissionTimeoutRef.current = null;
+        }
+        setIsSubmitting(false);
       }
       lastAgentStatusRef.current = event.agent_status;
     }
@@ -529,16 +541,25 @@ export function App() {
     if (isActionEvent(event)) {
       const prev = pendingActionsRef.current;
       const exists = prev.some((a) => a.tool_call_id === event.tool_call_id);
-      if (!exists) {
-        const next = [...prev, event];
-        pendingActionsRef.current = next;
-        setPendingActions(next);
-      }
+      if (exists) return;
+
+      const nextBatchId = typeof event.llm_response_id === 'string' ? event.llm_response_id : null;
+      const prevBatchId =
+        pendingActionsBatchIdRef.current ?? (prev.length && typeof prev[0].llm_response_id === 'string' ? prev[0].llm_response_id : null);
+      const next =
+        prev.length && prevBatchId && nextBatchId && prevBatchId !== nextBatchId
+          ? [event]
+          : [...prev, event];
+
+      pendingActionsRef.current = next;
+      pendingActionsBatchIdRef.current = nextBatchId;
+      setPendingActions(next);
     } else if (isObservationEvent(event) || isUserRejectObservation(event)) {
       const prev = pendingActionsRef.current;
       const next = prev.filter((a) => a.tool_call_id !== event.tool_call_id);
       if (next.length !== prev.length) {
         pendingActionsRef.current = next;
+        pendingActionsBatchIdRef.current = next.length ? (typeof next[0].llm_response_id === 'string' ? next[0].llm_response_id : null) : null;
         setPendingActions(next);
       }
       clearSubmissionState();
@@ -911,6 +932,7 @@ export function App() {
             setConversationId(payload.conversationId);
             setEvents([]);
             pendingActionsRef.current = [];
+            pendingActionsBatchIdRef.current = null;
             setPendingActions([]);
             agentStatusRef.current = undefined;
             setAgentStatus(undefined);


### PR DESCRIPTION
Fixes `oh-tab-5odv`.

- Clear `pendingActions` when agent leaves `WAITING_FOR_CONFIRMATION` (prevents stale actions from resurfacing later).
- Track a pending-action “batch” by `llm_response_id`; when a new batch arrives, replace instead of append.
- Add webview unit tests for both behaviors.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
