### PR TITLE
oh-tab-mbei: seed gemini-flash-hal profile

### DIFF
--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -136,8 +136,14 @@ Settings:
 - `openhands.hal.volume`: 0.0–1.0
 - `openhands.hal.cache`: boolean (default `true`)
 - Gemini (only for `voice_confirm`):
-  - `openhands.hal.gemini.model`: string (default: `gemini-2.5-flash`)
-  - `openhands.hal.gemini.baseUrl`: string (default: Gemini API base URL; allow proxies)
+  - LLM profile id: `gemini-flash-hal` (seeded by default)
+    - Provider: `gemini`
+    - Model (default): `gemini-2.5-flash`
+    - Base URL (default): Gemini API base URL (allow proxies)
+    - Configure model/baseUrl via the LLM Profiles UI by editing `gemini-flash-hal`.
+  - Fallback-only (if the profile cannot be loaded):
+    - `openhands.hal.gemini.model`
+    - `openhands.hal.gemini.baseUrl`
   - Settings UI placeholder: `openhands.secrets.geminiLlmApiKey`
   - Stored securely in SecretStorage: `GEMINI_API_KEY` (set via `openhands.setGeminiLlmApiKey`)
 

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -345,6 +345,7 @@ export const deleteProfile = (profileId: string, options: LLMProfileStoreOptions
 
 export const DEFAULT_LLM_PROFILE_IDS = [
   'gemini-flash',
+  'gemini-flash-hal',
   'gemini-flash-summarizer',
   'gpt-5',
   'gpt-5-mini',
@@ -361,6 +362,15 @@ const DEFAULT_LLM_PROFILES: Array<{ profileId: DefaultLlmProfileId; config: LLMC
       model: 'gemini-2.5-flash',
       baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
       profileName: 'Gemini Flash',
+    },
+  },
+  {
+    profileId: 'gemini-flash-hal',
+    config: {
+      provider: 'gemini',
+      model: 'gemini-2.5-flash',
+      baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
+      profileName: 'Gemini Flash (HAL)',
     },
   },
   {

--- a/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { createWebviewMessageHandler } from '../createWebviewMessageHandler';
+
+vi.mock('../../../hal/gemini/decisionClassifier', () => ({
+  classifyHalVoiceDecision: vi.fn(async () => ({ ok: true as const, decision: 'approve_local' as const })),
+}));
+
+vi.mock('../llmProfilesStore', () => ({
+  loadProfile: vi.fn(() => ({
+    profileId: 'gemini-flash-hal',
+    config: { provider: 'gemini', model: 'gemini-2.5-flash', baseUrl: 'https://profiles.example/v1beta' },
+  })),
+  listProfiles: vi.fn(() => []),
+  saveProfile: vi.fn(() => undefined),
+  deleteProfile: vi.fn(() => undefined),
+}));
+
+describe('createWebviewMessageHandler (HAL voice_confirm profile)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode as any).__resetMocks();
+  });
+
+  it('uses gemini-flash-hal LLM profile config when classifying voice decision', async () => {
+    const cfg = {
+      get: vi.fn((key: string, defaultValue?: unknown) => defaultValue),
+      inspect: vi.fn(() => ({})),
+      update: vi.fn(async () => undefined),
+    };
+
+    (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
+
+    const context = {
+      secrets: {
+        get: vi.fn(async (key: string) => (key === 'GEMINI_API_KEY' ? 'secret' : undefined)),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      },
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context,
+      host: { postMessage },
+      secretRegistry: { get: vi.fn(async (key: string) => (key === 'GEMINI_API_KEY' ? 'secret' : undefined)) } as any,
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp/openhands-conversations',
+      setWebviewReadyState: () => undefined,
+      setLastKnownLlmLabel: () => undefined,
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => undefined,
+      onRenderedEventsResponse: () => undefined,
+      onUiStateResponse: () => undefined,
+      onHalStateResponse: () => undefined,
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => undefined,
+    });
+
+    await handler({
+      type: 'halVoiceConfirmRequest',
+      requestId: 'r1',
+      mimeType: 'audio/wav',
+      audioBase64: 'Zm9v',
+    });
+
+    const { classifyHalVoiceDecision } = await import('../../../hal/gemini/decisionClassifier');
+    expect(classifyHalVoiceDecision).toHaveBeenCalledWith(expect.objectContaining({
+      baseUrl: 'https://profiles.example/v1beta',
+      model: 'gemini-2.5-flash',
+      apiKey: 'secret',
+    }));
+  });
+});

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -971,6 +971,23 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         }
 
         const settings = await settingsMgr.get();
+
+        const halGeminiConfig = (() => {
+          let baseUrl = settings.gemini.baseUrl;
+          let model = settings.gemini.model;
+          try {
+            const profile = llmProfilesStore.loadProfile('gemini-flash-hal', llmProfileStoreOptions());
+            const baseUrlFromProfile = typeof profile.config.baseUrl === 'string' ? profile.config.baseUrl.trim() : '';
+            const modelFromProfile = typeof profile.config.model === 'string' ? profile.config.model.trim() : '';
+            if (baseUrlFromProfile) baseUrl = baseUrlFromProfile;
+            if (modelFromProfile) model = modelFromProfile;
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            outputChannel?.appendLine(`[hal] Failed to load gemini-flash-hal profile; falling back to settings: ${reason}`);
+          }
+          return { baseUrl, model };
+        })();
+
         // Use the global Gemini provider key for HAL as well.
         // Preference order:
         // 1) SecretRegistry (VS Code SecretStorage key 'GEMINI_API_KEY', then process.env.GEMINI_API_KEY)
@@ -988,9 +1005,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         }
 
         const result = await classifyHalVoiceDecision({
-          baseUrl: settings.gemini.baseUrl,
+          baseUrl: halGeminiConfig.baseUrl,
           apiKey: halGeminiKey,
-          model: settings.gemini.model,
+          model: halGeminiConfig.model,
           mimeType: message.mimeType,
           audioBase64: message.audioBase64,
         });


### PR DESCRIPTION
Closes `oh-tab-mbei`.

- Adds a seeded default LLM profile `gemini-flash-hal` (provider `gemini`, default model `gemini-2.5-flash`).
- HAL `voice_confirm` decision classification now reads model/baseUrl from that profile (fallback to `openhands.hal.gemini.*` settings if the profile can't be loaded).
- Updates HAL PRD doc + adds a small host unit test.

Local checks: `npm test`, `npm run lint`, `npm run typecheck`.
