### PR TITLE
oh-tab-u3yb: auto-note user edits on save

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
@@ -232,6 +232,25 @@ describe('LocalConversation', () => {
     }
   });
 
+  it('records user messages without running when run=false', async () => {
+    const llm = new RecordingLLM();
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, tools: createDefaultTools() });
+
+    const events: Event[] = [];
+    conversation.on('event', (e: Event) => events.push(e));
+
+    await conversation.startNewConversation();
+    await conversation.sendUserMessage('Environment note: user edited file:\n/tmp/example.txt', { run: false });
+
+    expect(llm.requests).toHaveLength(0);
+    const userMessage = events.find((e): e is MessageEvent => isMessageEvent(e) && e.source === 'user');
+    expect(userMessage?.llm_message).toEqual({
+      role: 'user',
+      content: [{ type: 'text', text: 'Environment note: user edited file:\n/tmp/example.txt' }],
+    });
+    expect(events.some((e) => isMessageEvent(e) && e.source === 'agent')).toBe(false);
+  });
+
   it('supports tool introspection and updates tools only before user messages', async () => {
     const llm = new RecordingLLM();
     const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, tools: createDefaultTools() });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -199,12 +199,23 @@ export class LocalConversation extends EventEmitter {
     }
   }
 
-  async sendUserMessage(text: string) {
+  async sendUserMessage(text: string, options?: { run?: boolean }) {
+    const run = options?.run !== false;
     await this.lock.acquire(async () => {
       if (!this.conversationId) {
         await this.startNewConversation();
       }
       this.hasUserMessage = true;
+
+      if (!run) {
+        this.events.push({
+          kind: 'MessageEvent',
+          source: 'user',
+          llm_message: { role: 'user', content: [{ type: 'text', text }] },
+        } as Event);
+        return;
+      }
+
       await this.agent.run(text);
     });
   }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
@@ -150,4 +150,48 @@ describe('RemoteConversation', () => {
     ]);
     expect(parsed.workspace).toEqual({ kind: 'LocalWorkspace', working_dir: workspaceRoot });
   });
+
+  it('sends messages with run=false via HTTP', async () => {
+    const connectSpy = vi
+      .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')
+      .mockImplementation(() => {});
+
+    const fetchSpy = vi.fn((url: string, init?: RequestInit) => {
+      if (url === 'http://localhost:3000/api/conversations') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'conv-run-false' }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      if (url === 'http://localhost:3000/api/conversations/conv-run-false/events') {
+        const parsed = JSON.parse(init?.body as string) as { run?: unknown; role?: unknown; content?: unknown };
+        expect(parsed.run).toBe(false);
+        expect(parsed.role).toBe('user');
+        expect(Array.isArray(parsed.content)).toBe(true);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+    });
+
+    await conversation.startNewConversation();
+    await conversation.sendUserMessage('Environment note', { run: false });
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -392,28 +392,30 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
-  async sendUserMessage(text: string) {
+  async sendUserMessage(text: string, options?: { run?: boolean }) {
+    const run = options?.run !== false;
     if (!this.conversationId) {
       const id = await this.startNewConversation();
       if (!id) return;
     }
     const messagePayload: Message = { role: 'user', content: [{ type: 'text', text }] };
-    if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+    if (run && this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(messagePayload));
-    } else {
-      try {
-        const base = this.serverUrl.replace(/\/$/, '');
-        const headers = this.getAuthHeaders();
-        const httpPayload = { ...messagePayload, run: true };
-        const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/events`, {
-          method: 'POST', headers, body: JSON.stringify(httpPayload)
-        }, RemoteConversation.httpTimeoutMs);
-        if (!res.ok) {
-          const info = await res.text().catch(() => '');
-          this.emit('error', new Error(`Failed to send message (HTTP ${res.status})${info ? `: ${info}` : ''}`));
-        }
-      } catch (e) { this.emit('error', e); }
+      return;
     }
+
+    try {
+      const base = this.serverUrl.replace(/\/$/, '');
+      const headers = this.getAuthHeaders();
+      const httpPayload = { ...messagePayload, run };
+      const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/events`, {
+        method: 'POST', headers, body: JSON.stringify(httpPayload)
+      }, RemoteConversation.httpTimeoutMs);
+      if (!res.ok) {
+        const info = await res.text().catch(() => '');
+        this.emit('error', new Error(`Failed to send message (HTTP ${res.status})${info ? `: ${info}` : ''}`));
+      }
+    } catch (e) { this.emit('error', e); }
   }
 
   disconnect() {

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
 import type { BashEvent, ConversationInstance, Event } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
 import type { HostToWebviewMessage } from '../../shared/webviewMessages';
@@ -17,6 +18,8 @@ export type AttachConversationListenersDeps = {
 
   bufferConversationEvent: (event: Event) => number;
   resetConversationEventBacklog: (conversationId: string | undefined) => void;
+  trackAgentEditedFile?: (filePath: string) => void;
+  resetAgentEditedFiles?: () => void;
   safeStringify: (value: unknown) => string;
   renderError: (err: unknown) => string;
   handleTerminalEvent: (event: BashEvent) => void;
@@ -69,6 +72,19 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
         }
       }
       return;
+    }
+
+    try {
+      if (ev.kind === 'ObservationEvent' && ev.tool_name === 'file_editor') {
+        const observation = ev.observation as { command?: unknown; path?: unknown } | undefined;
+        const command = typeof observation?.command === 'string' ? observation.command : undefined;
+        const filePath = typeof observation?.path === 'string' ? observation.path : undefined;
+        if (command && command !== 'view' && filePath && path.isAbsolute(filePath)) {
+          deps.trackAgentEditedFile?.(filePath);
+        }
+      }
+    } catch (e) {
+      outputChannel?.appendLine(`[error] Failed to track agent-edited files: ${String(e)}`);
     }
 
     if (!isLlmStreamUpdate) {
@@ -131,6 +147,7 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     streamingState = initialLlmStreamingState;
 
     deps.resetConversationEventBacklog(id);
+    deps.resetAgentEditedFiles?.();
     const mode = deps.getConversationMode();
     const scopedKey = mode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
     void deps.context.workspaceState.update(scopedKey, id);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,11 @@ const sentTestEvents: Event[] = [];
 const MAX_PRINTED_EXIT_FOR = MAX_TERMINAL_EVENTS;
 const printedExitFor = new Map<string, true>();
 
+// Tracks which files the agent has edited during the current conversation.
+const agentEditedFiles = new Set<string>();
+const lastUserEditNoteAtMs = new Map<string, number>();
+const USER_EDIT_NOTE_DEBOUNCE_MS = 5000;
+
 function markPrintedExitFor(commandId: string): void {
   // LRU-ish: bump recency on re-add
   if (printedExitFor.has(commandId)) {
@@ -249,6 +254,38 @@ function execFileText(command: string, args: string[], cwd?: string): Promise<st
       resolve(typeof stdout === 'string' ? stdout : String(stdout));
     });
   });
