### PR TITLE
oh-tab-dh4r: centralize raw llm clearing

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.condensation-budget.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.condensation-budget.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../llm', async () => {
+  const actual = await vi.importActual<any>('../llm');
+  return {
+    ...actual,
+    loadProfile: vi.fn(),
+  };
+});
+
+describe('Agent condensation config', () => {
+  it('prefers profile maxInputTokens over settings when profileId is set', async () => {
+    const { loadProfile } = await import('../llm');
+    (loadProfile as any).mockReturnValue({
+      profileId: 'p1',
+      config: {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+        baseUrl: 'http://profile.test/v1',
+        maxInputTokens: 100,
+      },
+    });
+
+    const { Agent, ConversationState, EventLog } = await import('../runtime');
+    const events = new EventLog();
+    const state = new ConversationState({ eventLog: events });
+
+    const agent = new Agent({
+      settings: {
+        llm: { profileId: 'p1', maxInputTokens: 500, model: 'raw-model' },
+        agent: {},
+        conversation: {},
+        confirmation: { policy: 'never' },
+        secrets: {},
+      },
+      events,
+      state,
+      tools: [],
+    });
+
+    const config = (agent as any).getEffectiveLlmConfigForCondensation();
+    expect(config.maxInputTokens).toBe(100);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llmSettingsHelpers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llmSettingsHelpers.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { clearRawLlmFieldsWhenProfileSelected } from '../types/settings';
+
+describe('clearRawLlmFieldsWhenProfileSelected', () => {
+  it('leaves raw llm fields intact when profileId is not set', () => {
+    const input = {
+      profileId: null,
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      baseUrl: 'http://example.test',
+      openaiApiMode: 'chat_completions',
+      maxInputTokens: 123,
+      usageId: 'u1',
+    } as any;
+
+    expect(clearRawLlmFieldsWhenProfileSelected(input)).toEqual(input);
+  });
+
+  it('clears raw llm fields when profileId is set', () => {
+    const input = {
+      profileId: 'p1',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      baseUrl: 'http://example.test',
+      openaiApiMode: 'chat_completions',
+      apiVersion: '2025-01-01',
+      timeout: 10,
+      temperature: 0.5,
+      topP: 1,
+      topK: 5,
+      maxInputTokens: 123,
+      maxOutputTokens: 456,
+      reasoningEffort: 'high',
+      reasoningSummary: 'detailed',
+      inputCostPerToken: 0.1,
+      outputCostPerToken: 0.2,
+      usageId: 'u1',
+    } as any;
+
+    expect(clearRawLlmFieldsWhenProfileSelected(input)).toEqual({
+      ...input,
+      provider: undefined,
+      model: undefined,
+      openaiApiMode: undefined,
+      baseUrl: undefined,
+      apiVersion: undefined,
+      timeout: undefined,
+      temperature: undefined,
+      topP: undefined,
+      topK: undefined,
+      maxInputTokens: undefined,
+      maxOutputTokens: undefined,
+      reasoningEffort: undefined,
+      reasoningSummary: undefined,
+      inputCostPerToken: undefined,
+      outputCostPerToken: undefined,
+    });
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -11,6 +11,7 @@ import {
 } from '../runtime';
 import type { LLMClient } from '../llm';
 import type { BashEvent, Event } from '../types';
+import { clearRawLlmFieldsWhenProfileSelected } from '../types/settings';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import { LocalWorkspace } from '../../workspace/LocalWorkspace';
@@ -350,26 +351,11 @@ export class LocalConversation extends EventEmitter {
 
     const existing = this.settings.llm ?? {};
     const merged: OpenHandsSettings['llm'] = persisted.profileId
-      ? {
+      ? clearRawLlmFieldsWhenProfileSelected({
         ...existing,
         profileId: persisted.profileId,
         usageId: persisted.usageId ?? undefined,
-        provider: undefined,
-        model: undefined,
-        openaiApiMode: undefined,
-        baseUrl: undefined,
-        apiVersion: undefined,
-        timeout: undefined,
-        temperature: undefined,
-        topP: undefined,
-        topK: undefined,
-        maxInputTokens: undefined,
-        maxOutputTokens: undefined,
-        reasoningEffort: undefined,
-        reasoningSummary: undefined,
-        inputCostPerToken: undefined,
-        outputCostPerToken: undefined,
-      }
+      })
       : {
         ...existing,
         profileId: undefined,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -988,7 +988,7 @@ export class Agent extends EventEmitter {
         baseUrl: profileBaseUrl ?? configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[profileProvider],
         model: profileModel,
         openaiApiMode: profile.config.openaiApiMode ?? configuredOpenaiApiMode,
-        maxInputTokens: configuredMaxInputTokens ?? profileMaxInputTokens,
+        maxInputTokens: profileMaxInputTokens ?? configuredMaxInputTokens,
       };
     } catch {
       const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -26,6 +26,49 @@ export type LLMSettings = {
   outputCostPerToken?: number | null;
 };
 
+export const RAW_LLM_FIELDS_IGNORED_WHEN_PROFILE_SELECTED = [
+  'provider',
+  'model',
+  'openaiApiMode',
+  'baseUrl',
+  'apiVersion',
+  'timeout',
+  'temperature',
+  'topP',
+  'topK',
+  'maxInputTokens',
+  'maxOutputTokens',
+  'reasoningEffort',
+  'reasoningSummary',
+  'inputCostPerToken',
+  'outputCostPerToken',
+] as const;
+
+export type RawLlmFieldIgnoredWhenProfileSelected = (typeof RAW_LLM_FIELDS_IGNORED_WHEN_PROFILE_SELECTED)[number];
+
+export const clearRawLlmFieldsWhenProfileSelected = (llm: LLMSettings): LLMSettings => {
+  const profileId = typeof llm.profileId === 'string' ? llm.profileId.trim() : '';
+  if (!profileId) return llm;
+  return {
+    ...llm,
+    provider: undefined,
+    model: undefined,
+    openaiApiMode: undefined,
+    baseUrl: undefined,
+    apiVersion: undefined,
+    timeout: undefined,
+    temperature: undefined,
+    topP: undefined,
+    topK: undefined,
+    maxInputTokens: undefined,
+    maxOutputTokens: undefined,
+    reasoningEffort: undefined,
+    reasoningSummary: undefined,
+    inputCostPerToken: undefined,
+    outputCostPerToken: undefined,
+  };
+};
+
 export type ServerSettings = {
   serverUrl?: string | null;
 };


### PR DESCRIPTION
Bead: oh-tab-dh4r (part of oh-tab-ot3z)

Changes:
- Add clearRawLlmFieldsWhenProfileSelected helper (single source of truth for which raw llm.* fields are ignored when profileId is set).
- Use helper in LocalConversation.restorePersistedLlmConfig.
- Fix Agent.getEffectiveLlmConfigForCondensation to prefer profile maxInputTokens over raw settings when profileId is set.

Tests:
- npm test -w @openhands/agent-sdk-ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile-based LLM configuration now takes precedence over manually specified settings for max input tokens and other parameters.

* **Tests**
  * Added unit tests for agent condensation budget behavior and LLM settings management when profiles are selected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->