### PR TITLE
oh-tab-ycg2: extract Agent text sanitizers

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -41,6 +41,14 @@ import { getGeminiClient } from './geminiClient';
 import { summarizeTerminalObservationWithGeminiFlash } from './terminalObservationSummarizer';
 import { SYSTEM_PROMPT } from './systemPrompt';
 import { sanitizeChatMessages } from './sanitizeChatMessages';
+import {
+  ELLIPSIS,
+  redactAndTruncateArgs,
+  redactStringHeuristics,
+  sanitizeChatRequestForDebug,
+  sanitizeMessageForDebug,
+  truncateString,
+} from './textSanitizers';
 
 export type AgentRunInput = string | Message;
 
@@ -68,14 +76,9 @@ export interface AgentOptions {
 const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 
 // Simple utility to cap logged/tool result sizes
-const TRUNCATE_LIMIT = 2000;
-const ELLIPSIS = '…(truncated)';
 const CIRCULAR_REFERENCE_MARKER = '[Circular]';
 const TOOL_MESSAGE_MAX_CHARS = 8_000;
 const TOOL_MESSAGE_CLIP_MARKER = '<response clipped>';
-function truncateString(input: string): string {
-  return input.length > TRUNCATE_LIMIT ? input.slice(0, TRUNCATE_LIMIT) + ELLIPSIS : input;
-}
 
 function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
   if (typeof value === 'string') return truncateString(value);
@@ -127,50 +130,6 @@ function truncateToolMessage(text: string, maxChars = TOOL_MESSAGE_MAX_CHARS): s
   return `${head}\n${TOOL_MESSAGE_CLIP_MARKER}\n${tail}`;
 }
 
-const DEBUG_TOOL_TEXT_HEAD_CHARS = 100;
-const DEBUG_TOOL_TEXT_TAIL_CHARS = 100;
-const DEBUG_TOOL_TEXT_MAX_UNCLIPPED = DEBUG_TOOL_TEXT_HEAD_CHARS + DEBUG_TOOL_TEXT_TAIL_CHARS;
-function truncateToolMessageForDebug(text: string): string {
-  if (text.length <= DEBUG_TOOL_TEXT_MAX_UNCLIPPED) return text;
-  return `${text.slice(0, DEBUG_TOOL_TEXT_HEAD_CHARS)}…${text.slice(-DEBUG_TOOL_TEXT_TAIL_CHARS)}`;
-}
-
-function sanitizeToolCallsForDebug(toolCalls: ToolCall[] | undefined): ToolCall[] | undefined {
-  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return undefined;
-  return toolCalls.map((toolCall) => {
-    const rawArgs = toolCall.function.arguments;
-    const safeArgs = typeof rawArgs === 'string' ? redactAndTruncateArgs(rawArgs) : '';
-    return {
-      ...toolCall,
-      function: { ...toolCall.function, arguments: safeArgs },
-    };
-  });
-}
-
-function sanitizeMessageForDebug(message: Message): Message {
-  const safeToolCalls = sanitizeToolCallsForDebug(message.tool_calls);
-  const safeContent = message.role === 'tool'
-    ? message.content.map((item) => (
-      item.type === 'text'
-        ? { ...item, text: truncateToolMessageForDebug(item.text) }
-        : item
-    ))
-    : message.content;
-
-  const out: Message = { ...message, content: safeContent };
-  if (safeToolCalls) out.tool_calls = safeToolCalls;
-  return out;
-}
-
-function sanitizeChatRequestForDebug(request: ChatCompletionRequest): { systemPrompt: string; messages: Message[]; tools: string[] } {
-  const toolNames = (request.tools ?? []).map((t) => t.function?.name).filter((n): n is string => typeof n === 'string' && n.trim().length > 0);
-  return {
-    systemPrompt: 'SYSTEM_PROMPT',
-    messages: request.messages.map(sanitizeMessageForDebug),
-    tools: toolNames,
-  };
-}
-
 const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
 const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
 const TOOL_SUMMARY_MAX_CHARS = 1_000;
