### PR TITLE
[oh-tab-2mok] Tests: cover policy=always security_risk

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
@@ -67,6 +67,42 @@ describe('Agent security risk handling', () => {
     expect(parameters?.required).toContain('security_risk');
   });
 
+  it('includes security_risk in tool schema + prompt for always confirmations', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, unknown>, { ok: true }> = {
+      name: 'noop',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async () => ({ ok: true }),
+      description: 'No-op tool.',
+      parameters: {
+        type: 'object',
+        properties: {
+          value: { type: 'string' },
+        },
+        required: ['value'],
+      },
+    };
+
+    const llm = new MockLLM([{ type: 'text', text: 'ok' }, { type: 'finish' }]);
+    const agent = new Agent({
+      settings: { ...baseSettings, confirmation: { policy: 'always' } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('hello');
+
+    const request = llm.lastRequest;
+    expect(request).not.toBeNull();
+    expect(request?.systemPrompt).toContain('<SECURITY_RISK_ASSESSMENT>');
+
+    const parameters = request?.tools?.[0]?.function?.parameters as any;
+    expect(parameters?.properties?.security_risk).toBeTruthy();
+    expect(parameters?.required).toContain('security_risk');
+  });
+
   it('omits security_risk schema + prompt section when confirmations are disabled', async () => {
     const log = new EventLog();
     const tool: ToolDefinition<Record<string, unknown>, { ok: true }> = {


### PR DESCRIPTION
Closes bead: oh-tab-2mok.

Adds missing unit coverage for `confirmation.policy = "always"` in security-risk prompt/schema wiring:
- Asserts `<SECURITY_RISK_ASSESSMENT>` is present in the system prompt.
- Asserts tool schema requires `security_risk`.

Validation:
- `npx vitest run src/sdk/runtime/__tests__/Agent.security-risk.test.ts` (workspace `@openhands/agent-sdk-ts`)
