### PR TITLE
oh-tab-05rt: table-drive Agent.security-risk tests

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
@@ -30,113 +30,72 @@ const baseSettings: OpenHandsSettings = {
 
 const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-security-risk-'));
 
+const createNoopTool = (): ToolDefinition<Record<string, unknown>, { ok: true }> => ({
+  name: 'noop',
+  validate: (input) => input as Record<string, unknown>,
+  execute: async () => ({ ok: true }),
+  description: 'No-op tool.',
+  parameters: {
+    type: 'object',
+    properties: {
+      value: { type: 'string' },
+    },
+    required: ['value'],
+  },
+});
+
+type ConfirmationExpectation = {
+  label: string;
+  confirmation: OpenHandsSettings['confirmation'];
+  shouldIncludeSecurityRisk: boolean;
+};
+
 describe('Agent security risk handling', () => {
-  it('includes security_risk in tool schema + prompt for risky confirmations', async () => {
+  it.each<ConfirmationExpectation>([
+    {
+      label: 'risky confirmations',
+      confirmation: { policy: 'risky', riskyThreshold: 'HIGH', confirmUnknown: false },
+      shouldIncludeSecurityRisk: true,
+    },
+    {
+      label: 'always confirmations',
+      confirmation: { policy: 'always' },
+      shouldIncludeSecurityRisk: true,
+    },
+    {
+      label: 'confirmations disabled',
+      confirmation: { policy: 'never' },
+      shouldIncludeSecurityRisk: false,
+    },
+  ])('prompt and tool schema includes security_risk when $label', async ({ confirmation, shouldIncludeSecurityRisk }) => {
     const log = new EventLog();
-    const tool: ToolDefinition<Record<string, unknown>, { ok: true }> = {
-      name: 'noop',
-      validate: (input) => input as Record<string, unknown>,
-      execute: async () => ({ ok: true }),
-      description: 'No-op tool.',
-      parameters: {
-        type: 'object',
-        properties: {
-          value: { type: 'string' },
-        },
-        required: ['value'],
-      },
-    };
-
     const llm = new MockLLM([{ type: 'text', text: 'ok' }, { type: 'finish' }]);
     const agent = new Agent({
-      settings: { ...baseSettings, confirmation: { policy: 'risky', riskyThreshold: 'HIGH', confirmUnknown: false } },
+      settings: { ...baseSettings, confirmation },
       events: log,
       workspaceRoot: createWorkspaceRoot(),
       llmClient: llm,
-      tools: [tool],
+      tools: [createNoopTool()],
     });
 
     await agent.run('hello');
 
     const request = llm.lastRequest;
     expect(request).not.toBeNull();
-    expect(request?.systemPrompt).toContain('<SECURITY_RISK_ASSESSMENT>');
+    if (shouldIncludeSecurityRisk) {
+      expect(request?.systemPrompt).toContain('<SECURITY_RISK_ASSESSMENT>');
+    } else {
+      expect(request?.systemPrompt).not.toContain('<SECURITY_RISK_ASSESSMENT>');
+    }
 
     const parameters = request?.tools?.[0]?.function?.parameters as any;
-    expect(parameters?.properties?.security_risk).toBeTruthy();
-    expect(parameters?.required).toContain('security_risk');
-  });
-
-  it('includes security_risk in tool schema + prompt for always confirmations', async () => {
-    const log = new EventLog();
-    const tool: ToolDefinition<Record<string, unknown>, { ok: true }> = {
-      name: 'noop',
-      validate: (input) => input as Record<string, unknown>,
-      execute: async () => ({ ok: true }),
-      description: 'No-op tool.',
-      parameters: {
-        type: 'object',
-        properties: {
-          value: { type: 'string' },
-        },
-        required: ['value'],
-      },
-    };
-
-    const llm = new MockLLM([{ type: 'text', text: 'ok' }, { type: 'finish' }]);
-    const agent = new Agent({
-      settings: { ...baseSettings, confirmation: { policy: 'always' } },
-      events: log,
-      workspaceRoot: createWorkspaceRoot(),
-      llmClient: llm,
-      tools: [tool],
-    });
-
-    await agent.run('hello');
-
-    const request = llm.lastRequest;
-    expect(request).not.toBeNull();
-    expect(request?.systemPrompt).toContain('<SECURITY_RISK_ASSESSMENT>');
-
-    const parameters = request?.tools?.[0]?.function?.parameters as any;
-    expect(parameters?.properties?.security_risk).toBeTruthy();
-    expect(parameters?.required).toContain('security_risk');
-  });
-
-  it('omits security_risk schema + prompt section when confirmations are disabled', async () => {
-    const log = new EventLog();
-    const tool: ToolDefinition<Record<string, unknown>, { ok: true }> = {
-      name: 'noop',
-      validate: (input) => input as Record<string, unknown>,
-      execute: async () => ({ ok: true }),
-      description: 'No-op tool.',
-      parameters: {
-        type: 'object',
-        properties: {
-          value: { type: 'string' },
-        },
-        required: ['value'],
-      },
-    };
-
-    const llm = new MockLLM([{ type: 'text', text: 'ok' }, { type: 'finish' }]);
-    const agent = new Agent({
-      settings: { ...baseSettings, confirmation: { policy: 'never' } },
-      events: log,
-      workspaceRoot: createWorkspaceRoot(),
-      llmClient: llm,
-      tools: [tool],
-    });
-
-    await agent.run('hello');
-
-    const request = llm.lastRequest;
-    expect(request).not.toBeNull();
-    expect(request?.systemPrompt).not.toContain('<SECURITY_RISK_ASSESSMENT>');
-
-    const parameters = request?.tools?.[0]?.function?.parameters as any;
-    expect(parameters?.properties?.security_risk).toBeFalsy();
-    expect(parameters?.required ?? []).not.toContain('security_risk');
+    if (shouldIncludeSecurityRisk) {
+      expect(parameters?.properties?.security_risk).toBeTruthy();
+      expect(parameters?.required).toContain('security_risk');
+    } else {
+      expect(parameters?.properties?.security_risk).toBeFalsy();
+      expect(parameters?.required ?? []).not.toContain('security_risk');
+    }
   });
 
   it('treats unknown tool-provided security_risk as undefined', async () => {


### PR DESCRIPTION
Fixes oh-tab-05rt.

- Refactors `Agent.security-risk.test.ts` to a table-driven `it.each` for the confirmation policy cases.
- Keeps the same coverage: prompt includes/omits `<SECURITY_RISK_ASSESSMENT>` and tool schema requires/omits `security_risk`.

Tests:
- npm test -w @openhands/agent-sdk-ts
- npm run lint -w @openhands/agent-sdk-ts

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR refactors `Agent.security-risk.test.ts` to eliminate duplication by consolidating three nearly identical test cases into a single table-driven `it.each` test. The refactoring extracts the repeated tool definition into a `createNoopTool()` helper function and defines a `ConfirmationExpectation` type to structure test cases with three confirmation policies: `risky`, `always`, and `never`.

Key changes:
- Reduced 113 lines of duplicated test code to 72 lines using `it.each` with a data table
- Extracted tool definition to `createNoopTool()` helper (lines 33-45)
- Created `ConfirmationExpectation` type for test case structure (lines 47-51)
- Unified test logic with conditional assertions based on `shouldIncludeSecurityRisk` flag
- Maintained identical test coverage: verifies that `<SECURITY_RISK_ASSESSMENT>` prompt section and `security_risk` tool schema are present for `risky`/`always` policies and absent for `never` policy
- The fourth test (`treats unknown tool-provided security_risk as undefined`) remains unchanged

This is a clean refactoring that improves maintainability without changing behavior. The table-driven approach makes it easier to add new confirmation policy test cases in the future.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- This is a pure refactoring that eliminates code duplication without changing test logic or coverage. The table-driven approach is a standard testing pattern that improves maintainability. All test assertions remain identical to the original implementation.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts | Refactored three duplicated test cases into a single table-driven `it.each` test; coverage and assertions remain identical |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Agent as Agent
    participant MockLLM as MockLLM
    participant Tool as createNoopTool()
    
    Note over Test: it.each loops through 3 confirmation policies
    
    Test->>Agent: new Agent(settings, tools, llmClient)
    Note right of Agent: settings.confirmation = {<br/>policy: 'risky'/'always'/'never'}
    
    Test->>Agent: agent.run('hello')
    Agent->>MockLLM: streamChat(request)
    Note right of MockLLM: Captures systemPrompt<br/>and tool schemas
    MockLLM-->>Agent: [{ type: 'text' }, { type: 'finish' }]
    
    Test->>MockLLM: llm.lastRequest
    MockLLM-->>Test: ChatCompletionRequest
    
    alt shouldIncludeSecurityRisk = true (risky/always)
        Test->>Test: expect(systemPrompt).toContain('<SECURITY_RISK_ASSESSMENT>')
        Test->>Test: expect(tool.parameters.properties.security_risk).toBeTruthy()
        Test->>Test: expect(tool.parameters.required).toContain('security_risk')
    else shouldIncludeSecurityRisk = false (never)
        Test->>Test: expect(systemPrompt).not.toContain('<SECURITY_RISK_ASSESSMENT>')
        Test->>Test: expect(tool.parameters.properties.security_risk).toBeFalsy()
        Test->>Test: expect(tool.parameters.required).not.toContain('security_risk')
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->