@@ -195,70 +154,6 @@ function stringifyErrorWithCause(error: unknown, maxDepth = 4): string {
     return JSON.stringify(error);
   } catch {
     return String(error);
-  }
-}
-
-
-// Redaction utilities for tool-call argument logging
-const SENSITIVE_KEYS = new Set([
-  'apiKey', 'api_key', 'apikey',
-  'token', 'access_token', 'accessToken', 'refresh_token',
-  'authorization', 'authorization_header', 'auth',
-  'password', 'pass', 'pwd',
-  'secret', 'secret_key', 'secretKey', 'client_secret', 'clientSecret', 'private_key', 'privateKey',
-  'awsAccessKeyId', 'awsSecretAccessKey',
-  'sessionApiKey', 'session_api_key', 'x_api_key',
-]);
-function redactObject(input: unknown): unknown {
-  if (Array.isArray(input)) return input.map((v) => redactObject(v));
-  if (input && typeof input === 'object') {
-    const src = input as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(src)) {
-      if (SENSITIVE_KEYS.has(k.toString())) {
-        out[k] = '***';
-      } else if (typeof v === 'object') {
-        out[k] = redactObject(v);
-      } else if (typeof v === 'string') {
-        out[k] = redactStringHeuristics(v);
-      } else {
-        out[k] = v;
-      }
-    }
-    return out;
-  }
-  if (typeof input === 'string') return redactStringHeuristics(input);
-  return input;
-}
-function redactStringHeuristics(text: string): string {
-  let t = text;
-  // Authorization header
-  t = t.replace(/(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._-]+/gi, '$1***');
-  // Standalone Bearer tokens
-  t = t.replace(/(Bearer\s+)[A-Za-z0-9._-]+/gi, '$1***');
-  // Common token prefixes that may appear without key labels
-  const tokenPatterns = [
-    /sk-[A-Za-z0-9]{12,}/gi,
-    /ghp_[A-Za-z0-9]{12,}/gi,
-    /pat_[A-Za-z0-9_]{12,}/gi,
-  ];
-  tokenPatterns.forEach((pattern) => {
-    t = t.replace(pattern, '***');
-  });
-  // Common key=value or key: value patterns
-  const keyPattern = /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret)/gi;
-  t = t.replace(new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'), (_m, p1, _p2) => `${p1}: ***`);
-  // Query param style ...?api_key=xxx&
-  t = t.replace(new RegExp(`([?&])${keyPattern.source}=([^&\\s]+)`, 'gi'), (_m, sep, key) => `${sep}${key}=***`);
-  return t;
-}
-function redactAndTruncateArgs(raw: string): string {
-  try {
-    const parsed: unknown = JSON.parse(raw);
-    const redacted = redactObject(parsed);
-    return truncateString(JSON.stringify(redacted));
-  } catch {
-    return truncateString(redactStringHeuristics(raw));
   }
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest } from '../../llm';
+import type { Message } from '../../types';
+import {
+  ELLIPSIS,
+  redactAndTruncateArgs,
+  redactStringHeuristics,
+  sanitizeChatRequestForDebug,
+  sanitizeMessageForDebug,
+  truncateString,
+} from '../textSanitizers';
+
+describe('textSanitizers', () => {
+  it('truncateString appends ellipsis when over limit', () => {
+    expect(truncateString('a'.repeat(2000))).toHaveLength(2000);
+    const truncated = truncateString('a'.repeat(2001));
+    expect(truncated.endsWith(ELLIPSIS)).toBe(true);
+    expect(truncated.length).toBeGreaterThan(2001);
+  });
+
+  it('redactStringHeuristics masks bearer tokens and key-like patterns', () => {
+    expect(redactStringHeuristics('Authorization: Bearer SECRET')).toBe('Authorization: Bearer ***');
+    expect(redactStringHeuristics('Bearer SECRET')).toBe('Bearer ***');
+    expect(redactStringHeuristics('sk-abc123SECRETvalue')).toBe('***');
+    expect(redactStringHeuristics('ghp_abcdefghijklmnopqrstu')).toBe('***');
+    expect(redactStringHeuristics('apiKey=SECRET')).toBe('apiKey: ***');
+    // Query-string redaction may normalize `=` into `: ` depending on which regex fires first.
+    expect(redactStringHeuristics('?api_key=SECRET&x=1')).toBe('?api_key: ***&x=1');
+  });
+
+  it('redactAndTruncateArgs redacts JSON values for common sensitive keys', () => {
+    const raw = JSON.stringify({ apiKey: 'NOPE', nested: { token: 'NOPE2' } });
+    const output = redactAndTruncateArgs(raw);
+    const parsed = JSON.parse(output);
+    expect(parsed.apiKey).toBe('***');
+    expect(parsed.nested.token).toBe('***');
+  });
+
+  it('sanitizeMessageForDebug truncates tool text content', () => {
+    const message: Message = {
+      role: 'tool',
+      content: [{ type: 'text', text: 'a'.repeat(250), cache_prompt: false }],
+    };
+    const sanitized = sanitizeMessageForDebug(message);
+    expect(sanitized.role).toBe('tool');
+    const text = sanitized.content[0].type === 'text' ? sanitized.content[0].text : '';
+    expect(text).toContain('…');
+    expect(text.length).toBeLessThan(250);
+  });
+
+  it('sanitizeChatRequestForDebug strips system prompt and lists tool names', () => {
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'REAL_SYSTEM',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello', cache_prompt: false }] },
+        { role: 'tool', content: [{ type: 'text', text: 'a'.repeat(250), cache_prompt: false }] },
+      ],
+      tools: [{ type: 'function', function: { name: 'terminal', description: '', parameters: {} } }],
+    };
+
+    const sanitized = sanitizeChatRequestForDebug(request);
+    expect(sanitized.systemPrompt).toBe('SYSTEM_PROMPT');
+    expect(sanitized.tools).toEqual(['terminal']);
+    expect(sanitized.messages).toHaveLength(2);
+    const toolText = sanitized.messages[1].content[0].type === 'text' ? sanitized.messages[1].content[0].text : '';
+    expect(toolText).toContain('…');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -36,6 +36,14 @@ describe('textSanitizers', () => {
     expect(parsed.nested.token).toBe('***');
   });
 
+  it('redactAndTruncateArgs redacts hyphenated API key headers', () => {
+    const raw = JSON.stringify({ headers: { 'x-api-key': 'NOPE', Authorization: 'Bearer SECRET' } });
+    const output = redactAndTruncateArgs(raw);
+    const parsed = JSON.parse(output);
+    expect(parsed.headers['x-api-key']).toBe('***');
+    expect(parsed.headers.Authorization).toBe('***');
+  });
+
   it('sanitizeMessageForDebug truncates tool text content', () => {
     const message: Message = {
       role: 'tool',

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -41,7 +41,7 @@ describe('textSanitizers', () => {
     const output = redactAndTruncateArgs(raw);
     const parsed = JSON.parse(output);
     expect(parsed.headers['x-api-key']).toBe('***');
-    expect(parsed.headers.Authorization).toBe('***');
+    expect(parsed.headers.Authorization).toBe('Bearer ***');
   });
 
   it('sanitizeMessageForDebug truncates tool text content', () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -36,6 +36,10 @@ describe('textSanitizers', () => {
     expect(parsed.nested.token).toBe('***');
   });
 
+  it('redactAndTruncateArgs falls back to heuristic redaction for invalid JSON', () => {
+    expect(redactAndTruncateArgs('Authorization: Bearer SECRET')).toBe('Authorization: Bearer ***');
+  });
+
   it('redactAndTruncateArgs redacts hyphenated API key headers', () => {
     const raw = JSON.stringify({ headers: { 'x-api-key': 'NOPE', Authorization: 'Bearer SECRET' } });
     const output = redactAndTruncateArgs(raw);

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -19,42 +19,15 @@ const truncateToolMessageForDebug = (text: string): string => {
 };
 
 // Redaction utilities for tool-call argument logging.
-const normalizeKey = (key: string): string => key.toLowerCase().replace(/[^a-z0-9]/g, '');
-
-const SENSITIVE_KEY_NORMALIZED = new Set([
-  'apikey',
-  'token',
-  'accesstoken',
-  'refreshtoken',
-  'authorization',
-  'authorizationheader',
-  'auth',
-  'password',
-  'pass',
-  'pwd',
-  'secret',
-  'secretkey',
-  'clientsecret',
-  'privatekey',
-  'awsaccesskeyid',
-  'awssecretaccesskey',
-  'sessionapikey',
-  // Headers like `x-api-key` normalize to `xapikey` and are caught by the `apikey` marker below.
+const SENSITIVE_KEYS = new Set([
+  'apiKey', 'api_key', 'api-key', 'apikey',
+  'token', 'access_token', 'accessToken', 'refresh_token',
+  'authorization', 'authorization_header', 'auth',
+  'password', 'pass', 'pwd',
+  'secret', 'secret_key', 'secretKey', 'client_secret', 'clientSecret', 'private_key', 'privateKey',
+  'awsAccessKeyId', 'awsSecretAccessKey',
+  'sessionApiKey', 'session_api_key', 'x_api_key', 'x-api-key',
 ]);
-
-const isSensitiveKey = (key: string): boolean => {
-  const normalized = normalizeKey(key);
-  if (!normalized) return false;
-  if (SENSITIVE_KEY_NORMALIZED.has(normalized)) return true;
-  // Be conservative: for debug logs, it's better to over-redact than leak secrets.
-  if (normalized.includes('apikey')) return true;
-  if (normalized.endsWith('token')) return true;
-  if (normalized.includes('secret')) return true;
-  if (normalized.includes('password')) return true;
-  if (normalized.includes('privatekey')) return true;
-  if (normalized.includes('authorization')) return true;
-  return false;
-};
 
 const redactObject = (input: unknown): unknown => {
   if (Array.isArray(input)) return input.map((v) => redactObject(v));
@@ -62,7 +35,7 @@ const redactObject = (input: unknown): unknown => {
     const src = input as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(src)) {
-      if (isSensitiveKey(key.toString())) {
+      if (SENSITIVE_KEYS.has(key.toString())) {
         out[key] = '***';
       } else if (typeof value === 'object') {
         out[key] = redactObject(value);

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -19,15 +19,42 @@ const truncateToolMessageForDebug = (text: string): string => {
 };
 
 // Redaction utilities for tool-call argument logging.
-const SENSITIVE_KEYS = new Set([
-  'apiKey', 'api_key', 'apikey',
-  'token', 'access_token', 'accessToken', 'refresh_token',
-  'authorization', 'authorization_header', 'auth',
-  'password', 'pass', 'pwd',
-  'secret', 'secret_key', 'secretKey', 'client_secret', 'clientSecret', 'private_key', 'privateKey',
-  'awsAccessKeyId', 'awsSecretAccessKey',
-  'sessionApiKey', 'session_api_key', 'x_api_key',
+const normalizeKey = (key: string): string => key.toLowerCase().replace(/[^a-z0-9]/g, '');
+
+const SENSITIVE_KEY_NORMALIZED = new Set([
+  'apikey',
+  'token',
+  'accesstoken',
+  'refreshtoken',
+  'authorization',
+  'authorizationheader',
+  'auth',
+  'password',
+  'pass',
+  'pwd',
+  'secret',
+  'secretkey',
+  'clientsecret',
+  'privatekey',
+  'awsaccesskeyid',
+  'awssecretaccesskey',
+  'sessionapikey',
+  // Headers like `x-api-key` normalize to `xapikey` and are caught by the `apikey` marker below.
 ]);
+
+const isSensitiveKey = (key: string): boolean => {
+  const normalized = normalizeKey(key);
+  if (!normalized) return false;
+  if (SENSITIVE_KEY_NORMALIZED.has(normalized)) return true;
+  // Be conservative: for debug logs, it's better to over-redact than leak secrets.
+  if (normalized.includes('apikey')) return true;
+  if (normalized.endsWith('token')) return true;
+  if (normalized.includes('secret')) return true;
+  if (normalized.includes('password')) return true;
+  if (normalized.includes('privatekey')) return true;
+  if (normalized.includes('authorization')) return true;
+  return false;
+};
 
 const redactObject = (input: unknown): unknown => {
   if (Array.isArray(input)) return input.map((v) => redactObject(v));
@@ -35,7 +62,7 @@ const redactObject = (input: unknown): unknown => {
     const src = input as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(src)) {
-      if (SENSITIVE_KEYS.has(key.toString())) {
+      if (isSensitiveKey(key.toString())) {
         out[key] = '***';
       } else if (typeof value === 'object') {
         out[key] = redactObject(value);

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -1,0 +1,126 @@
+import type { ChatCompletionRequest } from '../llm';
+import type { Message, ToolCall } from '../types';
+
+// Shared truncation limit for logged/tool result sizes.
+const TRUNCATE_LIMIT = 2000;
+export const ELLIPSIS = '…(truncated)';
+
+export function truncateString(input: string): string {
+  return input.length > TRUNCATE_LIMIT ? input.slice(0, TRUNCATE_LIMIT) + ELLIPSIS : input;
+}
+
+const DEBUG_TOOL_TEXT_HEAD_CHARS = 100;
+const DEBUG_TOOL_TEXT_TAIL_CHARS = 100;
+const DEBUG_TOOL_TEXT_MAX_UNCLIPPED = DEBUG_TOOL_TEXT_HEAD_CHARS + DEBUG_TOOL_TEXT_TAIL_CHARS;
+
+const truncateToolMessageForDebug = (text: string): string => {
+  if (text.length <= DEBUG_TOOL_TEXT_MAX_UNCLIPPED) return text;
+  return `${text.slice(0, DEBUG_TOOL_TEXT_HEAD_CHARS)}…${text.slice(-DEBUG_TOOL_TEXT_TAIL_CHARS)}`;
+};
+
+// Redaction utilities for tool-call argument logging.
+const SENSITIVE_KEYS = new Set([
+  'apiKey', 'api_key', 'apikey',
+  'token', 'access_token', 'accessToken', 'refresh_token',
+  'authorization', 'authorization_header', 'auth',
+  'password', 'pass', 'pwd',
+  'secret', 'secret_key', 'secretKey', 'client_secret', 'clientSecret', 'private_key', 'privateKey',
+  'awsAccessKeyId', 'awsSecretAccessKey',
+  'sessionApiKey', 'session_api_key', 'x_api_key',
+]);
+
+const redactObject = (input: unknown): unknown => {
+  if (Array.isArray(input)) return input.map((v) => redactObject(v));
+  if (input && typeof input === 'object') {
+    const src = input as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(src)) {
+      if (SENSITIVE_KEYS.has(key.toString())) {
+        out[key] = '***';
+      } else if (typeof value === 'object') {
+        out[key] = redactObject(value);
+      } else if (typeof value === 'string') {
+        out[key] = redactStringHeuristics(value);
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+  if (typeof input === 'string') return redactStringHeuristics(input);
+  return input;
+};
+
+export function redactStringHeuristics(text: string): string {
+  let t = text;
+  // Authorization header
+  t = t.replace(/(Authorization\s*:\s*Bearer\s+)[A-Za-z0-9._-]+/gi, '$1***');
+  // Standalone Bearer tokens
+  t = t.replace(/(Bearer\s+)[A-Za-z0-9._-]+/gi, '$1***');
+  // Common token prefixes that may appear without key labels
+  const tokenPatterns = [
+    /sk-[A-Za-z0-9]{12,}/gi,
+    /ghp_[A-Za-z0-9]{12,}/gi,
+    /pat_[A-Za-z0-9_]{12,}/gi,
+  ];
+  tokenPatterns.forEach((pattern) => {
+    t = t.replace(pattern, '***');
+  });
+  // Common key=value or key: value patterns
+  const keyPattern = /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret)/gi;
+  t = t.replace(
+    new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'),
+    (_m, p1, _p2) => `${p1}: ***`,
+  );
+  // Query param style ...?api_key=xxx&
+  t = t.replace(new RegExp(`([?&])${keyPattern.source}=([^&\\s]+)`, 'gi'), (_m, sep, key) => `${sep}${key}=***`);
+  return t;
+}
+
+export function redactAndTruncateArgs(raw: string): string {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    const redacted = redactObject(parsed);
+    return truncateString(JSON.stringify(redacted));
+  } catch {
+    return truncateString(redactStringHeuristics(raw));
+  }
+}
+
+const sanitizeToolCallsForDebug = (toolCalls: ToolCall[] | undefined): ToolCall[] | undefined => {
+  if (!Array.isArray(toolCalls) || toolCalls.length === 0) return undefined;
+  return toolCalls.map((toolCall) => {
+    const rawArgs = toolCall.function.arguments;
+    const safeArgs = typeof rawArgs === 'string' ? redactAndTruncateArgs(rawArgs) : '';
+    return {
+      ...toolCall,
+      function: { ...toolCall.function, arguments: safeArgs },
+    };
+  });
+};
+
+export const sanitizeMessageForDebug = (message: Message): Message => {
+  const safeToolCalls = sanitizeToolCallsForDebug(message.tool_calls);
+  const safeContent = message.role === 'tool'
+    ? message.content.map((item) => (
+      item.type === 'text'
+        ? { ...item, text: truncateToolMessageForDebug(item.text) }
+        : item
+    ))
+    : message.content;
+
+  const out: Message = { ...message, content: safeContent };
+  if (safeToolCalls) out.tool_calls = safeToolCalls;
+  return out;
+};
+
+export function sanitizeChatRequestForDebug(request: ChatCompletionRequest): { systemPrompt: string; messages: Message[]; tools: string[] } {
+  const toolNames = (request.tools ?? [])
+    .map((t) => t.function?.name)
+    .filter((n): n is string => typeof n === 'string' && n.trim().length > 0);
+  return {
+    systemPrompt: 'SYSTEM_PROMPT',
+    messages: request.messages.map(sanitizeMessageForDebug),
+    tools: toolNames,
+  };
+}


### PR DESCRIPTION
Implements the next slice of `oh-tab-ycg2` (Agent.ts tech debt): extract debug/redaction/truncation helpers out of `Agent.ts` into a dedicated module.

Changes
- New `packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts`
- `Agent.ts` now imports these helpers
- Adds unit tests in `packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts`

Bead: `oh-tab-ycg2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Moved debug redaction and truncation logic into a centralized text-sanitization module.
  * Added a public utility for consistent truncation and ellipsis handling in debug displays.

* **Tests**
  * Added tests for truncation, token/key redaction, nested-argument redaction, and sanitized message/request assembly.

* **Bug Fixes**
  * Strengthened redaction and truncation applied to debug output and logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->