### PR TITLE
oh-tab-nwdv/uu2d: anchor context + skills popovers

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -27,7 +27,7 @@ import { useStatusMessages, type StatusBannerState } from './app/useStatusMessag
 
 // Component imports
 import { Header } from './Header';
-import { InputArea, ContextPicker, SkillsPopover } from './InputArea';
+import { InputArea } from './InputArea';
 import { ConfirmationPrompt } from './ConfirmationPrompt';
 import { StatusBanner } from './StatusBanner';
 import { HistoryView } from './HistoryView';
@@ -1592,8 +1592,19 @@ export function App() {
           onOpenLlmProfilesEdit={handleOpenLlmProfilesEdit}
           onOpenContext={handleOpenContext}
           contextCount={selectedContextFiles.length}
+          showContextPicker={showContextPicker}
+          contextPickerFiles={workspaceFiles}
+          contextPickerSelectedFiles={selectedContextFiles}
+          onToggleContextFile={handleToggleContextFile}
+          contextQuery={contextQuery}
+          onContextQueryChange={setContextQuery}
+          onCloseContextPicker={handleCloseContextPicker}
           onOpenSkills={handleOpenSkills}
           skillsCount={skills.length}
+          showSkillsPopover={showSkillsPopover}
+          skillsPopoverSkills={skills}
+          onOpenSkill={handleOpenSkill}
+          onCloseSkillsPopover={() => setShowSkillsPopover(false)}
           onOpenAttachments={handleOpenAttachments}
           attachments={attachments}
           onOpenAttachment={handleOpenAttachment}
@@ -1603,29 +1614,6 @@ export function App() {
           onRemoveInlineImage={handleRemoveInlineImage}
           onSelectionChange={handleSelectionChange}
         />
-
-        {/* Context picker popover */}
-        {showContextPicker && (
-          <ContextPicker
-            isOpen
-            onClose={handleCloseContextPicker}
-            files={workspaceFiles}
-            selectedFiles={selectedContextFiles}
-            onToggleFile={handleToggleContextFile}
-            searchQuery={contextQuery}
-            onSearchChange={setContextQuery}
-          />
-        )}
-
-        {/* Skills popover */}
-        {showSkillsPopover && (
-          <SkillsPopover
-            isOpen
-            onClose={() => setShowSkillsPopover(false)}
-            skills={skills}
-            onOpenSkill={handleOpenSkill}
-          />
-        )}
 
         {/* Bottom status bar (below prompt + controls) */}
         <div

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -17,9 +17,20 @@ interface InputAreaProps {
   // Context picker
   onOpenContext: () => void;
   contextCount?: number;
+  showContextPicker?: boolean;
+  contextPickerFiles?: string[];
+  contextPickerSelectedFiles?: string[];
+  onToggleContextFile?: (file: string) => void;
+  contextQuery?: string;
+  onContextQueryChange?: (query: string) => void;
+  onCloseContextPicker?: (reason: CloseReason) => void;
   // Skills
   onOpenSkills: () => void;
   skillsCount?: number;
+  showSkillsPopover?: boolean;
+  skillsPopoverSkills?: Array<{ label: string; path: string }>;
+  onOpenSkill?: (path: string) => void;
+  onCloseSkillsPopover?: (reason: CloseReason) => void;
   // Attachments
   onOpenAttachments?: () => void;
   attachments?: Array<{ uri: string; label: string }>;
@@ -49,8 +60,19 @@ export function InputArea({
   onOpenLlmProfilesEdit,
   onOpenContext,
   contextCount = 0,
+  showContextPicker = false,
+  contextPickerFiles = [],
+  contextPickerSelectedFiles = [],
+  onToggleContextFile,
+  contextQuery = '',
+  onContextQueryChange,
+  onCloseContextPicker,
   onOpenSkills,
   skillsCount = 0,
+  showSkillsPopover = false,
+  skillsPopoverSkills = [],
+  onOpenSkill,
+  onCloseSkillsPopover,
   onOpenAttachments,
   attachments = [],
   onOpenAttachment,
@@ -225,12 +247,25 @@ export function InputArea({
 
         {/* Accessory buttons row */}
         <div className="flex items-center gap-2 mt-3">
-          <AccessoryButton
-            label="Add context"
-            displayLabel="@"
-            onClick={onOpenContext}
-            badge={contextCount > 0 ? contextCount : undefined}
-          />
+          <div className="relative">
+            <AccessoryButton
+              label="Add context"
+              displayLabel="@"
+              onClick={onOpenContext}
+              badge={contextCount > 0 ? contextCount : undefined}
+            />
+            {showContextPicker && onCloseContextPicker && onToggleContextFile && onContextQueryChange && (
+              <ContextPicker
+                isOpen
+                onClose={onCloseContextPicker}
+                files={contextPickerFiles}
+                selectedFiles={contextPickerSelectedFiles}
+                onToggleFile={onToggleContextFile}
+                searchQuery={contextQuery}
+                onSearchChange={onContextQueryChange}
+              />
+            )}
+          </div>
 
           <LlmProfileSelector
             profileId={llmProfileId}
@@ -241,12 +276,22 @@ export function InputArea({
             onOpenEdit={onOpenLlmProfilesEdit}
           />
 
-          <AccessoryButton
-            icon="mortar-board"
-            label="Skills"
-            onClick={onOpenSkills}
-            badge={skillsCount > 0 ? skillsCount : undefined}
-          />
+          <div className="relative">
+            <AccessoryButton
+              icon="mortar-board"
+              label="Skills"
+              onClick={onOpenSkills}
+              badge={skillsCount > 0 ? skillsCount : undefined}
+            />
+            {showSkillsPopover && onCloseSkillsPopover && onOpenSkill && (
+              <SkillsPopover
+                isOpen
+                onClose={onCloseSkillsPopover}
+                skills={skillsPopoverSkills}
+                onOpenSkill={onOpenSkill}
+              />
+            )}
+          </div>
 
           {onOpenMCP && (
             <AccessoryButton
@@ -618,7 +663,7 @@ export function ContextPicker({
   return (
     <div
       ref={popoverRef}
-      className="absolute bottom-full left-0 mb-2 w-80 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
+      className="absolute bottom-full left-0 mb-1 w-80 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
       style={{
         background: 'linear-gradient(135deg, rgba(28, 25, 23, 0.98) 0%, rgba(12, 10, 9, 0.98) 100%)',
       }}
@@ -761,7 +806,7 @@ export function SkillsPopover({
   return (
     <div
       ref={popoverRef}
-      className="absolute bottom-full left-0 mb-2 w-80 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
+      className="absolute bottom-full left-0 mb-1 w-64 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
       style={{
         background: 'linear-gradient(135deg, rgba(28, 25, 23, 0.98) 0%, rgba(12, 10, 9, 0.98) 100%)',
       }}


### PR DESCRIPTION
Fixes oh-tab-nwdv.
Fixes oh-tab-uu2d.

- Anchor @ context picker popover to the @ button.
- Anchor Skills popover to the Skills button and reduce width.

Tests:
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal input component architecture to consolidate context and skills UI control into the InputArea component.
  * Applied minor UI spacing adjustments to context picker and skills components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Refactored popover rendering to anchor `ContextPicker` and `SkillsPopover` to their respective buttons by moving them from `App.tsx` into `InputArea.tsx`.

- Removed `ContextPicker` and `SkillsPopover` imports from `App.tsx` (no longer rendered at top level)
- Passed popover state and handlers from `App` down to `InputArea` as props (showContextPicker, contextPickerFiles, onToggleContextFile, etc.)
- Wrapped `@` button and Skills button in `<div className="relative">` containers within `InputArea`
- Rendered popovers inside these relative containers for proper anchoring with `absolute bottom-full left-0`
- Adjusted `SkillsPopover` width from `w-80` to `w-64` for more compact layout
- Changed both popovers' `mb-2` to `mb-1` for tighter spacing

This architectural change improves the UI by positioning popovers directly relative to their trigger buttons rather than floating at the App level.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- Pure refactoring that moves popover rendering logic without changing behavior. All props are properly threaded through interfaces, positioning logic remains identical (absolute bottom-full left-0), and the changes only affect UI component structure. The PR author reports tests, typecheck, and lint all pass.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/webview-src/components/App.tsx | Moved ContextPicker and SkillsPopover rendering into InputArea component by passing state and handlers as props |
| src/webview-src/components/InputArea.tsx | Wrapped context and skills buttons in relative divs to anchor popovers, adjusted widths (Skills: 80→64, ContextPicker: mb-2→mb-1) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant App
    participant InputArea
    participant AccessoryButton
    participant ContextPicker
    participant SkillsPopover

    Note over App,InputArea: Before: Popovers rendered in App.tsx
    Note over App,InputArea: After: Popovers rendered in InputArea.tsx

    User->>AccessoryButton: Click @ button
    AccessoryButton->>InputArea: onClick={onOpenContext}
    InputArea->>App: onOpenContext handler
    App->>App: setShowContextPicker(true)
    App->>InputArea: Pass showContextPicker={true}
    InputArea->>ContextPicker: Render in relative div
    Note over AccessoryButton,ContextPicker: ContextPicker anchored to @ button<br/>using relative positioning
    
    User->>AccessoryButton: Click Skills button
    AccessoryButton->>InputArea: onClick={onOpenSkills}
    InputArea->>App: onOpenSkills handler
    App->>App: setShowSkillsPopover(true)
    App->>InputArea: Pass showSkillsPopover={true}
    InputArea->>SkillsPopover: Render in relative div (w-64)
    Note over AccessoryButton,SkillsPopover: SkillsPopover anchored to Skills button<br/>using relative positioning
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->