### PR TITLE
oh-tab-r0jq: make e2e provider keys deterministic

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -567,6 +567,42 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     return { ok: true, profileId, hasKey: true };
   });
 
+  const setProviderApiKey = vscode.commands.registerCommand('openhands._setProviderApiKey', async (raw: unknown) => {
+    const providerRaw = (raw as { provider?: unknown } | undefined)?.provider;
+    if (typeof providerRaw !== 'string') throw new Error('provider is required');
+    const provider = providerRaw.trim();
+    if (!['openai', 'anthropic', 'openrouter', 'litellm_proxy', 'gemini'].includes(provider)) {
+      throw new Error('provider must be one of: openai, anthropic, openrouter, litellm_proxy, gemini');
+    }
+    const apiKeyRaw = (raw as { apiKey?: unknown } | undefined)?.apiKey;
+    const apiKey = typeof apiKeyRaw === 'string' ? apiKeyRaw.trim() : '';
+
+    const key = (() => {
+      switch (provider) {
+        case 'openrouter':
+          return 'OPENROUTER_API_KEY';
+        case 'litellm_proxy':
+          return 'LITELLM_API_KEY';
+        case 'anthropic':
+          return 'ANTHROPIC_API_KEY';
+        case 'gemini':
+          return 'GEMINI_API_KEY';
+        default:
+          return 'OPENAI_API_KEY';
+      }
+    })();
+
+    if (!apiKey) {
+      await deps.context.secrets.delete(key);
+      deps.secretRegistry.set(key, undefined);
+      return { ok: true, provider, key, hasKey: false };
+    }
+
+    await deps.context.secrets.store(key, apiKey);
+    deps.secretRegistry.set(key, apiKey);
+    return { ok: true, provider, key, hasKey: true };
+  });
+
   const injectTerminalEvent = vscode.commands.registerCommand('openhands._injectTerminalEvent', (raw: unknown) => {
     if (!isBashEvent(raw)) {
       return { injected: false, error: 'Invalid BashEvent structure' };
@@ -599,6 +635,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     deleteProfile,
     selectProfile,
     setProfileApiKey,
+    setProviderApiKey,
     injectTerminalEvent,
   ];
 }

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -36,20 +36,22 @@ export async function run(): Promise<void> {
   const mock = await startMockLlmServer();
 
   try {
-    console.log('[llmSwitching] env:', {
-      OPENAI_API_KEY: Boolean(process.env.OPENAI_API_KEY),
-      ANTHROPIC_API_KEY: Boolean(process.env.ANTHROPIC_API_KEY),
-      OPENROUTER_API_KEY: Boolean(process.env.OPENROUTER_API_KEY),
-      LITELLM_API_KEY: Boolean(process.env.LITELLM_API_KEY),
-      GEMINI_API_KEY: Boolean(process.env.GEMINI_API_KEY),
-    });
-
     await vscode.commands.executeCommand('openhands.open');
 
     await pollUntil(async () => {
       const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
       return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
     }, 15000);
+
+    const setProviderApiKey = async (provider: string, apiKey: string): Promise<void> => {
+      await vscode.commands.executeCommand('openhands._setProviderApiKey', { provider, apiKey });
+    };
+
+    await setProviderApiKey('openai', 'sk-e2e-openai');
+    await setProviderApiKey('anthropic', 'sk-e2e-anthropic');
+    await setProviderApiKey('openrouter', 'sk-e2e-openrouter');
+    await setProviderApiKey('litellm_proxy', 'sk-e2e-litellm');
+    await setProviderApiKey('gemini', 'sk-e2e-gemini');
 
     const cfg = vscode.workspace.getConfiguration();
     const setLlmConfig = async (


### PR DESCRIPTION
Bead: oh-tab-r0jq

Why
- Our E2E LLM-switching suite shouldn’t depend on host env vars like `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / etc.

What
- Add dev-only command `openhands._setProviderApiKey` to seed/clear provider-specific API keys in VS Code SecretStorage (and in-process `secretRegistry`).
- Update `tests/e2e/suite/llmSwitching.ts` to use that command with dummy keys instead of reading `process.env`.

Testing
- `npm test`
- `npm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR makes E2E tests deterministic by removing dependency on host environment variables for LLM provider API keys.

**Changes:**
- Added `openhands._setProviderApiKey` command to seed provider-specific API keys (OPENAI_API_KEY, ANTHROPIC_API_KEY, etc.) in VS Code SecretStorage and in-process `secretRegistry`
- Updated `llmSwitching.ts` E2E suite to use the new command with dummy keys (`sk-e2e-openai`, `sk-e2e-anthropic`, etc.) instead of reading `process.env`
- The command stores keys both in VS Code's persistent `secrets` storage and the runtime `secretRegistry` for immediate use

**Implementation details:**
- The command validates provider names against an allowlist: `openai`, `anthropic`, `openrouter`, `litellm_proxy`, `gemini`
- Maps each provider to its corresponding environment variable key (e.g., `anthropic` → `ANTHROPIC_API_KEY`)
- Supports clearing keys by passing an empty `apiKey` string
- Returns `{ ok: true, provider, key, hasKey }` for verification

**Testing:**
All tests pass, including the E2E suite that exercises this new code path across 9 provider/profile scenarios.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-contained to dev/test infrastructure with no production impact. The new command follows existing patterns (`_setProfileApiKey`), includes proper validation, and all tests pass. The E2E suite now runs deterministically without relying on host environment state.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/dev/registerDiagnosticsCommands.ts | Added `_setProviderApiKey` command for deterministic E2E test setup |
| tests/e2e/suite/llmSwitching.ts | Replaced env var reads with deterministic provider key seeding for E2E tests |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as E2E Test Suite
    participant VSCode as VS Code Commands
    participant Secrets as VS Code Secrets
    participant Registry as secretRegistry
    participant SDK as Agent SDK
    
    Note over Test: llmSwitching.ts starts
    Test->>VSCode: _setProviderApiKey('openai', 'sk-e2e-openai')
    VSCode->>Secrets: secrets.store('OPENAI_API_KEY', 'sk-e2e-openai')
    VSCode->>Registry: set('OPENAI_API_KEY', 'sk-e2e-openai')
    VSCode-->>Test: { ok: true, hasKey: true }
    
    Test->>VSCode: _setProviderApiKey('anthropic', 'sk-e2e-anthropic')
    VSCode->>Secrets: secrets.store('ANTHROPIC_API_KEY', 'sk-e2e-anthropic')
    VSCode->>Registry: set('ANTHROPIC_API_KEY', 'sk-e2e-anthropic')
    VSCode-->>Test: { ok: true, hasKey: true }
    
    Note over Test: Repeat for openrouter, litellm, gemini...
    
    Test->>VSCode: setLlmConfig({ provider: 'anthropic', ... })
    Test->>VSCode: sendMessage('E2E step 1: anthropic')
    VSCode->>SDK: Create LLM client
    SDK->>Registry: get('ANTHROPIC_API_KEY')
    Registry-->>SDK: 'sk-e2e-anthropic'
    SDK->>SDK: Use deterministic key for request
    
    Note over Test,SDK: No dependency on process.env
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->