### PR TITLE
[oh-tab-noxj] Enable Security Analyzer by default

### DIFF
--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -117,7 +117,7 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
   - openhands.confirmation.policy: enum ('never' | 'always' | 'risky') (default: 'never')
   - openhands.confirmation.risky.threshold: enum ('LOW' | 'MEDIUM' | 'HIGH') (default: 'MEDIUM')
   - openhands.confirmation.risky.confirmUnknown: boolean (default: true)
-  - openhands.agent.enableSecurityAnalyzer: boolean (default: false)
+  - openhands.agent.enableSecurityAnalyzer: boolean (default: true)
 - Store secrets in VS Code SecretStorage (never in settings.json)
   - Implemented keys:
     - openhands.sessionApiKey (used for X-Session-API-Key / WS query param)

--- a/package.json
+++ b/package.json
@@ -294,7 +294,7 @@
         "properties": {
           "openhands.agent.enableSecurityAnalyzer": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "order": 1,
             "markdownDescription": "Enable LLMSecurityAnalyzer for action inspection."
           },

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -49,7 +49,7 @@ const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
   servers: [],
   llm: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
-  agent: { enableSecurityAnalyzer: false, debug: false, summarizeToolCalls: false },
+  agent: { enableSecurityAnalyzer: true, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
   elevenlabs: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -33,7 +33,7 @@ describe('SettingsManager', () => {
     expect(s.llm.reasoningSummary).toBeUndefined();
     // Local mode requires a default model for the local Agent to run.
     expect(s.llm.model).toBe('claude-sonnet-4-20250514');
-    expect(s.agent.enableSecurityAnalyzer).toBe(false);
+    expect(s.agent.enableSecurityAnalyzer).toBe(true);
     expect(s.agent.debug).toBe(false);
     expect(s.elevenlabs.enabled).toBe(false);
     expect(s.elevenlabs.mode).toBe('tts_only');
@@ -363,7 +363,7 @@ describe('SettingsManager', () => {
     const s = await mgr.get();
 
     expect(s.serverUrl).toBeUndefined();
-    expect(s.agent.enableSecurityAnalyzer).toBe(false);
+    expect(s.agent.enableSecurityAnalyzer).toBe(true);
     expect(s.agent.debug).toBe(false);
     expect(s.conversation.maxIterations).toBe(50);
     expect(s.confirmation.policy).toBe('never');


### PR DESCRIPTION
Bead: `oh-tab-noxj`

Changes:
- Flip `openhands.agent.enableSecurityAnalyzer` default to `true` in `package.json` settings schema
- Flip SettingsManager default to `true`
- Update unit tests + docs for the new default

Rationale:
- Remote-mode tool calls rely on the security analyzer to produce `security_risk` out-of-the-box; defaulting this off caused confusing “no risk/no HAL” behavior until users discovered the toggle.
