### PR TITLE
oh-tab-a8qw: Avoid double-close on History backdrop

### DIFF
--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -276,7 +276,7 @@ export function HistoryView({
   return (
     <div className="fixed inset-0 z-50 flex" role="dialog" aria-label="Conversation History" aria-modal="true">
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} aria-hidden="true" />
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" aria-hidden="true" />
 
       {/* Panel */}
       <div


### PR DESCRIPTION
Follow-up to Gemini inline review on #470: HistoryView already closes on outside click via `useCloseOnEscapeAndOutsideClick`, so having `onClick={onClose}` on the backdrop could trigger `onClose` twice.

Change:
- Remove the redundant backdrop click handler and rely on the hook.

Tests:
- `npx vitest run src/webview-src/__tests__/HistoryView.test.tsx`

Bead: oh-tab-a8qw