+}
+
+async function getGitHeadDiffSummaryForFile(filePath: string): Promise<string> {
+  const cwd = path.dirname(filePath);
+  let root: string;
+  try {
+    root = (await execFileText('git', ['rev-parse', '--show-toplevel'], cwd)).trim();
+  } catch {
+    return '(no HEAD available)';
+  }
+
+  const relative = path.relative(root, filePath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return '(no HEAD available)';
+  }
+
+  const isTracked = await execFileText('git', ['ls-files', '--error-unmatch', '--', relative], root)
+    .then(() => true)
+    .catch(() => false);
+  if (!isTracked) {
+    return '(no HEAD available: untracked file)';
+  }
+
+  try {
+    const stat = await execFileText('git', ['diff', '--no-color', '--stat', 'HEAD', '--', relative], root);
+    const trimmed = stat.trim();
+    if (!trimmed) return '(no changes vs HEAD)';
+    const maxChars = 2000;
+    return trimmed.length > maxChars ? `${trimmed.slice(0, maxChars)}\n…(truncated)` : trimmed;
+  } catch {
+    return '(no HEAD available)';
+  }
 }
 
 async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ repoName: string; branchName: string }> {
@@ -495,6 +532,32 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  context.subscriptions.push(
+    vscode.workspace.onDidSaveTextDocument((document) => {
+      void (async () => {
+        const activeConversation = conversation;
+        if (!activeConversation?.getConversationId()) return;
+        if (document.uri.scheme !== 'file') return;
+
+        const filePath = document.uri.fsPath;
+        if (!agentEditedFiles.has(filePath)) return;
+
+        const now = Date.now();
+        const last = lastUserEditNoteAtMs.get(filePath);
+        if (typeof last === 'number' && now - last < USER_EDIT_NOTE_DEBOUNCE_MS) return;
+        lastUserEditNoteAtMs.set(filePath, now);
+
+        const diffSummary = await getGitHeadDiffSummaryForFile(filePath);
+        const note = ['Environment note: user edited file:', filePath, diffSummary].join('\n');
+        try {
+          await activeConversation.sendUserMessage(note, { run: false });
+        } catch (err) {
+          outputChannel?.appendLine(`[error] Failed to record user edit note: ${renderError(err)}`);
+        }
+      })();
+    })
+  );
+
   const handleTerminalEvent = (event: BashEvent) => {
     receivedTerminalEvents.push({ type: event.type, timestamp: Date.now() });
     if (receivedTerminalEvents.length > MAX_TERMINAL_EVENTS) {
@@ -632,6 +695,8 @@ export function activate(context: vscode.ExtensionContext) {
         conversation?.removeAllListeners();
         conversation?.disconnect();
       } catch {}
+      agentEditedFiles.clear();
+      lastUserEditNoteAtMs.clear();
 
       const persistenceDir =
         desiredMode === 'local'
@@ -689,6 +754,13 @@ export function activate(context: vscode.ExtensionContext) {
         isVerboseEventLogging: () => verboseEventLogging,
         bufferConversationEvent,
         resetConversationEventBacklog,
+        trackAgentEditedFile: (filePath) => {
+          agentEditedFiles.add(filePath);
+        },
+        resetAgentEditedFiles: () => {
+          agentEditedFiles.clear();
+          lastUserEditNoteAtMs.clear();
+        },
         transformEventForWebview: (event, webview) => transformEventForWebviewWithPastedImages(event, { webview, pastedImagesBaseDir }),
         safeStringify,
         renderError,

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -7,6 +7,7 @@ const mockCommands = new Map<string, Function>();
 const mockSubscriptions: Array<{ dispose: () => void }> = [];
 const mockConfigListeners: Function[] = [];
 const mockActiveTextEditorListeners: Function[] = [];
+const mockSaveTextDocumentListeners: Function[] = [];
 const mockConfigValues = new Map<string, any>();
 const mockWebviewViewProviders = new Map<string, any>();
 
@@ -34,6 +35,12 @@ export const workspace = {
   registerTextDocumentContentProvider: vi.fn(() => ({ dispose: vi.fn() })),
   onDidChangeConfiguration: vi.fn((listener: Function) => {
     mockConfigListeners.push(listener);
+    const disposable = { dispose: vi.fn() };
+    mockSubscriptions.push(disposable);
+    return disposable;
+  }),
+  onDidSaveTextDocument: vi.fn((listener: Function) => {
+    mockSaveTextDocumentListeners.push(listener);
     const disposable = { dispose: vi.fn() };
     mockSubscriptions.push(disposable);
     return disposable;
@@ -170,6 +177,7 @@ export function __resetMocks() {
   mockSubscriptions.length = 0;
   mockConfigListeners.length = 0;
   mockActiveTextEditorListeners.length = 0;
+  mockSaveTextDocumentListeners.length = 0;
   mockConfigValues.clear();
   mockWebviewViewProviders.clear();
   // Reset common spies to default implementations
@@ -179,6 +187,7 @@ export function __resetMocks() {
   ;(mockConfiguration.update as any).mockClear();
   ;(workspace.registerTextDocumentContentProvider as any).mockClear();
   ;(workspace.onDidChangeConfiguration as any).mockClear();
+  ;(workspace.onDidSaveTextDocument as any).mockClear();
   ;(window.showInformationMessage as any).mockClear();
   ;(window.showErrorMessage as any).mockClear();
   ;(window.showWarningMessage as any).mockClear();
@@ -205,4 +214,8 @@ export function __triggerConfigChange(e: any) {
 
 export function __triggerActiveTextEditorChange(editor: any) {
   mockActiveTextEditorListeners.forEach((listener) => listener(editor));
+}
+
+export function __triggerDidSaveTextDocument(document: any) {
+  mockSaveTextDocumentListeners.forEach((listener) => listener(document));
 }


### PR DESCRIPTION
Implements oh-tab-u3yb: when the agent edits a file (file_editor write observation), saving that file in VS Code injects a synthetic user note into the conversation history (debounced per file). The note includes a best-effort git HEAD ↔ working diff stat.

Key points:
- Uses sendUserMessage(note, { run: false }) to append without running.
- Works for both local and remote conversations (remote uses POST /events with run=false).

Tests:
- npm test
- npm run lint
- npm run typecheck (after npm run build -w @openhands/agent-sdk-ts)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now send messages without triggering agent execution using the `run: false` option.
  * The system now tracks files edited by the agent and automatically notifies the conversation when users modify those files, including a summary of changes.

* **Tests**
  * Added test coverage for sending messages without agent execution in both local and remote conversation scenarios.
  * Updated test infrastructure to support document save event simulation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->