### PR TITLE
oh-tab-dy01: Profiles dropdown replaces list

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -41,8 +41,9 @@ describe('LLM Profiles view', () => {
 
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileButton = await screen.findByLabelText('Edit profile gpt-5');
-    fireEvent.click(profileButton);
+    const profileSelect = await screen.findByLabelText('Profile');
+    await waitFor(() => expect(profileSelect).not.toBeDisabled());
+    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -230,7 +231,9 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+    const profileSelect = await screen.findByLabelText('Profile');
+    await waitFor(() => expect(profileSelect).not.toBeDisabled());
+    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -272,7 +275,9 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+    const profileSelect = await screen.findByLabelText('Profile');
+    await waitFor(() => expect(profileSelect).not.toBeDisabled());
+    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -330,7 +335,9 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+    const profileSelect = await screen.findByLabelText('Profile');
+    await waitFor(() => expect(profileSelect).not.toBeDisabled());
+    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -486,7 +493,9 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    fireEvent.click(await screen.findByLabelText('Edit profile gpt-5'));
+    const profileSelect = await screen.findByLabelText('Profile');
+    await waitFor(() => expect(profileSelect).not.toBeDisabled());
+    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -613,7 +613,15 @@ export function LlmProfilesView(props: {
     }
   };
 
-  const selectedIsActive = (candidate: string) => candidate === selectedProfileId;
+  const NEW_PROFILE_SELECT_VALUE = '__new__';
+  const profileSelectId = profileFieldId('profile-select');
+  const profileSelectValue = selectedProfileId ?? NEW_PROFILE_SELECT_VALUE;
+  const profileSelectOptions = useMemo(() => {
+    if (selectedProfileId && !sortedProfiles.includes(selectedProfileId)) {
+      return [...sortedProfiles, selectedProfileId].sort((a, b) => a.localeCompare(b));
+    }
+    return sortedProfiles;
+  }, [selectedProfileId, sortedProfiles]);
   const canEditApiKey = mode === 'edit' && !!selectedProfileId && !loadingProfile;
   const providerRequiresApiKey = Boolean(form.provider);
   const providerDocsUrl = form.provider ? PROVIDER_DOCS_URLS[form.provider] : null;
@@ -649,6 +657,18 @@ export function LlmProfilesView(props: {
     && overrideProfileApiKey
     && apiKeyStatus.state === 'ready'
     && apiKeyStatus.hasProfileKey;
+
+  const handleSelectProfile = useCallback((next: string) => {
+    if (next === profileSelectValue) return;
+    if (next === NEW_PROFILE_SELECT_VALUE) {
+      startCreate();
+      requestAnimationFrame(() => {
+        nameInputRef.current?.focus();
+      });
+      return;
+    }
+    void startEdit(next);
+  }, [NEW_PROFILE_SELECT_VALUE, profileSelectValue, startCreate, startEdit]);
 
   const handleSetApiKey = useCallback(async () => {
     if (!selectedProfileId) return;
@@ -803,52 +823,34 @@ export function LlmProfilesView(props: {
 
         {/* Body */}
         <div className="flex-1 overflow-hidden flex">
-          {/* Left: list */}
-          <div className="w-64 border-r border-white/[0.08] flex flex-col">
-            <div className="flex-1 overflow-y-auto p-3 space-y-1">
-              {loadingList ? (
-                <div className="text-sm text-stone-500 px-2 py-2">Loading profiles…</div>
-              ) : sortedProfiles.length === 0 ? (
-                <div className="px-2 py-3">
-                  <div className="text-sm text-stone-300 mb-1">No profiles found</div>
-                  <div className="text-xs text-stone-500">Create one to get started.</div>
-                </div>
-              ) : (
-                sortedProfiles.map((id) => (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => { void startEdit(id); }}
-                    className={`
-                      w-full text-left px-3 py-2 rounded-lg
-                      text-sm font-mono
-                      transition-colors
-                      border
-                      ${selectedIsActive(id)
-                        ? 'bg-brand-500/15 border-brand-500/25 text-brand-200'
-                        : 'bg-white/[0.02] border-white/[0.04] text-stone-300 hover:bg-white/[0.05] hover:border-white/[0.08]'}
-                    `}
-                    aria-label={`Edit profile ${id}`}
-                    title={id}
-                  >
-                    {id}
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
-
-          {/* Right: editor */}
           <div className="flex-1 flex flex-col overflow-hidden">
-            <div className="px-6 py-5 border-b border-white/[0.06]">
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <div className="text-sm text-stone-500">
-                    {mode === 'create' ? 'Create a new profile' : 'Edit profile'}
-                  </div>
-                  <div className="text-lg font-semibold text-stone-100 mt-1">
-                    {mode === 'create' ? (form.name.trim() ? form.name.trim() : 'New profile') : (selectedProfileId ?? '—')}
-                  </div>
+            <div className="px-6 py-5 border-b border-white/[0.06] space-y-4">
+              <div>
+                <FieldLabel label="Profile" htmlFor={profileSelectId} />
+                <SelectField
+                  id={profileSelectId}
+                  value={profileSelectValue}
+                  onChange={handleSelectProfile}
+                  disabled={loadingList}
+                >
+                  <option value={NEW_PROFILE_SELECT_VALUE}>New Profile…</option>
+                  {profileSelectOptions.map((id) => (
+                    <option key={id} value={id}>{id}</option>
+                  ))}
+                </SelectField>
+                {loadingList ? (
+                  <div className="text-xs text-stone-500 mt-1">Loading profiles…</div>
+                ) : profileSelectOptions.length === 0 ? (
+                  <div className="text-xs text-stone-500 mt-1">No profiles found. Create one to get started.</div>
+                ) : null}
+              </div>
+
+              <div>
+                <div className="text-sm text-stone-500">
+                  {mode === 'create' ? 'Create a new profile' : 'Edit profile'}
+                </div>
+                <div className="text-lg font-semibold text-stone-100 mt-1">
+                  {mode === 'create' ? (form.name.trim() ? form.name.trim() : 'New profile') : (selectedProfileId ?? '—')}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
Implements bead oh-tab-dy01.

- Removes left-column profile list in LLM Profiles view.
- Adds a Profile dropdown above the edit form with a ‘New Profile…’ option.
- Updates webview tests accordingly.

Tests:
- npx vitest run src/webview-src/__tests__/LlmProfilesView.test.tsx
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **User Interface**
  * Profile selection interface redesigned to use a dropdown menu instead of a side list.
  * Improved profile creation workflow with enhanced focus management and clearer visual indication of create versus edit modes.

* **Tests**
  * Test suite updated to reflect new profile selection interaction pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->