### PR TITLE
oh-tab-ycg2: extract sanitizeChatMessages

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -40,6 +40,7 @@ import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
 import { getGeminiClient } from './geminiClient';
 import { summarizeTerminalObservationWithGeminiFlash } from './terminalObservationSummarizer';
 import { SYSTEM_PROMPT } from './systemPrompt';
+import { sanitizeChatMessages } from './sanitizeChatMessages';
 
 export type AgentRunInput = string | Message;
 
@@ -1012,7 +1013,7 @@ export class Agent extends EventEmitter {
         return event.llm_message;
       });
     const messages = (() => {
-      const sanitized = this.sanitizeChatMessages(rawMessages);
+      const sanitized = sanitizeChatMessages(rawMessages);
       const summaryMessage = this.buildToolSummaryMessage();
       return summaryMessage ? [...sanitized, summaryMessage] : sanitized;
     })();
@@ -1169,87 +1170,6 @@ export class Agent extends EventEmitter {
       ...this.pendingToolSummaries.map((entry) => `- ${entry.toolName}: ${entry.summary}`),
     ];
     return { role: 'assistant', content: [{ type: 'text', text: lines.join('\n') }] };
-  }
-
-  // OpenAI-compatible providers require that assistant tool_calls are followed by tool messages for each tool_call_id.
-  // If we encounter conversation-level tool execution failures, we intentionally do not emit tool messages; sanitize
-  // orphan tool_calls from the next request to avoid poisoning the conversation history.
-  private sanitizeChatMessages(messages: Message[]): Message[] {
-    const sanitized: Array<Message | null> = [];
-
-    let pendingAssistantIndex: number | null = null;
-    let pendingAssistantMessage: Message | null = null;
-    let pendingToolResponseIds = new Set<string>();
-    let pendingToolMessageIndices: number[] = [];
-
-    const hasMeaningfulAssistantContent = (message: Message): boolean => {
-      if (message.responses_reasoning_item) return true;
-      if (typeof message.reasoning_content === 'string' && message.reasoning_content.trim().length > 0) return true;
-      return message.content.some((part) => (part.type === 'text' ? part.text.trim().length > 0 : true));
-    };
-
-    const flushPendingAssistant = () => {
-      if (pendingAssistantIndex === null || !pendingAssistantMessage) return;
-
-      const originalToolCalls = pendingAssistantMessage.tool_calls ?? [];
-      const matchingToolCalls = originalToolCalls.filter((call) => pendingToolResponseIds.has(call.id));
-
-      if (matchingToolCalls.length === 0) {
-        const withoutToolCalls: Message = { ...pendingAssistantMessage, tool_calls: undefined };
-        const keepAssistant = hasMeaningfulAssistantContent(withoutToolCalls);
-        sanitized[pendingAssistantIndex] = keepAssistant ? withoutToolCalls : null;
-        for (const idx of pendingToolMessageIndices) sanitized[idx] = null;
-      } else {
-        const keptToolIds = new Set<string>(matchingToolCalls.map((call) => call.id));
-        sanitized[pendingAssistantIndex] = { ...pendingAssistantMessage, tool_calls: matchingToolCalls };
-        for (const idx of pendingToolMessageIndices) {
-          const message = sanitized[idx];
-          if (!message || message.role !== 'tool') continue;
-          const toolCallId = message.tool_call_id;
-          if (typeof toolCallId !== 'string' || !keptToolIds.has(toolCallId)) {
-            sanitized[idx] = null;
-          }
-        }
-      }
-
-      pendingAssistantIndex = null;
-      pendingAssistantMessage = null;
-      pendingToolResponseIds = new Set<string>();
-      pendingToolMessageIndices = [];
-    };
-
-    for (const message of messages) {
-      if (message.role === 'assistant') {
-        flushPendingAssistant();
-
-        if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
-          pendingAssistantIndex = sanitized.length;
-          pendingAssistantMessage = message;
-          pendingToolResponseIds = new Set<string>();
-        }
-
-        sanitized.push(message);
-        continue;
-      }
-
-      if (pendingAssistantMessage && message.role === 'tool' && typeof message.tool_call_id === 'string') {
-        pendingToolResponseIds.add(message.tool_call_id);
-        pendingToolMessageIndices.push(sanitized.length);
-        sanitized.push(message);
-        continue;
-      }
-
-      if (message.role === 'tool') {
-        // Drop orphan tool messages (they can occur after condensation filters older assistant tool_calls).
-        continue;
-      }
-
-      sanitized.push(message);
-    }
-
-    flushPendingAssistant();
-
-    return sanitized.filter((message): message is Message => Boolean(message));
   }
 
   private getToolDefinitions(): LLMToolDefinition[] {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/sanitizeChatMessages.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/sanitizeChatMessages.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { Message, ToolCall } from '../../types';
+import { sanitizeChatMessages } from '../sanitizeChatMessages';
+
+const toolCall = (id: string): ToolCall => ({
+  id,
+  type: 'function',
+  function: { name: 'terminal', arguments: '{"command":"echo hi"}' },
+});
+
+describe('sanitizeChatMessages', () => {
+  it('drops orphan tool messages', () => {
+    const messages: Message[] = [
+      { role: 'tool', name: 'terminal', tool_call_id: 'call_1', content: [{ type: 'text', text: 'hi' }] },
+    ];
+    expect(sanitizeChatMessages(messages)).toEqual([]);
+  });
+
+  it('keeps only tool_calls that have tool responses', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Running tools' }],
+        tool_calls: [toolCall('call_1'), toolCall('call_2')],
+      },
+      { role: 'tool', name: 'terminal', tool_call_id: 'call_1', content: [{ type: 'text', text: 'ok' }] },
+      { role: 'user', content: [{ type: 'text', text: 'next' }] },
+    ];
+
+    const sanitized = sanitizeChatMessages(messages);
+    expect(sanitized).toHaveLength(3);
+    expect(sanitized[0]?.role).toBe('assistant');
+    expect(sanitized[0]?.tool_calls?.map((c) => c.id)).toEqual(['call_1']);
+    expect(sanitized[1]).toEqual(messages[1]);
+    expect(sanitized[2]).toEqual(messages[2]);
+  });
+
+  it('removes tool_calls when no tool responses exist but keeps meaningful assistant content', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'I will try a tool.' }],
+        tool_calls: [toolCall('call_1')],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'ok' }] },
+    ];
+
+    const sanitized = sanitizeChatMessages(messages);
+    expect(sanitized).toHaveLength(2);
+    expect(sanitized[0]?.role).toBe('assistant');
+    expect(sanitized[0]?.tool_calls).toBeUndefined();
+  });
+
+  it('drops assistant messages that only contained orphan tool_calls and no meaningful content', () => {
+    const messages: Message[] = [
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: '   ' }],
+        tool_calls: [toolCall('call_1')],
+      },
+      { role: 'user', content: [{ type: 'text', text: 'ok' }] },
+    ];
+
+    const sanitized = sanitizeChatMessages(messages);
+    expect(sanitized).toEqual([messages[1]]);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/sanitizeChatMessages.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/sanitizeChatMessages.ts
@@ -1,0 +1,83 @@
+import type { Message } from '../types';
+
+// OpenAI-compatible providers require that assistant tool_calls are followed by tool messages for each tool_call_id.
+// If we encounter conversation-level tool execution failures, we intentionally do not emit tool messages; sanitize
+// orphan tool_calls from the next request to avoid poisoning the conversation history.
+export function sanitizeChatMessages(messages: Message[]): Message[] {
+  const sanitized: Array<Message | null> = [];
+
+  let pendingAssistantIndex: number | null = null;
+  let pendingAssistantMessage: Message | null = null;
+  let pendingToolResponseIds = new Set<string>();
+  let pendingToolMessageIndices: number[] = [];
+
+  const hasMeaningfulAssistantContent = (message: Message): boolean => {
+    if (message.responses_reasoning_item) return true;
+    if (typeof message.reasoning_content === 'string' && message.reasoning_content.trim().length > 0) return true;
+    return message.content.some((part) => (part.type === 'text' ? part.text.trim().length > 0 : true));
+  };
+
+  const flushPendingAssistant = () => {
+    if (pendingAssistantIndex === null || !pendingAssistantMessage) return;
+
+    const originalToolCalls = pendingAssistantMessage.tool_calls ?? [];
+    const matchingToolCalls = originalToolCalls.filter((call) => pendingToolResponseIds.has(call.id));
+
+    if (matchingToolCalls.length === 0) {
+      const withoutToolCalls: Message = { ...pendingAssistantMessage, tool_calls: undefined };
+      const keepAssistant = hasMeaningfulAssistantContent(withoutToolCalls);
+      sanitized[pendingAssistantIndex] = keepAssistant ? withoutToolCalls : null;
+      for (const idx of pendingToolMessageIndices) sanitized[idx] = null;
+    } else {
+      const keptToolIds = new Set<string>(matchingToolCalls.map((call) => call.id));
+      sanitized[pendingAssistantIndex] = { ...pendingAssistantMessage, tool_calls: matchingToolCalls };
+      for (const idx of pendingToolMessageIndices) {
+        const message = sanitized[idx];
+        if (!message || message.role !== 'tool') continue;
+        const toolCallId = message.tool_call_id;
+        if (typeof toolCallId !== 'string' || !keptToolIds.has(toolCallId)) {
+          sanitized[idx] = null;
+        }
+      }
+    }
+
+    pendingAssistantIndex = null;
+    pendingAssistantMessage = null;
+    pendingToolResponseIds = new Set<string>();
+    pendingToolMessageIndices = [];
+  };
+
+  for (const message of messages) {
+    if (message.role === 'assistant') {
+      flushPendingAssistant();
+
+      if (Array.isArray(message.tool_calls) && message.tool_calls.length > 0) {
+        pendingAssistantIndex = sanitized.length;
+        pendingAssistantMessage = message;
+        pendingToolResponseIds = new Set<string>();
+      }
+
+      sanitized.push(message);
+      continue;
+    }
+
+    if (pendingAssistantMessage && message.role === 'tool' && typeof message.tool_call_id === 'string') {
+      pendingToolResponseIds.add(message.tool_call_id);
+      pendingToolMessageIndices.push(sanitized.length);
+      sanitized.push(message);
+      continue;
+    }
+
+    if (message.role === 'tool') {
+      // Drop orphan tool messages (they can occur after condensation filters older assistant tool_calls).
+      continue;
+    }
+
+    sanitized.push(message);
+  }
+
+  flushPendingAssistant();
+
+  return sanitized.filter((message): message is Message => Boolean(message));
+}
+


### PR DESCRIPTION
Implements part of oh-tab-ycg2 (Agent.ts tech debt): extract `sanitizeChatMessages` into a dedicated helper module.

Why
- Keeps `Agent.ts` focused on the runtime loop.
- Makes the message-sanitization behavior easier to test and reuse.

Changes
- New `packages/agent-sdk-ts/src/sdk/runtime/sanitizeChatMessages.ts`.
- `Agent.ts` now imports and uses the helper.
- Adds unit tests covering key sanitization scenarios.

Tests
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run build:types -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced conversation history processing to properly clean and validate messages, removing orphaned or unmatched tool-related messages for improved OpenAI-compatible provider integration and overall conversation reliability.

* **Tests**
  * Added comprehensive test coverage for message sanitization, validating proper handling of tool calls, responses, and conversation flow scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->