### PR TITLE
[oh-tab-205c] Cleanup security_risk tool schema logic

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1144,15 +1144,14 @@ export class Agent extends EventEmitter {
     if (!this.shouldIncludeSecurityRiskAssessment()) return definitions;
 
     return definitions.map((tool): LLMToolDefinition => {
-      const fn = tool.function ?? ({} as LLMToolDefinition['function']);
+      const fn = tool.function;
       const parameters =
         fn.parameters && typeof fn.parameters === 'object' && !Array.isArray(fn.parameters)
           ? (fn.parameters as Record<string, unknown>)
           : {};
-      const existingProps = parameters.properties;
       const properties =
-        existingProps && typeof existingProps === 'object' && !Array.isArray(existingProps)
-          ? ({ ...(existingProps as Record<string, unknown>) } as Record<string, unknown>)
+        parameters.properties && typeof parameters.properties === 'object' && !Array.isArray(parameters.properties)
+          ? { ...(parameters.properties as Record<string, unknown>) }
           : {};
 
       if (!properties.security_risk) {
@@ -1163,9 +1162,8 @@ export class Agent extends EventEmitter {
         };
       }
 
-      const existingRequired = parameters.required;
-      const required = Array.isArray(existingRequired)
-        ? existingRequired.filter((value): value is string => typeof value === 'string')
+      const required = Array.isArray(parameters.required)
+        ? parameters.required.filter((value): value is string => typeof value === 'string')
         : [];
       if (!required.includes('security_risk')) {
         required.unshift('security_risk');

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
@@ -12,8 +12,8 @@ class MockLLM implements LLMClient {
   lastRequest: ChatCompletionRequest | null = null;
   constructor(private readonly chunks: LLMStreamChunk[]) {}
 
-  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
-    this.lastRequest = _request;
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.lastRequest = request;
     for (const chunk of this.chunks) {
       yield chunk;
     }


### PR DESCRIPTION
Fixes `oh-tab-205c`.

- Simplify `Agent.getToolDefinitions()` security_risk schema augmentation (no behavior change).
- Rename `MockLLM.streamChat(_request)` → `streamChat(request)` now that it’s used.

Tests:
- `npm test -w @openhands/agent-sdk-ts`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal code structure by eliminating intermediate variables and unnecessary fallback assignments in tool handling logic.
  * Improved test code clarity through parameter naming updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->