### PR TITLE
oh-tab-9lij: E2E server selection via webview

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1066,6 +1066,14 @@ export function App() {
               postMessage({ type: 'send', text: normalized, contextFiles: [], attachments: [] });
               break;
             }
+            case 'selectServer': {
+              const url = (rawPayload as { url?: unknown } | undefined)?.url;
+              if (typeof url !== 'string') break;
+              const normalized = url.trim();
+              if (!normalized) break;
+              postMessage({ type: 'selectServer', url: normalized });
+              break;
+            }
             case 'setLlmProfileId': {
               const profileIdRaw = (rawPayload as { profileId?: unknown } | undefined)?.profileId;
               if (profileIdRaw === undefined) break;

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -58,16 +58,20 @@ export async function run(): Promise<void> {
     return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
-  await vscode.workspace.getConfiguration().update(
-    'openhands.serverUrl',
-    serverUrl,
-    vscode.ConfigurationTarget.Global
-  );
+  await vscode.commands.executeCommand('openhands._serversSet', { servers: [serverUrl], serverUrl: '' });
   await vscode.workspace.getConfiguration().update(
     'openhands.conversation.maxIterations',
     1,
     vscode.ConfigurationTarget.Global
   );
+
+  const selectServer = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'selectServer',
+    payload: { url: serverUrl },
+  });
+  if (!selectServer?.sent) {
+    throw new Error(`selectServer action was not sent: ${JSON.stringify(selectServer)}`);
+  }
 
   await pollUntil(async () => {
     const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');


### PR DESCRIPTION
Implements bead oh-tab-9lij.

- Adds a new webview E2E action `selectServer` that posts the real `selectServer` host message.
- Updates `tests/e2e/suite/agentServerRemote.ts` to switch to remote via `openhands._serversSet` + `openhands._webviewAction({ action: "selectServer" })` instead of directly writing `openhands.serverUrl`.

Local checks:
- `npm run typecheck`
- `npx vitest run src/webview-src/__tests__/App.advanced.test.tsx`
