### PR TITLE
oh-tab-l95w: Add active editor path to system prompt

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
+import { AgentContext } from '../..';
 import { isSystemPromptEvent } from '../../types';
 import type { OpenHandsSettings } from '../../types/settings';
 
@@ -62,5 +63,38 @@ describe('Agent system prompt', () => {
     const systemPromptEvent = log.list().find(isSystemPromptEvent);
     expect(systemPromptEvent).toBeDefined();
     expect(systemPromptEvent.system_prompt.text).toBe(systemPrompt);
+  });
+
+  it('includes the latest AgentContext systemMessageSuffix on each LLM request', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 3 },
+      confirmation: { policy: 'never' },
+      secrets: {},
+    };
+    const log = new EventLog();
+    const llm = new RecordingLLM();
+    const agentContext = new AgentContext({ systemMessageSuffix: 'Currently opened in the editor: /tmp/first.ts' });
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      agentContext,
+    });
+
+    await agent.run('hi');
+    expect(llm.requests[0]?.systemPrompt).toContain('Currently opened in the editor: /tmp/first.ts');
+
+    agentContext.systemMessageSuffix = 'Currently opened in the editor: /tmp/second.ts';
+    await agent.run('hi again');
+    expect(llm.requests[1]?.systemPrompt).toContain('Currently opened in the editor: /tmp/second.ts');
+    expect(llm.requests[1]?.systemPrompt).not.toContain('Currently opened in the editor: /tmp/first.ts');
+
+    agentContext.systemMessageSuffix = undefined;
+    await agent.run('hi again (cleared)');
+    expect(llm.requests[2]?.systemPrompt).not.toContain('Currently opened in the editor:');
   });
 });

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -472,6 +472,45 @@ describe('Chat view behavior', () => {
     expect(mockContext.workspaceState.update).toHaveBeenCalledWith('openhands.conversationId.local', undefined);
   });
 
