### PR TITLE
oh-tab-nu3q: debug log sanitized LLM payloads

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -125,6 +125,50 @@ function truncateToolMessage(text: string, maxChars = TOOL_MESSAGE_MAX_CHARS): s
   return `${head}\n${TOOL_MESSAGE_CLIP_MARKER}\n${tail}`;
 }
 
+const DEBUG_TOOL_TEXT_HEAD_CHARS = 100;
+const DEBUG_TOOL_TEXT_TAIL_CHARS = 100;
+const DEBUG_TOOL_TEXT_MAX_UNCLIPPED = DEBUG_TOOL_TEXT_HEAD_CHARS + DEBUG_TOOL_TEXT_TAIL_CHARS;
+function truncateToolMessageForDebug(text: string): string {
+  if (text.length <= DEBUG_TOOL_TEXT_MAX_UNCLIPPED) return text;
+  return `${text.slice(0, DEBUG_TOOL_TEXT_HEAD_CHARS)}…${text.slice(-DEBUG_TOOL_TEXT_TAIL_CHARS)}`;
+}
+
+function sanitizeToolCallsForDebug(toolCalls: ToolCall[] | undefined): ToolCall[] | undefined {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return undefined;
+  return toolCalls.map((toolCall) => {
+    const rawArgs = toolCall.function.arguments;
+    const safeArgs = typeof rawArgs === 'string' ? redactAndTruncateArgs(rawArgs) : '';
+    return {
+      ...toolCall,
+      function: { ...toolCall.function, arguments: safeArgs },
+    };
+  });
+}
+
+function sanitizeMessageForDebug(message: Message): Message {
+  const safeToolCalls = sanitizeToolCallsForDebug(message.tool_calls);
+  const safeContent = message.role === 'tool'
+    ? message.content.map((item) => (
+      item.type === 'text'
+        ? { ...item, text: truncateToolMessageForDebug(item.text) }
+        : item
+    ))
+    : message.content;
+
+  const out: Message = { ...message, content: safeContent };
+  if (safeToolCalls) out.tool_calls = safeToolCalls;
+  return out;
+}
+
+function sanitizeChatRequestForDebug(request: ChatCompletionRequest): { systemPrompt: string; messages: Message[]; tools: string[] } {
+  const toolNames = (request.tools ?? []).map((t) => t.function?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0);
+  return {
+    systemPrompt: 'SYSTEM_PROMPT',
+    messages: request.messages.map(sanitizeMessageForDebug),
+    tools: toolNames,
+  };
+}
+
 const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
 const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
 const TOOL_SUMMARY_MAX_CHARS = 1_000;
@@ -747,6 +791,29 @@ export class Agent extends EventEmitter {
           }
         }
 
