### PR TITLE
oh-tab-y86z: remove redundant select guard

### DIFF
--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -659,7 +659,6 @@ export function LlmProfilesView(props: {
     && apiKeyStatus.hasProfileKey;
 
   const handleSelectProfile = useCallback((next: string) => {
-    if (next === profileSelectValue) return;
     if (next === NEW_PROFILE_SELECT_VALUE) {
       startCreate();
       requestAnimationFrame(() => {
@@ -668,7 +667,7 @@ export function LlmProfilesView(props: {
       return;
     }
     void startEdit(next);
-  }, [NEW_PROFILE_SELECT_VALUE, profileSelectValue, startCreate, startEdit]);
+  }, [startCreate, startEdit]);
 
   const handleSetApiKey = useCallback(async () => {
     if (!selectedProfileId) return;


### PR DESCRIPTION
Fixes bead `oh-tab-y86z`.

- Remove redundant `if (next === profileSelectValue) return;` guard from the Profiles select onChange handler.
- Drop the unnecessary `profileSelectValue` dependency from the callback.

Tests:
- `npx vitest run src/webview-src/__tests__/LlmProfilesView.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that prevented profile creation and editing operations from executing when reselecting a profile that was already selected. The application now consistently processes these profile management actions regardless of whether you're selecting a new profile or reselecting the currently active one, ensuring more predictable behavior throughout your workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->