### PR TITLE
oh-tab-dfu0: update baseline-browser-mapping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3815,9 +3815,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.20",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
-      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
+      "version": "2.9.11",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.11.tgz",
+      "integrity": "sha512-Sg0xJUNDU1sJNGdfGWhVHX0kkZ+HWcvmVymJbj6NSgZZmW/8S9Y2HQ5euytnIgakgxN6papOAWiwDo1ctFDcoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -12361,6 +12361,7 @@
         "@typescript-eslint/eslint-plugin": "^8.44.1",
         "@typescript-eslint/parser": "^8.44.1",
         "@vitest/coverage-v8": "^3.2.4",
+        "baseline-browser-mapping": "^2.9.11",
         "eslint": "^9.36.0",
         "tsup": "^8.3.0",
         "typescript": "^5.9.2",

--- a/packages/agent-sdk-ts/package.json
+++ b/packages/agent-sdk-ts/package.json
@@ -43,6 +43,7 @@
     "@typescript-eslint/eslint-plugin": "^8.44.1",
     "@typescript-eslint/parser": "^8.44.1",
     "@vitest/coverage-v8": "^3.2.4",
+    "baseline-browser-mapping": "^2.9.11",
     "eslint": "^9.36.0",
     "tsup": "^8.3.0",
     "typescript": "^5.9.2",


### PR DESCRIPTION
Fixes oh-tab-dfu0.

- Adds `baseline-browser-mapping@latest` as a devDependency for `@openhands/agent-sdk-ts` so `npm run lint` no longer emits the staleness warning.

Tests:
- npm run lint
- npm test

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `baseline-browser-mapping@^2.9.11` as a devDependency to the agent-sdk-ts package to resolve a staleness warning emitted by `npm run lint`.

- Updated `baseline-browser-mapping` from version 2.8.20 to 2.9.11
- Added explicit devDependency declaration in `packages/agent-sdk-ts/package.json`
- Updated corresponding entries in `package-lock.json`

This is a maintenance fix that eliminates a warning from the TypeScript ESLint plugin, which depends on baseline-browser-mapping for browser compatibility data.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- This is a straightforward dependency version update that adds an explicit devDependency to resolve a build tooling warning. The change only affects development-time linting and does not impact runtime behavior or production code. The version bump from 2.8.20 to 2.9.11 is a minor/patch update that maintains compatibility.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent-sdk-ts/package.json | Added `baseline-browser-mapping@^2.9.11` as devDependency to resolve staleness warning from `npm run lint` |
| package-lock.json | Updated `baseline-browser-mapping` from 2.8.20 to 2.9.11 and added reference in agent-sdk-ts package |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant NPM as npm lint
    participant ESLint as @typescript-eslint/eslint-plugin
    participant BBM as baseline-browser-mapping
    
    Dev->>NPM: npm run lint
    NPM->>ESLint: Run ESLint
    ESLint->>BBM: Check dependency version
    BBM-->>ESLint: Version 2.8.20 (stale)
    ESLint-->>NPM: Emit staleness warning
    NPM-->>Dev: Show warning
    
    Note over Dev: PR #492: Add baseline-browser-mapping@^2.9.11
    
    Dev->>NPM: npm run lint (after PR)
    NPM->>ESLint: Run ESLint
    ESLint->>BBM: Check dependency version
    BBM-->>ESLint: Version 2.9.11 (current)
    ESLint-->>NPM: No warning
    NPM-->>Dev: Clean output
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->