### PR TITLE
oh-tab-1tya: Tools picker

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
@@ -231,4 +231,21 @@ describe('LocalConversation', () => {
       expect(extra.text).toContain('<EXTRA_INFO>');
     }
   });
+
+  it('supports tool introspection and updates tools only before user messages', async () => {
+    const llm = new RecordingLLM();
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, tools: createDefaultTools() });
+
+    expect(conversation.getToolNames()).toEqual(['terminal', 'file_editor', 'task_tracker', 'browser']);
+
+    conversation.setTools([new TerminalTool()]);
+    expect(conversation.getToolNames()).toEqual(['terminal']);
+
+    await conversation.sendUserMessage('hi');
+
+    expect(() => conversation.setTools([new TerminalTool()])).toThrow('Cannot change tools after the conversation has started');
+
+    await conversation.startNewConversation();
+    expect(() => conversation.setTools([new TerminalTool()])).not.toThrow();
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -49,13 +49,14 @@ export class LocalConversation extends EventEmitter {
   private readonly secrets: SecretRegistry;
   private readonly lock = new AsyncLock();
   private readonly customLlmClient?: LLMClient;
-  private readonly tools: ToolDefinition<unknown, unknown>[];
+  private tools: ToolDefinition<unknown, unknown>[];
   private readonly persistenceDir?: string;
   private persistence?: ConversationPersistence;
   private readonly agentContext?: AgentContext;
   private agent: Agent;
   private readonly llmRegistry: LLMRegistry;
   private readonly stats: ConversationStats;
+  private hasUserMessage = false;
 
   constructor(options: LocalConversationOptions) {
     super();
@@ -93,9 +94,22 @@ export class LocalConversation extends EventEmitter {
     this.persistLlmConfig();
   }
 
+  getToolNames(): string[] {
+    return this.tools.map((tool) => tool.name);
+  }
+
+  setTools(tools: ToolDefinition<unknown, unknown>[]): void {
+    if (this.hasUserMessage) {
+      throw new Error('Cannot change tools after the conversation has started');
+    }
+    this.tools = tools;
+    this.agent = this.createAgent();
+  }
+
   startNewConversation(): Promise<string | undefined> {
     // Create a brand-new conversation id and fresh runtime (EventLog/State/Agent)
     this.conversationId = `local-${Date.now().toString(36)}`;
+    this.hasUserMessage = false;
 
     // Reset persistence so a new store is created for the new id (if configured)
     this.persistence = undefined;
@@ -123,6 +137,7 @@ export class LocalConversation extends EventEmitter {
   restoreConversation(id: string) {
     // Switch to a new runtime bound to the requested conversation id
     this.conversationId = id;
+    this.hasUserMessage = true;
 
     // If no persistence config exists at all, surface info and start fresh
     if (!this.persistenceDir && !this.persistence) {
@@ -189,6 +204,7 @@ export class LocalConversation extends EventEmitter {
       if (!this.conversationId) {
         await this.startNewConversation();
       }
+      this.hasUserMessage = true;
       await this.agent.run(text);
     });
   }

--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWebviewMessageHandler } from '../webview/host/createWebviewMessageHandler';
+
+describe('Tools picker host messages', () => {
+  const createHandler = (conversation?: any) => {
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context: {} as any,
+      host: { postMessage },
+      getConversation: () => conversation,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp',
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    return { handler, postMessage };
+  };
+
+  it('responds to requestTools with the local tools list', async () => {
+    const state = { toolNames: ['terminal', 'task_tracker'] };
+    const conversation = {
+      mode: 'local',
+      getToolNames: vi.fn(() => state.toolNames),
+      setTools: vi.fn(),
+    };
+
+    const { handler, postMessage } = createHandler(conversation);
+    await handler({ type: 'requestTools' } as any);
+
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'toolsList',
+      enabledToolIds: ['terminal', 'task_tracker'],
+    }));
+
+    const payload = postMessage.mock.calls[0][0] as any;
+    expect(payload.tools).toEqual([
+      { id: 'terminal', label: 'Terminal' },
+      { id: 'file_editor', label: 'File Editor' },
+      { id: 'task_tracker', label: 'Task Tracker' },
+    ]);
+  });
+
+  it('applies setEnabledTools by calling conversation.setTools', async () => {
+    const state = { toolNames: ['terminal', 'file_editor', 'task_tracker'] as string[] };
+    const conversation = {
+      mode: 'local',
+      getToolNames: vi.fn(() => state.toolNames),
+      setTools: vi.fn((tools: Array<{ name: string }>) => {
+        state.toolNames = tools.map((t) => t.name);
+      }),
+    };
+
+    const { handler, postMessage } = createHandler(conversation);
+    await handler({ type: 'setEnabledTools', toolIds: ['file_editor'] } as any);
+
+    expect(conversation.setTools).toHaveBeenCalledTimes(1);
+    const arg = (conversation.setTools as any).mock.calls[0][0] as Array<{ name: string }>;
+    expect(arg.map((t) => t.name)).toEqual(['file_editor']);
+
+    const toolsListPayload = postMessage.mock.calls
+      .map((call) => call[0])
+      .find((msg) => msg?.type === 'toolsList') as any;
+
+    expect(toolsListPayload.enabledToolIds).toEqual(['file_editor']);
+  });
+});
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,15 +17,13 @@ import { ConversationEventBacklog, type BufferedConversationEvent } from './conv
 import { OpenHandsTerminalLogPseudoterminal } from './terminal/OpenHandsTerminalLogPseudoterminal';
 import { registerDiagnosticsCommands, type RenderedEventsInfo, type UiStateSnapshot } from './dev/registerDiagnosticsCommands';
 import type { HostToWebviewMessage } from './shared/webviewMessages';
