### PR TITLE
[oh-tab-5nb3] Show last-turn context tokens

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -38,46 +38,55 @@ describe('App toolbar interactions', () => {
     expect(totalsRow).not.toHaveTextContent('Total cost:');
 
     await act(async () => {
-      window.dispatchEvent(new MessageEvent('message', {
-        data: {
-          type: 'event',
-          event: {
-            kind: 'ConversationStateUpdateEvent',
-            key: 'stats',
-            value: {
-              usage_to_metrics: {
-                default: {
-                  accumulated_cost: 0.0123,
-                  accumulated_token_usage: { prompt_tokens: 10, completion_tokens: 5 },
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              key: 'stats',
+              value: {
+                usage_to_metrics: {
+                  default: {
+                    accumulated_cost: 0.0123,
+                    accumulated_token_usage: { prompt_tokens: 10, completion_tokens: 5 },
+                    token_usages: [{ prompt_tokens: 10, completion_tokens: 5 }],
+                  },
                 },
               },
             },
           },
-        },
-      }));
+        }),
+      );
     });
 
     expect(totalsRow).toHaveTextContent('Context: 10 tokens');
     expect(totalsRow).toHaveTextContent('Total cost: $0.0123');
 
     await act(async () => {
-      window.dispatchEvent(new MessageEvent('message', {
-        data: {
-          type: 'event',
-          event: {
-            kind: 'ConversationStateUpdateEvent',
-            key: 'stats',
-            value: {
-              usage_to_metrics: {
-                default: {
-                  accumulated_cost: 0,
-                  accumulated_token_usage: { prompt_tokens: 12, completion_tokens: 0 },
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              key: 'stats',
+              value: {
+                usage_to_metrics: {
+                  default: {
+                    accumulated_cost: 0,
+                    accumulated_token_usage: { prompt_tokens: 22, completion_tokens: 5 },
+                    token_usages: [
+                      { prompt_tokens: 10, completion_tokens: 5 },
+                      { prompt_tokens: 12, completion_tokens: 0 },
+                    ],
+                  },
                 },
               },
             },
           },
-        },
-      }));
+        }),
+      );
     });
 
     expect(totalsRow).toHaveTextContent('Context: 12 tokens');

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -134,6 +134,62 @@ describe('App toolbar interactions', () => {
     expect(totalsRow).not.toHaveTextContent('—');
   });
 
