### PR TITLE
oh-tab-kge4: drop terminal exitCode back-compat

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -1080,7 +1080,7 @@ const result = await terminal.execute({
 }, context);
 
 console.log(result.stdout);
-console.log(result.exitCode);
+console.log(result.exit_code);
 ```
 
 ### FileEditorTool

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1696,7 +1696,13 @@ export class Agent extends EventEmitter {
     })();
 
     const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs ?? '';
-    const exitCode = record.exit_code ?? record.exitCode;
+    const exitCodeRaw = record.exit_code;
+    const exitCode =
+      typeof exitCodeRaw === 'string' || typeof exitCodeRaw === 'number'
+        ? exitCodeRaw
+        : exitCodeRaw === null
+          ? null
+          : undefined;
     const stdout = typeof record.stdout === 'string' ? record.stdout : undefined;
     const stderr = typeof record.stderr === 'string' ? record.stderr : undefined;
     const timedOut = record.timeout === true;
@@ -1709,7 +1715,7 @@ export class Agent extends EventEmitter {
       const summary = await summarizeTerminalObservationWithGeminiFlash(
         {
           command,
-          exitCode: typeof exitCode === 'string' || typeof exitCode === 'number' ? exitCode : exitCode === null ? null : undefined,
+          exit_code: exitCode,
           stdout,
           stderr,
           timedOut,
@@ -1731,12 +1737,13 @@ export class Agent extends EventEmitter {
 
   private emitTerminalEvents(toolCall: ToolCall, result: unknown): void {
     if (!this.options.onTerminalEvent) return;
-    const payload = result as { command?: string; stdout?: string; stderr?: string; exitCode?: number };
+    const payload = result as { command?: string; stdout?: string; stderr?: string; exit_code?: number | null };
     const commandId = toolCall.id;
     const timestamp = new Date().toISOString();
     const command = this.maskSecretsInText(payload.command ?? toolCall.function.arguments);
     const stdout = payload.stdout ? this.maskSecretsInText(payload.stdout) : null;
     const stderr = payload.stderr ? this.maskSecretsInText(payload.stderr) : null;
+    const exitCode = typeof payload.exit_code === 'number' ? payload.exit_code : 0;
     const events: BashEvent[] = [
       {
         id: randomUUID(),
@@ -1752,7 +1759,7 @@ export class Agent extends EventEmitter {
         timestamp,
         command_id: commandId,
         order: 1,
-        exit_code: payload.exitCode ?? 0,
+        exit_code: exitCode,
         stdout,
         stderr,
       },

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts
@@ -110,7 +110,7 @@ describe('Agent tool message formatting', () => {
       validate: (input) => input as Record<string, unknown>,
       execute: async () => ({
         command: `echo ${secretValue}`,
-        exitCode: 0,
+        exit_code: 0,
         stdout: `hello ${secretValue}`,
         stderr: '',
         timeout: false,

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts
@@ -91,10 +91,10 @@ describe('Agent truncates tool logs and observations', () => {
 
   it('truncates large stdout results in ObservationEvent and tool message', async () => {
     const log = new EventLog();
-    const tool: ToolDefinition<{ command: string }, { stdout: string; exitCode: number }> = {
+    const tool: ToolDefinition<{ command: string }, { stdout: string; exit_code: number }> = {
       name: 'terminal',
       validate: (input) => input as { command: string },
-      execute: async () => ({ stdout: LONG_STDOUT, exitCode: 0 }),
+      execute: async () => ({ stdout: LONG_STDOUT, exit_code: 0 }),
     };
 
     const llm = new MockLLM([

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -30,7 +30,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     const llm = new RecordingLLM('Printed supersecretvalue.');
 
     const summary = await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'echo supersecretvalue', exitCode: 0, stdout: 'supersecretvalue\n', stderr: '' },
+      { command: 'echo supersecretvalue', exit_code: 0, stdout: 'supersecretvalue\n', stderr: '' },
       { secrets, llmClient: llm, maxPromptChars: 10_000 }
     );
 
@@ -51,7 +51,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
 
     const llm = new RecordingLLM('Printed abc.');
     const summary = await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'echo abc', exitCode: 0, stdout: 'abc\n', stderr: '' },
+      { command: 'echo abc', exit_code: 0, stdout: 'abc\n', stderr: '' },
       { secrets, llmClient: llm, maxPromptChars: 10_000 }
     );
 
@@ -68,7 +68,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
   it('falls back to deterministic summary when gemini fails', async () => {
     const secrets = new SecretRegistry();
     const summary = await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'git status', exitCode: 2, stdout: '', stderr: 'fatal: not a git repository' },
+      { command: 'git status', exit_code: 2, stdout: '', stderr: 'fatal: not a git repository' },
       { secrets, llmClient: new ThrowingLLM() }
     );
 
@@ -79,7 +79,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     const secrets = new SecretRegistry();
     const llm = new RecordingLLM('   ');
     const summary = await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'pwd', exitCode: 0, stdout: '/tmp\n', stderr: '' },
+      { command: 'pwd', exit_code: 0, stdout: '/tmp\n', stderr: '' },
       { secrets, llmClient: llm }
     );
 
@@ -90,7 +90,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     const secrets = new SecretRegistry();
     const llm = new RecordingLLM('abcdefghij');
     const summary = await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'echo hello', exitCode: 0, stdout: 'hello\n', stderr: '' },
+      { command: 'echo hello', exit_code: 0, stdout: 'hello\n', stderr: '' },
       { secrets, llmClient: llm, maxSummaryChars: 5 }
     );
 
@@ -102,7 +102,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     const secrets = new SecretRegistry();
     const llm = new RecordingLLM('OK');
     await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'echo', exitCode: 0, stdout: 'from-stdout\n', stderr: '' },
+      { command: 'echo', exit_code: 0, stdout: 'from-stdout\n', stderr: '' },
       { secrets, llmClient: llm, maxOutputChars: 0, maxPromptChars: 10_000 }
     );
 
@@ -120,7 +120,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     const llm = new RecordingLLM('OK');
 
     await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'echo hello', exitCode: 0, stdout: 'hello\n', stderr: '' },
+      { command: 'echo hello', exit_code: 0, stdout: 'hello\n', stderr: '' },
       { secrets, llmClient: llm, maxPromptChars: 1 }
     );
 
@@ -138,7 +138,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     const maxPromptChars = '<output clipped>'.length + 2;
 
     await summarizeTerminalObservationWithGeminiFlash(
-      { command: 'echo hello', exitCode: 0, stdout: 'hello\n', stderr: '' },
+      { command: 'echo hello', exit_code: 0, stdout: 'hello\n', stderr: '' },
       { secrets, llmClient: llm, maxPromptChars }
     );
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -4,7 +4,7 @@ import type { SecretRegistry } from './SecretRegistry';
 
 export interface TerminalObservationInput {
   command: string;
-  exitCode: number | string | null | undefined;
+  exit_code: number | string | null | undefined;
   stdout?: string | null;
   stderr?: string | null;
   timedOut?: boolean;
@@ -56,7 +56,7 @@ const maskSecrets = (text: string, secrets: SecretRegistry): string => {
   return masked;
 };
 
-const summarizeExitCodeFallback = (exitCode: TerminalObservationInput['exitCode']): string => {
+const summarizeExitCodeFallback = (exitCode: TerminalObservationInput['exit_code']): string => {
   const normalized =
     typeof exitCode === 'number' ? exitCode.toString() : typeof exitCode === 'string' && exitCode.trim() ? exitCode.trim() : 'unknown';
   return normalized === '0' ? 'Done.' : `Done (exit code ${normalized}).`;
@@ -77,7 +77,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
   const maxPromptChars = resolveNonNegativeIntOption(options.maxPromptChars, DEFAULT_MAX_PROMPT_CHARS);
   const maxSummaryChars = resolveNonNegativeIntOption(options.maxSummaryChars, DEFAULT_MAX_SUMMARY_CHARS);
 
-  const fallback = truncateSummary(summarizeExitCodeFallback(input.exitCode), maxSummaryChars);
+  const fallback = truncateSummary(summarizeExitCodeFallback(input.exit_code), maxSummaryChars);
   const stdout = typeof input.stdout === 'string' ? input.stdout.trimEnd() : '';
   const stderr = typeof input.stderr === 'string' ? input.stderr.trimEnd() : '';
   const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
@@ -89,7 +89,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
     '- Do not include secrets or long output excerpts.',
     '',
     `Command: ${input.command || '(empty)'}`,
-    `Exit code: ${input.exitCode ?? 'unknown'}`,
+    `Exit code: ${input.exit_code ?? 'unknown'}`,
     `Timed out: ${input.timedOut ? 'yes' : 'no'}`,
     `Output truncated: ${input.wasTruncated ? 'yes' : 'no'}`,
     '',

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -16,16 +16,12 @@ export interface TerminalArgs {
 export interface TerminalResult {
   command?: string | null;
   exit_code?: number | null;
-  // Back-compat for older consumers (e.g. BashEvent adapters).
-  exitCode?: number | null;
   timeout?: boolean;
   stdout?: string;
   stderr?: string;
   previous?: {
     command: string;
     exit_code: number | null;
-    // Back-compat for older consumers (e.g. BashEvent adapters).
-    exitCode: number | null;
     stdout: string;
     stderr: string;
   };
@@ -512,7 +508,7 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
   readonly description = TOOL_DESCRIPTION;
   readonly schema = terminalSchema;
   private session: TerminalSession | null = null;
-  private queue: Promise<TerminalResult> = Promise.resolve({ command: null, exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: '' });
+  private queue: Promise<TerminalResult> = Promise.resolve({ command: null, exit_code: 0, timeout: false, stdout: '', stderr: '' });
 
   async execute(args: z.infer<typeof terminalSchema>, context: ToolContext): Promise<TerminalResult> {
     const run = async (): Promise<TerminalResult> => {
@@ -522,7 +518,7 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
         }
         await this.session?.reset(context.workspace.root);
         this.session = null;
-        return { command: args.command ?? '', exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: 'Terminal session reset.' };
+        return { command: args.command ?? '', exit_code: 0, timeout: false, stdout: '', stderr: 'Terminal session reset.' };
       }
 
       if (!this.session) {
@@ -553,13 +549,11 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
         stdout: result.stdout,
         stderr: result.stderr,
         exit_code: exitCode,
-        exitCode,
         timeout: exitCode === -1,
         previous: result.previous
           ? {
               command: result.previous.command,
               exit_code: result.previous.exitCode,
-              exitCode: result.previous.exitCode,
               stdout: result.previous.stdout,
               stderr: result.previous.stderr,
             }
@@ -569,8 +563,8 @@ export class TerminalTool extends ZodTool<z.infer<typeof terminalSchema>, Termin
 
     const resultPromise = this.queue.then(run, run);
     this.queue = resultPromise.then(
-      () => ({ command: null, exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: '' }),
-      () => ({ command: null, exit_code: 0, exitCode: 0, timeout: false, stdout: '', stderr: '' }),
+      () => ({ command: null, exit_code: 0, timeout: false, stdout: '', stderr: '' }),
+      () => ({ command: null, exit_code: 0, timeout: false, stdout: '', stderr: '' }),
     );
     return resultPromise;
   }

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -200,7 +200,6 @@ describe('TerminalTool session behavior', () => {
 
     expect(next.previous).toBeDefined();
     expect(next.previous?.exit_code).toBe(1);
-    expect(next.previous?.exitCode).toBe(1);
     expect(next.previous?.command).toContain('sleep 0.15');
 
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });


### PR DESCRIPTION
Closes `oh-tab-kge4` by removing the camelCase `exitCode` back-compat fields from TerminalTool results and runtime handling.

Changes:
- TerminalTool now emits only `exit_code` (and `previous.exit_code`).
- Agent terminal summarizer + BashEvent emission use `exit_code` only.
- Updated affected unit tests + doc snippet.

Local checks:
- `npm test`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized exit code property naming in terminal tool results from `exitCode` to `exit_code`. This is a breaking change requiring code updates for users of the TerminalTool.

* **Tests**
  * Updated tests to align with new property naming convention.

* **Documentation**
  * Updated documentation examples to reflect property naming changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->