### PR TITLE
oh-tab-ot3z: local restore ignores raw llm.* when profileId

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -145,6 +145,40 @@ describe('LocalConversation persistence', () => {
     expect(restoredSettings.llm.model).toBeUndefined();
   });
 
+  it('does not persist or restore raw LLM fields when a profileId is present', async () => {
+    const dir = makeTempDir('local-conversation-llm-profile-only-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const llm = new MockLLM([{ type: 'text', text: 'hello' }, { type: 'finish' }]);
+
+    const conversation = new LocalConversation({
+      settings: { ...baseSettings, llm: { profileId: 'sonnet-45', baseUrl: 'http://should-not-persist', temperature: 0.25 } },
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+    const id = await conversation.startNewConversation();
+    await conversation.sendUserMessage('hello');
+
+    const store = new FileStore({ rootDir: dir, conversationId: id! });
+    expect(store.readLlmConfig?.()).toEqual({ profileId: 'sonnet-45' });
+
+    store.writeLlmConfig?.({ profileId: 'sonnet-45', baseUrl: 'http://persisted', temperature: 0.9 });
+
+    const restored = new LocalConversation({
+      settings: { ...baseSettings, llm: { model: 'restored-model', baseUrl: 'http://restored', temperature: 0.1 } },
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+    restored.restoreConversation(id!);
+
+    const restoredSettings = (restored as unknown as { settings: OpenHandsSettings }).settings;
+    expect(restoredSettings.llm.profileId).toBe('sonnet-45');
+    expect(restoredSettings.llm.model).toBeUndefined();
+    expect(restoredSettings.llm.baseUrl).toBeUndefined();
+    expect(restoredSettings.llm.temperature).toBeUndefined();
+  });
+
   it('ignores corrupted persisted LLM config', async () => {
     const dir = makeTempDir('local-conversation-llm-corrupt-');
     const workspaceRoot = makeTempDir('local-workspace-');

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -308,32 +308,34 @@ export class LocalConversation extends EventEmitter {
     const usageId = toOptionalNonEmptyString(llm.usageId);
     if (usageId) config.usageId = usageId;
 
-    if (llm.openaiApiMode) config.openaiApiMode = llm.openaiApiMode;
+    if (!profileId) {
+      if (llm.openaiApiMode) config.openaiApiMode = llm.openaiApiMode;
 
-    const baseUrl = toOptionalNonEmptyString(llm.baseUrl);
-    if (baseUrl) config.baseUrl = baseUrl;
-    const apiVersion = toOptionalNonEmptyString(llm.apiVersion);
-    if (apiVersion) config.apiVersion = apiVersion;
+      const baseUrl = toOptionalNonEmptyString(llm.baseUrl);
+      if (baseUrl) config.baseUrl = baseUrl;
+      const apiVersion = toOptionalNonEmptyString(llm.apiVersion);
+      if (apiVersion) config.apiVersion = apiVersion;
 
-    if (typeof llm.timeout === 'number' && Number.isFinite(llm.timeout)) config.timeoutSeconds = llm.timeout;
-    if (typeof llm.temperature === 'number' && Number.isFinite(llm.temperature)) config.temperature = llm.temperature;
-    if (typeof llm.topP === 'number' && Number.isFinite(llm.topP)) config.topP = llm.topP;
-    if (typeof llm.topK === 'number' && Number.isFinite(llm.topK)) config.topK = llm.topK;
-    if (typeof llm.maxInputTokens === 'number' && Number.isFinite(llm.maxInputTokens)) {
-      config.maxInputTokens = llm.maxInputTokens;
-    }
-    if (typeof llm.maxOutputTokens === 'number' && Number.isFinite(llm.maxOutputTokens)) {
-      config.maxOutputTokens = llm.maxOutputTokens;
-    }
+      if (typeof llm.timeout === 'number' && Number.isFinite(llm.timeout)) config.timeoutSeconds = llm.timeout;
+      if (typeof llm.temperature === 'number' && Number.isFinite(llm.temperature)) config.temperature = llm.temperature;
+      if (typeof llm.topP === 'number' && Number.isFinite(llm.topP)) config.topP = llm.topP;
+      if (typeof llm.topK === 'number' && Number.isFinite(llm.topK)) config.topK = llm.topK;
+      if (typeof llm.maxInputTokens === 'number' && Number.isFinite(llm.maxInputTokens)) {
+        config.maxInputTokens = llm.maxInputTokens;
+      }
+      if (typeof llm.maxOutputTokens === 'number' && Number.isFinite(llm.maxOutputTokens)) {
+        config.maxOutputTokens = llm.maxOutputTokens;
+      }
 
-    if (llm.reasoningEffort) config.reasoningEffort = llm.reasoningEffort;
-    if (llm.reasoningSummary) config.reasoningSummary = llm.reasoningSummary;
+      if (llm.reasoningEffort) config.reasoningEffort = llm.reasoningEffort;
+      if (llm.reasoningSummary) config.reasoningSummary = llm.reasoningSummary;
 
-    if (typeof llm.inputCostPerToken === 'number' && Number.isFinite(llm.inputCostPerToken)) {
-      config.inputCostPerToken = llm.inputCostPerToken;
-    }
-    if (typeof llm.outputCostPerToken === 'number' && Number.isFinite(llm.outputCostPerToken)) {
-      config.outputCostPerToken = llm.outputCostPerToken;
+      if (typeof llm.inputCostPerToken === 'number' && Number.isFinite(llm.inputCostPerToken)) {
+        config.inputCostPerToken = llm.inputCostPerToken;
+      }
+      if (typeof llm.outputCostPerToken === 'number' && Number.isFinite(llm.outputCostPerToken)) {
+        config.outputCostPerToken = llm.outputCostPerToken;
+      }
     }
 
     if (!Object.keys(config).length) return;
@@ -347,26 +349,47 @@ export class LocalConversation extends EventEmitter {
     if (!persisted.profileId && !persisted.model) return;
 
     const existing = this.settings.llm ?? {};
-    const merged: OpenHandsSettings['llm'] = {
-      ...existing,
-      profileId: persisted.profileId ?? undefined,
-      provider: persisted.provider ?? undefined,
-      model: persisted.model ?? undefined,
-      usageId: persisted.usageId ?? undefined,
-      openaiApiMode: persisted.openaiApiMode ?? undefined,
-      baseUrl: persisted.baseUrl ?? undefined,
-      apiVersion: persisted.apiVersion ?? undefined,
-      timeout: persisted.timeoutSeconds ?? undefined,
-      temperature: persisted.temperature ?? undefined,
-      topP: persisted.topP ?? undefined,
-      topK: persisted.topK ?? undefined,
-      maxInputTokens: persisted.maxInputTokens ?? undefined,
-      maxOutputTokens: persisted.maxOutputTokens ?? undefined,
-      reasoningEffort: persisted.reasoningEffort ?? undefined,
-      reasoningSummary: persisted.reasoningSummary ?? undefined,
-      inputCostPerToken: persisted.inputCostPerToken ?? undefined,
-      outputCostPerToken: persisted.outputCostPerToken ?? undefined,
-    };
+    const merged: OpenHandsSettings['llm'] = persisted.profileId
+      ? {
+        ...existing,
+        profileId: persisted.profileId,
+        usageId: persisted.usageId ?? undefined,
+        provider: undefined,
+        model: undefined,
+        openaiApiMode: undefined,
+        baseUrl: undefined,
+        apiVersion: undefined,
+        timeout: undefined,
+        temperature: undefined,
+        topP: undefined,
+        topK: undefined,
+        maxInputTokens: undefined,
+        maxOutputTokens: undefined,
+        reasoningEffort: undefined,
+        reasoningSummary: undefined,
+        inputCostPerToken: undefined,
+        outputCostPerToken: undefined,
+      }
+      : {
+        ...existing,
+        profileId: undefined,
+        provider: persisted.provider ?? undefined,
+        model: persisted.model ?? undefined,
+        usageId: persisted.usageId ?? undefined,
+        openaiApiMode: persisted.openaiApiMode ?? undefined,
+        baseUrl: persisted.baseUrl ?? undefined,
+        apiVersion: persisted.apiVersion ?? undefined,
+        timeout: persisted.timeoutSeconds ?? undefined,
+        temperature: persisted.temperature ?? undefined,
+        topP: persisted.topP ?? undefined,
+        topK: persisted.topK ?? undefined,
+        maxInputTokens: persisted.maxInputTokens ?? undefined,
+        maxOutputTokens: persisted.maxOutputTokens ?? undefined,
+        reasoningEffort: persisted.reasoningEffort ?? undefined,
+        reasoningSummary: persisted.reasoningSummary ?? undefined,
+        inputCostPerToken: persisted.inputCostPerToken ?? undefined,
+        outputCostPerToken: persisted.outputCostPerToken ?? undefined,
+      };
 
     this.settings = { ...this.settings, llm: merged };
     this.agent.setSettings(this.settings);


### PR DESCRIPTION
Part of `oh-tab-ot3z` (LLM profiles source-of-truth).

What changed
- When `profileId` is present, `LocalConversation` persistence now writes only `profileId` (+ optional `usageId`) and does not persist raw `llm.*` fields like baseUrl/temperature/token limits.
- On restore, if the persisted config has a `profileId`, we apply `profileId` (+ optional `usageId`) and clear raw config fields in-memory (prevents mixing profile config with persisted raw overrides).

Tests
- Added unit coverage in `packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts`.

`npm test -w @openhands/agent-sdk-ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed LLM configuration persistence logic to correctly handle profile-based settings. When a profile ID is configured, raw LLM fields such as model, temperature, and API endpoint settings are no longer persisted or restored, ensuring profile-based configurations take precedence. Only the profile ID is retained for restoration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->