### PR TITLE
oh-tab-i4d5: Show check when profile API key override is set

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -79,6 +79,8 @@ describe('LLM Profiles view', () => {
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
 
+    expect(screen.queryByLabelText('API key override set')).toBeNull();
+
     const apiKeyInput = await screen.findByLabelText('API key override');
     fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
@@ -117,6 +119,7 @@ describe('LLM Profiles view', () => {
     });
 
     expect(await screen.findByText('Override set')).toBeInTheDocument();
+    expect(await screen.findByLabelText('API key override set')).toBeInTheDocument();
 
     expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
   });

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -644,6 +644,12 @@ export function LlmProfilesView(props: {
     return '—';
   })();
 
+  const showProfileApiKeyOverrideSetIndicator = canEditApiKey
+    && providerRequiresApiKey
+    && overrideProfileApiKey
+    && apiKeyStatus.state === 'ready'
+    && apiKeyStatus.hasProfileKey;
+
   const handleSetApiKey = useCallback(async () => {
     if (!selectedProfileId) return;
     const profileId = selectedProfileId;
@@ -934,7 +940,16 @@ export function LlmProfilesView(props: {
 
                     {mode === 'edit' && canEditApiKey && providerRequiresApiKey && overrideProfileApiKey && (
                       <div className="mt-3">
-                        <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyEdit" />
+                        <div className="flex items-center gap-2">
+                          <FieldLabel label="API key override" required htmlFor="llmProfilesApiKeyEdit" />
+                          {showProfileApiKeyOverrideSetIndicator && (
+                            <span
+                              className="codicon codicon-check text-emerald-400 text-sm"
+                              aria-label="API key override set"
+                              title="API key override set"
+                            />
+                          )}
+                        </div>
                         <div className="mt-2">
                           <InputField
                             ref={apiKeyInputRef}


### PR DESCRIPTION
Adds a subtle green checkmark next to the **API key override** label when the per-profile API key override is enabled and a profile key is already stored.

- No secret value is revealed.
- Uses codicon check.

Tests:
- `npx vitest run src/webview-src/__tests__/LlmProfilesView.test.tsx`

Bead: oh-tab-i4d5
