### PR TITLE
oh-tab-0vlx: context tokens use main LLM

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -150,6 +150,46 @@ describe('App toolbar interactions', () => {
     expect(totalsRow).not.toHaveTextContent('—');
   });
 
+  it('uses the main agent usage bucket for context tokens (not sum across usages)', async () => {
+    render(<App />);
+
+    const totalsRow = await screen.findByTestId('header-totals-row');
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'remote', llmProfileLabel: 'gpt-5' }
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'event',
+          event: {
+            kind: 'ConversationStateUpdateEvent',
+            key: 'stats',
+            value: {
+              usage_to_metrics: {
+                main: {
+                  accumulated_cost: 0.0123,
+                  accumulated_token_usage: { prompt_tokens: 100, completion_tokens: 20, per_turn_token: 50 },
+                },
+                summarizer: {
+                  accumulated_cost: 0.0004,
+                  accumulated_token_usage: { prompt_tokens: 10, completion_tokens: 5, per_turn_token: 20 },
+                },
+              },
+              usage_to_labels: {
+                main: 'gpt-5',
+                summarizer: 'gemini-flash-summarizer',
+              },
+            },
+          },
+        },
+      }));
+    });
+
+    expect(totalsRow).toHaveTextContent('Context: 50 tokens');
+    expect(totalsRow).toHaveTextContent('Total cost: $0.0127');
+  });
+
   it('resets llm usage guard when starting a new conversation', async () => {
     render(<App />);
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -312,6 +312,8 @@ export function App() {
     pendingActionsBatchIdRef,
     submissionTimeoutRef,
     hasLlmUsageRef,
+    llmProfileLabel,
+    llmProfileId,
     eventId,
     showStatusMessage,
     maybeUpdateHalFlow,

--- a/src/webview-src/components/app/conversationStats.ts
+++ b/src/webview-src/components/app/conversationStats.ts
@@ -8,7 +8,27 @@ const asFiniteNumber = (raw: unknown): number | null => {
 const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
   !!candidate && typeof candidate === 'object';
 
-export const computeConversationTotalsFromStats = (value: unknown): ConversationTotals | null => {
+type ConversationTotalsStatsOptions = {
+  /**
+   * Prefer using a single "main" usage bucket when computing context tokens,
+   * rather than summing across all usageIds (summarizers/HAL/etc).
+   */
+  mainUsageId?: string;
+  /**
+   * Label hints to match against `usage_to_labels` (e.g. active profile name/id).
+   */
+  mainUsageLabels?: string[];
+};
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed : undefined;
+};
+
+export const computeConversationTotalsFromStats = (
+  value: unknown,
+  options: ConversationTotalsStatsOptions = {},
+): ConversationTotals | null => {
   const getTokenUsageArray = (metric: Record<string, unknown>): unknown[] | null => {
     // Token usage history keys vary across backends/versions; keep fallbacks for restores.
     const raw = metric.tokenUsages ?? metric.token_usages ?? metric.token_usages_history ?? metric.tokenUsagesHistory;
@@ -35,7 +55,60 @@ export const computeConversationTotalsFromStats = (value: unknown): Conversation
   const usageToMetricsRaw = value.usage_to_metrics ?? value.usageToMetrics ?? value.service_to_metrics ?? value.serviceToMetrics;
   if (!isRecord(usageToMetricsRaw)) return null;
 
-  let contextTokens = 0;
+  const usageToLabelsRaw = value.usage_to_labels ?? value.usageToLabels;
+  const usageToLabels = isRecord(usageToLabelsRaw) ? usageToLabelsRaw : null;
+  const labelHints = (options.mainUsageLabels ?? [])
+    .map((label) => toOptionalNonEmptyString(label))
+    .filter((label): label is string => typeof label === 'string');
+
+  const pickMainUsageId = (): string | undefined => {
+    const explicitUsageId = toOptionalNonEmptyString(options.mainUsageId);
+    if (explicitUsageId && Object.prototype.hasOwnProperty.call(usageToMetricsRaw, explicitUsageId)) {
+      return explicitUsageId;
+    }
+
+    if (usageToLabels && labelHints.length) {
+      const normalizedLabelByUsage = new Map<string, string>();
+      for (const [usageId, label] of Object.entries(usageToLabels)) {
+        const normalized = toOptionalNonEmptyString(label);
+        if (normalized) normalizedLabelByUsage.set(usageId, normalized);
+      }
+      for (const hint of labelHints) {
+        for (const [usageId, label] of normalizedLabelByUsage.entries()) {
+          if (label === hint) return usageId;
+        }
+      }
+    }
+
+    for (const fallbackId of ['default', 'default-llm']) {
+      if (Object.prototype.hasOwnProperty.call(usageToMetricsRaw, fallbackId)) return fallbackId;
+    }
+
+    const usageIds = Object.keys(usageToMetricsRaw);
+    if (usageIds.length === 1) return usageIds[0];
+
+    // Best-effort heuristic: pick the usage with the largest last prompt token count.
+    let best: { usageId: string; promptTokens: number } | null = null;
+    for (const [usageId, metricRaw] of Object.entries(usageToMetricsRaw)) {
+      if (!isRecord(metricRaw)) continue;
+      const lastPrompt = getLastRequestPromptTokens(metricRaw);
+      if (lastPrompt === null) continue;
+      if (!best || lastPrompt > best.promptTokens) {
+        best = { usageId, promptTokens: lastPrompt };
+      }
+    }
+    return best?.usageId;
+  };
+
+  const mainUsageId = pickMainUsageId();
+  const contextTokens = (() => {
+    if (!mainUsageId) return 0;
+    const metricRaw = usageToMetricsRaw[mainUsageId];
+    if (!isRecord(metricRaw)) return 0;
+    const lastPrompt = getLastRequestPromptTokens(metricRaw);
+    return lastPrompt !== null && lastPrompt > 0 ? lastPrompt : 0;
+  })();
+
   let accumulatedPromptTokens = 0;
   let accumulatedCompletionTokens = 0;
   let totalCost = 0;
@@ -45,9 +118,6 @@ export const computeConversationTotalsFromStats = (value: unknown): Conversation
     const costRaw = metricRaw.accumulatedCost ?? metricRaw.accumulated_cost;
     const cost = asFiniteNumber(costRaw);
     if (cost !== null && cost > 0) totalCost += cost;
-
-    const lastPrompt = getLastRequestPromptTokens(metricRaw);
-    if (lastPrompt !== null && lastPrompt > 0) contextTokens += lastPrompt;
 
     const usageRaw = metricRaw.accumulatedTokenUsage ?? metricRaw.accumulated_token_usage;
     if (!isRecord(usageRaw)) continue;

--- a/src/webview-src/components/app/conversationStats.ts
+++ b/src/webview-src/components/app/conversationStats.ts
@@ -17,7 +17,7 @@ type ConversationTotalsStatsOptions = {
   /**
    * Label hints to match against `usage_to_labels` (e.g. active profile name/id).
    */
-  mainUsageLabels?: string[];
+  mainUsageLabels?: Array<string | null | undefined>;
 };
 
 const toOptionalNonEmptyString = (value: unknown): string | undefined => {
@@ -61,12 +61,15 @@ export const computeConversationTotalsFromStats = (
     .map((label) => toOptionalNonEmptyString(label))
     .filter((label): label is string => typeof label === 'string');
 
-  const pickMainUsageId = (): string | undefined => {
+  const pickByExplicitId = (): string | undefined => {
     const explicitUsageId = toOptionalNonEmptyString(options.mainUsageId);
     if (explicitUsageId && Object.prototype.hasOwnProperty.call(usageToMetricsRaw, explicitUsageId)) {
       return explicitUsageId;
     }
+    return undefined;
+  };
 
+  const pickByLabelHint = (): string | undefined => {
     if (usageToLabels && labelHints.length) {
       const normalizedLabelByUsage = new Map<string, string>();
       for (const [usageId, label] of Object.entries(usageToLabels)) {
@@ -79,14 +82,22 @@ export const computeConversationTotalsFromStats = (
         }
       }
     }
+    return undefined;
+  };
 
+  const pickByFallbackId = (): string | undefined => {
     for (const fallbackId of ['default', 'default-llm']) {
       if (Object.prototype.hasOwnProperty.call(usageToMetricsRaw, fallbackId)) return fallbackId;
     }
+    return undefined;
+  };
 
+  const pickBySingleUsage = (): string | undefined => {
     const usageIds = Object.keys(usageToMetricsRaw);
-    if (usageIds.length === 1) return usageIds[0];
+    return usageIds.length === 1 ? usageIds[0] : undefined;
+  };
 
+  const pickByHeuristic = (): string | undefined => {
     // Best-effort heuristic: pick the usage with the largest last prompt token count.
     let best: { usageId: string; promptTokens: number } | null = null;
     for (const [usageId, metricRaw] of Object.entries(usageToMetricsRaw)) {
@@ -98,6 +109,14 @@ export const computeConversationTotalsFromStats = (
       }
     }
     return best?.usageId;
+  };
+
+  const pickMainUsageId = (): string | undefined => {
+    return pickByExplicitId()
+      ?? pickByLabelHint()
+      ?? pickByFallbackId()
+      ?? pickBySingleUsage()
+      ?? pickByHeuristic();
   };
 
   const mainUsageId = pickMainUsageId();

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -105,10 +105,7 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     }
 
     if (event.key === 'stats') {
-      const mainUsageLabels = [llmProfileLabel, llmProfileId].filter(
-        (label): label is string => typeof label === 'string' && label.trim().length > 0
-      );
-      const totals = computeConversationTotalsFromStats(event.value, { mainUsageLabels });
+      const totals = computeConversationTotalsFromStats(event.value, { mainUsageLabels: [llmProfileLabel, llmProfileId] });
       if (totals) {
         setConversationTotals((prev) => {
           const nextContextTokens = hasLlmUsageRef.current ? prev.contextTokens : totals.contextTokens;

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -32,6 +32,8 @@ type UseConversationEventsOptions = {
   pendingActionsBatchIdRef: MutableRefObject<string | null>;
   submissionTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
   hasLlmUsageRef: MutableRefObject<boolean>;
+  llmProfileLabel: string | null | undefined;
+  llmProfileId: string | null;
   eventId: MutableRefObject<number>;
   showStatusMessage: ShowStatusMessage;
   maybeUpdateHalFlow: () => void;
@@ -53,6 +55,8 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     pendingActionsBatchIdRef,
     submissionTimeoutRef,
     hasLlmUsageRef,
+    llmProfileLabel,
+    llmProfileId,
     eventId,
     showStatusMessage,
     maybeUpdateHalFlow,
@@ -101,7 +105,10 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     }
 
     if (event.key === 'stats') {
-      const totals = computeConversationTotalsFromStats(event.value);
+      const mainUsageLabels = [llmProfileLabel, llmProfileId].filter(
+        (label): label is string => typeof label === 'string' && label.trim().length > 0
+      );
+      const totals = computeConversationTotalsFromStats(event.value, { mainUsageLabels });
       if (totals) {
         setConversationTotals((prev) => {
           const nextContextTokens = hasLlmUsageRef.current ? prev.contextTokens : totals.contextTokens;
@@ -126,6 +133,8 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     lastAgentStatusRef,
     pendingActionsBatchIdRef,
     pendingActionsRef,
+    llmProfileId,
+    llmProfileLabel,
     setAgentStatus,
     setConversationTotals,
     setIsSubmitting,
@@ -215,4 +224,3 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
 
   return { handleEvent };
 }
-


### PR DESCRIPTION
Fixes Context tokens display: compute from the main agent usage bucket only (not sum across usages like summarizers/HAL). Total cost remains summed across usages.

- Webview picks main usage via stats.usage_to_labels matching active profile label/id (with fallbacks).
- Adds unit test coverage.

Checks: npm test, npm run typecheck, npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed context token display to accurately derive from the main usage bucket in scenarios with multiple usage types, improving token count accuracy
  * Improved total cost calculation to properly aggregate costs from the appropriate usage bucket

* **New Features**
  * Enhanced LLM profile tracking to better categorize and identify usage metrics

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->