### PR TITLE
oh-tab-ula0: add FinishTool

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1271,6 +1271,7 @@ export class Agent extends EventEmitter {
 
     return definitions.map((tool): LLMToolDefinition => {
       const fn = tool.function;
+      if (fn.name === 'finish') return tool;
       const parameters =
         fn.parameters && typeof fn.parameters === 'object' && !Array.isArray(fn.parameters)
           ? (fn.parameters as Record<string, unknown>)

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -30,6 +30,7 @@ import {
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import { FinishTool } from '../../tools/FinishTool';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
 import { LLMSummarizingCondenser } from '../context';
@@ -273,6 +274,7 @@ export class Agent extends EventEmitter {
   private orchestratorPromise?: Promise<AgentOrchestrator>;
   private paused = false;
   private cancelled = false;
+  private finished = false;
   private pendingAction?: { toolCall: ToolCall; actionEvent: ActionEvent; args: Record<string, unknown> };
   private pendingWorkspaceAccess?: { paths: string[] };
   private readonly agentContext?: AgentContext;
@@ -295,7 +297,10 @@ export class Agent extends EventEmitter {
     this.state.attachEventLog(this.events);
     this.secrets = options.secrets ?? new SecretRegistry();
     const providedTools = options.tools ?? [];
-    this.tools = new Map(providedTools.map((tool) => [tool.name, tool]));
+    const toolsWithFinish = providedTools.some((tool) => tool.name === 'finish')
+      ? providedTools
+      : [...providedTools, new FinishTool()];
+    this.tools = new Map(toolsWithFinish.map((tool) => [tool.name, tool]));
     this.registry = options.registry;
     this.conversationStats = options.conversationStats;
     this.confirmation = { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true };
@@ -645,6 +650,7 @@ export class Agent extends EventEmitter {
 
   async run(input: AgentRunInput): Promise<Message | undefined> {
     this.cancelled = false;
+    this.finished = false;
     return this.lock.acquire(async () => {
       this.ensureSystemPrompt();
       this.pushUserMessage(input);
@@ -742,7 +748,7 @@ export class Agent extends EventEmitter {
   }
 
   private async runLoop(): Promise<Message | undefined> {
-    if (this.paused || this.pendingAction || this.cancelled) {
+    if (this.paused || this.pendingAction || this.cancelled || this.finished) {
       return undefined;
     }
 
@@ -761,7 +767,7 @@ export class Agent extends EventEmitter {
     }
     let lastAssistantMessage: Message | undefined;
 
-    while (!this.paused && !this.pendingAction && !this.cancelled && this.state.snapshot.iteration < maxIterations) {
+    while (!this.paused && !this.pendingAction && !this.cancelled && !this.finished && this.state.snapshot.iteration < maxIterations) {
       this.state.setStatus('RUNNING');
       const llmConfig = this.getEffectiveLlmConfigForCondensation();
       let response: Awaited<ReturnType<AgentOrchestrator['runChat']>> | undefined;
@@ -890,6 +896,7 @@ export class Agent extends EventEmitter {
       }
 
       let toolExecutionFailed = false;
+      let finishedThisTurn = false;
       for (const toolCall of toolCalls) {
         // Log raw tool call for debugging visibility
         try {
@@ -927,6 +934,11 @@ export class Agent extends EventEmitter {
         const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
         const recordedAction = this.events.push(actionEvent) as ActionEvent;
 
+        if (finishedThisTurn) {
+          this.emitSkippedToolCall(toolCall, recordedAction, 'Skipped: finish tool already called in this run.');
+          continue;
+        }
+
         const workspaceAccess = this.getRequiredWorkspaceAccess(toolCall.function.name, actionArgs);
         if (workspaceAccess) {
           this.pauseForConfirmation({ toolCall, actionEvent: recordedAction, args: actionArgs }, workspaceAccess);
@@ -940,6 +952,10 @@ export class Agent extends EventEmitter {
 
         try {
           await this.executeTool(toolCall, recordedAction, actionArgs);
+          if (toolCall.function.name === 'finish') {
+            finishedThisTurn = true;
+            this.finished = true;
+          }
         } catch (error) {
           if (error instanceof ClassifiedToolExecutionError && error.classification === 'conversation') {
             this.events.push(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
@@ -949,6 +965,11 @@ export class Agent extends EventEmitter {
           toolExecutionFailed = true;
           // Continue processing other tool calls but mark this iteration as failed
         }
+      }
+
+      if (finishedThisTurn) {
+        this.state.setStatus('IDLE');
+        break;
       }
 
       if (toolExecutionFailed) {
@@ -1526,6 +1547,7 @@ export class Agent extends EventEmitter {
   }
 
   private requiresConfirmation(action: ActionEvent): boolean {
+    if (action.tool_name === 'finish') return false;
     const policy = this.confirmation.policy ?? 'never';
     if (policy === 'never') return false;
     if (policy === 'always') return true;
@@ -1533,6 +1555,29 @@ export class Agent extends EventEmitter {
     if (!risk) return this.confirmation.confirmUnknown ?? true;
     const threshold = this.confirmation.riskyThreshold ?? 'MEDIUM';
     return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(threshold);
+  }
+
+  private emitSkippedToolCall(toolCall: ToolCall, actionEvent: ActionEvent, reason: string): void {
+    const maskedReason = this.maskSecretsInText(reason);
+    const clipped = truncateToolMessage(maskedReason);
+    this.events.push({
+      kind: 'ObservationEvent',
+      source: 'environment',
+      observation: { skipped: true, reason: maskedReason },
+      tool_name: toolCall.function.name,
+      tool_call_id: toolCall.id,
+      action_id: actionEvent.id ?? randomUUID(),
+    } as Event);
+    this.events.push({
+      kind: 'MessageEvent',
+      source: 'environment',
+      llm_message: {
+        role: 'tool',
+        tool_call_id: toolCall.id,
+        name: toolCall.function.name,
+        content: [{ type: 'text', text: clipped }],
+      },
+    } as Event);
   }
 
   private getRequiredWorkspaceAccess(

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.finish-tool.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.finish-tool.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, EventLog } from '../';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import type { Event } from '../../types';
+import { isObservationEvent } from '../../types';
+import type { OpenHandsSettings } from '../../types/settings';
+import type { ToolDefinition } from '../../types/tools';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 2 },
+  confirmation: { policy: 'always', confirmUnknown: true, riskyThreshold: 'MEDIUM' },
+  secrets: {},
+};
+
+describe('FinishTool', () => {
+  it('stops the run and skips subsequent tool calls in the same batch', async () => {
+    const log = new EventLog();
+    let executed = 0;
+
+    const terminalTool: ToolDefinition<{ command: string }, { stdout: string }> = {
+      name: 'terminal',
+      validate: (input) => input as { command: string },
+      execute: async () => {
+        executed += 1;
+        return { stdout: 'hi' };
+      },
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tools' },
+      { type: 'tool_call_delta', id: 'f1', name: 'finish', arguments: JSON.stringify({ message: 'done' }) },
+      { type: 'tool_call_delta', id: 't1', name: 'terminal', arguments: JSON.stringify({ command: 'echo hi' }) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/tmp', llmClient: llm, tools: [terminalTool] });
+    await agent.run('go');
+
+    expect(executed).toBe(0);
+    expect(agent.state.snapshot.status).toBe('IDLE');
+
+    const events = log.list() as Event[];
+    const terminalObs = events.find((evt) => isObservationEvent(evt) && evt.tool_name === 'terminal');
+    expect(terminalObs).toBeTruthy();
+    const observation = (terminalObs as any).observation as Record<string, unknown>;
+    expect(observation.skipped).toBe(true);
+  });
+
+  it('never requires confirmation even when policy=always', async () => {
+    const log = new EventLog();
+    const llm = new MockLLM([
+      { type: 'text', text: 'All done' },
+      { type: 'tool_call_delta', id: 'f1', name: 'finish', arguments: JSON.stringify({ message: 'done' }) },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: '/tmp', llmClient: llm, tools: [] });
+    await agent.run('go');
+
+    expect(agent.state.snapshot.status).toBe('IDLE');
+    expect(log.list().some((evt) => evt.kind === 'PauseEvent')).toBe(false);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/tools/FinishTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FinishTool.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+import type { ToolContext } from './types';
+import { ZodTool } from './zod-tool';
+
+const finishSchema = z.object({
+  message: z
+    .string()
+    .optional()
+    .describe('Optional short final message describing why the agent is finished.'),
+});
+
+export type FinishToolArgs = z.infer<typeof finishSchema>;
+
+export type FinishToolResult = {
+  message?: string;
+};
+
+export class FinishTool extends ZodTool<FinishToolArgs, FinishToolResult> {
+  readonly name = 'finish';
+  readonly description = 'Signal that the agent is finished and should stop the current run.';
+  readonly schema = finishSchema;
+
+  execute(args: FinishToolArgs, _context: ToolContext): Promise<FinishToolResult> {
+    const message = typeof args.message === 'string' ? args.message.trim() : '';
+    return Promise.resolve(message ? { message } : {});
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/index.ts
+++ b/packages/agent-sdk-ts/src/tools/index.ts
@@ -2,6 +2,7 @@ export * from './IntegratedTerminalRunner';
 export * from './TerminalTool';
 export * from './FileEditorTool';
 export * from './TaskTrackerTool';
+export * from './FinishTool';
 export * from './BrowserTool';
 export * from './BrowserUseTool';
 export * from './DelegateTool';


### PR DESCRIPTION
Closes `oh-tab-ula0`.

- Adds `FinishTool` to `@openhands/agent-sdk-ts` and exports it.
- Agent runtime always includes `finish` tool and treats it as a stop sentinel:
  - never requires confirmation
  - stops the current run when called
  - skips (synthetically resolves) subsequent tool calls in the same batch
- Adds unit tests covering stop behavior + confirmation exemption.

Local checks: `npm test`, `npm run lint`, `npm run typecheck`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a finish tool enabling agents to explicitly signal task completion and gracefully end runs.
  * Finish tool immediately stops subsequent tool execution once invoked, preventing unintended cascading actions in the same batch.
  * Finish tool bypasses confirmation requirements across all policies, allowing seamless task completion without user prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->