### PR TITLE
oh-tab-zpl6: keep status banner visible

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1630,7 +1630,10 @@ export function App() {
         )}
 
         {/* Bottom status bar (below prompt + controls) */}
-        <div className={statusBanner ? 'px-4 pt-2 pb-2' : ''} data-testid="status-row">
+        <div
+          className="px-4 pt-2 pb-2 bg-[var(--vscode-editor-background)]/95 backdrop-blur-md min-h-[64px]"
+          data-testid="status-row"
+        >
           {statusBanner && (
             <StatusBanner
               message={statusBanner.message}

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1631,7 +1631,7 @@ export function App() {
 
         {/* Bottom status bar (below prompt + controls) */}
         <div
-          className="px-4 pt-2 pb-2 bg-[var(--vscode-editor-background)]/95 backdrop-blur-md min-h-[64px]"
+          className="px-4 pt-2 pb-2 bg-[var(--vscode-editor-background)]/95 backdrop-blur-md min-h-16"
           data-testid="status-row"
         >
           {statusBanner && (

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -123,7 +123,7 @@ export function InputArea({
   const canSend = value.trim().length > 0 || inlineImages.length > 0;
 
   return (
-    <div className="sticky bottom-0 z-30 border-t border-white/[0.06] bg-[var(--vscode-editor-background)]/95 backdrop-blur-md">
+    <div className="z-30 border-t border-white/[0.06] bg-[var(--vscode-editor-background)]/95 backdrop-blur-md">
       <div className="px-4 py-4">
         {/* Main input container */}
         <div


### PR DESCRIPTION
Fixes bead `oh-tab-zpl6`.

- Remove `sticky bottom-0` from `InputArea` (it already sits outside the scroll container).
- Reserve bottom `status-row` height + match background so `StatusBanner` stays visible and doesn’t clip.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced status row display with consistent styling
  * Updated input area layout positioning behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->