### PR TITLE
oh-tab-wom3: dedupe LlmProfileApiKeyStatusInfo

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -2,6 +2,18 @@ import type { BashEvent, Event } from '@openhands/agent-sdk-ts';
 import type { LLMConfiguration } from '@openhands/agent-sdk-ts';
 import type { OpenHandsSettings, SavedServer } from '../settings/SettingsManager';
 
+export type LlmProfileApiKeyStatusInfo = {
+  hasKey: boolean;
+  hasProfileKey: boolean;
+  hasProviderKey: boolean;
+  providerKeyName?: string;
+};
+
+export type LlmProfileApiKeyStatusOverrides = {
+  provider?: string;
+  baseUrl?: string;
+};
+
 export type HostToWebviewMessage =
   | {
     type: 'status';
@@ -20,16 +32,7 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileSaveResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileDeleteResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileDeleteResponse'; requestId: string; ok: false; profileId: string; error: string }
-  | {
-    type: 'llmProfileApiKeyStatusResponse';
-    requestId: string;
-    ok: true;
-    profileId: string;
-    hasKey: boolean;
-    hasProfileKey: boolean;
-    hasProviderKey: boolean;
-    providerKeyName?: string;
-  }
+  | ({ type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: true; profileId: string } & LlmProfileApiKeyStatusInfo)
   | { type: 'llmProfileApiKeyStatusResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: false; profileId: string; error: string }
@@ -82,7 +85,7 @@ export type WebviewToHostMessage =
   | { type: 'llmProfileLoadRequest'; requestId: string; profileId: string }
   | { type: 'llmProfileSaveRequest'; requestId: string; profileId: string; profile: unknown }
   | { type: 'llmProfileDeleteRequest'; requestId: string; profileId: string }
-  | { type: 'llmProfileApiKeyStatusRequest'; requestId: string; profileId: string; provider?: string; baseUrl?: string }
+  | ({ type: 'llmProfileApiKeyStatusRequest'; requestId: string; profileId: string } & LlmProfileApiKeyStatusOverrides)
   | { type: 'llmProfileApiKeySetRequest'; requestId: string; profileId: string; apiKey: string }
   | { type: 'selectServer'; url: string }
   | { type: 'addServer'; server: SavedServer }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -45,7 +45,7 @@ import {
   MessageEventBlock,
   StreamingMessageBlock,
 } from './EventBlock';
-import type { WebviewToHostMessage } from '../../shared/webviewMessages';
+import type { LlmProfileApiKeyStatusInfo, LlmProfileApiKeyStatusOverrides, WebviewToHostMessage } from '../../shared/webviewMessages';
 
 type RenderedEvent = { id: number; event: Event };
 
@@ -188,18 +188,6 @@ type PendingLlmProfilesRequest =
     reject: (error: Error) => void;
     timeout: ReturnType<typeof setTimeout>;
   };
-
-type LlmProfileApiKeyStatusInfo = {
-  hasKey: boolean;
-  hasProfileKey: boolean;
-  hasProviderKey: boolean;
-  providerKeyName?: string;
-};
-
-type LlmProfileApiKeyStatusOverrides = {
-  provider?: string;
-  baseUrl?: string;
-};
 
 /**
  * Event dispatcher: routes agent-sdk events to appropriate rendering components.

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useCallback, useEffect, useMemo, useRef, useState, type Rea
 import type { LLMConfiguration } from '@openhands/agent-sdk-ts';
 import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideClick';
 import { getVscodeApi } from '../shared/vscodeApi';
-import type { WebviewToHostMessage } from '../../shared/webviewMessages';
+import type { LlmProfileApiKeyStatusInfo, LlmProfileApiKeyStatusOverrides, WebviewToHostMessage } from '../../shared/webviewMessages';
 
 type ProfileFormMode = 'create' | 'edit';
 
@@ -34,20 +34,8 @@ type FieldErrors = Partial<Record<keyof ProfileFormState, string>>;
 type ApiKeyStatus =
   | { state: 'unknown' }
   | { state: 'loading' }
-  | { state: 'ready'; hasKey: boolean; hasProfileKey: boolean; hasProviderKey: boolean; providerKeyName?: string }
+  | ({ state: 'ready' } & LlmProfileApiKeyStatusInfo)
   | { state: 'error'; error: string };
-
-type LlmProfileApiKeyStatusInfo = {
-  hasKey: boolean;
-  hasProfileKey: boolean;
-  hasProviderKey: boolean;
-  providerKeyName?: string;
-};
-
-type LlmProfileApiKeyStatusOverrides = {
-  provider?: string;
-  baseUrl?: string;
-};
 
 const EMPTY_FORM: ProfileFormState = {
   name: '',


### PR DESCRIPTION
Fixes oh-tab-wom3.

- Deduplicates `LlmProfileApiKeyStatusInfo` / `LlmProfileApiKeyStatusOverrides` into `src/shared/webviewMessages.ts`.
- Updates `src/webview-src/components/App.tsx` and `src/webview-src/components/LlmProfilesView.tsx` to import the shared types.

Note: `DEFAULT_NO_CHANGE_TIMEOUT_SECONDS` is already 60s in `packages/agent-sdk-ts/src/tools/TerminalTool.ts`.

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated API key status type definitions into shared module to improve code organization and reduce duplication across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Consolidated duplicate type definitions `LlmProfileApiKeyStatusInfo` and `LlmProfileApiKeyStatusOverrides` into `src/shared/webviewMessages.ts`. Both `App.tsx` and `LlmProfilesView.tsx` now import these types from the shared module instead of defining them locally.

**Key changes:**
- Defined `LlmProfileApiKeyStatusInfo` and `LlmProfileApiKeyStatusOverrides` in the shared module
- Refactored message types to use TypeScript intersection types (`&`) for cleaner composition
- Updated imports in `App.tsx` and `LlmProfilesView.tsx` to use the shared types
- Removed duplicate local type definitions from both component files

The refactor follows the DRY principle and ensures type consistency across the codebase.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- This is a pure refactoring PR that eliminates code duplication by consolidating type definitions into a shared location. The changes are straightforward: type definitions are moved to a central location and imported where needed. The PR author has already run the required tests (npm test, npm run typecheck, npm run lint), and the changes don't introduce any new logic or behavior - they only reorganize existing types. The intersection type syntax used is standard TypeScript and maintains full type safety.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/shared/webviewMessages.ts | Added shared type definitions `LlmProfileApiKeyStatusInfo` and `LlmProfileApiKeyStatusOverrides`; refactored message types to use intersection types |
| src/webview-src/components/App.tsx | Removed duplicate type definitions; now imports `LlmProfileApiKeyStatusInfo` and `LlmProfileApiKeyStatusOverrides` from shared module |
| src/webview-src/components/LlmProfilesView.tsx | Removed duplicate type definitions; now imports `LlmProfileApiKeyStatusInfo` and `LlmProfileApiKeyStatusOverrides` from shared module |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as App.tsx
    participant LPV as LlmProfilesView.tsx
    participant WM as webviewMessages.ts
    participant Host as Extension Host

    Note over WM: Shared Type Definitions
    WM->>WM: LlmProfileApiKeyStatusInfo
    WM->>WM: LlmProfileApiKeyStatusOverrides
    
    App->>WM: Import shared types
    LPV->>WM: Import shared types
    
    Note over App,LPV: Both components use<br/>same type definitions
    
    App->>Host: llmProfileApiKeyStatusRequest<br/>(with LlmProfileApiKeyStatusOverrides)
    Host->>App: llmProfileApiKeyStatusResponse<br/>(with LlmProfileApiKeyStatusInfo)
    
    LPV->>Host: llmProfileApiKeyStatusRequest<br/>(with LlmProfileApiKeyStatusOverrides)
    Host->>LPV: llmProfileApiKeyStatusResponse<br/>(with LlmProfileApiKeyStatusInfo)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->