### PR TITLE
oh-tab-lmoa: SecretRegistry precedence tests

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SecretStorage } from 'vscode';
+import { SecretRegistry } from '../SecretRegistry';
+
+const secretName = 'test_secret_registry_key';
+const envKey = secretName.toUpperCase();
+
+function makeStorage(value: string | undefined) {
+  const getSpy = vi.fn(async () => value);
+  const storage = { get: getSpy } as unknown as SecretStorage;
+  return { storage, getSpy };
+}
+
+describe('SecretRegistry', () => {
+  let previousEnvValue: string | undefined;
+
+  beforeEach(() => {
+    previousEnvValue = process.env[envKey];
+    delete process.env[envKey];
+  });
+
+  afterEach(() => {
+    if (previousEnvValue === undefined) {
+      delete process.env[envKey];
+    } else {
+      process.env[envKey] = previousEnvValue;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('prefers SecretStorage over env when both are present', async () => {
+    process.env[envKey] = 'from-env';
+    const { storage, getSpy } = makeStorage('from-storage');
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-storage');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+    expect(getSpy).toHaveBeenCalledWith(secretName);
+  });
+
+  it('falls back to env when SecretStorage is empty', async () => {
+    process.env[envKey] = 'from-env';
+    const { storage, getSpy } = makeStorage(undefined);
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-env');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns SecretStorage when env is absent', async () => {
+    const { storage, getSpy } = makeStorage('from-storage');
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-storage');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches values after first read (SecretStorage precedence)', async () => {
+    process.env[envKey] = 'from-env';
+    const { storage, getSpy } = makeStorage('from-storage');
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-storage');
+
+    process.env[envKey] = 'changed-env';
+    getSpy.mockResolvedValue('changed-storage');
+
+    await expect(registry.get(secretName)).resolves.toBe('from-storage');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches env values after first read when no SecretStorage is provided', async () => {
+    process.env[envKey] = 'from-env';
+    const registry = new SecretRegistry(undefined, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-env');
+
+    process.env[envKey] = 'changed-env';
+
+    await expect(registry.get(secretName)).resolves.toBe('from-env');
+  });
+});
+


### PR DESCRIPTION
Fixes oh-tab-lmoa.

- Adds unit tests for SecretRegistry.get() precedence (SecretStorage over env) and caching.

Tests:
- npm test
- npm run typecheck
- npm run lint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added unit tests for `SecretRegistry.get()` to verify precedence and caching behavior.

- Tests confirm `SecretStorage` takes precedence over environment variables
- Tests verify fallback to environment variables when `SecretStorage` is empty
- Tests validate caching works correctly after first read
- All test cases properly clean up environment state with `beforeEach`/`afterEach` hooks
- Mock implementation uses `vi.fn()` to track `SecretStorage.get()` calls

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-structured unit tests with proper mocking and cleanup
- Tests are comprehensive, properly isolated with setup/teardown, use appropriate mocking, and align with the implementation. No logical errors, security issues, or code quality concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts | Added comprehensive unit tests for SecretRegistry.get() precedence (SecretStorage over env) and caching behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant SecretRegistry
    participant Cache as this.secrets (Map)
    participant Storage as SecretStorage
    participant Env as process.env

    Client->>SecretRegistry: get(secretName)
    
    SecretRegistry->>Cache: has(secretName)?
    alt Already cached
        Cache-->>SecretRegistry: true
        SecretRegistry->>Cache: get(secretName)
        Cache-->>Client: cached value
    else Not cached
        Cache-->>SecretRegistry: false
        
        alt SecretStorage available
            SecretRegistry->>Storage: get(secretName)
            Storage-->>SecretRegistry: stored value or undefined
            
            alt stored value exists
                SecretRegistry->>Cache: set(secretName, stored)
                SecretRegistry-->>Client: stored value
            else stored value is undefined
                SecretRegistry->>Env: process.env[SECRETNAME]
                
                alt env value exists
                    SecretRegistry->>Cache: set(secretName, envValue)
                    SecretRegistry-->>Client: env value
                else no env value
                    SecretRegistry-->>Client: undefined
                end
            end
        else No SecretStorage
            SecretRegistry->>Env: process.env[SECRETNAME]
            
            alt env value exists
                SecretRegistry->>Cache: set(secretName, envValue)
                SecretRegistry-->>Client: env value
            else no env value
                SecretRegistry-->>Client: undefined
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->