+import { resolveLocalTools } from './shared/localTools';
 import {
   AgentContext,
   Conversation,
   type ConversationInstance,
-  FileEditorTool,
   LLMFactory,
   SecretRegistry,
-  TaskTrackerTool,
-  TerminalTool,
   type BashEvent,
   type Event,
   isBashCommand,
@@ -233,12 +231,6 @@ function flushConversationEventBacklog(params: {
     transformEvent,
   });
 }
-
-const createDefaultLocalTools = () => [
-  new TerminalTool(),
-  new FileEditorTool(),
-  new TaskTrackerTool(),
-];
 
 /** Render an error for logging/display (handles Error objects and unknown values) */
 function renderError(err: unknown): string {
@@ -663,7 +655,7 @@ export function activate(context: vscode.ExtensionContext) {
         serverUrl: settings.serverUrl ?? undefined,
         settings,
         workspaceRoot,
-        tools: settings.serverUrl ? undefined : createDefaultLocalTools(),
+        tools: settings.serverUrl ? undefined : resolveLocalTools(),
         secrets,
         persistenceDir,
         agentContext,

--- a/src/shared/localTools.ts
+++ b/src/shared/localTools.ts
@@ -1,0 +1,67 @@
+import type { ToolDefinition } from '@openhands/agent-sdk-ts';
+import { FileEditorTool, TaskTrackerTool, TerminalTool } from '@openhands/agent-sdk-ts';
+
+export type LocalToolId = 'terminal' | 'file_editor' | 'task_tracker';
+
+export type LocalToolDescriptor = {
+  id: LocalToolId;
+  label: string;
+};
+
+const LOCAL_TOOLS: LocalToolDescriptor[] = [
+  { id: 'terminal', label: 'Terminal' },
+  { id: 'file_editor', label: 'File Editor' },
+  { id: 'task_tracker', label: 'Task Tracker' },
+];
+
+type LocalToolInstances = Record<LocalToolId, ToolDefinition<unknown, unknown>>;
+
+let instances: LocalToolInstances | null = null;
+
+export function listLocalToolDescriptors(): LocalToolDescriptor[] {
+  return [...LOCAL_TOOLS];
+}
+
+export function getDefaultLocalToolIds(): LocalToolId[] {
+  return LOCAL_TOOLS.map((tool) => tool.id);
+}
+
+export function normalizeLocalToolIds(value: unknown): LocalToolId[] | null {
+  if (value === undefined) return null;
+  if (!Array.isArray(value)) return null;
+
+  const out: LocalToolId[] = [];
+  const seen = new Set<LocalToolId>();
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const id = item.trim() as LocalToolId;
+    if (id !== 'terminal' && id !== 'file_editor' && id !== 'task_tracker') continue;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+  }
+  return out;
+}
+
+function getOrCreateLocalToolInstances(): LocalToolInstances {
+  if (instances) return instances;
+  instances = {
+    terminal: new TerminalTool(),
+    file_editor: new FileEditorTool(),
+    task_tracker: new TaskTrackerTool(),
+  };
+  return instances;
+}
+
+export function resolveLocalTools(toolIds?: LocalToolId[] | null): ToolDefinition<unknown, unknown>[] {
+  const resolved: ToolDefinition<unknown, unknown>[] = [];
+  const byId = getOrCreateLocalToolInstances();
+  const ids = toolIds === undefined || toolIds === null ? getDefaultLocalToolIds() : toolIds;
+
+  for (const id of ids) {
+    if (id === 'terminal' || id === 'file_editor' || id === 'task_tracker') {
+      resolved.push(byId[id]);
+    }
+  }
+  return resolved;
+}

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -50,6 +50,7 @@ export type HostToWebviewMessage =
   }
   | { type: 'workspaceFiles'; files: string[] }
   | { type: 'skillsList'; skills: Array<{ label: string; path: string }> }
