### PR TITLE
oh-tab-a1op: keep provider key hint in sync

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -82,7 +82,7 @@ export type WebviewToHostMessage =
   | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string }
   | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown }
   | { type: 'llmProfileDeleteRequest'; requestId: string; profileId: string }
-  | { type: 'llmProfileApiKeyStatusRequest'; requestId: string; profileId: string }
+  | { type: 'llmProfileApiKeyStatusRequest'; requestId: string; profileId: string; provider?: string; baseUrl?: string }
   | { type: 'llmProfileApiKeySetRequest'; requestId: string; profileId: string; apiKey: string }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -182,6 +182,80 @@ describe('LLM Profiles view', () => {
     expect(screen.queryByDisplayValue('sk-test')).not.toBeInTheDocument();
   });
 
+  it('updates the provider key hint immediately when the provider changes in edit mode', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    fireEvent.click(screen.getByLabelText('LLM Profiles'));
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+
+    const listRequest = getLastPostedOfType('llmProfilesListRequest');
+    postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
+
+    const profileSelect = await screen.findByLabelText('Profile');
+    await waitFor(() => expect(profileSelect).not.toBeDisabled());
+    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
+    });
+
+    const loadRequest = getLastPostedOfType('llmProfileLoadRequest');
+    postToWindow({
+      type: 'llmProfileLoadResponse',
+      requestId: loadRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      profile: { model: 'gpt-5', provider: 'openai' },
+    });
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    expect(statusRequest.provider).toBe('openai');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: true,
+      hasProfileKey: false,
+      hasProviderKey: true,
+      providerKeyName: 'OPENAI_API_KEY',
+    });
+
+    expect(await screen.findByText('Using OPENAI_API_KEY')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'litellm_proxy' } });
+
+    await waitFor(() => {
+      const latest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+      expect(latest).toBeTruthy();
+      expect(latest.requestId).not.toBe(statusRequest.requestId);
+      expect(latest.provider).toBe('litellm_proxy');
+    });
+
+    const statusRequest2 = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest2.requestId,
+      ok: true,
+      profileId: 'gpt-5',
+      hasKey: true,
+      hasProfileKey: false,
+      hasProviderKey: true,
+      providerKeyName: 'LITELLM_API_KEY',
+    });
+
+    expect(await screen.findByText('Using LITELLM_API_KEY')).toBeInTheDocument();
+    expect(screen.queryByText('Using OPENAI_API_KEY')).toBeNull();
+  });
+
   it('supports a collapsible Advanced settings section', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -196,6 +196,11 @@ type LlmProfileApiKeyStatusInfo = {
   providerKeyName?: string;
 };
 
+type LlmProfileApiKeyStatusOverrides = {
+  provider?: string;
+  baseUrl?: string;
+};
+
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.
  */
@@ -382,7 +387,10 @@ export function App() {
     });
   }, [postMessage]);
 
