### PR TITLE
oh-tab-ib7f: Gemini summarizers use profile config

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.gemini-profile-generation-config.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.gemini-profile-generation-config.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_PROVIDER_BASE_URLS, LLMFactory, saveProfile } from '..';
+import { SecretRegistry } from '../../runtime/SecretRegistry';
+
+describe('LLMFactory (Gemini): generationConfig from profile', () => {
+  it('uses temperature + maxOutputTokens from the profile when not overridden', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sdk-gemini-profile-'));
+    const originalFetch = globalThis.fetch;
+    try {
+      saveProfile(
+        'test-gemini-profile',
+        {
+          provider: 'gemini',
+          model: 'gemini-2.5-flash',
+          baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
+          profileName: 'Test Gemini Profile',
+          temperature: 0.42,
+          maxOutputTokens: 123,
+        },
+        { rootDir: dir },
+      );
+
+      const secrets = new SecretRegistry();
+      secrets.set('GEMINI_API_KEY', 'test-gemini-key');
+
+      const factory = new LLMFactory(
+        {
+          profileId: 'test-gemini-profile',
+          // NOTE: model is required by the type but ignored by LLMFactory when profileId is present.
+          model: 'unused',
+          usageId: 'test-gemini-client',
+        },
+        { secrets, preferredApiKeys: 'GEMINI_API_KEY', profileStoreOptions: { rootDir: dir } },
+      );
+      const client = await factory.createClient();
+
+      let capturedBody: any | null = null;
+      const fetchMock = vi.fn(async (_url: string, init?: any) => {
+        capturedBody = JSON.parse(init?.body ?? '{}');
+        return new Response('data: [DONE]\n\n', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      });
+      globalThis.fetch = fetchMock as any;
+
+      for await (const chunk of client.streamChat({
+        systemPrompt: 'You are a test.',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      })) {
+        if (chunk.type === 'finish') break;
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(capturedBody).toBeTruthy();
+      expect(capturedBody.generationConfig).toEqual({ temperature: 0.42, maxOutputTokens: 123 });
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -345,6 +345,7 @@ export const deleteProfile = (profileId: string, options: LLMProfileStoreOptions
 
 export const DEFAULT_LLM_PROFILE_IDS = [
   'gemini-flash',
+  'gemini-flash-summarizer',
   'gpt-5',
   'gpt-5-mini',
   'sonnet-45',
@@ -360,6 +361,17 @@ const DEFAULT_LLM_PROFILES: Array<{ profileId: DefaultLlmProfileId; config: LLMC
       model: 'gemini-2.5-flash',
       baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
       profileName: 'Gemini Flash',
+    },
+  },
+  {
+    profileId: 'gemini-flash-summarizer',
+    config: {
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
+      profileName: 'Gemini Flash (Summarizer)',
+      temperature: 0.2,
+      maxOutputTokens: 512,
     },
   },
   {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -36,6 +36,7 @@ import { LLMSummarizingCondenser } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
 import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
+import { getGeminiClient } from './geminiClient';
 import { summarizeTerminalObservationWithGeminiFlash } from './terminalObservationSummarizer';
 import { SYSTEM_PROMPT } from './systemPrompt';
 
@@ -124,7 +125,7 @@ function truncateToolMessage(text: string, maxChars = TOOL_MESSAGE_MAX_CHARS): s
   return `${head}\n${TOOL_MESSAGE_CLIP_MARKER}\n${tail}`;
 }
 
-const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash';
+const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
 const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
 const TOOL_SUMMARY_MAX_CHARS = 1_000;
 
@@ -487,22 +488,7 @@ export class Agent extends EventEmitter {
     if (this.toolSummarizerInitPromise) return this.toolSummarizerInitPromise;
 
     this.toolSummarizerInitPromise = (async () => {
-      const factory = new LLMFactory(
-        {
-          profileId: TOOL_SUMMARY_PROFILE_ID,
-          model: TOOL_SUMMARY_PROFILE_ID,
-          usageId: 'tool-summarizer',
-          temperature: 0.2,
-          maxOutputTokens: 256,
-        },
-        {
-          secrets: this.secrets,
-          // Prefer the provider-specific key so a user's primary LLM key (often OpenAI) doesn't
-          // accidentally override Gemini summarizers when both are configured.
-          preferredApiKeys: 'GEMINI_API_KEY',
-        },
-      );
-      const client = await factory.createClient();
+      const client = await getGeminiClient(this.secrets, { usageId: 'tool-summarizer', profileId: TOOL_SUMMARY_PROFILE_ID });
       this.toolSummarizerClient = client;
       return client;
     })();

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts
@@ -38,8 +38,7 @@ describe('Gemini summarizers prefer GEMINI_API_KEY', () => {
 
     await getGeminiClient(secrets, {
       usageId: 'test-gemini-client',
-      profileId: 'gemini-flash',
-      model: 'gemini-flash',
+      profileId: 'gemini-flash-summarizer',
     });
 
     expect(secrets.calls[0]).toBe('GEMINI_API_KEY');
@@ -69,4 +68,3 @@ describe('Gemini summarizers prefer GEMINI_API_KEY', () => {
     expect(secrets.calls[0]).toBe('GEMINI_API_KEY');
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -167,9 +167,7 @@ export async function summarizeFileChangesWithGeminiFlash(
     options.llmClient ??
     (await getGeminiClient(options.secrets, {
       usageId: 'file-diff-summarizer',
-      profileId: 'gemini-flash',
-      model: 'gemini-flash',
-      maxOutputTokens: 256,
+      profileId: 'gemini-flash-summarizer',
     }));
   let text = '';
   for await (const chunk of client.streamChat(request)) {

--- a/packages/agent-sdk-ts/src/sdk/runtime/geminiClient.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/geminiClient.ts
@@ -5,30 +5,27 @@ import type { SecretRegistry } from './SecretRegistry';
 export interface GeminiClientOptions {
   usageId: string;
   profileId?: string;
-  model?: string;
-  temperature?: number;
-  maxOutputTokens?: number;
 }
 
-const DEFAULT_GEMINI_PROFILE_ID = 'gemini-flash';
+const DEFAULT_GEMINI_SUMMARIZER_PROFILE_ID = 'gemini-flash-summarizer';
 
 /**
  * Gemini-only helper for creating a Google GenAI client for runtime summarizers.
  *
- * Note: This is intentionally *not* a cross-provider helper. It supports multiple
- * Gemini models (Flash/Pro/etc.) by allowing callers to override `profileId`/`model`.
+ * Note: This is intentionally *not* a cross-provider helper. It is intended for
+ * deterministic summarizers that should derive model + generation config from a
+ * selected profile (not per-call overrides).
  */
 export const getGeminiClient = async (secrets: SecretRegistry, options: GeminiClientOptions): Promise<LLMClient> => {
-  const profileId = options.profileId ?? DEFAULT_GEMINI_PROFILE_ID;
-  const model = options.model ?? profileId;
+  const profileId = options.profileId ?? DEFAULT_GEMINI_SUMMARIZER_PROFILE_ID;
 
   const factory = new LLMFactory(
     {
       profileId,
-      model,
       usageId: options.usageId,
-      temperature: options.temperature ?? 0.2,
-      maxOutputTokens: options.maxOutputTokens,
+      // NOTE: `model` is required by the type but is sourced from the profile when
+      // `profileId` is present (LLMFactory ignores the override).
+      model: profileId,
     },
     {
       secrets,

--- a/packages/agent-sdk-ts/src/sdk/runtime/gitChangeSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/gitChangeSummarizer.ts
@@ -229,9 +229,7 @@ export async function summarizeGitChangesWithGeminiFlash(
     options.llmClient ??
     (await getGeminiClient(options.secrets, {
       usageId: 'git-change-summarizer',
-      profileId: 'gemini-flash',
-      model: 'gemini-flash',
-      maxOutputTokens: 512,
+      profileId: 'gemini-flash-summarizer',
     }));
   let text = '';
   for await (const chunk of client.streamChat(request)) {

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -108,9 +108,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
       options.llmClient ??
       (await getGeminiClient(options.secrets, {
         usageId: 'terminal-observation-summarizer',
-        profileId: 'gemini-flash',
-        model: 'gemini-flash',
-        maxOutputTokens: 256,
+        profileId: 'gemini-flash-summarizer',
       }));
     let text = '';
     for await (const chunk of client.streamChat(request)) {

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -34,7 +34,7 @@ export type AgentSettings = {
   enableSecurityAnalyzer?: boolean;
   debug?: boolean;
   /**
-   * When enabled, generates short summaries of tool executions (using the `gemini-flash` LLM profile)
+   * When enabled, generates short summaries of tool executions (using the `gemini-flash-summarizer` LLM profile)
    * and injects them into the next agent LLM request as additional context.
    */
   summarizeToolCalls?: boolean;


### PR DESCRIPTION
Fixes bead `oh-tab-ib7f`.

- Add default profile `gemini-flash-summarizer` (tuned for deterministic summarizers).
- Update `getGeminiClient` + summarizers (file diff / git change / terminal obs) to derive model + generation settings from the profile (no per-call overrides).
- Update Agent tool summarizer to use the same profile.
- Add unit coverage that Gemini `generationConfig` is sourced from profile values.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint -w @openhands/agent-sdk-ts`
