### PR TITLE
oh-tab-l1it: log sanitized LLM payloads

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.redaction.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.redaction.test.ts
@@ -67,7 +67,7 @@ describe('Agent redacts sensitive tool-call arguments in llm_tool_call_raw', () 
     expect(parsed.nested.client_secret).toBe('***');
     expect(parsed.arr[0].secret_key).toBe('***');
     // Authorization header value should be masked
-    expect(parsed.headers.Authorization).toContain('Bearer ***');
+    expect(parsed.headers.Authorization).toBe('***');
   });
 
   it('masks nested secrets and token-like strings without requiring key names', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -41,11 +41,20 @@ describe('textSanitizers', () => {
   });
 
   it('redactAndTruncateArgs redacts hyphenated API key headers', () => {
-    const raw = JSON.stringify({ headers: { 'x-api-key': 'NOPE', Authorization: 'Bearer SECRET' } });
+    const raw = JSON.stringify({
+      headers: {
+        'x-api-key': 'NOPE',
+        'x-goog-api-key': 'NOPE2',
+        'xi-api-key': 'NOPE3',
+        Authorization: 'Bearer SECRET',
+      },
+    });
     const output = redactAndTruncateArgs(raw);
     const parsed = JSON.parse(output);
     expect(parsed.headers['x-api-key']).toBe('***');
-    expect(parsed.headers.Authorization).toBe('Bearer ***');
+    expect(parsed.headers['x-goog-api-key']).toBe('***');
+    expect(parsed.headers['xi-api-key']).toBe('***');
+    expect(parsed.headers.Authorization).toBe('***');
   });
 
   it('sanitizeMessageForDebug truncates tool text content', () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -38,7 +38,9 @@ const shouldRedactKey = (key: string): boolean => {
     normalized.includes('password') ||
     normalized.endsWith('token') ||
     normalized === 'auth' ||
-    normalized.includes('authorization')
+    normalized.includes('authorization') ||
+    normalized === 'pass' ||
+    normalized === 'pwd'
   );
 };
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -29,13 +29,26 @@ const SENSITIVE_KEYS = new Set([
   'sessionApiKey', 'session_api_key', 'x_api_key', 'x-api-key',
 ]);
 
+const shouldRedactKey = (key: string): boolean => {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return (
+    normalized.includes('apikey') ||
+    normalized.includes('accesskey') ||
+    normalized.includes('secret') ||
+    normalized.includes('password') ||
+    normalized.endsWith('token') ||
+    normalized === 'auth' ||
+    normalized.includes('authorization')
+  );
+};
+
 const redactObject = (input: unknown): unknown => {
   if (Array.isArray(input)) return input.map((v) => redactObject(v));
   if (input && typeof input === 'object') {
     const src = input as Record<string, unknown>;
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(src)) {
-      if (SENSITIVE_KEYS.has(key.toString())) {
+      if (SENSITIVE_KEYS.has(key.toString()) || shouldRedactKey(key.toString())) {
         out[key] = '***';
       } else if (typeof value === 'object') {
         out[key] = redactObject(value);

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -62,9 +62,21 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     }
 
     if (ev.kind === 'ConversationStateUpdateEvent' && (ev.key === 'llm_request_payload' || ev.key === 'llm_response_payload')) {
+      const key = ev.key ?? 'llm_payload';
       const shouldLogToDebugConsole = deps.context.extensionMode !== vscode.ExtensionMode.Production;
+      const shouldLogToOutputChannel = shouldLogToDebugConsole || deps.isVerboseEventLogging();
+
+      if (shouldLogToOutputChannel) {
+        const outputChannel = deps.getOutputChannel();
+        try {
+          outputChannel?.appendLine(`[llm][${key}]`);
+          outputChannel?.appendLine(deps.safeStringify(ev.value));
+        } catch (e) {
+          outputChannel?.appendLine(`[llm][${key}] <failed to stringify: ${String(e)}>`);
+        }
+      }
+
       if (shouldLogToDebugConsole) {
-        const key = ev.key ?? 'llm_payload';
         try {
           console.debug(`[openhands][${key}] ${deps.safeStringify(ev.value)}`);
         } catch (e) {

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -67,7 +67,6 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
       const shouldLogToOutputChannel = shouldLogToDebugConsole || deps.isVerboseEventLogging();
 
       if (shouldLogToOutputChannel) {
-        const outputChannel = deps.getOutputChannel();
         try {
           outputChannel?.appendLine(`[llm][${key}]`);
           outputChannel?.appendLine(deps.safeStringify(ev.value));


### PR DESCRIPTION
Closes `oh-tab-l1it`.

- Log sanitized `llm_request_payload` / `llm_response_payload` events to the OpenHands Output channel (dev/test mode or verbose logging).
- Harden tool-arg redaction to catch hyphenated API-key headers (e.g. `x-goog-api-key`, `xi-api-key`) in JSON args.
- Update unit tests for the new redaction behavior.

Local checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added enhanced logging for payload events to the output channel during debug mode.

* **Bug Fixes**
  * Improved redaction of sensitive headers including Authorization and API key headers (x-api-key, x-goog-api-key, xi-api-key).
  * Implemented heuristic-based redaction for keys that semantically imply secrets (e.g., containing password, secret, or token patterns).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->