### PR TITLE
oh-tab-j070: simplify main usage stats

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -117,7 +117,6 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - `openhands.servers` - saved server list [{ url, label? }] for quick selection
 - `openhands.terminal.renderProgress` - coalesce carriage-return progress in terminal output
 - `openhands.llm.profileId` - selected LLM profile id from `~/.openhands/llm-profiles` (local alias; remote mode expands into `agent.llm` fields, no `profile_id` sent)
-- `openhands.llm.usageId` - maps to agent-sdk usage_id for metrics/cost tracking
 - `openhands.confirmation.policy` - never/always/risky; `risky.threshold` default MEDIUM; `risky.confirmUnknown`
 - `openhands.conversation.maxIterations` - iteration limit
 

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -71,7 +71,7 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
 - Current extension behavior (IMPLEMENTED)
   - Settings-driven configuration via SettingsManager
   - Default model: claude-sonnet-4-20250514 (configurable)
-  - Default usage_id: 'default-llm' (configurable)
+  - Main agent usageId: 'agent' (internal; not user-configurable)
   - API key stored in VS Code SecretStorage
   - All LLM parameters configurable via profiles or configuration wizard
   - ConnectionManager builds agent.llm payload dynamically from settings
@@ -90,7 +90,7 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
   - Do **not** send `profile_id` to the server until the agent-server supports it.
 - Merge rules
   - Profile config is canonical for provider/model/baseUrl/openaiApiMode and generation parameters.
-  - The only remaining VS Code LLM setting is `openhands.llm.usageId` (maps to the agent-sdk `usage_id`).
+  - The only remaining VS Code LLM setting is `openhands.llm.profileId`.
 
 4) VS Code settings split (IMPLEMENTED)
 - Keep simple values in VS Code Settings (configuration)
@@ -98,7 +98,6 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
   - openhands.servers: array of { url: string; label?: string } (saved servers for quick selection)
   - openhands.terminal.renderProgress: boolean (default: true) — coalesce carriage-return progress in terminal output
   - openhands.llm.profileId: string | null (default: null) — selects a profile from `~/.openhands/llm-profiles` (local alias; expanded into `agent.llm` for remote mode)
-  - openhands.llm.usageId: string (default: 'default-llm') — maps to agent-sdk usage_id
   - openhands.conversation.maxIterations: number (default: 50, max: 500)
   - openhands.confirmation.policy: enum ('never' | 'always' | 'risky') (default: 'never')
   - openhands.confirmation.risky.threshold: enum ('LOW' | 'MEDIUM' | 'HIGH') (default: 'MEDIUM')

--- a/package.json
+++ b/package.json
@@ -160,11 +160,6 @@
             "default": "",
             "order": 0,
             "markdownDescription": "LLM profile identifier (filename stem). OpenHands loads provider/model/baseUrl/tuning from `~/.openhands/llm-profiles/<profileId>.json`.\n\nTo manage profiles and API keys, use the **LLM Profiles** view inside the OpenHands sidebar."
-          },
-          "openhands.llm.usageId": {
-            "type": "string",
-            "order": 30,
-            "markdownDescription": "Optional usage_id for LLM metrics tracking. If unset in local mode, the SDK derives a stable id per provider/model/config so switching models preserves per-client metrics."
           }
         }
       },

--- a/scripts/dump-settings.ts
+++ b/scripts/dump-settings.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 export async function activate(): Promise<void> {
   const config = vscode.workspace.getConfiguration('openhands');
   console.log('openhands.llm.profileId:', config.get('llm.profileId'));
-  console.log('openhands.llm.usageId:', config.get('llm.usageId'));
   console.log('explicit profileId:', config.inspect('llm.profileId')?.workspaceValue ?? config.inspect('llm.profileId')?.globalValue);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -313,7 +313,6 @@ async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string
     // LLMFactory loads the effective provider/model/baseUrl/etc from the profile when profileId is set.
     // Keep `model` set to satisfy the type and for error context if the profile load fails.
     model,
-    usageId: normalizeNonEmptyString(settings.llm.usageId),
   }, {
     secrets,
     preferredApiKeys: [`openhands.llmProfileApiKey.${profileId}`],

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -237,7 +237,6 @@ export class SettingsManager {
       }
     }
 
-    const usageId = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.usageId'));
     const configuredProfileId = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.profileId'));
     const profileId = configuredProfileId && isSafeProfileId(configuredProfileId)
       ? configuredProfileId
