### PR TITLE
[oh-tab-orqc] Settings: rename ElevenLabs HAL config to HAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This repo uses Husky + lint-staged to run ESLint on staged `*.ts`/`*.tsx` files 
 - **OpenHands: Set Custom Secret 1/2/3** - Set custom secrets for additional integrations
 - Leave server URL blank for local mode, or set it to connect to an [agent-server](https://github.com/OpenHands/software-agent-sdk)
 
-**Using Gemini as the main agent LLM**: set `openhands.llm.provider = gemini`, set `openhands.llm.model` to a Gemini model id (for example `gemini-2.5-flash`), and store your API key via **OpenHands: Set API Key**. (The `openhands.gemini.*` settings are only used for HAL voice-confirm decision classification, not the agent’s main LLM.)
+**Using Gemini as the main agent LLM**: set `openhands.llm.provider = gemini`, set `openhands.llm.model` to a Gemini model id (for example `gemini-2.5-flash`), and store your API key via **OpenHands: Set API Key**. (The `openhands.hal.gemini.*` settings are only used for HAL voice-confirm decision classification, not the agent’s main LLM.)
 
 ## Documentation
 

--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -123,23 +123,23 @@ References:
 3) The test harness selects the decision via E2E command(s), then the extension executes it.
 
 ## Settings / configuration
-Proposed settings (names TBD):
-- `openhands.elevenlabs.enabled`: boolean (default `false`)
-- `openhands.elevenlabs.mode`: `bundled` | `tts_only` | `voice_confirm` (default: `tts_only`)
-- `openhands.elevenlabs.userName`: string (default: `Engel`) — used only for templated script lines in the HAL flow
+Settings:
+- `openhands.hal.enabled`: boolean (default `false`)
+- `openhands.hal.mode`: `bundled` | `tts_only` | `voice_confirm` (default: `tts_only`)
+- `openhands.hal.userName`: string (default: `Engel`) — used only for templated script lines in the HAL flow
 - API key:
   - Settings UI placeholder: `openhands.secrets.elevenLabsApiKey`
   - Stored securely in SecretStorage: `openhands.elevenLabsApiKey` (already implemented)
-- `openhands.elevenlabs.voiceAId`: string (`voice_hal` / HAL voice id)
-- `openhands.elevenlabs.voiceUserId`: string (`voice_user` / user voice id; used for `tts_only`)
-- `openhands.elevenlabs.modelId`: e.g. `eleven_turbo_v2` (optional)
-- `openhands.elevenlabs.volume`: 0.0–1.0
-- `openhands.elevenlabs.cache`: boolean (default `true`)
+- `openhands.hal.voiceAId`: string (`voice_hal` / HAL voice id)
+- `openhands.hal.voiceUserId`: string (`voice_user` / user voice id; used for `tts_only`)
+- `openhands.hal.modelId`: e.g. `eleven_turbo_v2` (optional)
+- `openhands.hal.volume`: 0.0–1.0
+- `openhands.hal.cache`: boolean (default `true`)
 - Gemini (only for `voice_confirm`):
-  - `openhands.gemini.model`: string (default: `gemini-2.5-flash`)
-  - `openhands.gemini.baseUrl`: string (default: Gemini API base URL; allow proxies)
+  - `openhands.hal.gemini.model`: string (default: `gemini-2.5-flash`)
+  - `openhands.hal.gemini.baseUrl`: string (default: Gemini API base URL; allow proxies)
   - Settings UI placeholder: `openhands.secrets.geminiApiKey`
-  - Stored securely in SecretStorage: `openhands.geminiApiKey`
+  - Stored securely in SecretStorage: `openhands.hal.geminiApiKey`
 
 ## Caching strategy (API mode)
 - Cache by `(voiceId, modelId, normalizedText)` → audio bytes

