### PR TITLE
oh-tab-8n0w: buffer terminal log until open

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -742,6 +742,7 @@ describe('Settings and modes', () => {
     (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
       const pty = options?.pty;
       if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
+      if (typeof pty?.open === 'function') pty.open();
       terminalInstance = { show: vi.fn(), dispose: vi.fn() };
       return terminalInstance;
     });
@@ -786,6 +787,7 @@ describe('Settings and modes', () => {
     (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
       const pty = options?.pty;
       if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 
@@ -841,6 +843,7 @@ describe('Settings and modes', () => {
       if (pty?.onDidWrite) {
         pty.onDidWrite((chunk: string) => writes.push(chunk));
       }
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 
@@ -951,6 +954,7 @@ describe('Settings and modes', () => {
       if (pty?.onDidWrite) {
         pty.onDidWrite((chunk: string) => writes.push(chunk));
       }
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 
@@ -995,6 +999,7 @@ describe('Settings and modes', () => {
       if (pty?.onDidWrite) {
         pty.onDidWrite((chunk: string) => writes.push(chunk));
       }
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 
@@ -1048,6 +1053,7 @@ describe('Settings and modes', () => {
       if (pty?.onDidWrite) {
         pty.onDidWrite((chunk: string) => writes.push(chunk));
       }
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 
@@ -1093,6 +1099,7 @@ describe('Settings and modes', () => {
       if (pty?.onDidWrite) {
         pty.onDidWrite((chunk: string) => writes.push(chunk));
       }
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 
@@ -1137,6 +1144,7 @@ describe('Settings and modes', () => {
       if (pty?.onDidWrite) {
         pty.onDidWrite((chunk: string) => writes.push(chunk));
       }
+      if (typeof pty?.open === 'function') pty.open();
       return { show: vi.fn(), dispose: vi.fn() } as any;
     });
 

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -154,6 +154,24 @@ function createMockContext(): Partial<vscode.ExtensionContext> {
   };
 }
 
+const mockOpenHandsTerminalLog = (options: { capturePty?: boolean } = {}) => {
+  const writes: string[] = [];
+  const terminals: any[] = [];
+  let lastPty: any;
+
+  (vscode.window.createTerminal as Mock).mockImplementation((createOptions: any) => {
+    const pty = createOptions?.pty;
+    if (options.capturePty) lastPty = pty;
+    if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
+    if (typeof pty?.open === 'function') pty.open();
+    const terminal = { show: vi.fn(), dispose: vi.fn() } as any;
+    terminals.push(terminal);
+    return terminal;
+  });
+
+  return { writes, terminals, getLastPty: () => lastPty };
+};
+
 describe('Extension Activation', () => {
   let mockContext: any;
   let extension: any;
@@ -737,15 +755,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    let terminalInstance: any;
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
-      if (typeof pty?.open === 'function') pty.open();
-      terminalInstance = { show: vi.fn(), dispose: vi.fn() };
-      return terminalInstance;
-    });
+    const { writes, terminals } = mockOpenHandsTerminalLog();
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -760,7 +770,7 @@ describe('Settings and modes', () => {
     expect(vscode.window.createTerminal).toHaveBeenCalledTimes(1);
 
     const closeHandler = (vscode.window.onDidCloseTerminal as Mock).mock.calls[0]?.[0];
-    closeHandler?.(terminalInstance);
+    closeHandler?.(terminals[0]);
 
     conv?.emit('terminal', {
       id: 'bash-2',
@@ -783,13 +793,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      if (pty?.onDidWrite) pty.onDidWrite((chunk: string) => writes.push(chunk));
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes } = mockOpenHandsTerminalLog();
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -837,15 +841,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      if (pty?.onDidWrite) {
-        pty.onDidWrite((chunk: string) => writes.push(chunk));
-      }
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes } = mockOpenHandsTerminalLog();
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -948,15 +944,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      if (pty?.onDidWrite) {
-        pty.onDidWrite((chunk: string) => writes.push(chunk));
-      }
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes } = mockOpenHandsTerminalLog();
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -991,17 +979,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    let ptyInstance: any;
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      ptyInstance = pty;
-      if (pty?.onDidWrite) {
-        pty.onDidWrite((chunk: string) => writes.push(chunk));
-      }
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes, getLastPty } = mockOpenHandsTerminalLog({ capturePty: true });
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -1014,6 +992,7 @@ describe('Settings and modes', () => {
       command: 'progress_output',
     });
 
+    const ptyInstance = getLastPty();
     expect(ptyInstance).toBeTruthy();
 
     // Simulate progress updates arriving in multiple chunks (including CSI K split across writes).
@@ -1045,17 +1024,7 @@ describe('Settings and modes', () => {
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-    const writes: string[] = [];
-    let ptyInstance: any;
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      ptyInstance = pty;
-      if (pty?.onDidWrite) {
-        pty.onDidWrite((chunk: string) => writes.push(chunk));
-      }
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes, getLastPty } = mockOpenHandsTerminalLog({ capturePty: true });
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -1068,6 +1037,7 @@ describe('Settings and modes', () => {
       command: 'progress_overflow',
     });
 
+    const ptyInstance = getLastPty();
     expect(ptyInstance).toBeTruthy();
 
     const huge = 'a'.repeat(200_001);
@@ -1091,17 +1061,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    let ptyInstance: any;
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      ptyInstance = pty;
-      if (pty?.onDidWrite) {
-        pty.onDidWrite((chunk: string) => writes.push(chunk));
-      }
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes, getLastPty } = mockOpenHandsTerminalLog({ capturePty: true });
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -1114,6 +1074,7 @@ describe('Settings and modes', () => {
       command: 'progress_colored',
     });
 
+    const ptyInstance = getLastPty();
     expect(ptyInstance).toBeTruthy();
 
     ptyInstance.write('\u001b[32mDownloading 1%\u001b[0m');
@@ -1136,17 +1097,7 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const writes: string[] = [];
-    let ptyInstance: any;
-    (vscode.window.createTerminal as Mock).mockImplementation((options: any) => {
-      const pty = options?.pty;
-      ptyInstance = pty;
-      if (pty?.onDidWrite) {
-        pty.onDidWrite((chunk: string) => writes.push(chunk));
-      }
-      if (typeof pty?.open === 'function') pty.open();
-      return { show: vi.fn(), dispose: vi.fn() } as any;
-    });
+    const { writes, getLastPty } = mockOpenHandsTerminalLog({ capturePty: true });
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
 
@@ -1159,6 +1110,7 @@ describe('Settings and modes', () => {
       command: 'sanitize_output',
     });
 
+    const ptyInstance = getLastPty();
     expect(ptyInstance).toBeTruthy();
 
     // OSC with BEL terminator

--- a/src/__tests__/openHandsTerminalLogPseudoterminal.test.ts
+++ b/src/__tests__/openHandsTerminalLogPseudoterminal.test.ts
@@ -10,6 +10,7 @@ function capturePtyWrites(pty: OpenHandsTerminalLogPseudoterminal): () => string
 describe('OpenHandsTerminalLogPseudoterminal', () => {
   it('sanitizes OSC control sequences (BEL terminator)', () => {
     const pty = new OpenHandsTerminalLogPseudoterminal({ renderProgress: false });
+    pty.open();
     const getOutput = capturePtyWrites(pty);
 
     pty.write('hello\u001b]0;title\u0007world\n');
@@ -19,6 +20,7 @@ describe('OpenHandsTerminalLogPseudoterminal', () => {
 
   it('sanitizes OSC control sequences (ST terminator)', () => {
     const pty = new OpenHandsTerminalLogPseudoterminal({ renderProgress: false });
+    pty.open();
     const getOutput = capturePtyWrites(pty);
 
     pty.write('hello\u001b]0;title\u001b\\world\n');
@@ -28,6 +30,7 @@ describe('OpenHandsTerminalLogPseudoterminal', () => {
 
   it('coalesces progress updates (CR) and flushes only the last update on newline', () => {
     const pty = new OpenHandsTerminalLogPseudoterminal();
+    pty.open();
     const getOutput = capturePtyWrites(pty);
 
     pty.write('foo\rbar\rbaz\n');
@@ -37,6 +40,7 @@ describe('OpenHandsTerminalLogPseudoterminal', () => {
 
   it('strips CSI K (erase-to-EOL) from flushed progress lines', () => {
     const pty = new OpenHandsTerminalLogPseudoterminal();
+    pty.open();
     const getOutput = capturePtyWrites(pty);
 
     pty.write(`Downloading 1%\u001b[K\rDownloading 2%\u001b[2K\n`);
@@ -46,6 +50,7 @@ describe('OpenHandsTerminalLogPseudoterminal', () => {
 
   it('carries incomplete CSI sequences across writes before flushing', () => {
     const pty = new OpenHandsTerminalLogPseudoterminal();
+    pty.open();
     const getOutput = capturePtyWrites(pty);
 
     pty.write(`Downloading \u001b[`);
@@ -53,5 +58,15 @@ describe('OpenHandsTerminalLogPseudoterminal', () => {
 
     expect(getOutput()).toBe('Downloading 100%\r\n');
   });
-});
 
+  it('buffers output written before open and flushes it on open', () => {
+    const pty = new OpenHandsTerminalLogPseudoterminal({ renderProgress: false });
+    const getOutput = capturePtyWrites(pty);
+
+    pty.write('hello\n');
+    expect(getOutput()).toBe('');
+
+    pty.open();
+    expect(getOutput()).toBe('[OpenHands] Terminal log (read-only)\r\nhello\r\n');
+  });
+});

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -9,11 +9,15 @@ import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
 import * as llmProfilesStore from '../webview/host/llmProfilesStore';
+import { OpenHandsTerminalLogPseudoterminal } from '../terminal/OpenHandsTerminalLogPseudoterminal';
 import { isBashEvent, type BashEvent, type ConversationInstance, type Event, type SecretRegistry } from '@openhands/agent-sdk-ts';
 
 export type TerminalLogInfo = {
   hasTerminal: boolean;
   received: number;
+  ptyOpened?: boolean;
+  preopenBufferedChars?: number;
+  preopenDroppedChars?: number;
   lastEvents?: Array<{ type?: string; timestamp: number }>;
 };
 
@@ -74,6 +78,7 @@ type RegisterDiagnosticsCommandsDeps = {
   getConversation: () => ConversationInstance | undefined;
   getConversationMode: () => 'local' | 'remote';
   getTerminal: () => vscode.Terminal | undefined;
+  getTerminalLogPty: () => OpenHandsTerminalLogPseudoterminal | undefined;
   getReceivedTerminalEventsCount: () => number;
   getRecentTerminalEvents?: (max?: number) => Array<{ type?: string; timestamp: number }>;
   getOutputChannel: () => vscode.OutputChannel | undefined;
@@ -137,12 +142,18 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
   const diag = vscode.commands.registerCommand('openhands._diagnostics', () => {
     const chatView = deps.getChatView();
     const terminal = deps.getTerminal();
+    const terminalPty = deps.getTerminalLogPty();
 
     const terminalInfo: TerminalLogInfo = {
       hasTerminal: !!terminal,
       received: deps.getReceivedTerminalEventsCount(),
       lastEvents: deps.getRecentTerminalEvents?.(10),
     };
+    if (terminalPty) {
+      terminalInfo.ptyOpened = terminalPty.isOpened();
+      terminalInfo.preopenBufferedChars = terminalPty.getPreopenBufferedChars();
+      terminalInfo.preopenDroppedChars = terminalPty.getPreopenDroppedChars();
+    }
 
     return {
       chat: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -524,7 +524,6 @@ export function activate(context: vscode.ExtensionContext) {
           vscode.workspace.getConfiguration().get<boolean>('openhands.terminal.renderProgress') ?? true;
         terminalLogPty = new OpenHandsTerminalLogPseudoterminal({ renderProgress });
         terminal = vscode.window.createTerminal({ name: 'OpenHands', pty: terminalLogPty });
-        terminal.show(true);
       } catch (e) {
         console.error('[Terminal] Failed to create terminal log:', e);
         terminal = undefined;
@@ -815,6 +814,7 @@ export function activate(context: vscode.ExtensionContext) {
     getConversation: () => conversation,
     getConversationMode: () => conversationMode,
     getTerminal: () => terminal,
+    getTerminalLogPty: () => terminalLogPty,
     getReceivedTerminalEventsCount: () => receivedTerminalEvents.length,
     getRecentTerminalEvents: (max = 10) => receivedTerminalEvents.slice(-Math.max(0, Math.min(max, MAX_TERMINAL_EVENTS))),
     onTerminalEvent: (event) => handleTerminalEvent(event),

--- a/src/terminal/OpenHandsTerminalLogPseudoterminal.ts
+++ b/src/terminal/OpenHandsTerminalLogPseudoterminal.ts
@@ -49,10 +49,15 @@ type TerminalLogPseudoterminalOptions = {
 export class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal {
   private static readonly PTY_WRITE_CHUNK_SIZE = 16_000;
   private static readonly MAX_PENDING_LINE_CHARS = 200_000;
+  private static readonly MAX_PREOPEN_BUFFER_CHARS = 200_000;
 
   private readonly writeEmitter = new vscode.EventEmitter<string>();
   private readonly closeEmitter = new vscode.EventEmitter<void>();
   private closed = false;
+  private opened = false;
+  private preopenChunks: string[] = [];
+  private preopenChars = 0;
+  private preopenDroppedChars = 0;
   private showedInputHint = false;
   private lastEndedWithNewline = true;
   private readonly renderProgress: boolean;
@@ -68,7 +73,28 @@ export class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal
   }
 
   open(): void {
-    this.writeLine('[OpenHands] Terminal log (read-only)');
+    if (this.closed) return;
+    this.opened = true;
+
+    const bufferedEndedWithNewline = this.lastEndedWithNewline;
+    const bufferedChunks = this.preopenChunks;
+    const bufferedDroppedChars = this.preopenDroppedChars;
+
+    this.preopenChunks = [];
+    this.preopenChars = 0;
+    this.preopenDroppedChars = 0;
+
+    this.writeRaw('[OpenHands] Terminal log (read-only)\n');
+    if (bufferedDroppedChars > 0) {
+      this.writeRaw(`[OpenHands] (Earlier output omitted: ${bufferedDroppedChars} chars)\n`);
+    }
+
+    if (bufferedChunks.length > 0) {
+      for (const chunk of bufferedChunks) {
+        this.writeEmitter.fire(chunk);
+      }
+      this.lastEndedWithNewline = bufferedEndedWithNewline;
+    }
   }
 
   close(): void {
@@ -85,6 +111,9 @@ export class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal
   }
 
   isClosed(): boolean { return this.closed; }
+  isOpened(): boolean { return this.opened; }
+  getPreopenBufferedChars(): number { return this.preopenChars; }
+  getPreopenDroppedChars(): number { return this.preopenDroppedChars; }
 
   ensureNewline(): void {
     if (this.progressLine || this.progressCarry) {
@@ -106,9 +135,29 @@ export class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal
     this.writeLine('');
   }
 
+  private bufferPreopenChunk(chunk: string): void {
+    if (!chunk) return;
+    this.preopenChunks.push(chunk);
+    this.preopenChars += chunk.length;
+
+    const max = OpenHandsTerminalLogPseudoterminal.MAX_PREOPEN_BUFFER_CHARS;
+    if (this.preopenChars <= max) return;
+
+    while (this.preopenChunks.length > 0 && this.preopenChars > max) {
+      const dropped = this.preopenChunks.shift();
+      if (!dropped) break;
+      this.preopenChars -= dropped.length;
+      this.preopenDroppedChars += dropped.length;
+    }
+  }
+
   private emitChunk(chunk: string): void {
     if (!chunk) return;
-    this.writeEmitter.fire(chunk);
+    if (!this.opened) {
+      this.bufferPreopenChunk(chunk);
+    } else {
+      this.writeEmitter.fire(chunk);
+    }
     this.lastEndedWithNewline = /\n$/.test(chunk);
   }
 
@@ -260,4 +309,3 @@ export class OpenHandsTerminalLogPseudoterminal implements vscode.Pseudoterminal
     this.write(`${line}\n`);
   }
 }
-

--- a/tests/e2e/suite/terminalLog.ts
+++ b/tests/e2e/suite/terminalLog.ts
@@ -46,10 +46,29 @@ export async function run(): Promise<void> {
   const exit: BashEvent = { ...nextBase(), type: 'BashExit', exit_code: 0 };
   await vscode.commands.executeCommand('openhands._injectTerminalEvent', exit);
 
-  // Verify diagnostics reflect terminal received events and that terminal exists
-  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-  if (!diag?.terminal?.hasTerminal) throw new Error('Expected OpenHands terminal to be created');
-  if (typeof diag?.terminal?.received !== 'number' || diag.terminal.received < 3) {
-    throw new Error(`Expected some terminal events, got: ${JSON.stringify(diag?.terminal)}`);
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return Boolean(diag?.terminal?.hasTerminal);
+  }, 15000);
+
+  // Verify diagnostics reflect terminal received events and that output is buffered until the terminal is opened.
+  const diagBeforeOpen: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  if (typeof diagBeforeOpen?.terminal?.received !== 'number' || diagBeforeOpen.terminal.received < 3) {
+    throw new Error(`Expected some terminal events, got: ${JSON.stringify(diagBeforeOpen?.terminal)}`);
   }
+  if (diagBeforeOpen?.terminal?.ptyOpened !== false) {
+    throw new Error(`Expected terminal PTY to be unopened before showing it, got: ${JSON.stringify(diagBeforeOpen?.terminal)}`);
+  }
+  if (typeof diagBeforeOpen?.terminal?.preopenBufferedChars !== 'number' || diagBeforeOpen.terminal.preopenBufferedChars <= 0) {
+    throw new Error(`Expected some pre-open buffered output, got: ${JSON.stringify(diagBeforeOpen?.terminal)}`);
+  }
+
+  const terminal = vscode.window.terminals.find((t) => t.name === 'OpenHands');
+  if (!terminal) throw new Error('Expected OpenHands terminal to exist');
+  terminal.show(false);
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return diag?.terminal?.ptyOpened === true && diag?.terminal?.preopenBufferedChars === 0;
+  }, 15000);
 }


### PR DESCRIPTION
Fixes bead `oh-tab-8n0w`.

- Buffer pseudoterminal writes until the VS Code terminal is opened (pre-open cap + dropped-chars notice).
- Stop auto-revealing the terminal panel (`terminal.show(true)`), so the log doesn't steal focus.
- Extend `openhands._diagnostics` with terminal-log PTY buffering/open state.
- Update unit + E2E coverage for the new buffering behavior.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal now buffers output that occurs before the terminal window opens, with visibility into buffered content and dropped character counts.
  * Diagnostics now expose terminal PTY state, including open status and preopen buffer metrics.

* **Tests**
  * Enhanced test coverage for terminal opening behavior and preopen buffering scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->