### PR TITLE
oh-tab-ot3z: prefer profile config in RemoteConversation

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -256,6 +256,79 @@ describe('RemoteConversation', () => {
     }
   });
 
+  it('prefers profile config over settings llm overrides when profileId is set', async () => {
+    const dir = makeTempDir('remote-conversation-profile-precedence-');
+    try {
+      saveProfile('p1', {
+        provider: 'openai',
+        model: 'profile-model',
+        baseUrl: 'https://profile.example',
+        apiVersion: '2025-01-01',
+        timeoutSeconds: 111,
+        temperature: 0.7,
+        topP: 0.8,
+        topK: 40,
+        maxInputTokens: 1234,
+        maxOutputTokens: 2345,
+        reasoningEffort: 'high',
+      }, { rootDir: dir });
+
+      let capturedReq: any = null;
+      const fetchMock = vi.fn(async (url: string, init?: any) => {
+        expect(url).toContain('/api/conversations');
+        capturedReq = JSON.parse(init?.body ?? '{}');
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({ id: 'conv-1' }),
+          text: async () => '',
+        } as any;
+      });
+      (globalThis as any).fetch = fetchMock;
+
+      const { RemoteConversation } = await import('../conversation/RemoteConversation');
+      const conversation = new RemoteConversation({
+        serverUrl: 'http://localhost:3000',
+        settings: {
+          ...baseSettings,
+          llm: {
+            profileId: 'p1',
+            model: 'settings-model',
+            baseUrl: 'https://settings.example',
+            apiVersion: '2025-12-31',
+            timeout: 999,
+            temperature: 0.1,
+            topP: 0.1,
+            topK: 1,
+            maxInputTokens: 1,
+            maxOutputTokens: 2,
+            reasoningEffort: 'low',
+          },
+        } as any,
+        profileStoreOptions: { rootDir: dir },
+      });
+
+      const id = await conversation.startNewConversation();
+      conversation.disconnect();
+
+      expect(id).toBe('conv-1');
+      const llm = capturedReq?.agent?.llm ?? {};
+      expect(llm.usage_id).toBe('p1');
+      expect(llm.model).toBe('profile-model');
+      expect(llm.base_url).toBe('https://profile.example');
+      expect(llm.api_version).toBe('2025-01-01');
+      expect(llm.timeout).toBe(111);
+      expect(llm.temperature).toBe(0.7);
+      expect(llm.top_p).toBe(0.8);
+      expect(llm.top_k).toBe(40);
+      expect(llm.max_input_tokens).toBe(1234);
+      expect(llm.max_output_tokens).toBe(2345);
+      expect(llm.reasoning_effort).toBe('high');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('omits invalid secret values when starting a new conversation', async () => {
     const fetchMock = vi.fn(async (url: string, init?: any) => {
       expect(url).toContain('/api/conversations');

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
@@ -68,7 +68,7 @@ describe('RemoteConversation', () => {
       const parsed = JSON.parse(init?.body as string) as { agent: { llm: Record<string, unknown> } };
       expect(parsed.agent.llm.profile_id).toBeUndefined();
       expect(parsed.agent.llm.model).toBe('gpt-5');
-      expect(parsed.agent.llm.base_url).toBe('http://override.example');
+      expect(parsed.agent.llm.base_url).toBe('http://profile.example');
     } finally {
       fs.rmSync(profilesRoot, { recursive: true, force: true });
     }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -175,41 +175,41 @@ export class RemoteConversation extends EventEmitter {
         : undefined;
       const effectiveUsageId = derivedUsageId ?? usageId ?? profileUsageId;
       const effectiveModel = profileModel ?? model;
-      const effectiveBaseUrl = baseUrl ?? profileBaseUrl;
-      const effectiveApiVersion = apiVersion ?? profileApiVersion;
+      const effectiveBaseUrl = profileBaseUrl ?? baseUrl;
+      const effectiveApiVersion = profileApiVersion ?? apiVersion;
 
       if (effectiveUsageId) llm.usage_id = effectiveUsageId;
       if (effectiveModel) llm.model = effectiveModel;
       if (effectiveBaseUrl) llm.base_url = effectiveBaseUrl;
       if (effectiveApiVersion) llm.api_version = effectiveApiVersion;
 
-      const effectiveTimeout = s?.llm.timeout ?? profileConfig?.timeoutSeconds;
+      const effectiveTimeout = profileConfig?.timeoutSeconds ?? s?.llm.timeout;
       if (typeof effectiveTimeout === 'number' && Number.isFinite(effectiveTimeout)) {
         llm.timeout = effectiveTimeout;
       }
-      const effectiveTemperature = s?.llm.temperature ?? profileConfig?.temperature;
+      const effectiveTemperature = profileConfig?.temperature ?? s?.llm.temperature;
       if (typeof effectiveTemperature === 'number' && Number.isFinite(effectiveTemperature)) {
         llm.temperature = effectiveTemperature;
       }
-      const effectiveTopP = s?.llm.topP ?? profileConfig?.topP;
+      const effectiveTopP = profileConfig?.topP ?? s?.llm.topP;
       if (typeof effectiveTopP === 'number' && Number.isFinite(effectiveTopP)) {
         llm.top_p = effectiveTopP;
       }
-      const effectiveTopK = s?.llm.topK ?? profileConfig?.topK;
+      const effectiveTopK = profileConfig?.topK ?? s?.llm.topK;
       if (typeof effectiveTopK === 'number' && Number.isFinite(effectiveTopK)) {
         llm.top_k = effectiveTopK;
       }
 
-      const maxInputTokens = s?.llm.maxInputTokens ?? profileConfig?.maxInputTokens;
+      const maxInputTokens = profileConfig?.maxInputTokens ?? s?.llm.maxInputTokens;
       if (typeof maxInputTokens === 'number' && Number.isFinite(maxInputTokens) && maxInputTokens > 0) {
         llm.max_input_tokens = Math.trunc(maxInputTokens);
       }
-      const maxOutputTokens = s?.llm.maxOutputTokens ?? profileConfig?.maxOutputTokens;
+      const maxOutputTokens = profileConfig?.maxOutputTokens ?? s?.llm.maxOutputTokens;
       if (typeof maxOutputTokens === 'number' && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0) {
         llm.max_output_tokens = Math.trunc(maxOutputTokens);
       }
 
-      const effectiveReasoningEffort = s?.llm.reasoningEffort ?? profileConfig?.reasoningEffort;
+      const effectiveReasoningEffort = profileConfig?.reasoningEffort ?? s?.llm.reasoningEffort;
       if (typeof effectiveReasoningEffort === 'string' && effectiveReasoningEffort) {
         llm.reasoning_effort = effectiveReasoningEffort;
       }


### PR DESCRIPTION
Part of `oh-tab-ot3z` (LLM profiles source-of-truth).

Changes
- RemoteConversation now prefers resolved profile config (model/baseUrl/apiVersion/timeout/temperature/topP/topK/token limits/reasoningEffort) over any raw settings values when `profileId` is set.
- Updated existing RemoteConversation profile-expansion test to reflect profile-first baseUrl.
- Added unit test asserting profile config wins over conflicting settings overrides.

Tests
- `npm test -w @openhands/agent-sdk-ts`