### PR TITLE
oh-tab-nv89: provider key precedence over openhands.llmApiKey

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.api-key-precedence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.api-key-precedence.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { LLMFactory } from '..';
+import { SecretRegistry } from '../../runtime/SecretRegistry';
+
+class TrackingSecretRegistry extends SecretRegistry {
+  readonly calls: string[] = [];
+
+  async get(name: string): Promise<string | undefined> {
+    this.calls.push(name);
+    return super.get(name);
+  }
+}
+
+describe('LLMFactory API key precedence', () => {
+  it('prefers provider-specific key over openhands.llmApiKey (openai)', async () => {
+    const secrets = new TrackingSecretRegistry();
+    secrets.set('openhands.llmApiKey', 'sk-global');
+    secrets.set('OPENAI_API_KEY', 'sk-openai');
+
+    const factory = new LLMFactory({ provider: 'openai', model: 'gpt-5-mini' }, { secrets });
+    await factory.createClient();
+
+    expect(secrets.calls).toEqual(['OPENAI_API_KEY']);
+  });
+
+  it('prefers provider-specific key over openhands.llmApiKey (litellm_proxy)', async () => {
+    const secrets = new TrackingSecretRegistry();
+    secrets.set('openhands.llmApiKey', 'sk-global');
+    secrets.set('LITELLM_API_KEY', 'sk-litellm');
+
+    const factory = new LLMFactory({ provider: 'litellm_proxy', model: 'gpt-4o-mini' }, { secrets });
+    await factory.createClient();
+
+    expect(secrets.calls).toEqual(['LITELLM_API_KEY']);
+  });
+
+  it('falls back to openhands.llmApiKey when provider key is missing', async () => {
+    const secrets = new TrackingSecretRegistry();
+    secrets.set('openhands.llmApiKey', 'sk-global');
+
+    const factory = new LLMFactory({ provider: 'openai', model: 'gpt-5-mini' }, { secrets });
+    await factory.createClient();
+
+    expect(secrets.calls).toEqual(['OPENAI_API_KEY', 'openhands.llmApiKey']);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -80,14 +80,17 @@ export class LLMFactory {
       const llmGlobalKey = 'openhands.llmApiKey';
       if (Array.isArray(preferredApiKeys)) {
         const keys = [...preferredApiKeys];
-        if (!keys.includes(llmGlobalKey)) keys.push(llmGlobalKey);
         if (!keys.includes(defaultApiKeyName)) keys.push(defaultApiKeyName);
+        if (!keys.includes(llmGlobalKey)) keys.push(llmGlobalKey);
         return keys;
       }
       if (typeof preferredApiKeys === 'string' && preferredApiKeys.trim()) {
-        return [preferredApiKeys, llmGlobalKey, defaultApiKeyName];
+        const keys = [preferredApiKeys];
+        if (!keys.includes(defaultApiKeyName)) keys.push(defaultApiKeyName);
+        if (!keys.includes(llmGlobalKey)) keys.push(llmGlobalKey);
+        return keys;
       }
-      return [llmGlobalKey, defaultApiKeyName];
+      return [defaultApiKeyName, llmGlobalKey];
     })();
     const apiKey =
       inlineApiKey ??


### PR DESCRIPTION
Implements `oh-tab-nv89` key precedence in `LLMFactory`:
- Prefer provider-specific SecretStorage key (e.g. `OPENAI_API_KEY`, `LITELLM_API_KEY`) when `apiKey` is unset.
- Fall back to `openhands.llmApiKey` only if provider key is missing.

Adds unit coverage to lock the ordering.

Bead: `oh-tab-nv89`

Tests:
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API key resolution order for LLM providers to correctly prioritize provider-specific keys over the global API key setting.

* **Tests**
  * Added comprehensive test suite verifying API key lookup precedence behavior across different provider configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->