### PR TITLE
oh-tab-7ezo: green check for provider key

### DIFF
--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -229,7 +229,8 @@ describe('LLM Profiles view', () => {
       providerKeyName: 'OPENAI_API_KEY',
     });
 
-    expect(await screen.findByText('Using OPENAI_API_KEY')).toBeInTheDocument();
+    expect(screen.queryByText('Using OPENAI_API_KEY')).toBeNull();
+    expect(await screen.findByLabelText('Provider key configured')).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'litellm_proxy' } });
 
@@ -252,8 +253,9 @@ describe('LLM Profiles view', () => {
       providerKeyName: 'LITELLM_API_KEY',
     });
 
-    expect(await screen.findByText('Using LITELLM_API_KEY')).toBeInTheDocument();
     expect(screen.queryByText('Using OPENAI_API_KEY')).toBeNull();
+    expect(screen.queryByText('Using LITELLM_API_KEY')).toBeNull();
+    expect(await screen.findByLabelText('Provider key configured')).toBeInTheDocument();
   });
 
   it('supports a collapsible Advanced settings section', async () => {

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -646,13 +646,19 @@ export function LlmProfilesView(props: {
     return { disabled: false, value };
   })();
 
+  const showProviderKeyConfiguredIndicator = providerRequiresApiKey
+    && mode === 'edit'
+    && apiKeyStatus.state === 'ready'
+    && apiKeyStatus.hasProviderKey
+    && !apiKeyStatus.hasProfileKey;
+
   const apiKeyStatusLabel = (() => {
     if (!providerRequiresApiKey) return '—';
     if (mode === 'create') return overrideProfileApiKey ? (apiKeyInput.trim() ? 'Draft' : 'Not set') : 'Use provider key';
     if (apiKeyStatus.state === 'loading') return 'Checking…';
     if (apiKeyStatus.state === 'ready') {
       if (apiKeyStatus.hasProfileKey) return 'Override set';
-      if (apiKeyStatus.hasProviderKey) return `Using ${apiKeyStatus.providerKeyName ?? 'provider key'}`;
+      if (apiKeyStatus.hasProviderKey) return '';
       return 'Missing';
     }
     if (apiKeyStatus.state === 'error') return 'Error';
@@ -900,7 +906,17 @@ export function LlmProfilesView(props: {
 
                       {providerRequiresApiKey ? (
                         <div className="flex flex-col items-end gap-2">
-                          <div className="text-xs text-stone-400">{apiKeyStatusLabel}</div>
+                          <div className="text-xs text-stone-400">
+                            {showProviderKeyConfiguredIndicator ? (
+                              <span
+                                className="codicon codicon-check text-green-400"
+                                title="Provider key configured"
+                                aria-label="Provider key configured"
+                              />
+                            ) : (
+                              apiKeyStatusLabel
+                            )}
+                          </div>
                           <label className="flex items-center gap-2 text-xs text-stone-300 select-none">
                             <input
                               type="checkbox"


### PR DESCRIPTION
Implements Beads issue `oh-tab-7ezo`.

- Replaces the visible "Using <KEY_NAME>" provider-key hint in LLM Profiles with a small green check icon.
- Keeps other API key statuses (Override set / Missing / Checking…) unchanged.

Tests
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Provider key configuration status now displays a visual confirmation icon instead of text when a provider key is configured but not actively in use by a profile.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->