@@ -272,7 +271,6 @@ export class SettingsManager {
     const provider = profileConfig?.provider ?? detectProviderFromBaseUrl(profileConfig?.baseUrl);
 
     const llm: LLMSettings = {
-      usageId,
       profileId: effectiveProfileId,
       provider,
       model: profileConfig?.model,
@@ -356,7 +354,6 @@ export class SettingsManager {
     }
 
     if (partial.llm) {
-      if (partial.llm.usageId !== undefined) ops.push(this.adapter.update('openhands.llm.usageId', partial.llm.usageId, target));
       if (partial.llm.profileId !== undefined) ops.push(this.adapter.update('openhands.llm.profileId', partial.llm.profileId, target));
     }
 

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -39,7 +39,6 @@ describe('SettingsManager', () => {
   it('returns defaults when unset', async () => {
     const s = await mgr.get();
     expect(s.serverUrl).toBeUndefined();
-    expect(s.llm.usageId).toBeUndefined();
     expect(s.llm.profileId).toBe('sonnet-45');
     expect(a.cfg.get('openhands.llm.profileId')).toBe('sonnet-45');
     expect(s.llm.provider).toBe('anthropic');
@@ -132,7 +131,6 @@ describe('SettingsManager', () => {
     await mgr.update({
       serverUrl: 'http://example:1234',
       llm: {
-        usageId: 'my-usage',
         profileId: 'gpt-5',
       },
       agent: { enableSecurityAnalyzer: true, debug: true },
@@ -156,7 +154,6 @@ describe('SettingsManager', () => {
     });
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
-    expect(s.llm.usageId).toBe('my-usage');
     expect(s.llm.profileId).toBe('gpt-5');
     expect(s.llm.provider).toBe('openai');
     expect(s.llm.model).toBe('gpt-5');

--- a/src/webview-src/components/app/conversationStats.ts
+++ b/src/webview-src/components/app/conversationStats.ts
@@ -14,16 +14,14 @@ type ConversationTotalsStatsOptions = {
    * rather than summing across all usageIds (summarizers/HAL/etc).
    */
   mainUsageId?: string;
-  /**
-   * Label hints to match against `usage_to_labels` (e.g. active profile name/id).
-   */
-  mainUsageLabels?: Array<string | null | undefined>;
 };
 
 const toOptionalNonEmptyString = (value: unknown): string | undefined => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   return trimmed ? trimmed : undefined;
 };
+
+const DEFAULT_MAIN_USAGE_ID = 'agent';
 
 export const computeConversationTotalsFromStats = (
   value: unknown,
@@ -55,71 +53,9 @@ export const computeConversationTotalsFromStats = (
   const usageToMetricsRaw = value.usage_to_metrics ?? value.usageToMetrics ?? value.service_to_metrics ?? value.serviceToMetrics;
   if (!isRecord(usageToMetricsRaw)) return null;
 
-  const usageToLabelsRaw = value.usage_to_labels ?? value.usageToLabels;
-  const usageToLabels = isRecord(usageToLabelsRaw) ? usageToLabelsRaw : null;
-  const labelHints = (options.mainUsageLabels ?? [])
-    .map((label) => toOptionalNonEmptyString(label))
-    .filter((label): label is string => typeof label === 'string');
-
-  const pickByLabelHint = (): string | undefined => {
-    if (usageToLabels && labelHints.length) {
-      const normalizedLabelByUsage = new Map<string, string>();
-      for (const [usageId, label] of Object.entries(usageToLabels)) {
-        const normalized = toOptionalNonEmptyString(label);
-        if (normalized) normalizedLabelByUsage.set(usageId, normalized);
-      }
-      for (const hint of labelHints) {
-        for (const [usageId, label] of normalizedLabelByUsage.entries()) {
-          if (label === hint) return usageId;
-        }
-      }
-    }
-    return undefined;
-  };
-
-  const pickByFallbackId = (): string | undefined => {
-    for (const fallbackId of ['default', 'default-llm']) {
-      if (Object.prototype.hasOwnProperty.call(usageToMetricsRaw, fallbackId)) return fallbackId;
-    }
-    return undefined;
-  };
-
-  const pickBySingleUsage = (): string | undefined => {
-    const usageIds = Object.keys(usageToMetricsRaw);
-    return usageIds.length === 1 ? usageIds[0] : undefined;
-  };
-
-  const pickByHeuristic = (): string | undefined => {
-    // Best-effort heuristic: pick the usage with the largest last prompt token count.
-    let best: { usageId: string; promptTokens: number } | null = null;
-    for (const [usageId, metricRaw] of Object.entries(usageToMetricsRaw)) {
-      if (!isRecord(metricRaw)) continue;
-      const lastPrompt = getLastRequestPromptTokens(metricRaw);
-      if (lastPrompt === null) continue;
-      if (!best || lastPrompt > best.promptTokens) {
-        best = { usageId, promptTokens: lastPrompt };
-      }
-    }
-    return best?.usageId;
-  };
-
-  const pickMainUsageId = (): string | undefined => {
-    const explicitUsageId = toOptionalNonEmptyString(options.mainUsageId);
-    if (explicitUsageId) {
-      return Object.prototype.hasOwnProperty.call(usageToMetricsRaw, explicitUsageId)
-        ? explicitUsageId
-        : undefined;
-    }
-
-    return pickByLabelHint()
-      ?? pickByFallbackId()
-      ?? pickBySingleUsage()
-      ?? pickByHeuristic();
-  };
-
-  const mainUsageId = pickMainUsageId();
+  const configuredUsageId = toOptionalNonEmptyString(options.mainUsageId);
+  const mainUsageId = configuredUsageId ?? DEFAULT_MAIN_USAGE_ID;
   const contextTokens = (() => {
-    if (!mainUsageId) return 0;
     const metricRaw = usageToMetricsRaw[mainUsageId];
     if (!isRecord(metricRaw)) return 0;
     const lastPrompt = getLastRequestPromptTokens(metricRaw);


### PR DESCRIPTION
Follow-up cleanup after #522.

- Webview stats: stop guessing main usage via labels/heuristics; default to usageId='agent'.
- Remove deprecated VS Code setting `openhands.llm.usageId` and related plumbing.
- Update docs mentioning usageId.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Removed the `openhands.llm.usageId` configuration option from user settings; the system now automatically handles usage identification without requiring manual setup.

* **Refactor**
  * Simplified internal LLM configuration processing, profile handling, and usage identifier resolution. Streamlined the mapping between settings UI and runtime behavior for improved consistency.

* **Tests**
  * Updated test expectations to reflect the simplified usage identification logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->