+  | { type: 'toolsList'; tools: Array<{ id: string; label: string }>; enabledToolIds: string[] }
   | { type: 'attachmentsSelected'; attachments: Array<{ uri: string; label: string; sizeBytes?: number }> }
   | { type: 'config'; serverUrl: string | null; mode: 'local' | 'remote' }
   | { type: 'conversationStarted'; conversationId: string }
@@ -72,6 +73,7 @@ export type WebviewToHostMessage =
   | { type: 'openSettings' }
   | { type: 'requestWorkspaceFiles' }
   | { type: 'requestSkills' }
+  | { type: 'requestTools' }
   | { type: 'openSkill'; path: string }
   | { type: 'openWorkspaceFile'; path: string }
   | { type: 'openMarkdownLink'; href: string }
@@ -93,6 +95,7 @@ export type WebviewToHostMessage =
   | { type: 'switchToLocal' }
   | { type: 'selectAttachments' }
   | { type: 'openAttachment'; uri: string }
+  | { type: 'setEnabledTools'; toolIds: string[] }
   | { type: 'send'; text: string; contextFiles?: string[]; attachments?: string[] }
   | { type: 'halTtsRequest'; requestId: string; conversationId: string; stepIndex: number }
   | { type: 'halVoiceConfirmRequest'; requestId: string; mimeType: string; audioBase64: string }

