### PR TITLE
[oh-tab-2myf] Apply confirmation settings changes immediately

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -294,6 +294,35 @@ describe('Chat view behavior', () => {
     expect(conv.setSettings).toHaveBeenCalledWith(mockSettings);
   });
 
+  it('refreshes the active conversation when confirmation settings change', async () => {
+    const view = await resolveChatView(mockContext);
+    expect(view).toBeTruthy();
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const conv = __getLastConversation();
+    expect(conv).toBeTruthy();
+
+    mockSettings = {
+      ...mockSettings,
+      confirmation: {
+        ...mockSettings.confirmation,
+        policy: 'always',
+      },
+    };
+
+    (vscode as any).__triggerConfigChange({
+      affectsConfiguration: (key: string) => key === 'openhands.confirmation' || key === 'openhands.confirmation.policy',
+    });
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((conv.setSettings as Mock).mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(conv.setSettings).toHaveBeenCalledWith(mockSettings);
+  });
+
   it('starts a fresh conversation on serverUrl changes (no auto-restore)', async () => {
     await resolveChatView(mockContext);
     const { __getLastConversation } = await import('@openhands/agent-sdk-ts');

--- a/src/settings/host/createConfigurationChangeHandler.ts
+++ b/src/settings/host/createConfigurationChangeHandler.ts
@@ -92,5 +92,18 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
         deps.getOutputChannel()?.appendLine(`[settings] Failed to apply LLM settings update: ${deps.renderError(err)}`);
       }
     }
+
+    if (e.affectsConfiguration('openhands.confirmation')) {
+      try {
+        await deps.ensureConversationAndConnection();
+        if (deps.getConversationMode() === 'remote') {
+          deps.getOutputChannel()?.appendLine('[settings] Confirmation settings updated (remote mode: applies on next conversation)');
+        } else {
+          deps.getOutputChannel()?.appendLine('[settings] Confirmation settings updated (local mode: applies immediately)');
+        }
+      } catch (err: unknown) {
+        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply confirmation settings update: ${deps.renderError(err)}`);
+      }
+    }
   };
 }


### PR DESCRIPTION
Fixes `oh-tab-2myf`.

- Add config-change handling for `openhands.confirmation` so updates call `ensureConversationAndConnection()` (and therefore `conversation.setSettings(...)`) without requiring reload.
- Add an extension unit test that toggles confirmation policy and asserts the active conversation is refreshed.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