+        if (this.debug) {
+          try {
+            const provider = llmConfig.provider ?? detectProviderFromBaseUrl(llmConfig.baseUrl);
+            const baseUrl = llmConfig.baseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider];
+            this.events.push({
+              kind: 'ConversationStateUpdateEvent',
+              source: 'agent',
+              key: 'llm_request_payload',
+              value: {
+                llm: {
+                  provider,
+                  model: llmConfig.model,
+                  baseUrl,
+                  ...(typeof llmConfig.openaiApiMode === 'string' ? { openaiApiMode: llmConfig.openaiApiMode } : {}),
+                },
+                request: sanitizeChatRequestForDebug(request),
+              },
+            } as Event);
+          } catch (error) {
+            console.warn('[Agent] Failed to emit llm_request_payload debug event:', error);
+          }
+        }
+
         const configuredMaxInputTokens = llmConfig.maxInputTokens;
         if (
           condensationAttempt < MAX_CONDENSATIONS_PER_STEP &&
@@ -758,7 +825,33 @@ export class Agent extends EventEmitter {
         }
 
         try {
-          response = await orchestrator.runChat(request);
+          const result = await orchestrator.runChat(request);
+          response = result;
+          if (this.debug) {
+            try {
+              const provider = llmConfig.provider ?? detectProviderFromBaseUrl(llmConfig.baseUrl);
+              const baseUrl = llmConfig.baseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider];
+              this.events.push({
+                kind: 'ConversationStateUpdateEvent',
+                source: 'agent',
+                key: 'llm_response_payload',
+                value: {
+                  llm: {
+                    provider,
+                    model: llmConfig.model,
+                    baseUrl,
+                    ...(typeof llmConfig.openaiApiMode === 'string' ? { openaiApiMode: llmConfig.openaiApiMode } : {}),
+                  },
+                  response: {
+                    message: sanitizeMessageForDebug(result.message),
+                    usage: result.usage,
+                  },
+                },
+              } as Event);
+            } catch (error) {
+              console.warn('[Agent] Failed to emit llm_response_payload debug event:', error);
+            }
+          }
           break;
         } catch (error) {
           if (condensationAttempt < MAX_CONDENSATIONS_PER_STEP && isContextLimitError(llmConfig.provider, error)) {
@@ -933,10 +1026,18 @@ export class Agent extends EventEmitter {
     return { summary, forgottenEventIds, summaryOffset };
   }
 
-  private getEffectiveLlmConfigForCondensation(): { provider: LLMProvider | undefined; maxInputTokens: number | undefined } {
+  private getEffectiveLlmConfigForCondensation(): {
+    provider: LLMProvider | undefined;
+    baseUrl: string | undefined;
+    model: string;
+    openaiApiMode: unknown;
+    maxInputTokens: number | undefined;
+  } {
     const llm = this.options.settings?.llm ?? {};
     const configuredBaseUrl = toOptionalNonEmptyString(llm.baseUrl);
+    const configuredModel = toOptionalNonEmptyString(llm.model) ?? '';
     const configuredProvider = llm.provider ?? undefined;
+    const configuredOpenaiApiMode = (llm as { openaiApiMode?: unknown } | undefined)?.openaiApiMode;
     const configuredMaxInputTokens =
       typeof llm.maxInputTokens === 'number' && Number.isFinite(llm.maxInputTokens) && llm.maxInputTokens > 0
         ? Math.trunc(llm.maxInputTokens)
@@ -944,14 +1045,19 @@ export class Agent extends EventEmitter {
 
     const profileId = toOptionalNonEmptyString(llm.profileId);
     if (!profileId || !isSafeProfileId(profileId)) {
+      const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
       return {
-        provider: configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl),
+        provider,
+        baseUrl: configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider],
+        model: configuredModel,
+        openaiApiMode: configuredOpenaiApiMode,
         maxInputTokens: configuredMaxInputTokens,
       };
     }
 
     try {
       const profile = loadProfile(profileId);
+      const profileModel = toOptionalNonEmptyString(profile.config.model) ?? configuredModel;
       const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
       const profileProvider = profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
       const profileMaxInputTokens =
@@ -962,11 +1068,18 @@ export class Agent extends EventEmitter {
           : undefined;
       return {
         provider: profileProvider,
+        baseUrl: profileBaseUrl ?? configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[profileProvider],
+        model: profileModel,
+        openaiApiMode: profile.config.openaiApiMode ?? configuredOpenaiApiMode,
         maxInputTokens: configuredMaxInputTokens ?? profileMaxInputTokens,
       };
     } catch {
+      const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
       return {
-        provider: configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl),
+        provider,
+        baseUrl: configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider],
+        model: configuredModel,
+        openaiApiMode: configuredOpenaiApiMode,
         maxInputTokens: configuredMaxInputTokens,
       };
     }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, EventLog } from '../';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class MultiCallMockLLM implements LLMClient {
+  private callIndex = 0;
+
+  constructor(private readonly calls: LLMStreamChunk[][]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    const chunks = this.calls[this.callIndex] ?? [];
+    this.callIndex += 1;
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model', provider: 'openai' },
+  agent: { debug: true },
+  conversation: { maxIterations: 2 },
+  confirmation: {},
+  secrets: {},
+};
+
+describe('Agent debug LLM payload events', () => {
+  it('emits sanitized request/response payloads (no system prompt, redacted tool args, truncated tool text)', async () => {
+    const log = new EventLog();
+
+    const tool: ToolDefinition<{ any: string }, { ok: boolean; output: string }> = {
+      name: 'noop',
+      validate: (input) => (input as unknown) as { any: string },
+      execute: async () => ({ ok: true, output: `TOOL_OUTPUT:${'x'.repeat(500)}` }),
+    };
+
+    const args = {
+      apiKey: 'SHOULD_NOT_LEAK',
+      note: 'x'.repeat(5000),
+    };
+
+    const llm = new MultiCallMockLLM([
+      [
+        { type: 'text', text: 'Using tool' },
+        { type: 'tool_call_delta', id: 'c1', name: 'noop', arguments: JSON.stringify(args) },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'done' },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/tmp', llmClient: llm, tools: [tool] });
+    await agent.run('go');
+
+    const requestPayloads = log
+      .list()
+      .filter((e) => e.kind === 'ConversationStateUpdateEvent' && (e as any).key === 'llm_request_payload')
+      .map((e) => (e as any).value);
+    expect(requestPayloads.length).toBeGreaterThanOrEqual(2);
+
+    const firstRequest = requestPayloads[0];
+    expect(firstRequest.request.systemPrompt).toBe('SYSTEM_PROMPT');
+    expect(Array.isArray(firstRequest.request.tools)).toBe(true);
+    expect(firstRequest.request.tools).toContain('noop');
+    expect(typeof firstRequest.request.tools[0]).toBe('string');
+
+    const secondRequest = requestPayloads[1];
+    const toolMessage = (secondRequest.request.messages as any[]).find((m) => m?.role === 'tool');
+    expect(toolMessage).toBeTruthy();
+    const toolText = Array.isArray(toolMessage?.content)
+      ? (toolMessage.content as any[]).find((c) => c?.type === 'text')?.text
+      : '';
+    expect(typeof toolText).toBe('string');
+    expect(toolText).toContain('…');
+    expect(toolText.length).toBe(201);
+
+    const responsePayloads = log
+      .list()
+      .filter((e) => e.kind === 'ConversationStateUpdateEvent' && (e as any).key === 'llm_response_payload')
+      .map((e) => (e as any).value);
+    expect(responsePayloads.length).toBeGreaterThanOrEqual(1);
+
+    const firstResponse = responsePayloads[0];
+    const toolCalls = firstResponse.response.message.tool_calls;
+    expect(Array.isArray(toolCalls)).toBe(true);
+    expect(toolCalls.length).toBeGreaterThan(0);
+    const argStr = toolCalls[0].function.arguments as string;
+    expect(typeof argStr).toBe('string');
+    expect(argStr).not.toContain('SHOULD_NOT_LEAK');
+    expect(argStr).toContain('***');
+    expect(argStr).toContain('…(truncated)');
+    expect(argStr.length).toBeLessThanOrEqual(2015);
+  });
+});
+

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -58,6 +58,19 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
       outputChannel?.appendLine('[llm] Streaming started...');
     }
 
+    if (ev.kind === 'ConversationStateUpdateEvent' && (ev.key === 'llm_request_payload' || ev.key === 'llm_response_payload')) {
+      const shouldLogToDebugConsole = deps.context.extensionMode !== vscode.ExtensionMode.Production;
+      if (shouldLogToDebugConsole) {
+        const key = ev.key ?? 'llm_payload';
+        try {
+          console.debug(`[openhands][${key}] ${deps.safeStringify(ev.value)}`);
+        } catch (e) {
+          console.debug(`[openhands][${key}] <failed to stringify: ${String(e)}>`); // Debug Console only
+        }
+      }
+      return;
+    }
+
     if (!isLlmStreamUpdate) {
       const isErrorLike = ev.kind === 'ConversationErrorEvent' || ev.kind === 'AgentErrorEvent';
       if (deps.isVerboseEventLogging() || isErrorLike) {


### PR DESCRIPTION
Bead: oh-tab-nu3q

What
- Add debug-only LLM request/response payload events in agent-sdk-ts when `settings.agent.debug` is enabled:
  - `llm_request_payload`: sanitized `ChatCompletionRequest` (system prompt replaced with literal `SYSTEM_PROMPT`, tool definitions reduced to names, tool-role text truncated to 100+…+100, tool-call args redacted/truncated).
  - `llm_response_payload`: normalized response `{ message, usage }` with tool-call args redacted/truncated.

Host logging
- Extension host listens for those state update events and logs them to Debug Console (`console.debug`) only when `extensionMode !== Production`.
- These debug payload events are not forwarded to the webview and are not buffered for replay.

Tests
- New unit test ensures payload sanitization + redaction/truncation.

Local checks
- `npm test`
- `npm run lint`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented debug-only LLM request/response payload logging when `settings.agent.debug` is enabled. The agent-sdk-ts now emits `llm_request_payload` and `llm_response_payload` events with sanitized data (system prompt replaced with literal string, tool definitions reduced to names, tool args redacted/truncated, tool-role text clipped to 100+…+100 chars). Extension host logs these events to Debug Console only in non-production mode; events are not forwarded to webview or buffered for replay.

Changes also expanded `getEffectiveLlmConfigForCondensation()` to return additional LLM config fields (`baseUrl`, `model`, `openaiApiMode`) needed for the debug payload events.

Test coverage added to verify sanitization, redaction, and truncation behavior.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is well-structured with proper sanitization to prevent leaking sensitive data. Debug logging is gated behind both debug flag and non-production mode. Changes are additive (no breaking changes), include comprehensive test coverage, and follow existing patterns in the codebase. The expanded return type for `getEffectiveLlmConfigForCondensation()` is backward-compatible and correctly provides the additional fields needed for debug events.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent-sdk-ts/src/sdk/runtime/Agent.ts | Added debug-only LLM payload logging with sanitization functions for request/response events |
| packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts | New test file verifying payload sanitization (system prompt, tool args redaction, text truncation) |
| src/conversation/host/attachConversationListeners.ts | Added debug console logging for LLM payload events in non-production mode, events not forwarded to webview |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Agent
    participant LLM
    participant Host
    participant DebugConsole

    User->>Agent: run('go')
    activate Agent
    
    Note over Agent: debug = true (from settings.agent.debug)
    
    Agent->>Agent: buildChatRequest()
    Agent->>Agent: sanitizeChatRequestForDebug(request)
    Note over Agent: - systemPrompt → 'SYSTEM_PROMPT'<br/>- tools → tool names only<br/>- tool args → redacted/truncated
    
    Agent->>Agent: emit llm_request_payload event
    Note over Agent: ConversationStateUpdateEvent<br/>with sanitized request
    
    Agent->>Host: event (llm_request_payload)
    Host->>Host: check extensionMode !== Production
    Host->>DebugConsole: console.debug(sanitized payload)
    Note over Host: Event NOT forwarded to webview<br/>Event NOT buffered for replay
    
    Agent->>LLM: orchestrator.runChat(request)
    activate LLM
    LLM-->>Agent: response
    deactivate LLM
    
    Agent->>Agent: sanitizeMessageForDebug(response.message)
    Note over Agent: - tool-call args → redacted/truncated<br/>- tool-role text → 100+…+100
    
    Agent->>Agent: emit llm_response_payload event
    Note over Agent: ConversationStateUpdateEvent<br/>with sanitized response
    
    Agent->>Host: event (llm_response_payload)
    Host->>Host: check extensionMode !== Production
    Host->>DebugConsole: console.debug(sanitized payload)
    Note over Host: Event NOT forwarded to webview<br/>Event NOT buffered for replay
    
    deactivate Agent
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->