-  const getLlmProfileApiKeyStatus = useCallback(async (profileId: string): Promise<LlmProfileApiKeyStatusInfo> => {
+  const getLlmProfileApiKeyStatus = useCallback(async (
+    profileId: string,
+    overrides?: LlmProfileApiKeyStatusOverrides
+  ): Promise<LlmProfileApiKeyStatusInfo> => {
     const requestId = createLlmProfilesRequestId('apiKeyStatus');
     return await new Promise<LlmProfileApiKeyStatusInfo>((resolve, reject) => {
       const timeout = setTimeout(() => {
@@ -390,7 +398,14 @@ export function App() {
         reject(new Error('Timed out fetching LLM profile API key status'));
       }, LLM_PROFILES_REQUEST_TIMEOUT_MS);
       pendingLlmProfilesRequestsRef.current.set(requestId, { kind: 'apiKeyStatus', resolve, reject, timeout });
-      postMessage({ type: 'llmProfileApiKeyStatusRequest', requestId, profileId });
+      const message: WebviewToHostMessage = {
+        type: 'llmProfileApiKeyStatusRequest',
+        requestId,
+        profileId,
+        provider: typeof overrides?.provider === 'string' ? overrides.provider : undefined,
+        baseUrl: typeof overrides?.baseUrl === 'string' ? overrides.baseUrl : undefined,
+      };
+      postMessage(message);
     });
   }, [postMessage]);
 

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -44,6 +44,11 @@ type LlmProfileApiKeyStatusInfo = {
   providerKeyName?: string;
 };
 
+type LlmProfileApiKeyStatusOverrides = {
+  provider?: string;
+  baseUrl?: string;
+};
+
 const EMPTY_FORM: ProfileFormState = {
   name: '',
   provider: '',
@@ -377,7 +382,7 @@ export function LlmProfilesView(props: {
   loadProfile: (profileId: string) => Promise<LLMConfiguration>;
   saveProfile: (profileId: string, profile: LLMConfiguration) => Promise<void>;
   deleteProfile: (profileId: string) => Promise<void>;
-  getApiKeyStatus: (profileId: string) => Promise<LlmProfileApiKeyStatusInfo>;
+  getApiKeyStatus: (profileId: string, overrides?: LlmProfileApiKeyStatusOverrides) => Promise<LlmProfileApiKeyStatusInfo>;
   setApiKey: (profileId: string, apiKey: string) => Promise<void>;
 }) {
   const {
@@ -426,11 +431,11 @@ export function LlmProfilesView(props: {
   const advancedSettingsLabelId = 'llmProfilesAdvancedSettingsLabel';
   const advancedSettingsPanelId = 'llmProfilesAdvancedSettingsPanel';
 
-  const refreshApiKeyStatus = useCallback(async (profileId: string) => {
+  const refreshApiKeyStatus = useCallback(async (profileId: string, overrides?: LlmProfileApiKeyStatusOverrides) => {
     if (activeProfileIdRef.current !== profileId) return;
     setApiKeyStatus({ state: 'loading' });
     try {
-      const status = await getApiKeyStatus(profileId);
+      const status = await getApiKeyStatus(profileId, overrides);
       if (activeProfileIdRef.current !== profileId) return;
       setApiKeyStatus({ state: 'ready', ...status });
       if (status.hasProfileKey) {
@@ -521,10 +526,7 @@ export function LlmProfilesView(props: {
         setLoadingProfile(false);
       }
     }
-    if (activeProfileIdRef.current === profileId) {
-      void refreshApiKeyStatus(profileId);
-    }
-  }, [applyEditorTransition, loadProfile, refreshApiKeyStatus]);
+  }, [applyEditorTransition, loadProfile]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -543,6 +545,12 @@ export function LlmProfilesView(props: {
     }
     startCreate();
   }, [activeProfileId, isOpen, openRequest, startCreate, startEdit]);
+
+  useEffect(() => {
+    if (mode !== 'edit' || !selectedProfileId || loadingProfile) return;
+    if (!form.provider) return;
+    void refreshApiKeyStatus(selectedProfileId, { provider: form.provider });
+  }, [form.provider, loadingProfile, mode, refreshApiKeyStatus, selectedProfileId]);
 
   const handleSave = useCallback(async () => {
     setSaveAttempted(true);

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -701,13 +701,13 @@ export function LlmProfilesView(props: {
       }
       await setApiKey(profileId, trimmed);
       setApiKeyInput('');
-      void refreshApiKeyStatus(profileId);
+      void refreshApiKeyStatus(profileId, form.provider ? { provider: form.provider } : undefined);
     } catch (err) {
       setApiKeyError(err instanceof Error ? err.message : String(err));
     } finally {
       setApiKeySaving(false);
     }
-  }, [apiKeyInput, refreshApiKeyStatus, selectedProfileId, setApiKey]);
+  }, [apiKeyInput, form.provider, refreshApiKeyStatus, selectedProfileId, setApiKey]);
 
   const handleClearApiKey = useCallback(async () => {
     if (!selectedProfileId) return;
@@ -716,13 +716,13 @@ export function LlmProfilesView(props: {
     setApiKeyError(null);
     try {
       await setApiKey(profileId, '');
-      void refreshApiKeyStatus(profileId);
+      void refreshApiKeyStatus(profileId, form.provider ? { provider: form.provider } : undefined);
     } catch (err) {
       setApiKeyError(err instanceof Error ? err.message : String(err));
     } finally {
       setApiKeySaving(false);
     }
-  }, [refreshApiKeyStatus, selectedProfileId, setApiKey]);
+  }, [form.provider, refreshApiKeyStatus, selectedProfileId, setApiKey]);
 
   const handleToggleOverrideProfileApiKey = useCallback((next: boolean) => {
     setOverrideProfileApiKey(next);

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -159,6 +159,14 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
     }
   };
 
+  const isLlmProvider = (value: string): value is LLMProvider => {
+    return value === 'openai'
+      || value === 'litellm_proxy'
+      || value === 'openrouter'
+      || value === 'anthropic'
+      || value === 'gemini';
+  };
+
   const hasStoredSecret = async (key: string): Promise<boolean> => {
     const trimmedKey = key.trim();
     if (!trimmedKey) return false;
@@ -577,7 +585,13 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           const stored = await context.secrets.get(key);
           const hasProfileKey = typeof stored === 'string' && stored.trim().length > 0;
           const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
-          const provider = profile.config.provider ?? detectProviderFromBaseUrl(profile.config.baseUrl);
+          const overrideProviderRaw = typeof message.provider === 'string' ? message.provider.trim() : '';
+          const overrideProvider = overrideProviderRaw && isLlmProvider(overrideProviderRaw) ? overrideProviderRaw : null;
+          const overrideBaseUrl = typeof message.baseUrl === 'string' ? message.baseUrl.trim() : '';
+          const provider = overrideProvider
+            ?? (overrideBaseUrl ? detectProviderFromBaseUrl(overrideBaseUrl) : null)
+            ?? profile.config.provider
+            ?? detectProviderFromBaseUrl(profile.config.baseUrl);
           const providerKeyName = getProviderApiKeyName(provider);
           const hasProviderKey = await hasStoredSecret(providerKeyName);
           void host.postMessage({


### PR DESCRIPTION
Bead: oh-tab-a1op

Fix
- When editing a profile, changing the Provider dropdown now immediately refreshes the provider-key hint/status based on the *draft* provider, not the last-saved profile provider.

Implementation
- Extend `llmProfileApiKeyStatusRequest` to accept optional `{ provider, baseUrl }` overrides.
- Webview (App/LlmProfilesView) sends the selected draft provider when it changes.
- Host handler uses the override provider (or override baseUrl) to compute `providerKeyName` + `hasProviderKey`.

Testing
- `npm test`
- `npm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented immediate provider key hint refresh when changing the Provider dropdown in profile edit mode.

**Key Changes:**
- Extended `llmProfileApiKeyStatusRequest` message to accept optional `provider` and `baseUrl` overrides
- Webview now sends the draft provider value when querying API key status
- Host handler uses override provider (if provided) to compute the correct `providerKeyName` instead of always using the saved profile's provider
- Added `useEffect` hook in `LlmProfilesView` that triggers API key status refresh whenever `form.provider` changes during edit mode
- Removed premature `refreshApiKeyStatus` call from `startEdit` to avoid race condition with the new useEffect
- Added comprehensive test coverage for the provider change behavior

**Technical Implementation:**
The fix works by passing the current draft provider state as an override parameter through the message chain (LlmProfilesView → App → Host). The host handler checks for the override provider first, then falls back to override baseUrl detection, then to the saved profile's provider. This ensures the hint reflects what the user is currently selecting, not what was last saved.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The implementation is clean, well-tested, and follows established patterns in the codebase. The change is focused and addresses the specific UX issue without introducing side effects. Type safety is maintained throughout with proper TypeScript guards. The test coverage is comprehensive and validates the exact behavior described in the PR. The code correctly handles the fallback chain (override provider → override baseUrl → saved provider → detected provider) and properly validates the provider string before using it.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/webview-src/components/App.tsx | Extended `getLlmProfileApiKeyStatus` to accept optional overrides and pass them to the host |
| src/webview-src/components/LlmProfilesView.tsx | Added useEffect to refresh API key status when draft provider changes; removed premature refresh from `startEdit` |
| src/webview/host/createWebviewMessageHandler.ts | Added `isLlmProvider` guard and override logic to compute provider from message or fallback to profile |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant LlmProfilesView
    participant App
    participant Host
    participant SecretStorage

    User->>LlmProfilesView: Select profile to edit
    LlmProfilesView->>App: loadProfile(profileId)
    App->>Host: llmProfileLoadRequest
    Host-->>App: llmProfileLoadResponse (config)
    App-->>LlmProfilesView: Profile loaded
    
    Note over LlmProfilesView: form.provider set from config

    LlmProfilesView->>App: getApiKeyStatus(profileId, {provider: form.provider})
    App->>Host: llmProfileApiKeyStatusRequest + override provider
    Host->>Host: Use override provider (not saved profile)
    Host->>Host: Compute providerKeyName from override
    Host->>SecretStorage: Check for provider key
    SecretStorage-->>Host: hasProviderKey
    Host-->>App: llmProfileApiKeyStatusResponse (with providerKeyName)
    App-->>LlmProfilesView: Display provider key hint

    User->>LlmProfilesView: Change provider dropdown
    Note over LlmProfilesView: form.provider updated (draft state)
    
    LlmProfilesView->>LlmProfilesView: useEffect detects form.provider change
    LlmProfilesView->>App: getApiKeyStatus(profileId, {provider: newProvider})
    App->>Host: llmProfileApiKeyStatusRequest + override provider
    Host->>Host: Use override provider from request
    Host->>Host: Compute providerKeyName from override
    Host->>SecretStorage: Check for new provider key
    SecretStorage-->>Host: hasProviderKey
    Host-->>App: llmProfileApiKeyStatusResponse (new providerKeyName)
    App-->>LlmProfilesView: Display updated provider key hint
    
    Note over LlmProfilesView: Hint updates immediately<br/>before saving profile
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->