### PR TITLE
oh-tab-ciw1: rename internal elevenlabs→hal

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { SettingsManager, type OpenHandsSettings } from './settings/SettingsManager';
 import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
-import { type HalStateSnapshot, isElevenLabsMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
+import { type HalStateSnapshot, isHalMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
 import { DEFAULT_HAL_STATE } from './shared/halDefaults';
 import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { maskSecretsInText } from './shared/maskSecrets';
@@ -447,7 +447,7 @@ export function activate(context: vscode.ExtensionContext) {
           pendingUiStateRequests.get(requestId)?.(info);
         },
         onHalStateResponse: (requestId, info) => {
-          const mode = isElevenLabsMode(info.mode) ? info.mode : DEFAULT_HAL_STATE.mode;
+          const mode = isHalMode(info.mode) ? info.mode : DEFAULT_HAL_STATE.mode;
           const phase = isHalPhase(info.phase) ? info.phase : DEFAULT_HAL_STATE.phase;
           const eye = isHalEye(info.eye) ? info.eye : DEFAULT_HAL_STATE.eye;
           const decision = isHalDecision(info.decision) ? info.decision : null;
@@ -1217,7 +1217,7 @@ export function activate(context: vscode.ExtensionContext) {
         const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
         const settings = await settingsMgr.get();
         if (chatView && chatWebviewReady) {
-          void chatView.webview.postMessage({ type: 'halSettings', hal: settings.elevenlabs } satisfies HostToWebviewMessage);
+          void chatView.webview.postMessage({ type: 'halSettings', hal: settings.hal } satisfies HostToWebviewMessage);
         }
       } catch (err: unknown) {
         outputChannel?.appendLine(`[settings] Failed to apply HAL settings update: ${renderError(err)}`);

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,5 +1,5 @@
 import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, ConversationSettings, ConfirmationSettings } from './SettingsAdapter';
-import type { ElevenLabsMode } from '../shared/halTypes';
+import type { HalMode } from '../shared/halTypes';
 import { normalizeServerUrl } from '../shared/serverUrls';
 
 export interface SavedServer {
@@ -7,9 +7,9 @@ export interface SavedServer {
   label?: string;
 }
 
-export type ElevenLabsSettings = {
+export type HalSettings = {
   enabled: boolean;
-  mode: ElevenLabsMode;
+  mode: HalMode;
   userName: string;
   voiceAId?: string;
   voiceUserId?: string;
@@ -28,7 +28,7 @@ export type OpenHandsSettings = ServerSettings & {
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
-  elevenlabs: ElevenLabsSettings;
+  hal: HalSettings;
   gemini: GeminiSettings;
   servers: SavedServer[];
   secrets: {
@@ -51,12 +51,12 @@ const DEFAULTS: OpenHandsSettings = {
   agent: { enableSecurityAnalyzer: true, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
-  elevenlabs: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },
+  hal: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },
   gemini: { model: 'gemini-2.5-flash', baseUrl: 'https://generativelanguage.googleapis.com/v1beta' },
   secrets: {}
 };
 
-const HAL_CONFIG_UPDATES: Array<[keyof ElevenLabsSettings, string]> = [
+const HAL_CONFIG_UPDATES: Array<[keyof HalSettings, string]> = [
   ['enabled', 'openhands.hal.enabled'],
   ['mode', 'openhands.hal.mode'],
   ['userName', 'openhands.hal.userName'],
@@ -121,7 +121,7 @@ const normalizeReasoningSummary = (value: unknown): LLMSettings['reasoningSummar
   }
 };
 
-const normalizeElevenLabsMode = (value: unknown, defaultValue: ElevenLabsMode): ElevenLabsMode => {
+const normalizeHalMode = (value: unknown, defaultValue: HalMode): HalMode => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   switch (trimmed) {
     case 'bundled':
@@ -299,23 +299,23 @@ export class SettingsManager {
       riskyThreshold: this.adapter.get<'LOW' | 'MEDIUM' | 'HIGH'>('openhands.confirmation.risky.threshold', DEFAULTS.confirmation.riskyThreshold) ?? DEFAULTS.confirmation.riskyThreshold,
       confirmUnknown: this.adapter.get<boolean>('openhands.confirmation.risky.confirmUnknown', DEFAULTS.confirmation.confirmUnknown) ?? DEFAULTS.confirmation.confirmUnknown,
     };
-    const elevenlabs: ElevenLabsSettings = {
-      enabled: this.adapter.get<boolean>('openhands.hal.enabled', DEFAULTS.elevenlabs.enabled) ?? DEFAULTS.elevenlabs.enabled,
-      mode: normalizeElevenLabsMode(
-        this.adapter.get<unknown>('openhands.hal.mode', DEFAULTS.elevenlabs.mode) ?? DEFAULTS.elevenlabs.mode,
-        DEFAULTS.elevenlabs.mode
+    const hal: HalSettings = {
+      enabled: this.adapter.get<boolean>('openhands.hal.enabled', DEFAULTS.hal.enabled) ?? DEFAULTS.hal.enabled,
+      mode: normalizeHalMode(
+        this.adapter.get<unknown>('openhands.hal.mode', DEFAULTS.hal.mode) ?? DEFAULTS.hal.mode,
+        DEFAULTS.hal.mode
       ),
       userName: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.hal.userName', DEFAULTS.elevenlabs.userName) ?? DEFAULTS.elevenlabs.userName
-      ) ?? DEFAULTS.elevenlabs.userName,
+        this.adapter.get<string | null>('openhands.hal.userName', DEFAULTS.hal.userName) ?? DEFAULTS.hal.userName
+      ) ?? DEFAULTS.hal.userName,
       voiceAId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.hal.voiceAId', null) ?? undefined),
       voiceUserId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.hal.voiceUserId', null) ?? undefined),
       modelId: normalizeNonEmptyString(this.adapter.get<string | null>('openhands.hal.modelId', null) ?? undefined),
       volume: clampUnitInterval(
-        this.adapter.get<number | null>('openhands.hal.volume', DEFAULTS.elevenlabs.volume) ?? DEFAULTS.elevenlabs.volume,
-        DEFAULTS.elevenlabs.volume
+        this.adapter.get<number | null>('openhands.hal.volume', DEFAULTS.hal.volume) ?? DEFAULTS.hal.volume,
+        DEFAULTS.hal.volume
       ),
-      cache: this.adapter.get<boolean>('openhands.hal.cache', DEFAULTS.elevenlabs.cache) ?? DEFAULTS.elevenlabs.cache,
+      cache: this.adapter.get<boolean>('openhands.hal.cache', DEFAULTS.hal.cache) ?? DEFAULTS.hal.cache,
     };
     const gemini: GeminiSettings = {
       model: normalizeNonEmptyString(
@@ -337,7 +337,7 @@ export class SettingsManager {
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
       customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
     };
-    return { serverUrl, servers, llm, agent, conversation, confirmation, elevenlabs, gemini, secrets };
+    return { serverUrl, servers, llm, agent, conversation, confirmation, hal, gemini, secrets };
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
@@ -405,9 +405,9 @@ export class SettingsManager {
       }
     }
 
-    if (partial.elevenlabs) {
+    if (partial.hal) {
       for (const [key, configKey] of HAL_CONFIG_UPDATES) {
-        const value = partial.elevenlabs[key];
+        const value = partial.hal[key];
         if (value !== undefined) ops.push(this.adapter.update(configKey, value, target));
       }
     }

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -35,14 +35,14 @@ describe('SettingsManager', () => {
     expect(s.llm.model).toBe('claude-sonnet-4-20250514');
     expect(s.agent.enableSecurityAnalyzer).toBe(true);
     expect(s.agent.debug).toBe(false);
-    expect(s.elevenlabs.enabled).toBe(false);
-    expect(s.elevenlabs.mode).toBe('tts_only');
-    expect(s.elevenlabs.userName).toBe('Engel');
-    expect(s.elevenlabs.voiceAId).toBeUndefined();
-    expect(s.elevenlabs.voiceUserId).toBeUndefined();
-    expect(s.elevenlabs.modelId).toBeUndefined();
-    expect(s.elevenlabs.volume).toBe(1);
-    expect(s.elevenlabs.cache).toBe(true);
+    expect(s.hal.enabled).toBe(false);
+    expect(s.hal.mode).toBe('tts_only');
+    expect(s.hal.userName).toBe('Engel');
+    expect(s.hal.voiceAId).toBeUndefined();
+    expect(s.hal.voiceUserId).toBeUndefined();
+    expect(s.hal.modelId).toBeUndefined();
+    expect(s.hal.volume).toBe(1);
+    expect(s.hal.cache).toBe(true);
     expect(s.gemini.model).toBe('gemini-2.5-flash');
     expect(s.gemini.baseUrl).toBe('https://generativelanguage.googleapis.com/v1beta');
   });
@@ -84,7 +84,7 @@ describe('SettingsManager', () => {
       agent: { enableSecurityAnalyzer: true, debug: true },
       conversation: { maxIterations: 42 },
       confirmation: { policy: 'risky', riskyThreshold: 'MEDIUM', confirmUnknown: false },
-      elevenlabs: {
+      hal: {
         enabled: true,
         mode: 'voice_confirm',
         userName: 'Alice',
@@ -115,14 +115,14 @@ describe('SettingsManager', () => {
     expect(s.confirmation.policy).toBe('risky');
     expect(s.confirmation.riskyThreshold).toBe('MEDIUM');
     expect(s.confirmation.confirmUnknown).toBe(false);
-    expect(s.elevenlabs.enabled).toBe(true);
-    expect(s.elevenlabs.mode).toBe('voice_confirm');
-    expect(s.elevenlabs.userName).toBe('Alice');
-    expect(s.elevenlabs.voiceAId).toBe('voice_hal');
-    expect(s.elevenlabs.voiceUserId).toBe('voice_user');
-    expect(s.elevenlabs.modelId).toBe('eleven_turbo_v2');
-    expect(s.elevenlabs.volume).toBe(0.25);
-    expect(s.elevenlabs.cache).toBe(false);
+    expect(s.hal.enabled).toBe(true);
+    expect(s.hal.mode).toBe('voice_confirm');
+    expect(s.hal.userName).toBe('Alice');
+    expect(s.hal.voiceAId).toBe('voice_hal');
+    expect(s.hal.voiceUserId).toBe('voice_user');
+    expect(s.hal.modelId).toBe('eleven_turbo_v2');
+    expect(s.hal.volume).toBe(0.25);
+    expect(s.hal.cache).toBe(false);
     expect(s.gemini.model).toBe('gemini-2.5-pro');
     expect(s.gemini.baseUrl).toBe('https://proxy.example.com/v1beta');
     expect(s.secrets.sessionApiKey).toBe('sess');
@@ -130,9 +130,9 @@ describe('SettingsManager', () => {
     // HAL no longer uses a separate Gemini key; it relies on GEMINI_API_KEY/global LLM key.
   });
 
-  it('sanitizes invalid ElevenLabs mode and clamps volume', async () => {
+  it('sanitizes invalid HAL mode and clamps volume', async () => {
     await mgr.update({
-      elevenlabs: {
+      hal: {
         mode: 'wat' as any,
         userName: '   ' as any,
         volume: 2 as any,
@@ -140,16 +140,16 @@ describe('SettingsManager', () => {
     });
 
     const s = await mgr.get();
-    expect(s.elevenlabs.mode).toBe('tts_only');
-    expect(s.elevenlabs.userName).toBe('Engel');
-    expect(s.elevenlabs.volume).toBe(1);
+    expect(s.hal.mode).toBe('tts_only');
+    expect(s.hal.userName).toBe('Engel');
+    expect(s.hal.volume).toBe(1);
 
     await mgr.update({
-      elevenlabs: { volume: -1 as any } as any,
+      hal: { volume: -1 as any } as any,
     });
 
     const s2 = await mgr.get();
-    expect(s2.elevenlabs.volume).toBe(0);
+    expect(s2.hal.volume).toBe(0);
   });
 
   it('clears secrets when undefined is provided', async () => {

--- a/src/shared/halScript.ts
+++ b/src/shared/halScript.ts
@@ -1,4 +1,4 @@
-import type { ElevenLabsMode } from './halTypes';
+import type { HalMode } from './halTypes';
 
 export type HalVoice = 'voice_hal' | 'voice_user';
 
@@ -27,7 +27,7 @@ export function getHalDialogueLines(userName: string): HalScriptLine[] {
   ];
 }
 
-export function getHalDialogueLinesForMode(userName: string, mode: ElevenLabsMode): HalScriptLine[] {
+export function getHalDialogueLinesForMode(userName: string, mode: HalMode): HalScriptLine[] {
   const lines = getHalDialogueLines(userName);
   if (mode === 'voice_confirm') {
     return lines.filter((line) => line.voice === 'voice_hal');

--- a/src/shared/halTypes.ts
+++ b/src/shared/halTypes.ts
@@ -16,12 +16,12 @@ export type HalEye = (typeof HAL_EYES)[number];
 export const HAL_DECISIONS = ['approve_local', 'teleport_remote', 'reject'] as const;
 export type HalDecision = (typeof HAL_DECISIONS)[number];
 
-export const ELEVENLABS_MODES = ['bundled', 'tts_only', 'voice_confirm'] as const;
-export type ElevenLabsMode = (typeof ELEVENLABS_MODES)[number];
+export const HAL_MODES = ['bundled', 'tts_only', 'voice_confirm'] as const;
+export type HalMode = (typeof HAL_MODES)[number];
 
 export type HalStateSnapshot = {
   enabled: boolean;
-  mode: ElevenLabsMode;
+  mode: HalMode;
   phase: HalPhase;
   eye: HalEye;
   stepIndex: number | null;
@@ -29,8 +29,8 @@ export type HalStateSnapshot = {
   lastError: string | null;
 };
 
-export const isElevenLabsMode = (value: unknown): value is ElevenLabsMode =>
-  typeof value === 'string' && (ELEVENLABS_MODES as readonly string[]).includes(value);
+export const isHalMode = (value: unknown): value is HalMode =>
+  typeof value === 'string' && (HAL_MODES as readonly string[]).includes(value);
 
 export const isHalPhase = (value: unknown): value is HalPhase =>
   typeof value === 'string' && (HAL_PHASES as readonly string[]).includes(value);
@@ -40,4 +40,3 @@ export const isHalEye = (value: unknown): value is HalEye =>
 
 export const isHalDecision = (value: unknown): value is HalDecision =>
   typeof value === 'string' && (HAL_DECISIONS as readonly string[]).includes(value);
-

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -37,7 +37,7 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
-  | { type: 'halSettings'; hal: OpenHandsSettings['elevenlabs'] }
+  | { type: 'halSettings'; hal: OpenHandsSettings['hal'] }
   | {
     type: 'historyList';
     conversations: Array<{

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -21,7 +21,7 @@ import { getVscodeApi } from '../shared/vscodeApi';
 import { MAX_RENDERED_EVENTS } from '../shared/constants';
 import { MAX_PASTED_IMAGE_BYTES, MAX_PASTED_IMAGES } from '../../shared/pasteLimits';
 import { escapeMarkdownAltText } from './app/pastedImages';
-import { useHalFlow, type ElevenLabsSettingsSnapshot } from './app/useHalFlow';
+import { useHalFlow, type HalSettingsSnapshot } from './app/useHalFlow';
 import { useInlineImageAttachments } from './app/useInlineImageAttachments';
 import { useStatusMessages, type StatusBannerState } from './app/useStatusMessages';
 
@@ -458,8 +458,8 @@ export function App() {
   }, [isSubmitting, postMessage, showStatusMessage]);
 
   const {
-    elevenlabs,
-    applyElevenlabsSettings,
+    halSettings,
+    applyHalSettings,
     halEnabled,
     halPhase,
     halEye,
@@ -697,7 +697,7 @@ export function App() {
         hasProfileKey?: unknown;
         hasProviderKey?: unknown;
         providerKeyName?: unknown;
-        hal?: Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
+        hal?: Partial<HalSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
         seq?: unknown;
         error?: unknown;
@@ -929,7 +929,7 @@ export function App() {
           break;
         }
         case 'halSettings':
-          applyElevenlabsSettings(payload.hal);
+          applyHalSettings(payload.hal);
           break;
         case 'halTtsResponse': {
           handleHalTtsResponse(payload);
@@ -1170,27 +1170,27 @@ export function App() {
 
     window.addEventListener('message', handler);
     return () => window.removeEventListener('message', handler);
-    }, [
-      applyElevenlabsSettings,
-      applyHalVoiceConfirmDecision,
-      events,
-      halStateRef,
-      handleConversationStarted,
-      handleEvent,
-      handleHalApprove,
-      handleHalExit,
+  }, [
+    applyHalSettings,
+    applyHalVoiceConfirmDecision,
+    events,
+    halStateRef,
+    handleConversationStarted,
+    handleEvent,
+    handleHalApprove,
+    handleHalExit,
     handleHalReject,
     handleHalTeleport,
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,
-      maybeUpdateHalFlow,
-      postMessage,
-      resetForServerTargetChange,
-      setStatusBanner,
-      showStatusMessage,
-    ]);
+    maybeUpdateHalFlow,
+    postMessage,
+    resetForServerTargetChange,
+    setStatusBanner,
+    showStatusMessage,
+  ]);
 
   // Auto-scroll to bottom when events change or streaming updates
   useEffect(() => {
@@ -1478,7 +1478,7 @@ export function App() {
   const firstHighRiskAction = pendingActions.find((action) => action.security_risk === 'HIGH');
   const halConversationKey = conversationId ?? 'unknown';
   const voiceConfirmFallbackToButtons =
-    elevenlabs.mode === 'voice_confirm' && halVoiceConfirmFallbackKey === halConversationKey;
+    halSettings.mode === 'voice_confirm' && halVoiceConfirmFallbackKey === halConversationKey;
   const halSessionKey =
     halEnabled && hasPendingConfirmation && firstHighRiskAction?.tool_call_id
       ? `${conversationId ?? 'unknown'}:${firstHighRiskAction.tool_call_id}`
@@ -1542,29 +1542,29 @@ export function App() {
       </div>
 
       {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}
-        {shouldShowHalOverlay && (
-          <HalOverlay
-            key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
-            userName={normalizeHalUserName(elevenlabs.userName)}
-            mode={elevenlabs.mode}
-            phase={halUiPhase}
-            eye={halEye}
-            line={halUiLine}
-            decision={halDecision}
-            lastError={halLastError}
-            isSubmitting={isSubmitting || halTeleporting}
-            startWithRejectInput={halForceRejectInput}
-            voiceConfirmFallbackToButtons={voiceConfirmFallbackToButtons}
-            onStartVoiceConfirm={handleStartVoiceConfirm}
-            onStopVoiceConfirm={handleStopVoiceConfirm}
-            onCancelVoiceConfirm={handleCancelVoiceConfirm}
-            onUseButtonsInstead={handleUseButtonsInstead}
-            onApprove={handleHalApprove}
-            onTeleport={handleHalTeleport}
-            onReject={handleHalReject}
-            onExit={handleHalExit}
-          />
-        )}
+      {shouldShowHalOverlay && (
+        <HalOverlay
+          key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
+          userName={normalizeHalUserName(halSettings.userName)}
+          mode={halSettings.mode}
+          phase={halUiPhase}
+          eye={halEye}
+          line={halUiLine}
+          decision={halDecision}
+          lastError={halLastError}
+          isSubmitting={isSubmitting || halTeleporting}
+          startWithRejectInput={halForceRejectInput}
+          voiceConfirmFallbackToButtons={voiceConfirmFallbackToButtons}
+          onStartVoiceConfirm={handleStartVoiceConfirm}
+          onStopVoiceConfirm={handleStopVoiceConfirm}
+          onCancelVoiceConfirm={handleCancelVoiceConfirm}
+          onUseButtonsInstead={handleUseButtonsInstead}
+          onApprove={handleHalApprove}
+          onTeleport={handleHalTeleport}
+          onReject={handleHalReject}
+          onExit={handleHalExit}
+        />
+      )}
 
       {/* Confirmation prompt (modal overlay) */}
       {hasPendingConfirmation && !shouldShowHalOverlay && (

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
-import type { ElevenLabsMode, HalDecision, HalEye, HalPhase } from '../../shared/halTypes';
+import type { HalDecision, HalEye, HalMode, HalPhase } from '../../shared/halTypes';
 
 type HalOverlayProps = {
   userName: string;
-  mode: ElevenLabsMode;
+  mode: HalMode;
   phase: HalPhase;
   eye: HalEye;
   line: string | null;

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -2,18 +2,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ActionEvent } from '@openhands/agent-sdk-ts';
 import { getHalDialogueLinesForMode, type HalScriptLine, type HalVoice } from '../../../shared/halScript';
 import { DEFAULT_HAL_STATE } from '../../../shared/halDefaults';
-import { isElevenLabsMode, isHalDecision, type ElevenLabsMode, type HalDecision, type HalEye, type HalPhase, type HalStateSnapshot } from '../../../shared/halTypes';
+import { isHalDecision, isHalMode, type HalDecision, type HalEye, type HalMode, type HalPhase, type HalStateSnapshot } from '../../../shared/halTypes';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import type { ShowStatusMessage } from './useStatusMessages';
 
-export type ElevenLabsSettingsSnapshot = {
+export type HalSettingsSnapshot = {
   enabled: boolean;
-  mode: ElevenLabsMode;
+  mode: HalMode;
   userName: string;
   volume: number;
 };
 
-const DEFAULT_ELEVENLABS_SETTINGS: ElevenLabsSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1 };
+const DEFAULT_HAL_SETTINGS: HalSettingsSnapshot = { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1 };
 
 type HalUiState = Pick<HalStateSnapshot, 'phase' | 'eye' | 'stepIndex' | 'decision' | 'lastError'>;
 
@@ -82,8 +82,8 @@ export function useHalFlow(deps: {
   handleApprove: () => void;
   handleReject: (reason?: string) => void;
 }) {
-  const [elevenlabs, setElevenlabs] = useState<ElevenLabsSettingsSnapshot>(DEFAULT_ELEVENLABS_SETTINGS);
-  const elevenlabsRef = useRef<ElevenLabsSettingsSnapshot>(DEFAULT_ELEVENLABS_SETTINGS);
+  const [halSettings, setHalSettings] = useState<HalSettingsSnapshot>(DEFAULT_HAL_SETTINGS);
+  const halSettingsRef = useRef<HalSettingsSnapshot>(DEFAULT_HAL_SETTINGS);
 
   const [halDisabledConversationId, setHalDisabledConversationId] = useState<string | null>(null);
   const [halPhase, setHalPhase] = useState<HalPhase>('idle');
@@ -121,8 +121,8 @@ export function useHalFlow(deps: {
   const halTeleportInProgressRef = useRef(false);
   const halStateRef = useRef<HalStateSnapshot>(DEFAULT_HAL_STATE);
 
-  const halSupportedMode = elevenlabs.mode === 'bundled' || elevenlabs.mode === 'tts_only' || elevenlabs.mode === 'voice_confirm';
-  const halEnabled = elevenlabs.enabled && halSupportedMode && halDisabledConversationId !== deps.conversationId;
+  const halSupportedMode = halSettings.mode === 'bundled' || halSettings.mode === 'tts_only' || halSettings.mode === 'voice_confirm';
+  const halEnabled = halSettings.enabled && halSupportedMode && halDisabledConversationId !== deps.conversationId;
 
   useEffect(() => {
     halEnabledRef.current = halEnabled;
@@ -141,8 +141,8 @@ export function useHalFlow(deps: {
   }, [halVoiceConfirmFallbackKey]);
 
   useEffect(() => {
-    elevenlabsRef.current = elevenlabs;
-  }, [elevenlabs]);
+    halSettingsRef.current = halSettings;
+  }, [halSettings]);
 
   useEffect(() => {
     halStepIndexRef.current = halStepIndex;
@@ -218,8 +218,8 @@ export function useHalFlow(deps: {
   }, [clearHalTimer, cleanupHalVoiceConfirm, stopHalAudio]);
 
   const halDialogueLines = useMemo(
-    () => getHalDialogueLinesForMode(elevenlabs.userName, elevenlabs.mode),
-    [elevenlabs.mode, elevenlabs.userName]
+    () => getHalDialogueLinesForMode(halSettings.userName, halSettings.mode),
+    [halSettings.mode, halSettings.userName]
   );
 
   useEffect(() => {
@@ -317,7 +317,7 @@ export function useHalFlow(deps: {
   useEffect(() => {
     if (halPhase !== 'dialogue') return;
     if (halStepIndex === null) return;
-    if (elevenlabsRef.current.mode !== 'bundled') return;
+    if (halSettingsRef.current.mode !== 'bundled') return;
 
     const sessionKey = halActiveKeyRef.current ?? 'unknown';
     const playKey = `${sessionKey}:${halStepIndex}`;
@@ -333,7 +333,7 @@ export function useHalFlow(deps: {
       return;
     }
 
-    const volume = elevenlabsRef.current.volume;
+    const volume = halSettingsRef.current.volume;
     stopHalAudio();
     const token = halAudioPlayTokenRef.current;
     const audio = new Audio(clipUrl);
@@ -380,7 +380,7 @@ export function useHalFlow(deps: {
     const url = getBundledHalMusicStingUrl();
     if (!url || typeof Audio !== 'function') return;
 
-    const volume = elevenlabsRef.current.volume;
+    const volume = halSettingsRef.current.volume;
     stopHalAudio();
     const token = halAudioPlayTokenRef.current;
     const audio = new Audio(url);
@@ -442,7 +442,7 @@ export function useHalFlow(deps: {
   useEffect(() => {
     if (halPhase !== 'dialogue') return;
     if (halStepIndex === null) return;
-    const mode = elevenlabsRef.current.mode;
+    const mode = halSettingsRef.current.mode;
     if (mode !== 'tts_only' && mode !== 'voice_confirm') return;
     const convoId = deps.conversationIdRef.current;
     if (!convoId) return;
@@ -465,7 +465,7 @@ export function useHalFlow(deps: {
   const handleStartVoiceConfirm = useCallback(() => {
     void (async () => {
       if (halPhaseRef.current !== 'awaiting_user') return;
-      if (elevenlabsRef.current.mode !== 'voice_confirm') return;
+      if (halSettingsRef.current.mode !== 'voice_confirm') return;
       if (halVoiceConfirmFallbackKeyRef.current === getHalConversationKey()) return;
       if (
         typeof navigator === 'undefined' ||
@@ -670,24 +670,24 @@ export function useHalFlow(deps: {
     deps.postMessage({ type: 'command', command: 'teleportAction' });
   }, [cleanupHalFlow, deps.postMessage, deps.showStatusMessage, resetHalUiState]);
 
-  const applyElevenlabsSettings = useCallback((raw: unknown) => {
+  const applyHalSettings = useCallback((raw: unknown) => {
     if (!raw || typeof raw !== 'object') return;
-    const prev = elevenlabsRef.current;
-    const next: ElevenLabsSettingsSnapshot = { ...prev };
-    const payload = raw as Partial<ElevenLabsSettingsSnapshot> & { [k: string]: unknown };
+    const prev = halSettingsRef.current;
+    const next: HalSettingsSnapshot = { ...prev };
+    const payload = raw as Partial<HalSettingsSnapshot> & { [k: string]: unknown };
     if (typeof payload.enabled === 'boolean') next.enabled = payload.enabled;
-    if (isElevenLabsMode(payload.mode)) next.mode = payload.mode;
+    if (isHalMode(payload.mode)) next.mode = payload.mode;
     if (typeof payload.userName === 'string') next.userName = payload.userName;
     if (typeof payload.volume === 'number' && Number.isFinite(payload.volume)) {
       next.volume = Math.min(1, Math.max(0, payload.volume));
     }
-    elevenlabsRef.current = next;
+    halSettingsRef.current = next;
     halEnabledRef.current = next.enabled && (next.mode === 'bundled' || next.mode === 'tts_only' || next.mode === 'voice_confirm');
-    setElevenlabs(next);
+    setHalSettings(next);
     maybeUpdateHalFlow();
   }, [maybeUpdateHalFlow]);
 
-    const handleHalTtsResponse = useCallback((payload: unknown) => {
+  const handleHalTtsResponse = useCallback((payload: unknown) => {
     const currentRequestId = halTtsRequestIdRef.current;
     const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
     if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) return;
@@ -707,7 +707,7 @@ export function useHalFlow(deps: {
         for (let i = 0; i < rawAudio.length; i += 1) {
           bytes[i] = rawAudio.charCodeAt(i);
         }
-        playHalAudioBytes(bytes, typeof volume === 'number' ? volume : elevenlabsRef.current.volume);
+        playHalAudioBytes(bytes, typeof volume === 'number' ? volume : halSettingsRef.current.volume);
       } catch {
         handleHalAudioFinished();
       }
@@ -729,15 +729,15 @@ export function useHalFlow(deps: {
     setHalTeleporting(false);
 
     if (shouldNotify) deps.showStatusMessage('error', `HAL audio disabled for this conversation: ${message}`);
-    }, [
-      cleanupHalFlow,
-      deps.conversationIdRef,
-      deps.showStatusMessage,
-      handleHalAudioFinished,
-      playHalAudioBytes,
-      resetHalUiState,
-      setHalSuppressedKeySynced,
-    ]);
+  }, [
+    cleanupHalFlow,
+    deps.conversationIdRef,
+    deps.showStatusMessage,
+    handleHalAudioFinished,
+    playHalAudioBytes,
+    resetHalUiState,
+    setHalSuppressedKeySynced,
+  ]);
 
     const applyHalVoiceConfirmDecision = useCallback((decision: HalDecision, options?: { rejectReason?: string }) => {
       cleanupHalVoiceConfirm();
@@ -822,18 +822,18 @@ export function useHalFlow(deps: {
   useEffect(() => {
     halStateRef.current = {
       enabled: halEnabled,
-      mode: elevenlabs.mode,
+      mode: halSettings.mode,
       phase: halPhase,
       eye: halEye,
       stepIndex: halPhase === 'dialogue' ? halStepIndex : null,
       decision: halDecision,
       lastError: halLastError,
     };
-  }, [elevenlabs.mode, halDecision, halEnabled, halEye, halLastError, halPhase, halStepIndex]);
+  }, [halDecision, halEnabled, halEye, halLastError, halPhase, halSettings.mode, halStepIndex]);
 
-    return {
-      elevenlabs,
-      applyElevenlabsSettings,
+  return {
+    halSettings,
+    applyHalSettings,
     halEnabled,
     halDisabledConversationId,
     halPhase,
@@ -856,12 +856,12 @@ export function useHalFlow(deps: {
     handleHalApprove,
     handleHalReject,
     handleHalTeleport,
-      handleHalTtsResponse,
-      applyHalVoiceConfirmDecision,
-      handleHalVoiceConfirmResponse,
-      handleHalTeleportUnavailable,
-      handleHalTeleportFailed,
-      handleConversationStarted,
-      resetForServerTargetChange,
-    };
+    handleHalTtsResponse,
+    applyHalVoiceConfirmDecision,
+    handleHalVoiceConfirmResponse,
+    handleHalTeleportUnavailable,
+    handleHalTeleportFailed,
+    handleConversationStarted,
+    resetForServerTargetChange,
+  };
 }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -257,7 +257,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         void host.postMessage({
           type: 'halSettings',
-          hal: initSettings.elevenlabs,
+          hal: initSettings.hal,
         });
 
         deps.flushConversationEventBacklog({
@@ -849,11 +849,12 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'halTtsRequest': {
         if (typeof message.requestId !== 'string' || typeof message.conversationId !== 'string') break;
         if (typeof message.stepIndex !== 'number' || !Number.isFinite(message.stepIndex)) break;
+
         const stepIndex = Math.trunc(message.stepIndex);
         if (stepIndex < 0) break;
 
         const settings = await settingsMgr.get();
-        const script = getHalDialogueLinesForMode(settings.elevenlabs.userName, settings.elevenlabs.mode);
+        const script = getHalDialogueLinesForMode(settings.hal.userName, settings.hal.mode);
         const line = script[stepIndex];
         if (!line) {
           void host.postMessage({ type: 'halTtsResponse', requestId: message.requestId, ok: false, error: 'Invalid HAL script line', shouldNotify: true });
@@ -861,15 +862,15 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         }
 
         const apiKey = settings.secrets.elevenLabsApiKey ?? '';
-        const voiceId = line.voice === 'voice_hal' ? (settings.elevenlabs.voiceAId ?? '') : (settings.elevenlabs.voiceUserId ?? '');
+        const voiceId = line.voice === 'voice_hal' ? (settings.hal.voiceAId ?? '') : (settings.hal.voiceUserId ?? '');
 
         const result = await getElevenlabsTtsGate().synthesize({
           conversationId: message.conversationId,
           apiKey,
           voiceId,
           text: line.text,
-          modelId: settings.elevenlabs.modelId,
-          cacheEnabled: settings.elevenlabs.cache,
+          modelId: settings.hal.modelId,
+          cacheEnabled: settings.hal.cache,
         });
 
         if (result.ok) {
@@ -878,7 +879,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
             requestId: message.requestId,
             ok: true,
             audioBase64: Buffer.from(result.bytes).toString('base64'),
-            volume: settings.elevenlabs.volume,
+            volume: settings.hal.volume,
           });
           break;
         }


### PR DESCRIPTION
Fixes oh-tab-ciw1.

- Renames internal settings/state from `elevenlabs` to `hal` (types, fields, helpers) while keeping the provider secret name `elevenLabsApiKey` unchanged.
- No user-visible VS Code setting keys changed (`openhands.hal.*` remains the schema + config namespace).

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal settings structure for improved consistency across the application.
  * Updated configuration property naming to reflect current system architecture.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Renamed internal settings and state from `elevenlabs` to `hal` throughout the codebase while maintaining backward compatibility with the `elevenLabsApiKey` secret name.

**Changes:**
- Types: `ElevenLabsSettings` → `HalSettings`, `ElevenLabsMode` → `HalMode`, `ELEVENLABS_MODES` → `HAL_MODES`
- Settings field: `OpenHandsSettings.elevenlabs` → `OpenHandsSettings.hal`
- Functions: `normalizeElevenLabsMode()` → `normalizeHalMode()`, `isElevenLabsMode()` → `isHalMode()`
- State variables: `elevenlabs` → `halSettings`, `applyElevenlabsSettings()` → `applyHalSettings()`
- Config keys remain `openhands.hal.*` (no user-facing changes)
- Secret name `elevenLabsApiKey` preserved for backward compatibility

**Test Coverage:**
- Updated unit tests in `SettingsManager.test.ts` verify the renaming works correctly
- All test assertions updated from `s.elevenlabs.*` to `s.hal.*`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- This is a clean internal refactoring with no functional changes. The renaming is consistent across all 10 files, maintains backward compatibility by preserving the `elevenLabsApiKey` secret name, keeps user-facing VS Code settings unchanged (`openhands.hal.*` namespace), and includes comprehensive test updates. All changes are purely cosmetic naming improvements.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/shared/halTypes.ts | Renamed type definitions and constants from ELEVENLABS_MODES/ElevenLabsMode to HAL_MODES/HalMode, updated type guards accordingly |
| src/settings/SettingsManager.ts | Renamed ElevenLabsSettings to HalSettings, updated all references from elevenlabs to hal in types and configuration keys |
| src/webview-src/components/app/useHalFlow.ts | Renamed all internal state and functions from elevenlabs to hal naming, updated type references throughout |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant VSCode as VS Code Settings
    participant SM as SettingsManager
    participant WV as Webview (App.tsx)
    participant HF as useHalFlow Hook
    participant HAL as HAL Overlay
    
    Note over VSCode,HAL: Settings Flow (elevenlabs → hal renaming)
    
    VSCode->>SM: openhands.hal.* config keys
    SM->>SM: normalizeHalMode()
    SM->>SM: Build HalSettings object
    Note right of SM: Type changed:<br/>ElevenLabsSettings → HalSettings
    SM-->>VSCode: OpenHandsSettings.hal
    
    WV->>SM: Request settings
    SM-->>WV: halSettings message
    Note right of WV: Field changed:<br/>elevenlabs → hal
    
    WV->>HF: applyHalSettings()
    Note right of HF: Function renamed:<br/>applyElevenlabsSettings → applyHalSettings
    HF->>HF: Update halSettings state
    Note right of HF: State renamed:<br/>elevenlabs → halSettings
    
    HF-->>WV: halEnabled, halPhase, halEye
    WV->>HAL: Render with halSettings
    Note right of HAL: Props use HalMode type<br/>(was ElevenLabsMode)
    
    Note over VSCode,HAL: Secret Storage (unchanged)
    SM->>VSCode: secrets.elevenLabsApiKey
    Note right of SM: Secret name preserved<br/>for backward compatibility
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->