### PR TITLE
oh-tab-9a10: sync profile selection state

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -230,7 +230,9 @@ describe('App toolbar interactions', () => {
       }));
     });
 
-    expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('gpt-4.1');
+    const profileButton = await screen.findByLabelText('LLM profile');
+    expect(profileButton).toHaveTextContent('None');
+    expect(profileButton).toHaveTextContent('gpt-4.1');
   });
 
   it('updates the LLM profile when selected in the dropdown', async () => {

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -26,6 +26,63 @@ describe('LLM Profiles view', () => {
     cleanup();
   });
 
+  it('defaults to the active profile when opened from the header', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    postToWindow({ type: 'llmProfilesUpdated', profiles: ['gpt-5', 'claude_4'], activeProfileId: 'gpt-5' });
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+    await screen.findByText('OpenHands - LLM Profiles');
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    expect(loadRequest.profileId).toBe('gpt-5');
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({
+      type: 'llmProfilesListResponse',
+      requestId: listRequest.requestId,
+      ok: true,
+      profiles: ['gpt-5', 'claude_4'],
+    });
+
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: { model: 'gpt-5', provider: 'openai' },
+    });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: false,
+      hasProfileKey: false,
+      hasProviderKey: false,
+      providerKeyName: 'OPENAI_API_KEY',
+    });
+
+    const profileSelect = await screen.findByLabelText('Profile');
+    expect(profileSelect).toHaveValue('gpt-5');
+    expect(await screen.findByText('Edit profile')).toBeInTheDocument();
+  });
+
   it('supports per-profile API key configuration', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1645,6 +1645,7 @@ export function App() {
       {/* LLM Profiles view (slide-over panel) */}
       <LlmProfilesView
         isOpen={showLlmProfiles}
+        activeProfileId={llmProfileId}
         onClose={() => setShowLlmProfiles(false)}
         openRequest={llmProfilesOpenRequest}
         listProfiles={listLlmProfiles}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -365,7 +365,7 @@ function LlmProfileSelector({
 
   const normalizedFallbackLabel = typeof fallbackLabel === 'string' ? fallbackLabel.trim() : '';
   const hasFallback = normalizedFallbackLabel.length > 0;
-  const shown = profileId ?? (hasFallback ? normalizedFallbackLabel : 'None');
+  const shown = profileId ?? (hasFallback ? `None (${normalizedFallbackLabel})` : 'None');
   const tooltip = profileId
     ? `LLM profile: ${profileId}`
     : hasFallback

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -370,6 +370,7 @@ const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(function Sel
 
 export function LlmProfilesView(props: {
   isOpen: boolean;
+  activeProfileId?: string | null;
   onClose: () => void;
   openRequest?: LlmProfilesViewOpenRequest | null;
   listProfiles: () => Promise<string[]>;
@@ -381,6 +382,7 @@ export function LlmProfilesView(props: {
 }) {
   const {
     isOpen,
+    activeProfileId,
     onClose,
     openRequest,
     listProfiles,
@@ -525,13 +527,22 @@ export function LlmProfilesView(props: {
   }, [applyEditorTransition, loadProfile, refreshApiKeyStatus]);
 
   useEffect(() => {
-    if (!isOpen || !openRequest) return;
-    if (openRequest.mode === 'create') {
+    if (!isOpen) return;
+    if (openRequest?.mode === 'create') {
       startCreate();
       return;
     }
-    void startEdit(openRequest.profileId);
-  }, [isOpen, openRequest, startCreate, startEdit]);
+    if (openRequest?.mode === 'edit') {
+      void startEdit(openRequest.profileId);
+      return;
+    }
+    const normalizedActiveProfileId = typeof activeProfileId === 'string' ? activeProfileId.trim() : '';
+    if (normalizedActiveProfileId) {
+      void startEdit(normalizedActiveProfileId);
+      return;
+    }
+    startCreate();
+  }, [activeProfileId, isOpen, openRequest, startCreate, startEdit]);
 
   const handleSave = useCallback(async () => {
     setSaveAttempted(true);


### PR DESCRIPTION
Fixes inconsistent LLM profile selection state across:
- Conversation input dropdown label vs selected row (when no profile selected, show `None (effectiveModel)` instead of looking like a profile)
- Profiles view default selection (opening from header now focuses the active profile when set)

Bead: `oh-tab-9a10`

Tests:
- `npm test`
- `npm run lint`