+  it('resets llm usage guard when starting a new conversation', async () => {
+    render(<App />);
+
+    const totalsRow = await screen.findByTestId('header-totals-row');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              key: 'llm_usage',
+              value: {
+                input: 10,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 10 tokens');
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Start new conversation'));
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              key: 'stats',
+              value: {
+                usage_to_metrics: {
+                  default: {
+                    accumulated_cost: 0,
+                    accumulated_token_usage: { prompt_tokens: 1, completion_tokens: 0, per_turn_token: 7 },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 7 tokens');
+  });
+
   it('shows the configured LLM profile in the input row', async () => {
     render(<App />);
 

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -44,13 +44,35 @@ describe('App toolbar interactions', () => {
             type: 'event',
             event: {
               kind: 'ConversationStateUpdateEvent',
+              key: 'llm_usage',
+              value: {
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 10 tokens');
+    expect(totalsRow).not.toHaveTextContent('Total cost:');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
               key: 'stats',
               value: {
                 usage_to_metrics: {
                   default: {
                     accumulated_cost: 0.0123,
-                    accumulated_token_usage: { prompt_tokens: 10, completion_tokens: 5 },
-                    token_usages: [{ prompt_tokens: 10, completion_tokens: 5 }],
+                    accumulated_token_usage: { prompt_tokens: 10, completion_tokens: 5, per_turn_token: 999 },
                   },
                 },
               },
@@ -70,16 +92,34 @@ describe('App toolbar interactions', () => {
             type: 'event',
             event: {
               kind: 'ConversationStateUpdateEvent',
+              key: 'llm_usage',
+              value: {
+                input: 12,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 12 tokens');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
               key: 'stats',
               value: {
                 usage_to_metrics: {
                   default: {
                     accumulated_cost: 0,
-                    accumulated_token_usage: { prompt_tokens: 22, completion_tokens: 5 },
-                    token_usages: [
-                      { prompt_tokens: 10, completion_tokens: 5 },
-                      { prompt_tokens: 12, completion_tokens: 0 },
-                    ],
+                    accumulated_token_usage: { prompt_tokens: 22, completion_tokens: 5, per_turn_token: 888 },
                   },
                 },
               },

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -88,6 +88,7 @@ const computeConversationTotalsFromStats = (value: unknown): ConversationTotals 
     return Number.isFinite(num) ? num : null;
   };
   const getTokenUsageArray = (metric: Record<string, unknown>): unknown[] | null => {
+    // Token usage history keys vary across backends/versions; keep fallbacks for restores.
     const raw = metric.tokenUsages ?? metric.token_usages ?? metric.token_usages_history ?? metric.tokenUsagesHistory;
     return Array.isArray(raw) ? raw : null;
   };

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -141,6 +141,15 @@ const computeConversationTotalsFromStats = (value: unknown): ConversationTotals 
   return { contextTokens, totalTokens, totalCost, costIsKnown };
 };
 
+const parseLlmUsageInputTokens = (value: unknown): number | null => {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const raw = record.input ?? record.inputTokens ?? record.promptTokens ?? record.prompt_tokens;
+  const num = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
+  if (!Number.isFinite(num)) return null;
+  return Math.max(0, Math.trunc(num));
+};
+
 type PendingLlmProfilesRequest =
   | {
     kind: 'list';
@@ -300,6 +309,7 @@ export function App() {
   const lastAgentStatusRef = useRef<string | undefined>(undefined);
   const streamingStateRef = useRef(initialLlmStreamingState);
   const submissionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasLlmUsageRef = useRef(false);
   const uiStateRef = useRef({
     input: '',
     showContextPicker: false,
@@ -524,19 +534,32 @@ export function App() {
       lastAgentStatusRef.current = event.agent_status;
     }
 
+    if (event.key === 'llm_usage') {
+      const inputTokens = parseLlmUsageInputTokens(event.value);
+      if (inputTokens !== null) {
+        hasLlmUsageRef.current = true;
+        setConversationTotals((prev) => {
+          if (prev.contextTokens === inputTokens) return prev;
+          return { ...prev, contextTokens: inputTokens };
+        });
+      }
+    }
+
     if (event.key === 'stats') {
       const totals = computeConversationTotalsFromStats(event.value);
       if (totals) {
         setConversationTotals((prev) => {
+          const nextContextTokens = hasLlmUsageRef.current ? prev.contextTokens : totals.contextTokens;
+          const nextTotals: ConversationTotals = { ...totals, contextTokens: nextContextTokens };
           if (
-            prev.contextTokens === totals.contextTokens
-            && prev.totalTokens === totals.totalTokens
-            && prev.totalCost === totals.totalCost
-            && prev.costIsKnown === totals.costIsKnown
+            prev.contextTokens === nextTotals.contextTokens
+            && prev.totalTokens === nextTotals.totalTokens
+            && prev.totalCost === nextTotals.totalCost
+            && prev.costIsKnown === nextTotals.costIsKnown
           ) {
             return prev;
           }
-          return totals;
+          return nextTotals;
         });
       }
     }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -87,13 +87,34 @@ const computeConversationTotalsFromStats = (value: unknown): ConversationTotals 
     const num = typeof raw === 'number' ? raw : typeof raw === 'string' ? Number(raw) : NaN;
     return Number.isFinite(num) ? num : null;
   };
+  const getTokenUsageArray = (metric: Record<string, unknown>): unknown[] | null => {
+    const raw = metric.tokenUsages ?? metric.token_usages ?? metric.token_usages_history ?? metric.tokenUsagesHistory;
+    return Array.isArray(raw) ? raw : null;
+  };
+  const getLastRequestPromptTokens = (metric: Record<string, unknown>): number | null => {
+    const tokenUsages = getTokenUsageArray(metric);
+    if (tokenUsages?.length) {
+      const last = tokenUsages[tokenUsages.length - 1];
+      if (isRecord(last)) {
+        const prompt = asFiniteNumber(last.promptTokens ?? last.prompt_tokens);
+        if (prompt !== null && prompt >= 0) return prompt;
+      }
+    }
+    const usageRaw = metric.accumulatedTokenUsage ?? metric.accumulated_token_usage;
+    if (isRecord(usageRaw)) {
+      const perTurn = asFiniteNumber(usageRaw.perTurnToken ?? usageRaw.per_turn_token);
+      if (perTurn !== null && perTurn >= 0) return perTurn;
+    }
+    return null;
+  };
 
   if (!isRecord(value)) return null;
   const usageToMetricsRaw = value.usage_to_metrics ?? value.usageToMetrics ?? value.service_to_metrics ?? value.serviceToMetrics;
   if (!isRecord(usageToMetricsRaw)) return null;
 
   let contextTokens = 0;
-  let completionTokens = 0;
+  let accumulatedPromptTokens = 0;
+  let accumulatedCompletionTokens = 0;
   let totalCost = 0;
 
   for (const metricRaw of Object.values(usageToMetricsRaw)) {
@@ -102,15 +123,18 @@ const computeConversationTotalsFromStats = (value: unknown): ConversationTotals 
     const cost = asFiniteNumber(costRaw);
     if (cost !== null && cost > 0) totalCost += cost;
 
+    const lastPrompt = getLastRequestPromptTokens(metricRaw);
+    if (lastPrompt !== null && lastPrompt > 0) contextTokens += lastPrompt;
+
     const usageRaw = metricRaw.accumulatedTokenUsage ?? metricRaw.accumulated_token_usage;
     if (!isRecord(usageRaw)) continue;
     const prompt = asFiniteNumber(usageRaw.promptTokens ?? usageRaw.prompt_tokens);
-    if (prompt !== null && prompt > 0) contextTokens += prompt;
+    if (prompt !== null && prompt > 0) accumulatedPromptTokens += prompt;
     const completion = asFiniteNumber(usageRaw.completionTokens ?? usageRaw.completion_tokens);
-    if (completion !== null && completion > 0) completionTokens += completion;
+    if (completion !== null && completion > 0) accumulatedCompletionTokens += completion;
   }
 
-  const totalTokens = contextTokens + completionTokens;
+  const totalTokens = accumulatedPromptTokens + accumulatedCompletionTokens;
   // Best-effort: treat cost as "known" only once we have non-zero usage + non-zero cost.
   const costIsKnown = totalTokens > 0 && totalCost > 0;
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -914,6 +914,7 @@ export function App() {
               setAgentStatus(undefined);
               setStreamingContent(null);
               setConversationTotals(INITIAL_CONVERSATION_TOTALS);
+              hasLlmUsageRef.current = false;
               eventId.current = 1;
               const api = getVscodeApi();
               api.setState?.({});
@@ -1243,6 +1244,7 @@ export function App() {
     setAgentStatus(undefined);
     setStreamingContent(null);
     setConversationTotals(INITIAL_CONVERSATION_TOTALS);
+    hasLlmUsageRef.current = false;
     eventId.current = 1;
     setInput('');
     setSelectedContextFiles([]);


### PR DESCRIPTION
Bead: `oh-tab-5nb3`

Change
- The header “Context: N tokens” now reflects **last-turn input tokens** from `ConversationStateUpdateEvent` key `llm_usage` (`value.input`).
- `stats` remains the source for cumulative totals (e.g. Total cost), but no longer overrides Context once `llm_usage` has been seen.

Test
- Updates `App.toolbar.test.tsx` to ensure Context tracks `llm_usage.input` across two turns (10 → 12) and is not overwritten by a conflicting `stats` payload.

Local
- `npm test` and `npm run typecheck` pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured token usage tracking to improve handling of prompt tokens, completion tokens, and context token counts across different backend versions.

* **Tests**
  * Updated test suite to reflect changes in token usage event structure and assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->