### PR TITLE
oh-tab-yr3e: address Gemini nits from PR #470

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1263,37 +1263,36 @@ export function App() {
     postMessage({ type: 'command', command: 'startNewConversation' });
   }, [postMessage, setInlineImages, setStatusBanner]);
 
-  const handleOpenHistory = useCallback(() => {
+  const closePanels = useCallback(() => {
     setShowLlmProfiles(false);
     setShowContextPicker(false);
     setShowSkillsPopover(false);
+    setShowHistory(false);
+  }, []);
+
+  const handleOpenHistory = useCallback(() => {
+    closePanels();
     setShowHistory(true);
     postMessage({ type: 'requestHistory' });
-  }, [postMessage]);
+  }, [closePanels, postMessage]);
 
   const handleOpenLlmProfiles = useCallback(() => {
     setLlmProfilesOpenRequest(null);
-    setShowHistory(false);
-    setShowContextPicker(false);
-    setShowSkillsPopover(false);
+    closePanels();
     setShowLlmProfiles(true);
-  }, []);
+  }, [closePanels]);
 
   const handleOpenLlmProfilesCreate = useCallback(() => {
     setLlmProfilesOpenRequest({ mode: 'create' });
-    setShowHistory(false);
-    setShowContextPicker(false);
-    setShowSkillsPopover(false);
+    closePanels();
     setShowLlmProfiles(true);
-  }, []);
+  }, [closePanels]);
 
   const handleOpenLlmProfilesEdit = useCallback((profileId: string) => {
     setLlmProfilesOpenRequest({ mode: 'edit', profileId });
-    setShowHistory(false);
-    setShowContextPicker(false);
-    setShowSkillsPopover(false);
+    closePanels();
     setShowLlmProfiles(true);
-  }, []);
+  }, [closePanels]);
 
   const handleOpenSettings = useCallback(() => {
     postMessage({ type: 'openSettingsPage' });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1268,31 +1268,31 @@ export function App() {
     setShowContextPicker(false);
     setShowSkillsPopover(false);
     setShowHistory(false);
-  }, []);
+  }, [setShowContextPicker, setShowHistory, setShowLlmProfiles, setShowSkillsPopover]);
 
   const handleOpenHistory = useCallback(() => {
     closePanels();
     setShowHistory(true);
     postMessage({ type: 'requestHistory' });
-  }, [closePanels, postMessage]);
+  }, [closePanels, postMessage, setShowHistory]);
 
   const handleOpenLlmProfiles = useCallback(() => {
     setLlmProfilesOpenRequest(null);
     closePanels();
     setShowLlmProfiles(true);
-  }, [closePanels]);
+  }, [closePanels, setLlmProfilesOpenRequest, setShowLlmProfiles]);
 
   const handleOpenLlmProfilesCreate = useCallback(() => {
     setLlmProfilesOpenRequest({ mode: 'create' });
     closePanels();
     setShowLlmProfiles(true);
-  }, [closePanels]);
+  }, [closePanels, setLlmProfilesOpenRequest, setShowLlmProfiles]);
 
   const handleOpenLlmProfilesEdit = useCallback((profileId: string) => {
     setLlmProfilesOpenRequest({ mode: 'edit', profileId });
     closePanels();
     setShowLlmProfiles(true);
-  }, [closePanels]);
+  }, [closePanels, setLlmProfilesOpenRequest, setShowLlmProfiles]);
 
   const handleOpenSettings = useCallback(() => {
     postMessage({ type: 'openSettingsPage' });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1263,36 +1263,32 @@ export function App() {
     postMessage({ type: 'command', command: 'startNewConversation' });
   }, [postMessage, setInlineImages, setStatusBanner]);
 
-  const closePanels = useCallback(() => {
-    setShowLlmProfiles(false);
+  const openMainPanel = useCallback((panel: 'history' | 'llmProfiles' | null) => {
+    setShowHistory(panel === 'history');
+    setShowLlmProfiles(panel === 'llmProfiles');
     setShowContextPicker(false);
     setShowSkillsPopover(false);
-    setShowHistory(false);
   }, [setShowContextPicker, setShowHistory, setShowLlmProfiles, setShowSkillsPopover]);
 
   const handleOpenHistory = useCallback(() => {
-    closePanels();
-    setShowHistory(true);
+    openMainPanel('history');
     postMessage({ type: 'requestHistory' });
-  }, [closePanels, postMessage, setShowHistory]);
+  }, [openMainPanel, postMessage]);
 
   const handleOpenLlmProfiles = useCallback(() => {
     setLlmProfilesOpenRequest(null);
-    closePanels();
-    setShowLlmProfiles(true);
-  }, [closePanels, setLlmProfilesOpenRequest, setShowLlmProfiles]);
+    openMainPanel('llmProfiles');
+  }, [openMainPanel, setLlmProfilesOpenRequest]);
 
   const handleOpenLlmProfilesCreate = useCallback(() => {
     setLlmProfilesOpenRequest({ mode: 'create' });
-    closePanels();
-    setShowLlmProfiles(true);
-  }, [closePanels, setLlmProfilesOpenRequest, setShowLlmProfiles]);
+    openMainPanel('llmProfiles');
+  }, [openMainPanel, setLlmProfilesOpenRequest]);
 
   const handleOpenLlmProfilesEdit = useCallback((profileId: string) => {
     setLlmProfilesOpenRequest({ mode: 'edit', profileId });
-    closePanels();
-    setShowLlmProfiles(true);
-  }, [closePanels, setLlmProfilesOpenRequest, setShowLlmProfiles]);
+    openMainPanel('llmProfiles');
+  }, [openMainPanel, setLlmProfilesOpenRequest]);
 
   const handleOpenSettings = useCallback(() => {
     postMessage({ type: 'openSettingsPage' });


### PR DESCRIPTION
Closes Gemini review nits from PR #470 by extracting a shared panel-closing helper in `App` and using it in History/Profiles open handlers.

- Bead: `oh-tab-yr3e`
- Tests: `npm test`, `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for panel management to enhance maintainability and reduce code duplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->