### PR TITLE
refactor(webview): centralize pending-actions batch ID derivation in App.tsx

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -586,18 +586,21 @@ export function App() {
       setIsSubmitting(false);
     };
 
+    // Helper to derive the pending-action batch ID from a list of actions.
+    const getBatchIdFromActions = (actions: readonly ActionEvent[]): string | null => {
+      if (!actions.length) return null;
+      const id = actions[0]?.llm_response_id;
+      return typeof id === 'string' ? id : null;
+    };
+
     if (isActionEvent(event)) {
       const prev = pendingActionsRef.current;
       const exists = prev.some((a) => a.tool_call_id === event.tool_call_id);
       if (exists) return;
 
       const nextBatchId = typeof event.llm_response_id === 'string' ? event.llm_response_id : null;
-      const prevBatchId =
-        pendingActionsBatchIdRef.current ?? (prev.length && typeof prev[0].llm_response_id === 'string' ? prev[0].llm_response_id : null);
-      const next =
-        prev.length && prevBatchId && nextBatchId && prevBatchId !== nextBatchId
-          ? [event]
-          : [...prev, event];
+      const prevBatchId = pendingActionsBatchIdRef.current ?? getBatchIdFromActions(prev);
+      const next = prev.length && prevBatchId && nextBatchId && prevBatchId !== nextBatchId ? [event] : [...prev, event];
 
       pendingActionsRef.current = next;
       pendingActionsBatchIdRef.current = nextBatchId;
@@ -607,7 +610,7 @@ export function App() {
       const next = prev.filter((a) => a.tool_call_id !== event.tool_call_id);
       if (next.length !== prev.length) {
         pendingActionsRef.current = next;
-        pendingActionsBatchIdRef.current = next.length ? (typeof next[0].llm_response_id === 'string' ? next[0].llm_response_id : null) : null;
+        pendingActionsBatchIdRef.current = getBatchIdFromActions(next);
         setPendingActions(next);
       }
       clearSubmissionState();

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -588,7 +588,6 @@ export function App() {
 
     // Helper to derive the pending-action batch ID from a list of actions.
     const getBatchIdFromActions = (actions: readonly ActionEvent[]): string | null => {
-      if (!actions.length) return null;
       const id = actions[0]?.llm_response_id;
       return typeof id === 'string' ? id : null;
     };


### PR DESCRIPTION
Context
A post-merge review comment on #458 suggested extracting a helper to derive the pending-actions batch ID in the webview to avoid duplicating logic between the ActionEvent and ObservationEvent branches in handlePendingActions.

What this PR does
- Extracts getBatchIdFromActions helper local to handlePendingActions
- Replaces duplicated conditional logic with calls to the helper in both branches
- No behavior change intended; improves readability and maintainability

Validation
- Installed dependencies with npm ci
- Ran all checks successfully:
  - npm test (packages/agent-sdk-ts and webview) – all passing
  - npm run typecheck – passing
  - npm run lint – passing

Notes
- This PR follows up on feedback not included in #458 after merge, purely a refactor.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b0bd835bb3d74f42b3d63eedbc833bc2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated batch ID computation logic to improve consistency across pending action operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->