### PR TITLE
oh-tab-xhhm: Prefer GEMINI_API_KEY for terminal summaries

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -495,7 +495,12 @@ export class Agent extends EventEmitter {
           temperature: 0.2,
           maxOutputTokens: 256,
         },
-        { secrets: this.secrets },
+        {
+          secrets: this.secrets,
+          // Prefer the provider-specific key so a user's primary LLM key (often OpenAI) doesn't
+          // accidentally override Gemini summarizers when both are configured.
+          preferredApiKeys: 'GEMINI_API_KEY',
+        },
       );
       const client = await factory.createClient();
       this.toolSummarizerClient = client;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Agent } from '..';
+import { getGeminiClient } from '../geminiClient';
+import { SecretRegistry } from '../SecretRegistry';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class TrackingSecretRegistry extends SecretRegistry {
+  readonly calls: string[] = [];
+
+  async get(name: string): Promise<string | undefined> {
+    this.calls.push(name);
+    return super.get(name);
+  }
+}
+
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sdk-tool-summarizer-keys-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('Gemini summarizers prefer GEMINI_API_KEY', () => {
+  it('getGeminiClient prefers GEMINI_API_KEY over openhands.llmApiKey', async () => {
+    const secrets = new TrackingSecretRegistry();
+    secrets.set('openhands.llmApiKey', 'sk-openai');
+    secrets.set('GEMINI_API_KEY', 'test-gemini-key');
+
+    await getGeminiClient(secrets, {
+      usageId: 'test-gemini-client',
+      profileId: 'gemini-flash',
+      model: 'gemini-flash',
+    });
+
+    expect(secrets.calls[0]).toBe('GEMINI_API_KEY');
+  });
+
+  it('Agent tool summarizer prefers GEMINI_API_KEY over openhands.llmApiKey', async () => {
+    const secrets = new TrackingSecretRegistry();
+    secrets.set('openhands.llmApiKey', 'sk-openai');
+    secrets.set('GEMINI_API_KEY', 'test-gemini-key');
+
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: { summarizeToolCalls: true },
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+
+    const agent = new Agent({
+      settings,
+      workspaceRoot: createWorkspaceRoot(),
+      secrets,
+    });
+
+    await (agent as any).getToolSummarizerClient();
+
+    expect(secrets.calls[0]).toBe('GEMINI_API_KEY');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/geminiClient.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/geminiClient.ts
@@ -30,7 +30,12 @@ export const getGeminiClient = async (secrets: SecretRegistry, options: GeminiCl
       temperature: options.temperature ?? 0.2,
       maxOutputTokens: options.maxOutputTokens,
     },
-    { secrets }
+    {
+      secrets,
+      // Prefer the provider-specific key so a user's primary LLM key (often OpenAI) doesn't
+      // accidentally override Gemini summarizers when both are configured.
+      preferredApiKeys: 'GEMINI_API_KEY',
+    }
   );
 
   return factory.createClient();

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -430,7 +430,7 @@ export function TerminalObservationSummary({
         aria-label={toggleLabel}
         title={toggleLabel}
       >
-        <span className="text-sm text-stone-300">{summaryText}</span>
+        <span className="flex-1 min-w-0 text-sm text-stone-300 whitespace-pre-wrap break-words">{summaryText}</span>
         <span className={`codicon codicon-chevron-${isExpanded ? 'up' : 'down'} text-[10px]`} />
       </button>
     </div>


### PR DESCRIPTION
Fixes P2 bug `oh-tab-xhhm`: terminal Tool Result blocks were often falling back to "Done." even when tool summarization was enabled, because Gemini summarizers could end up using the primary LLM key (`openhands.llmApiKey`, often OpenAI) instead of `GEMINI_API_KEY`.

Changes:
- Prefer `GEMINI_API_KEY` for Gemini runtime summarizers (`getGeminiClient`) and the Agent tool-summarizer client.
- Ensure terminal Tool Result summaries can wrap (no flex clipping) in `TerminalObservationSummary`.

Tests:
- `npm test -w @openhands/agent-sdk-ts`
- `npx vitest run src/webview-src/__tests__/event.rendering.test.tsx`

Bead: oh-tab-xhhm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for provider-specific API key preferences in the agent SDK.

* **Bug Fixes**
  * Fixed terminal observation summary display to properly wrap long text.

* **Tests**
  * Added tests validating API key selection behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->