### PR TITLE
oh-tab-s7qh: Indicate set secrets in settings

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -182,6 +182,119 @@ describe('Extension Activation', () => {
   });
 });
 
+describe('Secret indicator sync', () => {
+  let mockContext: any;
+  let extension: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    (vscode as any).__resetMocks();
+    mockSettings = structuredClone(defaultMockSettings);
+    mockContext = createMockContext();
+    extension = await import('../extension');
+  });
+
+  afterEach(() => {
+    extension?.deactivate?.();
+  });
+
+  it('writes a non-secret status marker for settings-backed secrets', async () => {
+    await extension.activate(mockContext);
+
+    const cfg = vscode.workspace.getConfiguration();
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((cfg.update as Mock).mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(cfg.update).toHaveBeenCalledWith('openhands.secrets.sessionApiKey', '✓ set', vscode.ConfigurationTarget.Global);
+    expect(cfg.update).not.toHaveBeenCalledWith(
+      'openhands.secrets.sessionApiKey',
+      defaultMockSettings.secrets.sessionApiKey,
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  it('writes status markers for secrets stored in SecretStorage', async () => {
+    const secretStorage = new Map<string, string>([['OPENAI_API_KEY', 'sk-test']]);
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+    mockContext.secrets.delete = vi.fn(async (key: string) => {
+      secretStorage.delete(key);
+    });
+
+    await extension.activate(mockContext);
+
+    const cfg = vscode.workspace.getConfiguration();
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((cfg.update as Mock).mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(cfg.update).toHaveBeenCalledWith('openhands.secrets.openaiApiKey', '✓ set', vscode.ConfigurationTarget.Global);
+    expect(cfg.update).not.toHaveBeenCalledWith(
+      'openhands.secrets.openaiApiKey',
+      secretStorage.get('OPENAI_API_KEY'),
+      vscode.ConfigurationTarget.Global
+    );
+  });
+
+  it('clears status markers when the underlying secret is not set', async () => {
+    (vscode as any).__getMockConfigValues().set('openhands.secrets.openaiApiKey', '✓ set');
+
+    const secretStorage = new Map<string, string>();
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+    mockContext.secrets.delete = vi.fn(async (key: string) => {
+      secretStorage.delete(key);
+    });
+
+    await extension.activate(mockContext);
+
+    const cfg = vscode.workspace.getConfiguration();
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((cfg.update as Mock).mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(cfg.update).toHaveBeenCalledWith('openhands.secrets.openaiApiKey', undefined, vscode.ConfigurationTarget.Global);
+  });
+
+  it('updates the status marker after a secret set command', async () => {
+    const secretStorage = new Map<string, string>();
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+    mockContext.secrets.delete = vi.fn(async (key: string) => {
+      secretStorage.delete(key);
+    });
+
+    await extension.activate(mockContext);
+
+    const cfg = vscode.workspace.getConfiguration();
+    (cfg.update as Mock).mockClear();
+
+    (vscode.window.showInputBox as Mock).mockResolvedValue('sk-new');
+    await vscode.commands.executeCommand('openhands.setOpenAiApiKey');
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((cfg.update as Mock).mock.calls.length > 0) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(cfg.update).toHaveBeenCalledWith('openhands.secrets.openaiApiKey', '✓ set', vscode.ConfigurationTarget.Global);
+  });
+});
+
 function createMockWebviewView() {
   const view: any = {
     visible: true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -809,6 +809,62 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   type SecretKey = keyof OpenHandsSettings['secrets'];
+
+  const SECRET_STATUS_SET_VALUE = '✓ set';
+
+  const syncSecretStatusIndicators = async (): Promise<void> => {
+    const cfg = vscode.workspace.getConfiguration();
+
+    const getIsSetFromSecretStorage = async (storageKey: string): Promise<boolean> => {
+      const value = await context.secrets.get(storageKey);
+      return typeof value === 'string' && value.trim().length > 0;
+    };
+
+    let settingsSecrets: OpenHandsSettings['secrets'] | undefined;
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+      settingsSecrets = (await settingsMgr.get())?.secrets;
+    } catch {
+      // Best-effort: do not surface errors for a purely UX indicator.
+      settingsSecrets = undefined;
+    }
+
+    const getIsSetFromSettingsSecrets = (value: unknown): boolean => typeof value === 'string' && value.trim().length > 0;
+
+    const indicators: Array<{ key: string; isSet: boolean }> = [
+      { key: 'openhands.secrets.openaiApiKey', isSet: await getIsSetFromSecretStorage('OPENAI_API_KEY') },
+      { key: 'openhands.secrets.anthropicApiKey', isSet: await getIsSetFromSecretStorage('ANTHROPIC_API_KEY') },
+      { key: 'openhands.secrets.openrouterApiKey', isSet: await getIsSetFromSecretStorage('OPENROUTER_API_KEY') },
+      { key: 'openhands.secrets.litellmApiKey', isSet: await getIsSetFromSecretStorage('LITELLM_API_KEY') },
+      { key: 'openhands.secrets.geminiLlmApiKey', isSet: await getIsSetFromSecretStorage('GEMINI_API_KEY') },
+
+      { key: 'openhands.secrets.sessionApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.sessionApiKey) },
+      { key: 'openhands.secrets.githubToken', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.githubToken) },
+      { key: 'openhands.secrets.geminiApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.geminiApiKey) },
+      { key: 'openhands.secrets.elevenLabsApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.elevenLabsApiKey) },
+      { key: 'openhands.secrets.customSecret1', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret1) },
+      { key: 'openhands.secrets.customSecret2', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret2) },
+      { key: 'openhands.secrets.customSecret3', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret3) },
+    ];
+
+    for (const indicator of indicators) {
+      const desired = indicator.isSet ? SECRET_STATUS_SET_VALUE : undefined;
+      const inspection = cfg.inspect<string>(indicator.key);
+      const currentGlobal = inspection?.globalValue;
+      if (currentGlobal === desired) continue;
+
+      await cfg.update(indicator.key, desired, vscode.ConfigurationTarget.Global);
+    }
+  };
+
+  const syncSecretStatusIndicatorsBestEffort = async (): Promise<void> => {
+    try {
+      await syncSecretStatusIndicators();
+    } catch {
+      // Best-effort; never block activation or secret updates.
+    }
+  };
+
   const registerSecretCommand = (
     commandId: string,
     options: {
@@ -856,6 +912,7 @@ export function activate(context: vscode.ExtensionContext) {
 
             const newSettings = await settingsMgr.get();
             conversation?.setSettings(newSettings);
+            await syncSecretStatusIndicatorsBestEffort();
             return;
           }
         }
@@ -878,6 +935,7 @@ export function activate(context: vscode.ExtensionContext) {
 
         const newSettings = await settingsMgr.get();
         conversation?.setSettings(newSettings);
+        await syncSecretStatusIndicatorsBestEffort();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`${options.errorPrefix}: ${message}`);
@@ -926,6 +984,7 @@ export function activate(context: vscode.ExtensionContext) {
             await context.secrets.delete(options.storageKey);
             secrets.set(options.storageKey, undefined);
             vscode.window.showInformationMessage(options.clearedMessage);
+            await syncSecretStatusIndicatorsBestEffort();
             return;
           }
         }
@@ -945,6 +1004,7 @@ export function activate(context: vscode.ExtensionContext) {
         await context.secrets.store(options.storageKey, trimmed);
         secrets.set(options.storageKey, trimmed);
         vscode.window.showInformationMessage(options.successMessage);
+        await syncSecretStatusIndicatorsBestEffort();
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         vscode.window.showErrorMessage(`${options.errorPrefix}: ${message}`);
@@ -1075,6 +1135,8 @@ export function activate(context: vscode.ExtensionContext) {
     clearedMessage: 'Custom secret 3 cleared.',
     errorPrefix: 'Failed to save custom secret 3',
   });
+
+  void syncSecretStatusIndicatorsBestEffort();
 
   const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {
     await ensureConversationAndConnection();

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -9,13 +9,27 @@ const mockConfigListeners: Function[] = [];
 const mockConfigValues = new Map<string, any>();
 const mockWebviewViewProviders = new Map<string, any>();
 
+const mockConfiguration = {
+  get: vi.fn((key: string, defaultValue?: any) => (mockConfigValues.has(key) ? mockConfigValues.get(key) : defaultValue)),
+  inspect: vi.fn((key: string) => ({
+    key,
+    globalValue: mockConfigValues.get(key),
+    workspaceValue: undefined,
+    workspaceFolderValue: undefined,
+    defaultValue: undefined,
+  })),
+  update: vi.fn(async (key: string, value: any) => {
+    if (value === undefined) {
+      mockConfigValues.delete(key);
+    } else {
+      mockConfigValues.set(key, value);
+    }
+  }),
+};
+
 // Workspace mock
 export const workspace = {
-  getConfiguration: vi.fn(() => ({
-    get: vi.fn((key: string, defaultValue?: any) => (mockConfigValues.has(key) ? mockConfigValues.get(key) : defaultValue)),
-    inspect: vi.fn(),
-    update: vi.fn(),
-  })),
+  getConfiguration: vi.fn(() => mockConfiguration),
   registerTextDocumentContentProvider: vi.fn(() => ({ dispose: vi.fn() })),
   onDidChangeConfiguration: vi.fn((listener: Function) => {
     mockConfigListeners.push(listener);
@@ -152,6 +166,9 @@ export function __resetMocks() {
   mockWebviewViewProviders.clear();
   // Reset common spies to default implementations
   ;(workspace.getConfiguration as any).mockClear();
+  ;(mockConfiguration.get as any).mockClear();
+  ;(mockConfiguration.inspect as any).mockClear();
+  ;(mockConfiguration.update as any).mockClear();
   ;(workspace.registerTextDocumentContentProvider as any).mockClear();
   ;(workspace.onDidChangeConfiguration as any).mockClear();
   ;(window.showInformationMessage as any).mockClear();


### PR DESCRIPTION
Fixes oh-tab-s7qh.

- Syncs `OpenHands: Secrets` placeholder settings (`openhands.secrets.*`) to show "✓ set" when the corresponding secret exists in VS Code SecretStorage.
- Clears the placeholder setting by unsetting it (writes `undefined`), so we don’t persist empty strings.
- Best-effort only; never logs or writes secret values.

Tests:
- `npm test`
- `npm run typecheck`