--- a/package.json
+++ b/package.json
@@ -355,16 +355,16 @@
       },
       {
         "type": "object",
-        "title": "OpenHands: HAL / ElevenLabs",
+        "title": "OpenHands: HAL",
         "order": 4,
         "properties": {
-          "openhands.elevenlabs.enabled": {
+          "openhands.hal.enabled": {
             "type": "boolean",
             "default": false,
             "order": 1,
             "markdownDescription": "Enable the HAL high-risk confirmation flow."
           },
-          "openhands.elevenlabs.mode": {
+          "openhands.hal.mode": {
             "type": "string",
             "enum": [
               "bundled",
@@ -375,31 +375,31 @@
             "order": 2,
             "markdownDescription": "HAL mode when enabled: `bundled` (E2E/CI), `tts_only` (TTS + buttons), `voice_confirm` (TTS + mic + Gemini)."
           },
-          "openhands.elevenlabs.userName": {
+          "openhands.hal.userName": {
             "type": "string",
             "default": "Engel",
             "order": 3,
             "markdownDescription": "User name used only in templated HAL script lines."
           },
-          "openhands.elevenlabs.voiceAId": {
+          "openhands.hal.voiceAId": {
             "type": "string",
             "default": "",
             "order": 4,
             "markdownDescription": "ElevenLabs voice ID for HAL (voice A)."
           },
-          "openhands.elevenlabs.voiceUserId": {
+          "openhands.hal.voiceUserId": {
             "type": "string",
             "default": "",
             "order": 5,
             "markdownDescription": "ElevenLabs voice ID for the user (voice B, used in `tts_only` mode)."
           },
-          "openhands.elevenlabs.modelId": {
+          "openhands.hal.modelId": {
             "type": "string",
             "default": "",
             "order": 6,
             "markdownDescription": "Optional ElevenLabs model id (e.g., `eleven_turbo_v2`)."
           },
-          "openhands.elevenlabs.volume": {
+          "openhands.hal.volume": {
             "type": "number",
             "default": 1,
             "order": 7,
@@ -407,19 +407,19 @@
             "maximum": 1,
             "markdownDescription": "Playback volume (0.0–1.0)."
           },
-          "openhands.elevenlabs.cache": {
+          "openhands.hal.cache": {
             "type": "boolean",
             "default": true,
             "order": 8,
             "markdownDescription": "Enable caching for generated ElevenLabs audio."
           },
-          "openhands.gemini.model": {
+          "openhands.hal.gemini.model": {
             "type": "string",
             "default": "gemini-2.5-flash",
             "order": 9,
             "markdownDescription": "Gemini model used for `voice_confirm` classification."
           },
-          "openhands.gemini.baseUrl": {
+          "openhands.hal.gemini.baseUrl": {
             "type": "string",
             "default": "https://generativelanguage.googleapis.com/v1beta",
             "order": 10,
@@ -544,7 +544,7 @@
             "default": "",
             "order": 8,
             "editPresentation": "singlelineText",
-            "markdownDescription": "**To set your Gemini API key for HAL decision classification securely:**\n\n[🔑 Configure Gemini API Key (HAL)](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `openhands.geminiApiKey`.)_"
+            "markdownDescription": "**To set your Gemini API key for HAL decision classification securely:**\n\n[🔑 Configure Gemini API Key (HAL)](command:openhands.setGeminiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `openhands.hal.geminiApiKey`.)_"
           },
           "openhands.secrets.elevenLabsApiKey": {
             "type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1134,7 +1134,7 @@ export function activate(context: vscode.ExtensionContext) {
         const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const settings = await settingsMgr.get();
         if (chatView && chatWebviewReady) {
-          void chatView.webview.postMessage({ type: 'elevenlabsSettings', elevenlabs: settings.elevenlabs } satisfies HostToWebviewMessage);
+          void chatView.webview.postMessage({ type: 'halSettings', hal: settings.elevenlabs } satisfies HostToWebviewMessage);
         }
       } catch (err: unknown) {
         outputChannel?.appendLine(`[settings] Failed to apply HAL settings update: ${renderError(err)}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1129,7 +1129,7 @@ export function activate(context: vscode.ExtensionContext) {
   const onConfigurationChange = async (e: vscode.ConfigurationChangeEvent) => {
     await onConfigurationChangeBase(e);
 
-    if (e.affectsConfiguration('openhands.elevenlabs')) {
+    if (e.affectsConfiguration('openhands.hal')) {
       try {
         const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const settings = await settingsMgr.get();
@@ -1137,7 +1137,7 @@ export function activate(context: vscode.ExtensionContext) {
           void chatView.webview.postMessage({ type: 'elevenlabsSettings', elevenlabs: settings.elevenlabs } satisfies HostToWebviewMessage);
         }
       } catch (err: unknown) {
-        outputChannel?.appendLine(`[settings] Failed to apply elevenlabs settings update: ${renderError(err)}`);
+        outputChannel?.appendLine(`[settings] Failed to apply HAL settings update: ${renderError(err)}`);
       }
     }
   };

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -58,14 +58,14 @@ const DEFAULTS: OpenHandsSettings = {
 };
 
 const ELEVENLABS_CONFIG_UPDATES: Array<[keyof ElevenLabsSettings, string]> = [
-  ['enabled', 'openhands.elevenlabs.enabled'],
-  ['mode', 'openhands.elevenlabs.mode'],
-  ['userName', 'openhands.elevenlabs.userName'],
-  ['voiceAId', 'openhands.elevenlabs.voiceAId'],
-  ['voiceUserId', 'openhands.elevenlabs.voiceUserId'],
-  ['modelId', 'openhands.elevenlabs.modelId'],
-  ['volume', 'openhands.elevenlabs.volume'],
-  ['cache', 'openhands.elevenlabs.cache'],
+  ['enabled', 'openhands.hal.enabled'],
+  ['mode', 'openhands.hal.mode'],
+  ['userName', 'openhands.hal.userName'],
+  ['voiceAId', 'openhands.hal.voiceAId'],
+  ['voiceUserId', 'openhands.hal.voiceUserId'],
+  ['modelId', 'openhands.hal.modelId'],
+  ['volume', 'openhands.hal.volume'],
+  ['cache', 'openhands.hal.cache'],
 ];
 
 const normalizeNonEmptyString = (value: string | null | undefined): string | undefined => {
@@ -301,29 +301,29 @@ export class SettingsManager {
       confirmUnknown: this.adapter.get<boolean>('openhands.confirmation.risky.confirmUnknown', DEFAULTS.confirmation.confirmUnknown) ?? DEFAULTS.confirmation.confirmUnknown,
     };
     const elevenlabs: ElevenLabsSettings = {
-      enabled: this.adapter.get<boolean>('openhands.elevenlabs.enabled', DEFAULTS.elevenlabs.enabled) ?? DEFAULTS.elevenlabs.enabled,
+      enabled: this.adapter.get<boolean>('openhands.hal.enabled', DEFAULTS.elevenlabs.enabled) ?? DEFAULTS.elevenlabs.enabled,
       mode: normalizeElevenLabsMode(
-        this.adapter.get<unknown>('openhands.elevenlabs.mode', DEFAULTS.elevenlabs.mode) ?? DEFAULTS.elevenlabs.mode,
+        this.adapter.get<unknown>('openhands.hal.mode', DEFAULTS.elevenlabs.mode) ?? DEFAULTS.elevenlabs.mode,
         DEFAULTS.elevenlabs.mode
       ),
       userName: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.elevenlabs.userName', DEFAULTS.elevenlabs.userName) ?? DEFAULTS.elevenlabs.userName
+        this.adapter.get<string | null>('openhands.hal.userName', DEFAULTS.elevenlabs.userName) ?? DEFAULTS.elevenlabs.userName
       ) ?? DEFAULTS.elevenlabs.userName,
-      voiceAId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.elevenlabs.voiceAId', null) ?? undefined),
-      voiceUserId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.elevenlabs.voiceUserId', null) ?? undefined),
-      modelId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.elevenlabs.modelId', null) ?? undefined),
+      voiceAId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.hal.voiceAId', null) ?? undefined),
+      voiceUserId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.hal.voiceUserId', null) ?? undefined),
+      modelId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.hal.modelId', null) ?? undefined),
       volume: clampUnitInterval(
-        this.adapter.get<number | null>('openhands.elevenlabs.volume', DEFAULTS.elevenlabs.volume) ?? DEFAULTS.elevenlabs.volume,
+        this.adapter.get<number | null>('openhands.hal.volume', DEFAULTS.elevenlabs.volume) ?? DEFAULTS.elevenlabs.volume,
         DEFAULTS.elevenlabs.volume
       ),
-      cache: this.adapter.get<boolean>('openhands.elevenlabs.cache', DEFAULTS.elevenlabs.cache) ?? DEFAULTS.elevenlabs.cache,
+      cache: this.adapter.get<boolean>('openhands.hal.cache', DEFAULTS.elevenlabs.cache) ?? DEFAULTS.elevenlabs.cache,
     };
     const gemini: GeminiSettings = {
       model: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.gemini.model', DEFAULTS.gemini.model) ?? DEFAULTS.gemini.model
+        this.adapter.get<string | null>('openhands.hal.gemini.model', DEFAULTS.gemini.model) ?? DEFAULTS.gemini.model
       ) ?? DEFAULTS.gemini.model,
       baseUrl: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.gemini.baseUrl', DEFAULTS.gemini.baseUrl) ?? DEFAULTS.gemini.baseUrl
+        this.adapter.get<string | null>('openhands.hal.gemini.baseUrl', DEFAULTS.gemini.baseUrl) ?? DEFAULTS.gemini.baseUrl
       ) ?? DEFAULTS.gemini.baseUrl,
     };
     const secrets = {
@@ -333,7 +333,7 @@ export class SettingsManager {
       awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
       githubToken: await this.adapter.getSecret('openhands.githubToken'),
       elevenLabsApiKey: await this.adapter.getSecret('openhands.elevenLabsApiKey'),
-      geminiApiKey: await this.adapter.getSecret('openhands.geminiApiKey'),
+      geminiApiKey: await this.adapter.getSecret('openhands.hal.geminiApiKey'),
       customSecret1: await this.adapter.getSecret('openhands.customSecret1'),
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
       customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
@@ -415,10 +415,10 @@ export class SettingsManager {
 
     if (partial.gemini) {
       if (partial.gemini.model !== undefined) {
-        ops.push(this.adapter.update('openhands.gemini.model', partial.gemini.model, target));
+        ops.push(this.adapter.update('openhands.hal.gemini.model', partial.gemini.model, target));
       }
       if (partial.gemini.baseUrl !== undefined) {
-        ops.push(this.adapter.update('openhands.gemini.baseUrl', partial.gemini.baseUrl, target));
+        ops.push(this.adapter.update('openhands.hal.gemini.baseUrl', partial.gemini.baseUrl, target));
       }
     }
 
@@ -442,7 +442,7 @@ export class SettingsManager {
         ops.push(this.adapter.storeSecret('openhands.elevenLabsApiKey', partial.secrets.elevenLabsApiKey));
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'geminiApiKey')) {
-        ops.push(this.adapter.storeSecret('openhands.geminiApiKey', partial.secrets.geminiApiKey));
+        ops.push(this.adapter.storeSecret('openhands.hal.geminiApiKey', partial.secrets.geminiApiKey));
       }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret1')) {
         ops.push(this.adapter.storeSecret('openhands.customSecret1', partial.secrets.customSecret1));

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -57,7 +57,7 @@ const DEFAULTS: OpenHandsSettings = {
   secrets: {}
 };
 
-const ELEVENLABS_CONFIG_UPDATES: Array<[keyof ElevenLabsSettings, string]> = [
+const HAL_CONFIG_UPDATES: Array<[keyof ElevenLabsSettings, string]> = [
   ['enabled', 'openhands.hal.enabled'],
   ['mode', 'openhands.hal.mode'],
   ['userName', 'openhands.hal.userName'],
@@ -407,7 +407,7 @@ export class SettingsManager {
     }
 
     if (partial.elevenlabs) {
-      for (const [key, configKey] of ELEVENLABS_CONFIG_UPDATES) {
+      for (const [key, configKey] of HAL_CONFIG_UPDATES) {
         const value = partial.elevenlabs[key];
         if (value !== undefined) ops.push(this.adapter.update(configKey, value, target));
       }

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -34,7 +34,7 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
-  | { type: 'elevenlabsSettings'; elevenlabs: OpenHandsSettings['elevenlabs'] }
+  | { type: 'halSettings'; hal: OpenHandsSettings['elevenlabs'] }
   | {
     type: 'historyList';
     conversations: Array<{

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -74,7 +74,7 @@ describe('HAL voice_confirm', () => {
     await renderAppAndWaitReady();
 
     vi.useFakeTimers();
-    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-voice-1') });
 
@@ -82,7 +82,7 @@ describe('HAL voice_confirm', () => {
     vi.useRealTimers();
 
     // Switch to voice_confirm at decision time.
-    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
 
     const recordButton = await screen.findByRole('button', { name: /record decision/i });
     fireEvent.click(recordButton);
@@ -97,13 +97,13 @@ describe('HAL voice_confirm', () => {
     await renderAppAndWaitReady();
 
     vi.useFakeTimers();
-    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-voice-2') });
     await advanceBundledDialogueToAwaitingUser();
     vi.useRealTimers();
 
-    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
 
     const stream = { getTracks: () => [{ stop: vi.fn() }] } as any;
     Object.defineProperty(window.navigator, 'mediaDevices', {
@@ -168,13 +168,13 @@ describe('HAL voice_confirm', () => {
     await renderAppAndWaitReady();
 
     vi.useFakeTimers();
-    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
     setWaitingForConfirmation();
     postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-voice-3') });
     await advanceBundledDialogueToAwaitingUser();
     vi.useRealTimers();
 
-    postToWindow({ type: 'elevenlabsSettings', elevenlabs: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'voice_confirm', userName: 'Engel', volume: 1 } });
 
     const stream = { getTracks: () => [{ stop: vi.fn() }] } as any;
     Object.defineProperty(window.navigator, 'mediaDevices', {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -692,7 +692,7 @@ export function App() {
         hasProfileKey?: unknown;
         hasProviderKey?: unknown;
         providerKeyName?: unknown;
-        elevenlabs?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
+        hal?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
         seq?: unknown;
         error?: unknown;
@@ -923,8 +923,8 @@ export function App() {
           }
           break;
         }
-        case 'elevenlabsSettings':
-          applyElevenlabsSettings(payload.elevenlabs);
+        case 'halSettings':
+          applyElevenlabsSettings(payload.hal);
           break;
         case 'halTtsResponse': {
           handleHalTtsResponse(payload);

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -248,8 +248,8 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         });
 
         void host.postMessage({
-          type: 'elevenlabsSettings',
-          elevenlabs: initSettings.elevenlabs,
+          type: 'halSettings',
+          hal: initSettings.elevenlabs,
         });
 
         deps.flushConversationEventBacklog({

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -94,8 +94,8 @@ export async function run(): Promise<void> {
   const cfg = vscode.workspace.getConfiguration();
   await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
   await cfg.update('openhands.servers', [], vscode.ConfigurationTarget.Global);
-  await cfg.update('openhands.elevenlabs.enabled', true, vscode.ConfigurationTarget.Global);
-  await cfg.update('openhands.elevenlabs.mode', 'bundled', vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.hal.enabled', true, vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.hal.mode', 'bundled', vscode.ConfigurationTarget.Global);
 
   await pollUntil(async () => {
     const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');


### PR DESCRIPTION
Closes bead: oh-tab-orqc.

Changes:
- Rename user-facing HAL settings from `openhands.elevenlabs.*` -> `openhands.hal.*` (clean break; no backwards compatibility).
- Move HAL voice-confirm Gemini classifier settings from `openhands.gemini.*` -> `openhands.hal.gemini.*`.
- Move the HAL classifier SecretStorage key from `openhands.geminiApiKey` -> `openhands.hal.geminiApiKey` (users must re-enter).
- Update SettingsManager, config change watcher, docs, and e2e HAL setup keys.

Validation:
- `npm run typecheck`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration references to reflect new HAL-unified settings namespace
  * Enhanced documentation on error handling, fallback behaviors, and caching strategies

* **Refactor**
  * Consolidated configuration keys under HAL namespace for improved organization
  * Clarified that Gemini LLM settings are now specifically scoped to HAL voice confirmation rather than global agent configuration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->