### PR TITLE
oh-tab-g0zf: remove 'None' from profile selector

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -274,6 +274,19 @@ describe('App toolbar interactions', () => {
     expect(profileButton).toHaveTextContent('Select profile…');
   });
 
+  it('shows a selector prompt when the active LLM profile is missing from the list', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'llmProfilesUpdated', profiles: ['gpt-5'], activeProfileId: 'missing-profile' }
+      }));
+    });
+
+    const profileButton = await screen.findByLabelText('LLM profile');
+    expect(profileButton).toHaveTextContent('Select profile…');
+  });
+
   it('updates the LLM profile when selected in the dropdown', async () => {
     render(<App />);
 

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -258,7 +258,7 @@ describe('App toolbar interactions', () => {
     expect(await screen.findByLabelText('LLM profile')).toHaveTextContent('gpt-4.1');
   });
 
-  it('shows the effective model label when no LLM profile is configured', async () => {
+  it('shows a selector prompt when no active LLM profile is configured', async () => {
     render(<App />);
 
     await act(async () => {
@@ -271,8 +271,7 @@ describe('App toolbar interactions', () => {
     });
 
     const profileButton = await screen.findByLabelText('LLM profile');
-    expect(profileButton).toHaveTextContent('None');
-    expect(profileButton).toHaveTextContent('gpt-4.1');
+    expect(profileButton).toHaveTextContent('Select profile…');
   });
 
   it('updates the LLM profile when selected in the dropdown', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -729,7 +729,7 @@ export function App() {
     postMessage({ type: 'switchToLocal' });
   }, [postMessage]);
 
-  const handleSelectLlmProfileId = useCallback((profileId: string | null) => {
+  const handleSelectLlmProfileId = useCallback((profileId: string) => {
     setLlmProfileId(profileId);
     postMessage({ type: 'setLlmProfileId', profileId });
   }, [postMessage]);
@@ -850,7 +850,6 @@ export function App() {
           disabled={status === 'offline'}
           llmProfileId={llmProfileId}
           llmProfiles={llmProfiles}
-          llmProfileLabel={llmProfileLabel}
           onSelectLlmProfileId={handleSelectLlmProfileId}
           onOpenLlmProfilesCreate={handleOpenLlmProfilesCreate}
           onOpenLlmProfilesEdit={handleOpenLlmProfilesEdit}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -443,14 +443,8 @@ function LlmProfileSelector({
   const hasValidSelection = typeof profileId === 'string' && sanitizedProfiles.includes(profileId);
   const selectedProfileId = hasValidSelection ? profileId : null;
   const shouldPromptCreate = selectedProfileId === null && !hasProfiles && Boolean(onOpenCreate);
-  const shown = selectedProfileId ?? (shouldPromptCreate ? 'New profile…' : (hasProfiles ? 'Select profile…' : 'New profile…'));
-  const tooltip = selectedProfileId
-    ? `LLM profile: ${selectedProfileId}`
-    : shouldPromptCreate
-      ? 'LLM profile: New profile…'
-      : hasProfiles
-        ? 'LLM profile: Select profile…'
-        : 'LLM profile: New profile…';
+  const shown = selectedProfileId ?? (hasProfiles ? 'Select profile…' : 'New profile…');
+  const tooltip = `LLM profile: ${shown}`;
 
   const handleSelect = (next: string) => {
     onSelect(next);

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -440,10 +440,12 @@ function LlmProfileSelector({
 
   const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
   const hasProfiles = sanitizedProfiles.length > 0;
-  const shouldPromptCreate = profileId === null && !hasProfiles && Boolean(onOpenCreate);
-  const shown = profileId ?? (shouldPromptCreate ? 'New profile…' : (hasProfiles ? 'Select profile…' : 'New profile…'));
-  const tooltip = profileId
-    ? `LLM profile: ${profileId}`
+  const hasValidSelection = typeof profileId === 'string' && sanitizedProfiles.includes(profileId);
+  const selectedProfileId = hasValidSelection ? profileId : null;
+  const shouldPromptCreate = selectedProfileId === null && !hasProfiles && Boolean(onOpenCreate);
+  const shown = selectedProfileId ?? (shouldPromptCreate ? 'New profile…' : (hasProfiles ? 'Select profile…' : 'New profile…'));
+  const tooltip = selectedProfileId
+    ? `LLM profile: ${selectedProfileId}`
     : shouldPromptCreate
       ? 'LLM profile: New profile…'
       : hasProfiles
@@ -455,7 +457,7 @@ function LlmProfileSelector({
     setIsOpen(false);
   };
 
-  const isSelected = (candidate: string) => candidate === profileId;
+  const isSelected = (candidate: string) => candidate === selectedProfileId;
 
   return (
     <div className="relative">

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -10,8 +10,7 @@ interface InputAreaProps {
   // LLM profile selector
   llmProfileId: string | null;
   llmProfiles: string[];
-  llmProfileLabel?: string | null;
-  onSelectLlmProfileId: (profileId: string | null) => void;
+  onSelectLlmProfileId: (profileId: string) => void;
   onOpenLlmProfilesCreate?: () => void;
   onOpenLlmProfilesEdit?: (profileId: string) => void;
   // Context picker
@@ -62,7 +61,6 @@ export function InputArea({
   placeholder = 'Ask OpenHands anything...',
   llmProfileId,
   llmProfiles,
-  llmProfileLabel,
   onSelectLlmProfileId,
   onOpenLlmProfilesCreate,
   onOpenLlmProfilesEdit,
@@ -285,7 +283,6 @@ export function InputArea({
           <LlmProfileSelector
             profileId={llmProfileId}
             profiles={llmProfiles}
-            fallbackLabel={llmProfileLabel}
             onSelect={onSelectLlmProfileId}
             onOpenCreate={onOpenLlmProfilesCreate}
             onOpenEdit={onOpenLlmProfilesEdit}
@@ -424,8 +421,7 @@ interface AccessoryButtonProps {
 interface LlmProfileSelectorProps {
   profileId: string | null;
   profiles: string[];
-  fallbackLabel?: string | null;
-  onSelect: (profileId: string | null) => void;
+  onSelect: (profileId: string) => void;
   onOpenCreate?: () => void;
   onOpenEdit?: (profileId: string) => void;
 }
@@ -433,7 +429,6 @@ interface LlmProfileSelectorProps {
 function LlmProfileSelector({
   profileId,
   profiles,
-  fallbackLabel,
   onSelect,
   onOpenCreate,
   onOpenEdit,
@@ -443,26 +438,24 @@ function LlmProfileSelector({
 
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose: () => setIsOpen(false), ref: popoverRef, delay: 100 });
 
-  const normalizedFallbackLabel = typeof fallbackLabel === 'string' ? fallbackLabel.trim() : '';
-  const hasFallback = normalizedFallbackLabel.length > 0;
   const sanitizedProfiles = profiles.filter((id) => typeof id === 'string' && id.trim().length > 0);
   const hasProfiles = sanitizedProfiles.length > 0;
   const shouldPromptCreate = profileId === null && !hasProfiles && Boolean(onOpenCreate);
-  const shown = profileId ?? (shouldPromptCreate ? 'New profile…' : (hasFallback ? `None (${normalizedFallbackLabel})` : 'None'));
+  const shown = profileId ?? (shouldPromptCreate ? 'New profile…' : (hasProfiles ? 'Select profile…' : 'New profile…'));
   const tooltip = profileId
     ? `LLM profile: ${profileId}`
     : shouldPromptCreate
       ? 'LLM profile: New profile…'
-      : hasFallback
-        ? `LLM profile: None (using ${normalizedFallbackLabel})`
-        : 'LLM profile: None';
+      : hasProfiles
+        ? 'LLM profile: Select profile…'
+        : 'LLM profile: New profile…';
 
-  const handleSelect = (next: string | null) => {
+  const handleSelect = (next: string) => {
     onSelect(next);
     setIsOpen(false);
   };
 
-  const isSelected = (candidate: string | null) => candidate === profileId;
+  const isSelected = (candidate: string) => candidate === profileId;
 
   return (
     <div className="relative">
@@ -556,25 +549,6 @@ function LlmProfileSelector({
                   );
                 })
               )}
-
-              <button
-                type="button"
-                onClick={() => handleSelect(null)}
-                role="option"
-                aria-selected={isSelected(null)}
-                className={`
-                  w-full text-left px-3 py-2 rounded-lg
-                  text-sm
-                  transition-colors duration-150
-                  hover:bg-white/10
-                  flex items-center gap-2
-                  ${isSelected(null) ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
-                `}
-              >
-                <span className="codicon codicon-circle-slash" />
-                <span className="flex-1">None</span>
-                {isSelected(null) && <span className="codicon codicon-check text-brand-400" />}
-              </button>
 
               <div className="my-1 border-t border-white/10" />
 


### PR DESCRIPTION
Profiles-only UX: remove the 'None' option from the conversation profile selector.

- Selector shows 'Select profile…' when there is no valid active profile id (unset or deleted).
- 'New profile…' remains available.
- Updates App/InputArea types accordingly.

Checks: npm test, npm run typecheck, npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM profile selection now requires choosing an active profile; the "None" option has been removed.
  
* **Bug Fixes**
  * Improved handling of missing or inactive LLM profiles with clearer "Select profile…" prompts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->