--- a/src/webview-src/__tests__/App.toolsPicker.test.tsx
+++ b/src/webview-src/__tests__/App.toolsPicker.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { App } from '../components/App';
+
+const mockApi = { postMessage: vi.fn() };
+
+describe('Tools picker', () => {
+  beforeEach(() => {
+    // @ts-expect-error mock VS Code API
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows tool count and toggles tools before the conversation starts', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local' }
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'toolsList',
+          tools: [
+            { id: 'terminal', label: 'Terminal' },
+            { id: 'file_editor', label: 'File Editor' },
+            { id: 'task_tracker', label: 'Task Tracker' },
+          ],
+          enabledToolIds: ['terminal', 'file_editor', 'task_tracker'],
+        }
+      }));
+    });
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toHaveTextContent('3');
+
+    mockApi.postMessage.mockClear();
+    await act(async () => {
+      fireEvent.click(toolsButton);
+    });
+    // Opening the popover re-requests the tools list.
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestTools' });
+    mockApi.postMessage.mockClear();
+
+    const terminalRow = await screen.findByLabelText('Terminal');
+    expect(terminalRow).toHaveAttribute('aria-selected', 'true');
+
+    await act(async () => {
+      fireEvent.click(terminalRow);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Tools' })).toHaveTextContent('2');
+    });
+
+    expect(mockApi.postMessage).toHaveBeenCalledWith({
+      type: 'setEnabledTools',
+      toolIds: ['file_editor', 'task_tracker'],
+    });
+    expect(screen.getByLabelText('Terminal')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('does not toggle tools after a user message and shows an info status message', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local' }
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'toolsList',
+          tools: [
+            { id: 'terminal', label: 'Terminal' },
+            { id: 'file_editor', label: 'File Editor' },
+            { id: 'task_tracker', label: 'Task Tracker' },
+          ],
+          enabledToolIds: ['terminal', 'file_editor', 'task_tracker'],
+        }
+      }));
+    });
+
+    await act(async () => {
+      fireEvent.click(await screen.findByRole('button', { name: 'Tools' }));
+    });
+    const terminalRow = await screen.findByLabelText('Terminal');
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'event',
+          event: {
+            kind: 'MessageEvent',
+            source: 'user',
+            llm_message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+          },
+        }
+      }));
+    });
+
+    mockApi.postMessage.mockClear();
+    await act(async () => {
+      fireEvent.click(terminalRow);
+    });
+
+    expect(mockApi.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'setEnabledTools' }));
+    expect(screen.getByTestId('status-row')).toHaveTextContent('To change Tools, please start a new conversation.');
+    expect(screen.getByLabelText('Terminal')).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -284,6 +284,11 @@ export function App() {
   const [showSkillsPopover, setShowSkillsPopover] = useState(false);
   const [skills, setSkills] = useState<{ label: string; path: string }[]>([]);
 
+  // Tools state (local mode only)
+  const [showToolsPopover, setShowToolsPopover] = useState(false);
+  const [tools, setTools] = useState<{ id: string; label: string }[]>([]);
+  const [enabledToolIds, setEnabledToolIds] = useState<string[]>([]);
+
   // History state
   const [history, setHistory] = useState<Array<{ id: string; title?: string; firstMessage?: string; timestamp: number; messageCount?: number }>>([]);
 
@@ -655,6 +660,7 @@ export function App() {
   useEffect(() => {
     const vscodeApi = getVscodeApi();
     let didRequestSkills = false;
+    let didRequestTools = false;
     const sendReady = () => {
       const state = vscodeApi.getState?.<WebviewPersistedState>() ?? {};
       const payload: WebviewToHostMessage = { type: 'webviewReady' };
@@ -664,6 +670,10 @@ export function App() {
       if (!didRequestSkills) {
         didRequestSkills = true;
         postMessage({ type: 'requestSkills' });
+      }
+      if (!didRequestTools) {
+        didRequestTools = true;
+        postMessage({ type: 'requestTools' });
       }
     };
 
@@ -704,6 +714,8 @@ export function App() {
         conversationId?: string;
         files?: string[];
         skills?: { label: string; path: string }[];
+        tools?: { id: string; label: string }[];
+        enabledToolIds?: string[];
         conversations?: ConversationsList;
         servers?: { url: string; label?: string }[];
         attachments?: Array<{ uri: string; label: string; sizeBytes?: number }>;
@@ -992,6 +1004,8 @@ export function App() {
             setAgentStatus(undefined);
             setStreamingContent(null);
             eventId.current = 1;
+            setShowToolsPopover(false);
+            postMessage({ type: 'requestTools' });
             // No toast: UI clears and restored/started messages will render naturally
             const api = getVscodeApi();
             api.setState?.({ conversationId: payload.conversationId, lastSeenSeq: 0 });
@@ -1015,6 +1029,19 @@ export function App() {
             );
           }
           break;
+        case 'toolsList': {
+          if (!Array.isArray(payload.tools) || !Array.isArray(payload.enabledToolIds)) break;
+          setTools(
+            payload.tools.filter((tool): tool is { id: string; label: string } => (
+              typeof tool === 'object'
+              && tool !== null
+              && typeof (tool as { id?: unknown }).id === 'string'
+              && typeof (tool as { label?: unknown }).label === 'string'
+            ))
+          );
+          setEnabledToolIds(payload.enabledToolIds.filter((id): id is string => typeof id === 'string'));
+          break;
+        }
         case 'queryUiState': {
           if (typeof payload.requestId === 'string') {
             postMessage({ type: 'uiStateResponse', requestId: payload.requestId, ...uiStateRef.current });
@@ -1035,6 +1062,7 @@ export function App() {
           switch (action) {
             case 'openContext':
               setShowSkillsPopover(false);
+              setShowToolsPopover(false);
               setShowContextPicker(true);
               postMessage({ type: 'requestWorkspaceFiles' });
               break;
@@ -1052,6 +1080,7 @@ export function App() {
             }
             case 'openSkills':
               setShowContextPicker(false);
+              setShowToolsPopover(false);
               setShowSkillsPopover(true);
               postMessage({ type: 'requestSkills' });
               break;
@@ -1229,6 +1258,7 @@ export function App() {
     mentionStartRef.current = at;
     setIsMentionActive(true);
     setShowSkillsPopover(false);
+    setShowToolsPopover(false);
     if (!showContextPicker) {
       postMessage({ type: 'requestWorkspaceFiles' });
       setShowContextPicker(true);
@@ -1263,6 +1293,7 @@ export function App() {
     setSelectedContextFiles([]);
     setAttachments([]);
     setInlineImages([]);
+    setShowToolsPopover(false);
     postMessage({ type: 'command', command: 'startNewConversation' });
   }, [postMessage, setInlineImages, setStatusBanner]);
 
@@ -1271,6 +1302,7 @@ export function App() {
     setShowLlmProfiles(panel === 'llmProfiles');
     setShowContextPicker(false);
     setShowSkillsPopover(false);
+    setShowToolsPopover(false);
   }, [setShowContextPicker, setShowHistory, setShowLlmProfiles, setShowSkillsPopover]);
 
   const handleOpenHistory = useCallback(() => {
@@ -1312,6 +1344,7 @@ export function App() {
     setInput('');
     setShowContextPicker(false);
     setShowSkillsPopover(false);
+    setShowToolsPopover(false);
     setContextQuery('');
     setSelectedContextFiles([]);
     setAttachments([]);
@@ -1328,6 +1361,7 @@ export function App() {
   // Context picker handlers
   const handleOpenContext = useCallback(() => {
     setShowSkillsPopover(false);
+    setShowToolsPopover(false);
     setShowContextPicker((prev) => {
       const willBeOpen = !prev;
       if (willBeOpen) {
@@ -1421,6 +1455,7 @@ export function App() {
   // Skills handlers
   const handleOpenSkills = useCallback(() => {
     setShowContextPicker(false);
+    setShowToolsPopover(false);
     setShowSkillsPopover((prev) => {
       const willBeOpen = !prev;
       if (willBeOpen) {
@@ -1435,6 +1470,40 @@ export function App() {
     postMessage({ type: 'openSkill', path });
     setShowSkillsPopover(false);
   }, [postMessage, showStatusMessage]);
+
+  const isToolSelectionLocked = events.some((ev) => isMessageEvent(ev.event) && ev.event.source === 'user');
+
+  const handleOpenTools = useCallback(() => {
+    setShowContextPicker(false);
+    setShowSkillsPopover(false);
+    setShowToolsPopover((prev) => {
+      const willBeOpen = !prev;
+      if (willBeOpen) {
+        postMessage({ type: 'requestTools' });
+      }
+      return willBeOpen;
+    });
+  }, [postMessage]);
+
+  const handleToggleTool = useCallback((toolId: string) => {
+    if (isToolSelectionLocked) {
+      showStatusMessage('info', 'To change Tools, please start a new conversation.', { autoDismiss: true, autoDismissDelay: 4000 });
+      return;
+    }
+
+    setEnabledToolIds((prev) => {
+      const known = new Set(tools.map((tool) => tool.id));
+      if (!known.has(toolId)) return prev;
+
+      const nextSet = new Set(prev);
+      if (nextSet.has(toolId)) nextSet.delete(toolId);
+      else nextSet.add(toolId);
+
+      const ordered = tools.map((t) => t.id).filter((id) => nextSet.has(id));
+      postMessage({ type: 'setEnabledTools', toolIds: ordered });
+      return ordered;
+    });
+  }, [isToolSelectionLocked, postMessage, showStatusMessage, tools]);
 
   // History handlers
   const handleSelectConversation = useCallback((id: string) => {
@@ -1605,6 +1674,13 @@ export function App() {
           skillsPopoverSkills={skills}
           onOpenSkill={handleOpenSkill}
           onCloseSkillsPopover={() => setShowSkillsPopover(false)}
+          onOpenTools={mode === 'local' ? handleOpenTools : undefined}
+          toolsCount={enabledToolIds.length}
+          showToolsPopover={showToolsPopover}
+          toolsPopoverTools={tools}
+          enabledToolIds={enabledToolIds}
+          onToggleTool={handleToggleTool}
+          onCloseToolsPopover={() => setShowToolsPopover(false)}
           onOpenAttachments={handleOpenAttachments}
           attachments={attachments}
           onOpenAttachment={handleOpenAttachment}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -776,7 +776,7 @@ export function ContextPicker({
   );
 }
 
-{/* Tools Popover */}
+// Tools Popover
 interface ToolDescriptor {
   id: string;
   label: string;
@@ -863,7 +863,7 @@ export function ToolsPopover({
   );
 }
 
-{/* Skills Popover */}
+// Skills Popover
 interface Skill {
   label: string;
   path: string;

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -31,6 +31,14 @@ interface InputAreaProps {
   skillsPopoverSkills?: Array<{ label: string; path: string }>;
   onOpenSkill?: (path: string) => void;
   onCloseSkillsPopover?: (reason: CloseReason) => void;
+  // Tools (local mode only)
+  onOpenTools?: () => void;
+  toolsCount?: number;
+  showToolsPopover?: boolean;
+  toolsPopoverTools?: Array<{ id: string; label: string }>;
+  enabledToolIds?: string[];
+  onToggleTool?: (toolId: string) => void;
+  onCloseToolsPopover?: (reason: CloseReason) => void;
   // Attachments
   onOpenAttachments?: () => void;
   attachments?: Array<{ uri: string; label: string }>;
@@ -73,6 +81,13 @@ export function InputArea({
   skillsPopoverSkills = [],
   onOpenSkill,
   onCloseSkillsPopover,
+  onOpenTools,
+  toolsCount = 0,
+  showToolsPopover = false,
+  toolsPopoverTools = [],
+  enabledToolIds = [],
+  onToggleTool,
+  onCloseToolsPopover,
   onOpenAttachments,
   attachments = [],
   onOpenAttachment,
@@ -275,6 +290,26 @@ export function InputArea({
             onOpenCreate={onOpenLlmProfilesCreate}
             onOpenEdit={onOpenLlmProfilesEdit}
           />
+
+          {onOpenTools && onToggleTool && (
+            <div className="relative">
+              <AccessoryButton
+                icon="tools"
+                label="Tools"
+                onClick={onOpenTools}
+                badge={toolsCount > 0 ? toolsCount : undefined}
+              />
+              {showToolsPopover && onCloseToolsPopover && (
+                <ToolsPopover
+                  isOpen
+                  onClose={onCloseToolsPopover}
+                  tools={toolsPopoverTools}
+                  enabledToolIds={enabledToolIds}
+                  onToggleTool={onToggleTool}
+                />
+              )}
+            </div>
+          )}
 
           <div className="relative">
             <AccessoryButton
@@ -737,6 +772,93 @@ export function ContextPicker({
           {selectedFiles.length} file{selectedFiles.length !== 1 ? 's' : ''} selected
         </div>
       )}
+    </div>
+  );
+}
+
+{/* Tools Popover */}
+interface ToolDescriptor {
+  id: string;
+  label: string;
+}
+
+interface ToolsPopoverProps {
+  isOpen: boolean;
+  onClose: (reason: CloseReason) => void;
+  tools: ToolDescriptor[];
+  enabledToolIds: string[];
+  onToggleTool: (toolId: string) => void;
+}
+
+export function ToolsPopover({
+  isOpen,
+  onClose,
+  tools,
+  enabledToolIds,
+  onToggleTool,
+}: ToolsPopoverProps) {
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: popoverRef, delay: 100 });
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={popoverRef}
+      className="absolute bottom-full left-0 mb-1 w-64 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
+      style={{
+        background: 'linear-gradient(135deg, rgba(28, 25, 23, 0.98) 0%, rgba(12, 10, 9, 0.98) 100%)',
+      }}
+    >
+      <div className="px-4 py-3 border-b border-white/[0.06]">
+        <div className="flex items-center gap-2">
+          <span className="codicon codicon-tools text-brand-400" />
+          <h3 className="font-semibold text-sm text-stone-200">Tools</h3>
+        </div>
+        <div className="mt-1 text-xs text-stone-500">
+          Select which tools the agent can use
+        </div>
+      </div>
+
+      <div className="overflow-y-auto max-h-64">
+        {tools.length === 0 ? (
+          <div className="px-4 py-8 text-center text-sm text-stone-500">
+            No tools available
+          </div>
+        ) : (
+          <div className="p-2 space-y-0.5" role="listbox" aria-label="Tools">
+            {tools.map((tool) => {
+              const isEnabled = enabledToolIds.includes(tool.id);
+              return (
+                <button
+                  key={tool.id}
+                  type="button"
+                  onClick={() => onToggleTool(tool.id)}
+                  role="option"
+                  aria-label={tool.label}
+                  aria-selected={isEnabled ? 'true' : 'false'}
+                  className={`
+                    w-full text-left px-3 py-2 rounded-lg
+                    text-sm
+                    transition-all duration-150
+                    flex items-center gap-2
+                    group
+                    ${isEnabled
+                      ? 'bg-brand-500/10 text-stone-200 border border-brand-500/25'
+                      : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300 border border-transparent'
+                    }
+                  `}
+                >
+                  <span className="codicon codicon-symbol-method text-brand-400/70" />
+                  <span className="flex-1 truncate">{tool.label}</span>
+                  {isEnabled && <span className="codicon codicon-check text-brand-400" />}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -23,9 +23,24 @@ import * as llmProfilesStore from './llmProfilesStore';
 import { listSkillFiles } from './skills';
 import { listWorkspaceFiles } from './workspaceFiles';
 import { resolveWorkspaceFilePath } from './workspacePaths';
+import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools } from '../../shared/localTools';
 
 export type WebviewHost = {
   postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
+};
+
+type LocalConversationToolControls = {
+  mode: 'local';
+  getToolNames: () => string[];
+  setTools: (tools: unknown[]) => void;
+};
+
+const isLocalConversationToolControls = (value: unknown): value is LocalConversationToolControls => {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<LocalConversationToolControls> & { [k: string]: unknown };
+  return candidate.mode === 'local'
+    && typeof candidate.getToolNames === 'function'
+    && typeof candidate.setTools === 'function';
 };
 
 function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
@@ -117,6 +132,26 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
   const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
   let elevenlabsTtsGate: TtsConversationGate | null = null;
+
+  const postToolsList = (): void => {
+    const mode = deps.getConversationMode();
+    if (mode !== 'local') {
+      void host.postMessage({ type: 'toolsList', tools: [], enabledToolIds: [] });
+      return;
+    }
+
+    const tools = listLocalToolDescriptors();
+    const conversation = deps.getConversation();
+    const enabledToolIds = (() => {
+      if (isLocalConversationToolControls(conversation)) {
+        const ids = normalizeLocalToolIds(conversation.getToolNames());
+        if (ids !== null) return ids;
+      }
+      return getDefaultLocalToolIds();
+    })();
+
+    void host.postMessage({ type: 'toolsList', tools, enabledToolIds });
+  };
 
   const postStatusError = (message: string): void => {
     void host.postMessage({
@@ -249,6 +284,8 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           activeProfileId: initSettings.llm.profileId ?? null,
         });
 
+        postToolsList();
+
         void host.postMessage({
           type: 'serverListUpdated',
           servers: initSettings.servers,
@@ -281,6 +318,37 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         const skills = await listSkillFiles();
         outputChannel?.appendLine(`[skills] Found ${skills.length} skill(s)`);
         void host.postMessage({ type: 'skillsList', skills });
+        break;
+      }
+      case 'requestTools': {
+        postToolsList();
+        break;
+      }
+      case 'setEnabledTools': {
+        const mode = deps.getConversationMode();
+        if (mode !== 'local') break;
+
+        const normalized = normalizeLocalToolIds(message.toolIds);
+        if (normalized === null) {
+          postStatusError('Invalid tools selection received from webview');
+          break;
+        }
+
+        const conversation = deps.getConversation();
+        if (!isLocalConversationToolControls(conversation)) {
+          postStatusError('Cannot update tools: conversation unavailable');
+          break;
+        }
+
+        try {
+          conversation.setTools(resolveLocalTools(normalized));
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          outputChannel?.appendLine(`[tools] Failed to update tools: ${reason}`);
+          void host.postMessage({ type: 'statusMessage', level: 'info', message: reason, autoDismiss: true, autoDismissDelay: 4000 });
+        }
+
+        postToolsList();
         break;
       }
       case 'openSkill': {
@@ -945,6 +1013,15 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
             break;
           case 'startNewConversation':
             await conversation?.startNewConversation();
+            if (isLocalConversationToolControls(conversation)) {
+              try {
+                conversation.setTools(resolveLocalTools(getDefaultLocalToolIds()));
+              } catch (err) {
+                const reason = err instanceof Error ? err.message : String(err);
+                outputChannel?.appendLine(`[tools] Failed to reset tools: ${reason}`);
+              }
+              postToolsList();
+            }
             break;
           case 'approveAction':
             await conversation?.approveAction();


### PR DESCRIPTION
Implements Beads issue `oh-tab-1tya` (Tools picker) for local mode.

- Adds a Tools control next to Skills in the input row with a popover list + per-conversation enable/disable.
- Locks selection after the first user message; clicking a tool shows: "To change Tools, please start a new conversation."
- Host wiring: `requestTools`/`toolsList` + `setEnabledTools`; local conversation supports safe tool reconfiguration before any user message.
- Tests: webview + host + agent-sdk coverage.

Tests
- `npm test`
- `npm run typecheck`
- `npm run lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tools Picker UI component enabling selection from Terminal, File Editor, and Task Tracker tools in local conversations.
  * Tool selections are locked after sending the first message in a conversation to ensure consistency.
  * Tool configuration resets when starting a new conversation, allowing fresh tool selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->