### PR TITLE
oh-tab-g0zf: prompt profile creation when none exist

### DIFF
--- a/src/webview-src/__tests__/LlmProfileDropdown.test.tsx
+++ b/src/webview-src/__tests__/LlmProfileDropdown.test.tsx
@@ -46,6 +46,22 @@ describe('LLM profile dropdown', () => {
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
   });
 
+  it('opens the Profiles view in create mode when no profiles exist', async () => {
+    render(<App />);
+    mockApi.postMessage.mockClear();
+
+    postToWindow({ type: 'llmProfilesUpdated', profiles: [], activeProfileId: null });
+
+    fireEvent.click(screen.getByLabelText('LLM profile'));
+
+    await screen.findByText('OpenHands - LLM Profiles');
+    expect(screen.getByText('Create a new profile')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfilesListRequest')).toBeTruthy();
+    });
+  });
+
   it('closes on selection and shows the selected profile when reopened', async () => {
     render(<App />);
     mockApi.postMessage.mockClear();

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -445,13 +445,17 @@ function LlmProfileSelector({
 
   const normalizedFallbackLabel = typeof fallbackLabel === 'string' ? fallbackLabel.trim() : '';
   const hasFallback = normalizedFallbackLabel.length > 0;
-  const shown = profileId ?? (hasFallback ? `None (${normalizedFallbackLabel})` : 'None');
+  const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
+  const hasProfiles = sanitizedProfiles.length > 0;
+  const shouldPromptCreate = profileId === null && !hasProfiles && Boolean(onOpenCreate);
+  const shown = profileId ?? (shouldPromptCreate ? 'New profile…' : (hasFallback ? `None (${normalizedFallbackLabel})` : 'None'));
   const tooltip = profileId
     ? `LLM profile: ${profileId}`
-    : hasFallback
-      ? `LLM profile: None (using ${normalizedFallbackLabel})`
-      : 'LLM profile: None';
-  const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
+    : shouldPromptCreate
+      ? 'LLM profile: New profile…'
+      : hasFallback
+        ? `LLM profile: None (using ${normalizedFallbackLabel})`
+        : 'LLM profile: None';
 
   const handleSelect = (next: string | null) => {
     onSelect(next);
@@ -464,7 +468,13 @@ function LlmProfileSelector({
     <div className="relative">
       <button
         type="button"
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => {
+          if (shouldPromptCreate && onOpenCreate) {
+            onOpenCreate();
+            return;
+          }
+          setIsOpen((prev) => !prev);
+        }}
         className={`
           inline-flex items-center gap-2
           px-3 py-2 rounded-lg


### PR DESCRIPTION
When there are no LLM profiles and `activeProfileId` is `null`, clicking the profile selector now opens LLM Profiles directly in *create* mode (instead of opening an empty dropdown that just shows “None”).

- Updates `LlmProfileSelector` in `src/webview-src/components/InputArea.tsx`
- Adds a small regression test in `src/webview-src/__tests__/LlmProfileDropdown.test.tsx`

Bead: `oh-tab-g0zf`