### PR TITLE
[oh-tab-xhhm] Attach Gemini terminal summary to Tool Result

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -36,6 +36,7 @@ import { LLMSummarizingCondenser } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
 import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
+import { summarizeTerminalObservationWithGeminiFlash } from './terminalObservationSummarizer';
 import { SYSTEM_PROMPT } from './systemPrompt';
 
 export type AgentRunInput = string | Message;
@@ -1484,7 +1485,8 @@ export class Agent extends EventEmitter {
     try {
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
       const result = await tool.execute(validated, context);
-      const enrichedResult = await this.maybeAttachFileDiffSummary(toolCall, result);
+      let enrichedResult = await this.maybeAttachFileDiffSummary(toolCall, result);
+      enrichedResult = await this.maybeAttachTerminalObservationSummary(toolCall, enrichedResult);
 
       if (toolCall.function.name === 'terminal') {
         this.emitTerminalEvents(toolCall, enrichedResult);
@@ -1564,6 +1566,60 @@ export class Agent extends EventEmitter {
       this.toolSummarizerFailed = true;
       if (this.debug) {
         console.warn('[Agent] File diff summarization failed; disabling for this session:', error);
+      }
+      return result;
+    }
+  }
+
+  private async maybeAttachTerminalObservationSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
+    if (toolCall.function.name !== 'terminal') return result;
+    if (!this.summarizeToolCallsEnabled) return result;
+    if (this.toolSummarizerFailed) return result;
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
+
+    const record = result as Record<string, unknown>;
+    if (typeof record.summary === 'string' && record.summary.trim()) return result;
+
+    const commandFromArgs = (() => {
+      const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
+      if (!rawArgs) return undefined;
+      try {
+        const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
+        return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
+      } catch {
+        return rawArgs;
+      }
+    })();
+
+    const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs ?? '';
+    const exitCode = record.exit_code ?? record.exitCode;
+    const stdout = typeof record.stdout === 'string' ? record.stdout : undefined;
+    const stderr = typeof record.stderr === 'string' ? record.stderr : undefined;
+    const timedOut = record.timeout === true;
+    const outputWasTruncated =
+      (typeof stdout === 'string' && stdout.includes(ELLIPSIS)) ||
+      (typeof stderr === 'string' && stderr.includes(ELLIPSIS));
+
+    try {
+      const llmClient = await this.getToolSummarizerClient();
+      const summary = await summarizeTerminalObservationWithGeminiFlash(
+        {
+          command,
+          exitCode: typeof exitCode === 'string' || typeof exitCode === 'number' ? exitCode : exitCode === null ? null : undefined,
+          stdout,
+          stderr,
+          timedOut,
+          wasTruncated: outputWasTruncated,
+        },
+        { secrets: this.secrets, llmClient },
+      );
+      if (!summary) return result;
+
+      return { ...record, summary };
+    } catch (error) {
+      this.toolSummarizerFailed = true;
+      if (this.debug) {
+        console.warn('[Agent] Terminal summarization failed; disabling for this session:', error);
       }
       return result;
     }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts
@@ -1,0 +1,144 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import { isObservationEvent, type ObservationEvent } from '../../types';
+import type { OpenHandsSettings } from '../../types/settings';
+import type { ToolDefinition } from '../../types/tools';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+class SummaryLLM implements LLMClient {
+  readonly requests: ChatCompletionRequest[] = [];
+
+  constructor(private readonly summary: string) {}
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
+    yield { type: 'text', text: this.summary };
+    yield { type: 'finish' };
+  }
+}
+
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-terminal-summary-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('Agent terminal ObservationEvent summaries (UI)', () => {
+  it('attaches observation.summary when tool summaries are enabled', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: { summarizeToolCalls: true },
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const log = new EventLog();
+    const summarizer = new SummaryLLM('Listed the repository status.');
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: 'git status',
+        exit_code: 0,
+        stdout: 'On branch develop\nnothing to commit, working tree clean\n',
+        stderr: '',
+        timeout: false,
+      }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Running terminal' },
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"git status"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      toolSummarizerClient: summarizer,
+      tools: [tool],
+    });
+
+    await agent.run('run terminal');
+
+    expect(summarizer.requests.some((req) => req.systemPrompt === 'You summarize terminal tool results for an IDE UI.')).toBe(true);
+
+    const observationEvent = log.list().find((event) => isObservationEvent(event) && event.tool_name === 'terminal');
+    expect(observationEvent).toBeTruthy();
+    const observation = (observationEvent as ObservationEvent).observation as Record<string, unknown>;
+    expect(observation.summary).toBe('Listed the repository status.');
+  });
+
+  it('does not attach observation.summary when disabled', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: { summarizeToolCalls: false },
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+    const log = new EventLog();
+    const summarizer = new SummaryLLM('should not be used');
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({
+        command: 'git status',
+        exit_code: 0,
+        stdout: 'clean\n',
+        stderr: '',
+        timeout: false,
+      }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Running terminal' },
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{"command":"git status"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      toolSummarizerClient: summarizer,
+      tools: [tool],
+    });
+
+    await agent.run('run terminal');
+
+    expect(summarizer.requests).toHaveLength(0);
+
+    const observationEvent = log.list().find((event) => isObservationEvent(event) && event.tool_name === 'terminal');
+    expect(observationEvent).toBeTruthy();
+    const observation = (observationEvent as ObservationEvent).observation as Record<string, unknown>;
+    expect(observation.summary).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Bead: `oh-tab-xhhm`

Fix
- When `openhands.agent.summarizeToolCalls` is enabled, local-mode terminal tool observations are enriched with `observation.summary` using the existing `summarizeTerminalObservationWithGeminiFlash` helper.
- This allows the webview Tool Result block to show a 1–3 sentence summary instead of the fallback “Done.” (while still allowing expansion to raw JSON).

Tests
- Adds `Agent.terminal-observation-summary.test.ts` to assert summary is attached when enabled and absent when disabled.
- `npm test` (root) passes locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added terminal output summarization for tool calls. When enabled in settings, terminal command results are automatically summarized for improved readability.

* **Tests**
  * Added test suite for terminal output summarization feature to validate behavior when enabled and disabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->