+  it('updates the local AgentContext system prompt suffix with the active editor file path', async () => {
+    mockSettings = { ...mockSettings, serverUrl: '' as any };
+    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', '');
+
+    (vscode.window as any).activeTextEditor = {
+      document: {
+        uri: {
+          scheme: 'file',
+          fsPath: '/test/workspace/src/initial.ts',
+        },
+      },
+    };
+
+    await resolveChatView(mockContext);
+
+    const { Conversation } = await import('@openhands/agent-sdk-ts');
+    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
+    expect(options?.agentContext).toBeTruthy();
+    const agentContext = options.agentContext as any;
+
+    expect(agentContext.systemMessageSuffix).toBe('Currently opened in the editor: /test/workspace/src/initial.ts');
+
+    const nextEditor = {
+      document: {
+        uri: {
+          scheme: 'file',
+          fsPath: '/test/workspace/src/next.ts',
+        },
+      },
+    };
+    (vscode.window as any).activeTextEditor = nextEditor;
+    (vscode as any).__triggerActiveTextEditorChange(nextEditor);
+    expect(agentContext.systemMessageSuffix).toBe('Currently opened in the editor: /test/workspace/src/next.ts');
+
+    (vscode.window as any).activeTextEditor = undefined;
+    (vscode as any).__triggerActiveTextEditorChange(undefined);
+    expect(agentContext.systemMessageSuffix).toBeUndefined();
+  });
+
   it('auto-disables tool-call summarization when Gemini key is missing (local mode)', async () => {
     const priorEnv = process.env.GEMINI_API_KEY;
     delete process.env.GEMINI_API_KEY;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,6 +54,8 @@ let secretRegistry: SecretRegistry | undefined;
 let conversationStoreRoot: string | undefined;
 let lastKnownLlmLabel: string | null = null;
 let verboseEventLogging = false;
+let localAgentContext: AgentContext | undefined;
+let activeEditorFilePath: string | undefined;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -321,6 +323,22 @@ function normalizeNonEmptyString(value: string | undefined | null): string | und
   return trimmed || undefined;
 }
 
+function resolveActiveEditorFilePath(editor: vscode.TextEditor | undefined): string | undefined {
+  if (!editor) return undefined;
+  const uri = editor.document.uri;
+  if (uri.scheme !== 'file') return undefined;
+  const fsPath = typeof uri.fsPath === 'string' ? uri.fsPath.trim() : '';
+  return fsPath || undefined;
+}
+
+function syncActiveEditorSystemMessageSuffix(editor: vscode.TextEditor | undefined): void {
+  activeEditorFilePath = resolveActiveEditorFilePath(editor);
+  if (!localAgentContext) return;
+  localAgentContext.systemMessageSuffix = activeEditorFilePath
+    ? `Currently opened in the editor: ${activeEditorFilePath}`
+    : undefined;
+}
+
 function resolveConfiguredPath(p: string): string {
   const raw = p.trim();
   if (raw.startsWith('~/') || raw === '~') {
@@ -478,6 +496,13 @@ export function activate(context: vscode.ExtensionContext) {
   devBridgeEnabled = isDevOrTest || enableFromSetting;
   void initFileLogger(context);
 
+  syncActiveEditorSystemMessageSuffix(vscode.window.activeTextEditor);
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      syncActiveEditorSystemMessageSuffix(editor);
+    })
+  );
+
   const handleTerminalEvent = (event: BashEvent) => {
     receivedTerminalEvents.push({ type: event.type, timestamp: Date.now() });
     if (receivedTerminalEvents.length > MAX_TERMINAL_EVENTS) {
@@ -630,6 +655,10 @@ export function activate(context: vscode.ExtensionContext) {
         desiredMode === 'local'
           ? new AgentContext({ loadUserSkills: true })
           : undefined;
+      localAgentContext = desiredMode === 'local' ? agentContext : undefined;
+      if (desiredMode === 'local') {
+        syncActiveEditorSystemMessageSuffix(vscode.window.activeTextEditor);
+      }
 
       const conversationOptions = {
         serverUrl: settings.serverUrl ?? undefined,
@@ -1238,6 +1267,8 @@ export function deactivate() {
   conversation = undefined;
   terminal = undefined;
   terminalLogPty = undefined;
+  localAgentContext = undefined;
+  activeEditorFilePath = undefined;
   pendingRenderedEventsRequests.clear();
   pendingUiStateRequests.clear();
   pendingHalStateRequests.clear();

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -6,6 +6,7 @@ import { vi } from 'vitest';
 const mockCommands = new Map<string, Function>();
 const mockSubscriptions: Array<{ dispose: () => void }> = [];
 const mockConfigListeners: Function[] = [];
+const mockActiveTextEditorListeners: Function[] = [];
 const mockConfigValues = new Map<string, any>();
 const mockWebviewViewProviders = new Map<string, any>();
 
@@ -69,6 +70,12 @@ export const window = {
   showQuickPick: vi.fn(),
   createTerminal: vi.fn(),
   onDidCloseTerminal: vi.fn(() => ({ dispose: vi.fn() })),
+  onDidChangeActiveTextEditor: vi.fn((listener: Function) => {
+    mockActiveTextEditorListeners.push(listener);
+    const disposable = { dispose: vi.fn() };
+    mockSubscriptions.push(disposable);
+    return disposable;
+  }),
   registerWebviewViewProvider: vi.fn((viewId: string, provider: any, _options?: any) => {
     mockWebviewViewProviders.set(viewId, provider);
     const disposable = { dispose: vi.fn(() => mockWebviewViewProviders.delete(viewId)) };
@@ -162,6 +169,7 @@ export function __resetMocks() {
   mockCommands.clear();
   mockSubscriptions.length = 0;
   mockConfigListeners.length = 0;
+  mockActiveTextEditorListeners.length = 0;
   mockConfigValues.clear();
   mockWebviewViewProviders.clear();
   // Reset common spies to default implementations
@@ -179,6 +187,7 @@ export function __resetMocks() {
   ;(window.showInputBox as any).mockClear();
   ;(window.showQuickPick as any).mockClear();
   ;(window.createTerminal as any).mockClear();
+  ;(window.onDidChangeActiveTextEditor as any).mockClear();
   ;(window.createTreeView as any).mockClear();
   ;(window.registerWebviewViewProvider as any).mockClear();
   ;(commands.registerCommand as any).mockClear();
@@ -192,4 +201,8 @@ export function __getMockWebviewViewProviders() { return mockWebviewViewProvider
 // Helper to manually trigger configuration change listeners (if needed by tests)
 export function __triggerConfigChange(e: any) {
   mockConfigListeners.forEach((listener) => listener(e));
+}
+
+export function __triggerActiveTextEditorChange(editor: any) {
+  mockActiveTextEditorListeners.forEach((listener) => listener(editor));
 }


### PR DESCRIPTION
Fixes oh-tab-l95w.

- Tracks VS Code active editor file path (file URIs only) and keeps it synced.
- In local mode, appends `Currently opened in the editor: <fsPath>` to the AgentContext system prompt suffix, updating live as the active editor changes.
- Adds unit tests (extension + agent-sdk) covering set/clear/switch.

Notes:
- Remote mode does not include this line (agent-server can’t see VS Code editor state).

Tests:
- npm test
- npm run typecheck
