### PR TITLE
oh-tab-fe1j: reserve usageId=agent

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
@@ -109,4 +109,39 @@ describe('LLMFactory profile selection', () => {
       }
     }
   });
+
+  it('keeps main agent usage under a stable usageId when switching profiles', async () => {
+    const dir = makeTempDir('llm-profile-switching-usageid-');
+    try {
+      saveProfile('gpt-5', { provider: 'openai', model: 'gpt-5' }, { rootDir: dir });
+      saveProfile('sonnet-45', { provider: 'anthropic', model: 'claude-sonnet-4-20250514' }, { rootDir: dir });
+
+      const registry = new LLMRegistry();
+      const stats = new ConversationStats();
+      registry.subscribe((event) => stats.registerLlm(event));
+
+      const first = await new LLMFactory(
+        { provider: 'openai', model: 'IGNORED', profileId: 'gpt-5', usageId: 'agent', apiKey: 'sk-inline' },
+        { registry, profileStoreOptions: { rootDir: dir } },
+      ).createClient();
+      expect(first).toBeInstanceOf(TrackedLLMClient);
+      (first as TrackedLLMClient).metrics.addTokenUsage({ promptTokens: 10, completionTokens: 1, responseId: 'r1' });
+
+      const second = await new LLMFactory(
+        { provider: 'openai', model: 'IGNORED', profileId: 'sonnet-45', usageId: 'agent', apiKey: 'sk-inline' },
+        { registry, profileStoreOptions: { rootDir: dir } },
+      ).createClient();
+      expect(second).toBeInstanceOf(TrackedLLMClient);
+      (second as TrackedLLMClient).metrics.addTokenUsage({ promptTokens: 5, completionTokens: 2, responseId: 'r2' });
+
+      expect(Object.keys(stats.usageToMetrics)).toEqual(['agent']);
+      expect(stats.usageToLabels.agent).toBe('sonnet-45');
+      expect(stats.usageToMetrics.agent.accumulatedTokenUsage).toMatchObject({
+        promptTokens: 15,
+        completionTokens: 3,
+      });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -218,7 +218,7 @@ describe('RemoteConversation', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('derives usage_id from profileId when usageId is default-llm', async () => {
+  it('always uses a stable usage_id of agent', async () => {
     const dir = makeTempDir('remote-conversation-profiles-');
     try {
       saveProfile('p1', { provider: 'openai', model: 'gpt-5-mini' }, { rootDir: dir });
@@ -250,7 +250,7 @@ describe('RemoteConversation', () => {
       conversation.disconnect();
 
       expect(id).toBe('conv-1');
-      expect(capturedReq?.agent?.llm?.usage_id).toBe('p1');
+      expect(capturedReq?.agent?.llm?.usage_id).toBe('agent');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -313,7 +313,7 @@ describe('RemoteConversation', () => {
 
       expect(id).toBe('conv-1');
       const llm = capturedReq?.agent?.llm ?? {};
-      expect(llm.usage_id).toBe('p1');
+      expect(llm.usage_id).toBe('agent');
       expect(llm.model).toBe('profile-model');
       expect(llm.base_url).toBe('https://profile.example');
       expect(llm.api_version).toBe('2025-01-01');

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -146,7 +146,6 @@ export class RemoteConversation extends EventEmitter {
         }
         return undefined;
       };
-      const usageId = toOptionalString(s?.llm.usageId);
       const profileId = toOptionalString(s?.llm.profileId);
       const model = toOptionalString(s?.llm.model);
       const baseUrl = toOptionalString(s?.llm.baseUrl);
@@ -165,20 +164,16 @@ export class RemoteConversation extends EventEmitter {
 
       // NOTE: profileId is a local alias only. Remote agent-server rejects unknown llm fields
       // (like `profile_id`) with strict schema validation.
-      const profileUsageId = toOptionalString(profileConfig?.usageId);
       const profileModel = profileConfig ? toOptionalString(profileConfig.model) : undefined;
       const profileBaseUrl = toOptionalString(profileConfig?.baseUrl);
       const profileApiVersion = toOptionalString(profileConfig?.apiVersion);
 
-      const derivedUsageId = profileId && (!usageId || usageId === 'default-llm')
-        ? profileId
-        : undefined;
-      const effectiveUsageId = derivedUsageId ?? usageId ?? profileUsageId;
+      const effectiveUsageId = 'agent';
       const effectiveModel = profileModel ?? model;
       const effectiveBaseUrl = profileBaseUrl ?? baseUrl;
       const effectiveApiVersion = profileApiVersion ?? apiVersion;
 
-      if (effectiveUsageId) llm.usage_id = effectiveUsageId;
+      llm.usage_id = effectiveUsageId;
       if (effectiveModel) llm.model = effectiveModel;
       if (effectiveBaseUrl) llm.base_url = effectiveBaseUrl;
       if (effectiveApiVersion) llm.api_version = effectiveApiVersion;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1188,10 +1188,7 @@ export class Agent extends EventEmitter {
     if (!profileId && !model) {
       return Promise.reject(new Error('LLM model is not configured'));
     }
-    const configuredUsageId = toOptionalNonEmptyString(s.llm?.usageId);
-    const effectiveUsageId = profileId && (!configuredUsageId || configuredUsageId === 'default-llm')
-      ? profileId
-      : configuredUsageId;
+    const effectiveUsageId = 'agent';
 
     const configuredApiKey = toOptionalNonEmptyString(s.secrets?.llmApiKey);
     const configuredApiKeyIsReference =

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -167,7 +167,7 @@ describe('App toolbar interactions', () => {
             key: 'stats',
             value: {
               usage_to_metrics: {
-                main: {
+                agent: {
                   accumulated_cost: 0.0123,
                   accumulated_token_usage: { prompt_tokens: 100, completion_tokens: 20, per_turn_token: 50 },
                 },
@@ -177,7 +177,7 @@ describe('App toolbar interactions', () => {
                 },
               },
               usage_to_labels: {
-                main: 'gpt-5',
+                agent: 'gpt-5',
                 summarizer: 'gemini-flash-summarizer',
               },
             },
@@ -231,7 +231,7 @@ describe('App toolbar interactions', () => {
               key: 'stats',
               value: {
                 usage_to_metrics: {
-                  default: {
+                  agent: {
                     accumulated_cost: 0,
                     accumulated_token_usage: { prompt_tokens: 1, completion_tokens: 0, per_turn_token: 7 },
                   },

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -109,7 +109,6 @@ export function App() {
   const [status, setStatus] = useState<'online' | 'offline' | 'connecting'>('offline');
   const [mode, setMode] = useState<'local' | 'remote'>('remote');
   const [conversationId, setConversationId] = useState<string | undefined>(undefined);
-  const [llmProfileLabel, setLlmProfileLabel] = useState<string | null | undefined>(undefined);
   const [llmProfileId, setLlmProfileId] = useState<string | null>(null);
   const [llmProfiles, setLlmProfiles] = useState<string[]>([]);
 
@@ -312,8 +311,6 @@ export function App() {
     pendingActionsBatchIdRef,
     submissionTimeoutRef,
     hasLlmUsageRef,
-    llmProfileLabel,
-    llmProfileId,
     eventId,
     showStatusMessage,
     maybeUpdateHalFlow,
@@ -387,7 +384,6 @@ export function App() {
     setHistory,
     setIsMentionActive,
     setLlmProfileId,
-    setLlmProfileLabel,
     setLlmProfiles,
     setMode,
     setPendingActions,

--- a/src/webview-src/components/app/conversationStats.ts
+++ b/src/webview-src/components/app/conversationStats.ts
@@ -61,14 +61,6 @@ export const computeConversationTotalsFromStats = (
     .map((label) => toOptionalNonEmptyString(label))
     .filter((label): label is string => typeof label === 'string');
 
-  const pickByExplicitId = (): string | undefined => {
-    const explicitUsageId = toOptionalNonEmptyString(options.mainUsageId);
-    if (explicitUsageId && Object.prototype.hasOwnProperty.call(usageToMetricsRaw, explicitUsageId)) {
-      return explicitUsageId;
-    }
-    return undefined;
-  };
-
   const pickByLabelHint = (): string | undefined => {
     if (usageToLabels && labelHints.length) {
       const normalizedLabelByUsage = new Map<string, string>();
@@ -112,8 +104,14 @@ export const computeConversationTotalsFromStats = (
   };
 
   const pickMainUsageId = (): string | undefined => {
-    return pickByExplicitId()
-      ?? pickByLabelHint()
+    const explicitUsageId = toOptionalNonEmptyString(options.mainUsageId);
+    if (explicitUsageId) {
+      return Object.prototype.hasOwnProperty.call(usageToMetricsRaw, explicitUsageId)
+        ? explicitUsageId
+        : undefined;
+    }
+
+    return pickByLabelHint()
       ?? pickByFallbackId()
       ?? pickBySingleUsage()
       ?? pickByHeuristic();

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -32,8 +32,6 @@ type UseConversationEventsOptions = {
   pendingActionsBatchIdRef: MutableRefObject<string | null>;
   submissionTimeoutRef: MutableRefObject<ReturnType<typeof setTimeout> | null>;
   hasLlmUsageRef: MutableRefObject<boolean>;
-  llmProfileLabel: string | null | undefined;
-  llmProfileId: string | null;
   eventId: MutableRefObject<number>;
   showStatusMessage: ShowStatusMessage;
   maybeUpdateHalFlow: () => void;
@@ -55,8 +53,6 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     pendingActionsBatchIdRef,
     submissionTimeoutRef,
     hasLlmUsageRef,
-    llmProfileLabel,
-    llmProfileId,
     eventId,
     showStatusMessage,
     maybeUpdateHalFlow,
@@ -105,7 +101,9 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     }
 
     if (event.key === 'stats') {
-      const totals = computeConversationTotalsFromStats(event.value, { mainUsageLabels: [llmProfileLabel, llmProfileId] });
+      const totals = computeConversationTotalsFromStats(event.value, {
+        mainUsageId: 'agent',
+      });
       if (totals) {
         setConversationTotals((prev) => {
           const nextContextTokens = hasLlmUsageRef.current ? prev.contextTokens : totals.contextTokens;
@@ -130,8 +128,6 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     lastAgentStatusRef,
     pendingActionsBatchIdRef,
     pendingActionsRef,
-    llmProfileId,
-    llmProfileLabel,
     setAgentStatus,
     setConversationTotals,
     setIsSubmitting,

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -75,7 +75,6 @@ export type HostMessageHandlerOptions = {
   setHistory: Dispatch<SetStateAction<ConversationsList>>;
   setIsMentionActive: Dispatch<SetStateAction<boolean>>;
   setLlmProfileId: Dispatch<SetStateAction<string | null>>;
-  setLlmProfileLabel: Dispatch<SetStateAction<string | null | undefined>>;
   setLlmProfiles: Dispatch<SetStateAction<string[]>>;
   setMode: Dispatch<SetStateAction<'local' | 'remote'>>;
   setPendingActions: Dispatch<SetStateAction<ActionEvent[]>>;
@@ -135,7 +134,6 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     setHistory,
     setIsMentionActive,
     setLlmProfileId,
-    setLlmProfileLabel,
     setLlmProfiles,
     setMode,
     setPendingActions,
@@ -206,10 +204,6 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
             setStatus(payload.status);
             if (payload.mode === 'local' || payload.mode === 'remote') {
               setMode(payload.mode);
-            }
-            const label = payload.llmProfileLabel;
-            if (typeof label === 'string' || label === null) {
-              setLlmProfileLabel(label);
             }
             const nextBanner: StatusBannerState | null =
               payload.mode === 'local'
@@ -710,7 +704,6 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     setHistory,
     setIsMentionActive,
     setLlmProfileId,
-    setLlmProfileLabel,
     setLlmProfiles,
     setMode,
     setPendingActions,


### PR DESCRIPTION
Implements bead oh-tab-fe1j.

- Main agent LLM metrics always use usageId='agent' (local + remote).
- Webview context tokens read only from 'agent' bucket (no label guessing).
- Helper/summarizer usageIds remain distinct.

Tests: npm test, npm run typecheck, npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified LLM usage tracking system to consolidate metrics under a unified identifier, ensuring consistent tracking when switching between LLM profiles.

* **Tests**
  * Expanded test coverage to validate stable usage metrics across profile configuration changes and model switching scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->