### PR TITLE
oh-tab-3ufp: drop legacy microagents skills dir

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -330,7 +330,7 @@ const augmented = context.getUserMessageSuffix(userMessage);
 - Support third-party files (.cursorrules, agents.md, AGENTS.md)
 - Match triggers against user messages
 - Extract variables from skill content (${variable_name} format)
-- Load user skills from ~/.openhands/skills/ and ~/.openhands/microagents/
+- Load user skills from ~/.openhands/skills/
 
 **Skill Types**:
 
@@ -456,7 +456,6 @@ Refactor ${target_file} using ${pattern} pattern.
 
 Skills are automatically loaded from:
 1. `~/.openhands/skills/` - Primary skills directory
-2. `~/.openhands/microagents/` - Legacy support
 
 Third-party files supported:
 - `.cursorrules` → skill name: "cursorrules"

--- a/packages/agent-sdk-ts/AGENTS.md
+++ b/packages/agent-sdk-ts/AGENTS.md
@@ -49,11 +49,10 @@ Prompt extension and skill management:
     - **KeywordTrigger**: Activated when keywords match user message
     - **TaskTrigger**: Activated for specific tasks with user input variables
   - Variable extraction for user input (${variable_name} format)
-  - `loadUserSkills()` function to load from ~/.openhands/skills/ and ~/.openhands/microagents/
+  - `loadUserSkills()` function to load from ~/.openhands/skills/
 
 Skills are loaded from:
 1. `~/.openhands/skills/` - Primary skills directory
-2. `~/.openhands/microagents/` - Legacy support
 
 ### 3. Runtime Layer (`src/runtime/`)
 Agent execution and state management:

--- a/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
@@ -35,7 +35,7 @@ export class AgentContext {
   /** Optional suffix to append to the user's message. */
   userMessageSuffix?: string;
 
-  /** Whether to automatically load user skills from ~/.openhands/skills/ and ~/.openhands/microagents/ */
+  /** Whether to automatically load user skills from ~/.openhands/skills/ */
   loadUserSkills: boolean;
 
   constructor(params?: {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -429,20 +429,17 @@ Content`);
   describe('loadUserSkills', () => {
     let tempDir: string;
     let skillsDir: string;
-    let microagentsDir: string;
     let originalDirs: string[];
 
     beforeEach(() => {
       tempDir = join(tmpdir(), `user-skills-test-${Date.now()}`);
       skillsDir = join(tempDir, '.openhands', 'skills');
-      microagentsDir = join(tempDir, '.openhands', 'microagents');
       mkdirSync(skillsDir, { recursive: true });
-      mkdirSync(microagentsDir, { recursive: true });
 
       // Save original directories and replace with test directories
       originalDirs = [...USER_SKILLS_DIRS];
       USER_SKILLS_DIRS.length = 0;
-      USER_SKILLS_DIRS.push(skillsDir, microagentsDir);
+      USER_SKILLS_DIRS.push(skillsDir);
     });
 
     afterEach(() => {
@@ -479,67 +476,6 @@ Test skill content`);
       expect(skills).toHaveLength(1);
       expect(skills[0].name).toBe('test-skill');
       expect(skills[0].content).toBe('Test skill content');
-    });
-
-    it('loads skills from legacy microagents directory', () => {
-      // Create a skill in the microagents directory
-      writeFileSync(join(microagentsDir, 'legacy-skill.md'), `---
-triggers:
-  - legacy
----
-
-Legacy skill content`);
-
-      const skills = loadUserSkills();
-
-      expect(skills).toHaveLength(1);
-      expect(skills[0].name).toBe('legacy-skill');
-      expect(skills[0].content).toBe('Legacy skill content');
-    });
-
-    it('loads and deduplicates skills from multiple directories', () => {
-      // Create skills in both directories
-      writeFileSync(join(skillsDir, 'unique-skill.md'), `---
-triggers:
-  - unique
----
-
-Unique skill`);
-
-      writeFileSync(join(microagentsDir, 'legacy-skill.md'), `---
-triggers:
-  - legacy
----
-
-Legacy skill`);
-
-      // Create duplicate skill (skills directory takes precedence)
-      writeFileSync(join(skillsDir, 'duplicate.md'), `---
-triggers:
-  - dup
----
-
-From skills directory`);
-
-      writeFileSync(join(microagentsDir, 'duplicate.md'), `---
-triggers:
-  - dup
----
-
-From microagents directory`);
-
-      const skills = loadUserSkills();
-
-      expect(skills).toHaveLength(3); // unique-skill, legacy-skill, duplicate (from skills dir)
-
-      const skillNames = skills.map(s => s.name);
-      expect(skillNames).toContain('unique-skill');
-      expect(skillNames).toContain('legacy-skill');
-      expect(skillNames).toContain('duplicate');
-
-      // Verify the duplicate is from skills directory (higher priority)
-      const duplicateSkill = skills.find(s => s.name === 'duplicate');
-      expect(duplicateSkill?.content).toBe('From skills directory');
     });
 
     it('loads both repo skills and knowledge skills', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -300,15 +300,12 @@ export function loadSkillsFromDir(skillDir: string): {
  */
 export const USER_SKILLS_DIRS = [
   join(homedir(), '.openhands', 'skills'),
-  join(homedir(), '.openhands', 'microagents'), // Legacy support
 ];
 
 /**
  * Load skills from user's home directory.
  *
- * Searches for skills in ~/.openhands/skills/ and ~/.openhands/microagents/
- * (legacy). Skills from both directories are merged, with skills/ taking
- * precedence for duplicate names.
+ * Searches for skills in ~/.openhands/skills/.
  *
  * @returns List of Skill objects loaded from user directories.
  *   Returns empty list if no skills found or loading fails.


### PR DESCRIPTION
Bead: oh-tab-3ufp

Change
- Remove legacy `~/.openhands/microagents` from user-skill discovery; only `~/.openhands/skills` is supported.

Code
- `USER_SKILLS_DIRS`: drop microagents entry.
- Update docstrings/JSDoc + architecture docs to remove microagents references.
- Remove unit tests that asserted loading from the legacy directory.

Testing
- `npm test`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed support for legacy microagents directory. User skills are now loaded exclusively from `~/.openhands/skills/`. Updated documentation and tests to reflect this simplified skill-loading behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed legacy `~/.openhands/microagents` directory from user-skill discovery, standardizing on `~/.openhands/skills` as the sole location.

**Changes Made:**
- Removed `~/.openhands/microagents` entry from `USER_SKILLS_DIRS` constant in `skill.ts:301-303`
- Updated JSDoc comments in `agent-context.ts:38` and `skill.ts:308` to reflect single directory
- Removed unit tests validating microagents directory loading and deduplication behavior (`skill.test.ts:481-543`)
- Updated architecture documentation in `agent-sdk-architecture.md` and `AGENTS.md`

**Impact:**
This is a clean removal of deprecated functionality. Users who had skills in `~/.openhands/microagents` will need to migrate them to `~/.openhands/skills`. The change simplifies the skill loading logic by eliminating the multi-directory search and deduplication code path.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risks
- Clean removal of deprecated functionality with comprehensive test coverage removal, documentation updates, and no remaining references to microagents anywhere in the codebase (verified via grep). The changes are logically consistent across all files.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent-sdk-ts/src/sdk/context/skills/skill.ts | Removed legacy microagents directory from USER_SKILLS_DIRS array and updated JSDoc comments |
| packages/agent-sdk-ts/src/sdk/context/agent-context.ts | Updated JSDoc comment to remove reference to legacy microagents directory |
| packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts | Removed unit tests that validated loading from legacy microagents directory and deduplication logic |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AgentContext
    participant loadUserSkills
    participant USER_SKILLS_DIRS
    participant loadSkillsFromDir
    participant Filesystem

    Note over User,Filesystem: Before PR: Legacy microagents support
    User->>AgentContext: Initialize with loadUserSkills=true
    AgentContext->>loadUserSkills: Load user skills
    loadUserSkills->>USER_SKILLS_DIRS: Get directories
    Note over USER_SKILLS_DIRS: ["~/.openhands/skills",<br/>"~/.openhands/microagents"]
    loadUserSkills->>loadSkillsFromDir: Load from ~/.openhands/skills
    loadSkillsFromDir->>Filesystem: Read skill files
    Filesystem-->>loadSkillsFromDir: Skill files
    loadSkillsFromDir-->>loadUserSkills: Skills from skills dir
    loadUserSkills->>loadSkillsFromDir: Load from ~/.openhands/microagents
    loadSkillsFromDir->>Filesystem: Read legacy skill files
    Filesystem-->>loadSkillsFromDir: Legacy skill files
    loadSkillsFromDir-->>loadUserSkills: Skills from microagents dir
    Note over loadUserSkills: Deduplicate by name,<br/>skills dir takes precedence
    loadUserSkills-->>AgentContext: Merged skills list

    Note over User,Filesystem: After PR: Only ~/.openhands/skills
    User->>AgentContext: Initialize with loadUserSkills=true
    AgentContext->>loadUserSkills: Load user skills
    loadUserSkills->>USER_SKILLS_DIRS: Get directories
    Note over USER_SKILLS_DIRS: ["~/.openhands/skills"]
    loadUserSkills->>loadSkillsFromDir: Load from ~/.openhands/skills
    loadSkillsFromDir->>Filesystem: Read skill files
    Filesystem-->>loadSkillsFromDir: Skill files
    loadSkillsFromDir-->>loadUserSkills: Skills from skills dir
    loadUserSkills-->>AgentContext: Skills list (no deduplication needed)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->