### PR TITLE
oh-tab-ot3z: profiles-only overrides in LLMFactory

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.gemini-profile-generation-config.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.gemini-profile-generation-config.test.ts
@@ -62,5 +62,64 @@ describe('LLMFactory (Gemini): generationConfig from profile', () => {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
-});
 
+  it('ignores generationConfig overrides when profileId is set', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-sdk-gemini-profile-'));
+    const originalFetch = globalThis.fetch;
+    try {
+      saveProfile(
+        'test-gemini-profile',
+        {
+          provider: 'gemini',
+          model: 'gemini-2.5-flash',
+          baseUrl: DEFAULT_PROVIDER_BASE_URLS.gemini,
+          profileName: 'Test Gemini Profile',
+          temperature: 0.42,
+          maxOutputTokens: 123,
+        },
+        { rootDir: dir },
+      );
+
+      const secrets = new SecretRegistry();
+      secrets.set('GEMINI_API_KEY', 'test-gemini-key');
+
+      const factory = new LLMFactory(
+        {
+          profileId: 'test-gemini-profile',
+          // NOTE: model is required by the type but ignored by LLMFactory when profileId is present.
+          model: 'unused',
+          usageId: 'test-gemini-client',
+          // Should not override the profile config when using profileId.
+          temperature: 0.9,
+          maxOutputTokens: 999,
+        },
+        { secrets, preferredApiKeys: 'GEMINI_API_KEY', profileStoreOptions: { rootDir: dir } },
+      );
+      const client = await factory.createClient();
+
+      let capturedBody: any | null = null;
+      const fetchMock = vi.fn(async (_url: string, init?: any) => {
+        capturedBody = JSON.parse(init?.body ?? '{}');
+        return new Response('data: [DONE]\n\n', {
+          status: 200,
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      });
+      globalThis.fetch = fetchMock as any;
+
+      for await (const chunk of client.streamChat({
+        systemPrompt: 'You are a test.',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      })) {
+        if (chunk.type === 'finish') break;
+      }
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(capturedBody).toBeTruthy();
+      expect(capturedBody.generationConfig).toEqual({ temperature: 0.42, maxOutputTokens: 123 });
+    } finally {
+      globalThis.fetch = originalFetch;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -59,11 +59,13 @@ export class LLMFactory {
       const requestedProfileName = normalizeOptionalString(this.config.profileName);
       if (requestedProfileName) merged.profileName = requestedProfileName;
 
-      for (const [key, value] of Object.entries(this.config)) {
-        if (value === undefined) continue;
-        if (key === 'profileId' || key === 'profileName' || key === 'provider' || key === 'model') continue;
-        (merged as unknown as Record<string, unknown>)[key] = value;
-      }
+      // Profiles-first: when `profileId` is set, treat the profile config as the single source
+      // of truth for provider/model/baseUrl/generation config. Only allow a small override
+      // set for runtime bookkeeping/secrets.
+      const requestedUsageId = normalizeOptionalString(this.config.usageId);
+      if (requestedUsageId) merged.usageId = requestedUsageId;
+      const requestedApiKey = normalizeOptionalString(this.config.apiKey);
+      if (requestedApiKey) merged.apiKey = requestedApiKey;
       return merged;
     })();
 

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -85,6 +85,29 @@ export async function run(): Promise<void> {
       geminiStreamGenerateContent: '/v1beta/models/gemini-2.5-flash:streamGenerateContent',
     } as const;
 
+    // For profiles-first behavior, tests must create profiles that point at the mock server
+    // (profile config should be the source of truth; settings overrides should not be needed).
+    const e2eProfiles = {
+      sonnet: 'e2e-switch-sonnet',
+      gpt5Mini: 'e2e-switch-gpt-5-mini',
+    } as const;
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: e2eProfiles.sonnet,
+      profile: {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+        baseUrl: v1BaseUrl,
+      },
+    });
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: e2eProfiles.gpt5Mini,
+      profile: {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        baseUrl: v1BaseUrl,
+      },
+    });
+
     // 1) Anthropic
     await setLlmConfig({
       profileId: null,
@@ -245,7 +268,7 @@ export async function run(): Promise<void> {
       context: 'step 7: gemini',
     });
 
-    // 8) LLM profile selection: Sonnet profile should override raw provider/model.
+    // 8) LLM profile selection: profile should override raw provider/model/baseUrl.
     await setLlmConfig({
       profileId: null,
       provider: 'openai',
@@ -256,7 +279,7 @@ export async function run(): Promise<void> {
 
     const setProfile = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
       action: 'setLlmProfileId',
-      payload: { profileId: 'sonnet-45' },
+      payload: { profileId: e2eProfiles.sonnet },
     });
     if (!setProfile?.sent) {
       throw new Error(`setLlmProfileId action was not sent: ${JSON.stringify(setProfile)}`);
@@ -265,36 +288,36 @@ export async function run(): Promise<void> {
     await pollUntil(async () => {
       const inspected = vscode.workspace.getConfiguration().inspect<string>('openhands.llm.profileId');
       const value = inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
-      return value === 'sonnet-45';
+      return value === e2eProfiles.sonnet;
     }, 15000);
     const profileSonnetReq = await sendAndWaitForRequestPath({
-      text: 'E2E step 8: profile sonnet-45',
+      text: `E2E step 8: profile ${e2eProfiles.sonnet}`,
       expectedPath: expectedPaths.anthropicMessages,
       getRequests: () => mock.requests,
     });
     assertRequestHeaders(profileSonnetReq, {
       present: ['x-api-key', 'anthropic-version'],
       absent: ['authorization', 'x-goog-api-key'],
-      context: 'step 8: profile sonnet-45',
+      context: `step 8: profile ${e2eProfiles.sonnet}`,
     });
 
-    // 9) LLM profile selection: gpt-5-mini profile should override raw provider/model.
+    // 9) LLM profile selection: profile should override raw provider/model/baseUrl.
     await setLlmConfig({
-      profileId: 'gpt-5-mini',
+      profileId: e2eProfiles.gpt5Mini,
       provider: 'anthropic',
       model: 'claude-sonnet-4-20250514',
       openaiApiMode: 'auto',
       baseUrl: v1BaseUrl,
     });
     const profileGptReq = await sendAndWaitForRequestPath({
-      text: 'E2E step 9: profile gpt-5-mini',
+      text: `E2E step 9: profile ${e2eProfiles.gpt5Mini}`,
       expectedPath: expectedPaths.openaiChatCompletions,
       getRequests: () => mock.requests,
     });
     assertRequestHeaders(profileGptReq, {
       present: ['authorization'],
       absent: ['x-api-key', 'x-goog-api-key'],
-      context: 'step 9: profile gpt-5-mini',
+      context: `step 9: profile ${e2eProfiles.gpt5Mini}`,
     });
 
     // Basic sanity: at least one request per step.


### PR DESCRIPTION
Makes `LLMFactory` treat the loaded profile config as the single source of truth when `profileId` is set.

- Stops applying arbitrary config overrides on top of a profile (provider/model/baseUrl/generation config)
- Still allows a small override set needed for runtime wiring: `usageId` + `apiKey` (+ optional `profileName` label override)
- Adds a regression test ensuring generationConfig overrides are ignored for Gemini profiles

Bead: `oh-tab-ot3z`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modified configuration precedence: profile settings now take priority when profileId is specified; only API key and usage tracking can be overridden at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
