### PR TITLE
oh-tab-gr06: profiles UI Temperature/Timeout

### DIFF
--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -413,33 +413,14 @@ function LlmProfileSelector({
               <span className="codicon codicon-symbol-parameter text-brand-400" />
               <h3 className="font-semibold text-sm">LLM Profile</h3>
             </div>
-          </div>
+            </div>
 
-          <div className="p-2 space-y-1" role="listbox" aria-label="LLM profiles">
-            <button
-              type="button"
-              onClick={() => handleSelect(null)}
-              role="option"
-              aria-selected={isSelected(null)}
-              className={`
-                w-full text-left px-3 py-2 rounded-lg
-                text-sm
-                transition-colors duration-150
-                hover:bg-white/10
-                flex items-center gap-2
-                ${isSelected(null) ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
-              `}
-            >
-              <span className="codicon codicon-circle-slash" />
-              <span className="flex-1">None</span>
-              {isSelected(null) && <span className="codicon codicon-check text-brand-400" />}
-            </button>
-
-            {sanitizedProfiles.length === 0 ? (
-              <div className="px-3 py-2 text-sm opacity-60">No profiles found</div>
-            ) : (
-              sanitizedProfiles.map((id) => {
-                const selected = isSelected(id);
+            <div className="p-2 space-y-1" role="listbox" aria-label="LLM profiles">
+              {sanitizedProfiles.length === 0 ? (
+                <div className="px-3 py-2 text-sm opacity-60">No profiles found</div>
+              ) : (
+                sanitizedProfiles.map((id) => {
+                  const selected = isSelected(id);
                 return (
                   <div
                     key={id}
@@ -482,15 +463,34 @@ function LlmProfileSelector({
 
                     {selected && <span className="codicon codicon-check text-brand-400" />}
                   </div>
-                );
-              })
-            )}
+                  );
+                })
+              )}
 
-            <div className="my-1 border-t border-white/10" />
+              <button
+                type="button"
+                onClick={() => handleSelect(null)}
+                role="option"
+                aria-selected={isSelected(null)}
+                className={`
+                  w-full text-left px-3 py-2 rounded-lg
+                  text-sm
+                  transition-colors duration-150
+                  hover:bg-white/10
+                  flex items-center gap-2
+                  ${isSelected(null) ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
+                `}
+              >
+                <span className="codicon codicon-circle-slash" />
+                <span className="flex-1">None</span>
+                {isSelected(null) && <span className="codicon codicon-check text-brand-400" />}
+              </button>
 
-            <button
-              type="button"
-              onClick={() => {
+              <div className="my-1 border-t border-white/10" />
+
+              <button
+                type="button"
+                onClick={() => {
                 if (!onOpenCreate) return;
                 setIsOpen(false);
                 onOpenCreate();

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -1092,38 +1092,38 @@ export function LlmProfilesView(props: {
                     )}
                   </div>
 
-                  <div>
-                    <FieldLabel label="OpenAI API mode" htmlFor={profileFieldId('openaiApiMode')} />
-                    <div className="mt-2">
-                      <SelectField
-                        id={profileFieldId('openaiApiMode')}
-                        value={form.openaiApiMode}
-                        onChange={(v) => update('openaiApiMode', v as ProfileFormState['openaiApiMode'])}
-                        disabled={form.provider !== 'openai'}
-                      >
-                        <option value="auto">auto</option>
-                        <option value="chat_completions">chat_completions</option>
-                        <option value="responses">responses</option>
-                      </SelectField>
-                      <FieldError message={errors.openaiApiMode} />
+                    <div>
+                      <FieldLabel label="OpenAI API mode" htmlFor={profileFieldId('openaiApiMode')} />
+                      <div className="mt-2">
+                        <SelectField
+                          id={profileFieldId('openaiApiMode')}
+                          value={form.openaiApiMode}
+                          onChange={(v) => update('openaiApiMode', v as ProfileFormState['openaiApiMode'])}
+                          disabled={form.provider !== 'openai'}
+                        >
+                          <option value="auto">auto</option>
+                          <option value="chat_completions">chat_completions</option>
+                          <option value="responses">responses</option>
+                        </SelectField>
+                        <FieldError message={errors.openaiApiMode} />
+                      </div>
+                    </div>
+
+                    <div>
+                      <FieldLabel label="Temperature" htmlFor={profileFieldId('temperature')} />
+                      <div className="mt-2">
+                        <InputField
+                          id={profileFieldId('temperature')}
+                          value={form.temperature}
+                          onChange={(v) => update('temperature', v)}
+                          placeholder="0.2"
+                        />
+                        <FieldError message={errors.temperature} />
+                      </div>
                     </div>
                   </div>
 
-                  <div>
-                    <FieldLabel label="Timeout (seconds)" htmlFor={profileFieldId('timeoutSeconds')} />
-                    <div className="mt-2">
-                      <InputField
-                        id={profileFieldId('timeoutSeconds')}
-                        value={form.timeoutSeconds}
-                        onChange={(v) => update('timeoutSeconds', v)}
-                        placeholder="60"
-                      />
-                      <FieldError message={errors.timeoutSeconds} />
-                    </div>
-                  </div>
-                </div>
-
-                <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
+                  <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
                   <button
                     type="button"
                     onClick={() => setIsAdvancedOpen((prev) => !prev)}
@@ -1163,24 +1163,24 @@ export function LlmProfilesView(props: {
                           />
                           <FieldError message={errors.apiVersion} />
                         </div>
-                      </div>
-
-                      <div className="grid grid-cols-3 gap-4">
-                        <div>
-                          <FieldLabel label="Temperature" htmlFor={profileFieldId('temperature')} />
-                          <div className="mt-2">
-                            <InputField
-                              id={profileFieldId('temperature')}
-                              value={form.temperature}
-                              onChange={(v) => update('temperature', v)}
-                              placeholder="0.2"
-                            />
-                            <FieldError message={errors.temperature} />
-                          </div>
                         </div>
-                        <div>
-                          <FieldLabel label="Top P" htmlFor={profileFieldId('topP')} />
-                          <div className="mt-2">
+
+                        <div className="grid grid-cols-3 gap-4">
+                          <div>
+                            <FieldLabel label="Timeout (seconds)" htmlFor={profileFieldId('timeoutSeconds')} />
+                            <div className="mt-2">
+                              <InputField
+                                id={profileFieldId('timeoutSeconds')}
+                                value={form.timeoutSeconds}
+                                onChange={(v) => update('timeoutSeconds', v)}
+                                placeholder="60"
+                              />
+                              <FieldError message={errors.timeoutSeconds} />
+                            </div>
+                          </div>
+                          <div>
+                            <FieldLabel label="Top P" htmlFor={profileFieldId('topP')} />
+                            <div className="mt-2">
                             <InputField
                               id={profileFieldId('topP')}
                               value={form.topP}


### PR DESCRIPTION
Fixes oh-tab-gr06.

- LLM Profiles view: moved Temperature into the main section, moved Timeout into Advanced.
- Conversation view profile dropdown: moved 'None' to the end (just above the New profile action).

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Temperature parameter is now accessible in the main profile settings panel, allowing fine-tuned control over response generation characteristics.

* **UI/UX Improvements**
  * Timeout configuration has been relocated from main settings to the Advanced section, providing a cleaner primary interface.
  * Profile selection list now treats the None option as a standard list item, improving the overall selection experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Reorganized LLM profile UI fields by moving Temperature to the main section and Timeout to Advanced settings, and reordered the conversation profile dropdown to show 'None' at the end.

**Changes:**
- `InputArea.tsx`: moved 'None' profile option to end of list (above 'New profile' separator)
- `LlmProfilesView.tsx`: swapped Temperature and Timeout positions between main and Advanced sections

**Issues found:**
- Indentation inconsistency in `LlmProfilesView.tsx` - two divs have extra indentation (20 spaces instead of 18)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge after fixing the indentation issue
- The changes are straightforward UI reorganization with clear intent. One minor indentation inconsistency was found that should be corrected to maintain code quality, but it doesn't affect functionality
- src/webview-src/components/LlmProfilesView.tsx needs indentation fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/webview-src/components/InputArea.tsx | Moved 'None' option to end of profile dropdown list (before 'New profile' action), improving UX by prioritizing actual profiles |
| src/webview-src/components/LlmProfilesView.tsx | Moved Temperature to main section and Timeout to Advanced, but introduced indentation inconsistency |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant InputArea
    participant LlmProfilesView
    
    Note over User,LlmProfilesView: Profile Dropdown Reordering
    User->>InputArea: Click profile selector
    InputArea->>InputArea: Render profiles list
    InputArea->>InputArea: Show actual profiles first
    InputArea->>InputArea: Show 'None' option (moved to end)
    InputArea->>InputArea: Show separator
    InputArea->>InputArea: Show 'New profile' action
    InputArea->>User: Display reordered dropdown
    
    Note over User,LlmProfilesView: Profile View Field Reorganization
    User->>LlmProfilesView: Open profile settings
    LlmProfilesView->>LlmProfilesView: Render main section
    LlmProfilesView->>LlmProfilesView: Show Temperature field (moved from Advanced)
    LlmProfilesView->>User: Display main section
    User->>LlmProfilesView: Expand Advanced settings
    LlmProfilesView->>LlmProfilesView: Show Timeout field (moved from main)
    LlmProfilesView->>User: Display Advanced section
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->