### PR TITLE
oh-tab-f6jb: plain status bar message

### DIFF
--- a/src/webview-src/__tests__/StatusBanner.test.tsx
+++ b/src/webview-src/__tests__/StatusBanner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StatusBanner } from '../components/StatusBanner';
+
+describe('StatusBanner', () => {
+  it('renders without toast-style chrome (border/rounded/shadow)', () => {
+    render(
+      <StatusBanner
+        message="Local mode: running without remote server"
+        level="info"
+        onDismiss={() => {}}
+        dismissible={false}
+        autoDismiss={false}
+      />
+    );
+
+    const banner = screen.getByRole('alert');
+    expect(banner).not.toHaveClass('border');
+    expect(banner).not.toHaveClass('rounded-lg');
+    expect(banner.className).not.toContain('shadow-event');
+  });
+});
+

--- a/src/webview-src/components/StatusBanner.tsx
+++ b/src/webview-src/components/StatusBanner.tsx
@@ -26,24 +26,15 @@ export function StatusBanner({
   const levelConfig = {
     info: {
       icon: 'info',
-      bgColor: 'bg-brand-500/10',
-      borderColor: 'border-brand-500/20',
-      textColor: 'text-brand-200',
-      iconColor: '#E8A642',
+      textColor: 'text-stone-200',
     },
     warn: {
       icon: 'warning',
-      bgColor: 'bg-amber-500/10',
-      borderColor: 'border-amber-500/20',
-      textColor: 'text-amber-200',
-      iconColor: '#FBBF24',
+      textColor: 'text-[var(--brand-primary)]',
     },
     error: {
       icon: 'error',
-      bgColor: 'bg-red-500/10',
-      borderColor: 'border-red-400/20',
-      textColor: 'text-red-200',
-      iconColor: '#F87171',
+      textColor: 'text-[var(--event-error)]',
     },
   };
 
@@ -52,18 +43,16 @@ export function StatusBanner({
   return (
     <div
       className={`
-        ${config.bgColor} ${config.borderColor} ${config.textColor}
-        border rounded-lg p-3
+        ${config.textColor}
         flex items-center gap-3
+        text-sm
         animate-slide-down
-        shadow-event
       `}
       role="alert"
       aria-live="polite"
     >
       <span
-        className={`codicon codicon-${config.icon} flex-shrink-0`}
-        style={{ color: config.iconColor }}
+        className={`codicon codicon-${config.icon} flex-shrink-0 ${config.textColor}`}
       />
       <div
         className={`flex-1 text-sm ${level === 'error' ? 'break-words' : 'truncate'}`}


### PR DESCRIPTION
Fixes oh-tab-f6jb.

- Removes toast-style border/background/shadow from the bottom status bar message.
- Applies per-level text colors (info=white, warn=orange, error=coral).

Tests:
- npm test
- npm run typecheck
- npm run lint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Simplified the bottom status bar by removing toast-style visual decoration (borders, rounded corners, background colors, shadows) and replacing them with plain text using per-level color coding.

- Removed: `bgColor`, `borderColor`, `iconColor` fields and their corresponding CSS classes
- Changed text colors: info uses `text-stone-200` (white), warn uses `text-[var(--brand-primary)]` (orange), error uses `text-[var(--event-error)]` (coral)
- Added test coverage to verify toast-style classes are no longer present
- Maintained accessibility attributes (`role="alert"`, `aria-live="polite"`)
- Preserved auto-dismiss and dismiss functionality

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Clean UI simplification with appropriate test coverage, no logical errors or breaking changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/webview-src/components/StatusBanner.tsx | Removed toast-style styling (border/background/shadow), simplified to plain text with color-coded levels |
| src/webview-src/__tests__/StatusBanner.test.tsx | Added new test to verify removal of toast-style CSS classes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant StatusBanner
    participant CSS

    App->>App: Event triggers status update
    App->>App: setStatusBanner({message, level})
    App->>StatusBanner: Render with props
    StatusBanner->>StatusBanner: Map level to config
    Note over StatusBanner: info → text-stone-200<br/>warn → text-[var(--brand-primary)]<br/>error → text-[var(--event-error)]
    StatusBanner->>CSS: Apply text color classes
    Note over StatusBanner,CSS: No border/background/shadow<br/>(removed toast styling)
    StatusBanner->>StatusBanner: Render icon with color
    StatusBanner->>StatusBanner: Render message
    StatusBanner->>StatusBanner: Setup autoDismiss timer
    StatusBanner-->>App: Display plain status message
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->