### PR TITLE
oh-tab-ycg2: extract LLM client/config helpers

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -10,7 +10,6 @@ import {
   DEFAULT_PROVIDER_BASE_URLS,
   detectProviderFromBaseUrl,
   isContextLimitError,
-  LLMFactory,
   loadProfile,
   wouldExceedMaxInputTokens,
 } from '../llm';
@@ -49,6 +48,8 @@ import {
   sanitizeMessageForDebug,
   truncateString,
 } from './textSanitizers';
+import { getEffectiveLlmConfigForCondensation as resolveCondensationLlmConfig } from './condensationLlmConfig';
+import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } from './createLlmClientFromSettings';
 
 export type AgentRunInput = string | Message;
 
@@ -950,56 +951,7 @@ export class Agent extends EventEmitter {
     openaiApiMode: unknown;
     maxInputTokens: number | undefined;
   } {
-    const llm = this.options.settings?.llm ?? {};
-    const configuredBaseUrl = toOptionalNonEmptyString(llm.baseUrl);
-    const configuredModel = toOptionalNonEmptyString(llm.model) ?? '';
-    const configuredProvider = llm.provider ?? undefined;
-    const configuredOpenaiApiMode = (llm as { openaiApiMode?: unknown } | undefined)?.openaiApiMode;
-    const configuredMaxInputTokens =
-      typeof llm.maxInputTokens === 'number' && Number.isFinite(llm.maxInputTokens) && llm.maxInputTokens > 0
-        ? Math.trunc(llm.maxInputTokens)
-        : undefined;
-
-    const profileId = toOptionalNonEmptyString(llm.profileId);
-    if (!profileId || !isSafeProfileId(profileId)) {
-      const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
-      return {
-        provider,
-        baseUrl: configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider],
-        model: configuredModel,
-        openaiApiMode: configuredOpenaiApiMode,
-        maxInputTokens: configuredMaxInputTokens,
-      };
-    }
-
-    try {
-      const profile = loadProfile(profileId);
-      const profileModel = toOptionalNonEmptyString(profile.config.model) ?? configuredModel;
-      const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
-      const profileProvider = profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
-      const profileMaxInputTokens =
-        typeof profile.config.maxInputTokens === 'number' &&
-        Number.isFinite(profile.config.maxInputTokens) &&
-        profile.config.maxInputTokens > 0
-          ? Math.trunc(profile.config.maxInputTokens)
-          : undefined;
-      return {
-        provider: profileProvider,
-        baseUrl: profileBaseUrl ?? configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[profileProvider],
-        model: profileModel,
-        openaiApiMode: profile.config.openaiApiMode ?? configuredOpenaiApiMode,
-        maxInputTokens: profileMaxInputTokens ?? configuredMaxInputTokens,
-      };
-    } catch {
-      const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
-      return {
-        provider,
-        baseUrl: configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider],
-        model: configuredModel,
-        openaiApiMode: configuredOpenaiApiMode,
-        maxInputTokens: configuredMaxInputTokens,
-      };
-    }
+    return resolveCondensationLlmConfig(this.options.settings);
   }
 
   /**
@@ -1182,63 +1134,13 @@ export class Agent extends EventEmitter {
   }
 
   private createLlmClientFromSettings(): Promise<LLMClient> {
-    const s = this.options.settings;
-    const profileId = toOptionalNonEmptyString(s.llm?.profileId);
-    const model = toOptionalNonEmptyString(s.llm?.model);
-    if (!profileId && !model) {
-      return Promise.reject(new Error('LLM model is not configured'));
-    }
-    const effectiveUsageId = 'agent';
-
-    const configuredApiKey = toOptionalNonEmptyString(s.secrets?.llmApiKey);
-    const configuredApiKeyIsReference =
-      typeof configuredApiKey === 'string' && /^[A-Z0-9_]+$/.test(configuredApiKey);
-    const configuredApiKeyInline = configuredApiKeyIsReference ? undefined : configuredApiKey;
-    this.secrets.set('openhands.llmApiKey', configuredApiKeyInline);
-
-    const preferredApiKeys = (() => {
-      if (!profileId || !isSafeProfileId(profileId)) return undefined;
-      const keys: string[] = [`openhands.llmProfileApiKey.${profileId}`];
-      if (configuredApiKeyIsReference && configuredApiKey) {
-        keys.push(configuredApiKey);
-      }
-      return keys;
-    })();
-
-    const config = {
-      profileId,
-      provider: s.llm.provider ?? undefined,
-      model: model ?? '',
-      openaiApiMode: s.llm.openaiApiMode ?? undefined,
-      usageId: effectiveUsageId,
-      baseUrl: s.llm.baseUrl ?? undefined,
-      apiKey: profileId ? undefined : configuredApiKey,
-      apiVersion: s.llm.apiVersion ?? undefined,
-      timeoutSeconds: s.llm.timeout ?? undefined,
-      temperature: s.llm.temperature ?? undefined,
-      topP: s.llm.topP ?? undefined,
-      topK: s.llm.topK ?? undefined,
-      maxInputTokens: s.llm.maxInputTokens ?? undefined,
-      maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
-      reasoningEffort: s.llm.reasoningEffort ?? undefined,
-      reasoningSummary: s.llm.reasoningSummary ?? undefined,
-      inputCostPerToken: s.llm.inputCostPerToken ?? undefined,
-      outputCostPerToken: s.llm.outputCostPerToken ?? undefined,
-    };
-    const factory = new LLMFactory(config, {
+    return createLlmClientFromSettingsFromConfig({
+      settings: this.options.settings,
       secrets: this.secrets,
-      preferredApiKeys,
       registry: this.registry,
-      onMetricsUpdate: (usageId, metrics) => {
-        if (!this.conversationStats) return;
-        // ensure entry exists and reference the same metrics
-        if (!this.conversationStats.usageToMetrics[usageId]) {
-          this.conversationStats.usageToMetrics[usageId] = metrics;
-        }
-        this.state.setValue('stats', this.conversationStats.toJSON());
-      },
+      conversationStats: this.conversationStats,
+      state: this.state,
     });
-    return factory.createClient();
   }
 
   private toConversationErrorEvent(error: unknown, options?: { code?: string; message?: string }): Event {

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensationLlmConfig.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensationLlmConfig.ts
@@ -1,0 +1,73 @@
+import type { LLMProvider } from '../llm';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, loadProfile } from '../llm';
+import type { OpenHandsSettings } from '../types/settings';
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const isSafeProfileId = (profileId: string): boolean => {
+  if (!profileId.trim()) return false;
+  if (profileId !== profileId.trim()) return false;
+  if (profileId.includes('/') || profileId.includes('\\')) return false;
+  return /^[a-zA-Z0-9._-]+$/.test(profileId);
+};
+
+const toOptionalPositiveInteger = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+  return Math.trunc(value);
+};
+
+export function getEffectiveLlmConfigForCondensation(settings: OpenHandsSettings): {
+  provider: LLMProvider | undefined;
+  baseUrl: string | undefined;
+  model: string;
+  openaiApiMode: unknown;
+  maxInputTokens: number | undefined;
+} {
+  const llm = settings.llm ?? {};
+  const configuredBaseUrl = toOptionalNonEmptyString(llm.baseUrl);
+  const configuredModel = toOptionalNonEmptyString(llm.model) ?? '';
+  const configuredProvider = llm.provider ?? undefined;
+  const configuredOpenaiApiMode = (llm as { openaiApiMode?: unknown } | undefined)?.openaiApiMode;
+  const configuredMaxInputTokens = toOptionalPositiveInteger(llm.maxInputTokens);
+
+  const profileId = toOptionalNonEmptyString(llm.profileId);
+  if (!profileId || !isSafeProfileId(profileId)) {
+    const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
+    return {
+      provider,
+      baseUrl: configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider],
+      model: configuredModel,
+      openaiApiMode: configuredOpenaiApiMode,
+      maxInputTokens: configuredMaxInputTokens,
+    };
+  }
+
+  try {
+    const profile = loadProfile(profileId);
+    const profileModel = toOptionalNonEmptyString(profile.config.model) ?? configuredModel;
+    const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
+    const profileProvider = profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
+    const profileMaxInputTokens = toOptionalPositiveInteger(profile.config.maxInputTokens);
+    return {
+      provider: profileProvider,
+      baseUrl: profileBaseUrl ?? configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[profileProvider],
+      model: profileModel,
+      openaiApiMode: profile.config.openaiApiMode ?? configuredOpenaiApiMode,
+      maxInputTokens: profileMaxInputTokens ?? configuredMaxInputTokens,
+    };
+  } catch {
+    const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
+    return {
+      provider,
+      baseUrl: configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider],
+      model: configuredModel,
+      openaiApiMode: configuredOpenaiApiMode,
+      maxInputTokens: configuredMaxInputTokens,
+    };
+  }
+}
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
@@ -1,0 +1,90 @@
+import type { LLMClient } from '../llm';
+import { LLMFactory } from '../llm';
+import type { LLMRegistry } from '../llm/registry';
+import type { OpenHandsSettings } from '../types/settings';
+import type { ConversationState } from './ConversationState';
+import type { ConversationStats } from './ConversationStats';
+import type { SecretRegistry } from './SecretRegistry';
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const isSafeProfileId = (profileId: string): boolean => {
+  if (!profileId.trim()) return false;
+  if (profileId !== profileId.trim()) return false;
+  if (profileId.includes('/') || profileId.includes('\\')) return false;
+  return /^[a-zA-Z0-9._-]+$/.test(profileId);
+};
+
+export function createLlmClientFromSettings(params: {
+  settings: OpenHandsSettings;
+  secrets: SecretRegistry;
+  registry?: LLMRegistry;
+  conversationStats?: ConversationStats;
+  state: ConversationState;
+}): Promise<LLMClient> {
+  const { settings: s, secrets, registry, conversationStats, state } = params;
+
+  const profileId = toOptionalNonEmptyString(s.llm?.profileId);
+  const model = toOptionalNonEmptyString(s.llm?.model);
+  if (!profileId && !model) {
+    return Promise.reject(new Error('LLM model is not configured'));
+  }
+
+  const effectiveUsageId = 'agent';
+
+  const configuredApiKey = toOptionalNonEmptyString(s.secrets?.llmApiKey);
+  const configuredApiKeyIsReference =
+    typeof configuredApiKey === 'string' && /^[A-Z0-9_]+$/.test(configuredApiKey);
+  const configuredApiKeyInline = configuredApiKeyIsReference ? undefined : configuredApiKey;
+  secrets.set('openhands.llmApiKey', configuredApiKeyInline);
+
+  const preferredApiKeys = (() => {
+    if (!profileId || !isSafeProfileId(profileId)) return undefined;
+    const keys: string[] = [`openhands.llmProfileApiKey.${profileId}`];
+    if (configuredApiKeyIsReference && configuredApiKey) {
+      keys.push(configuredApiKey);
+    }
+    return keys;
+  })();
+
+  const config = {
+    profileId,
+    provider: s.llm.provider ?? undefined,
+    model: model ?? '',
+    openaiApiMode: s.llm.openaiApiMode ?? undefined,
+    usageId: effectiveUsageId,
+    baseUrl: s.llm.baseUrl ?? undefined,
+    apiKey: profileId ? undefined : configuredApiKey,
+    apiVersion: s.llm.apiVersion ?? undefined,
+    timeoutSeconds: s.llm.timeout ?? undefined,
+    temperature: s.llm.temperature ?? undefined,
+    topP: s.llm.topP ?? undefined,
+    topK: s.llm.topK ?? undefined,
+    maxInputTokens: s.llm.maxInputTokens ?? undefined,
+    maxOutputTokens: s.llm.maxOutputTokens ?? undefined,
+    reasoningEffort: s.llm.reasoningEffort ?? undefined,
+    reasoningSummary: s.llm.reasoningSummary ?? undefined,
+    inputCostPerToken: s.llm.inputCostPerToken ?? undefined,
+    outputCostPerToken: s.llm.outputCostPerToken ?? undefined,
+  };
+
+  const factory = new LLMFactory(config, {
+    secrets,
+    preferredApiKeys,
+    registry,
+    onMetricsUpdate: (usageId, metrics) => {
+      if (!conversationStats) return;
+      if (!conversationStats.usageToMetrics[usageId]) {
+        conversationStats.usageToMetrics[usageId] = metrics;
+      }
+      state.setValue('stats', conversationStats.toJSON());
+    },
+  });
+
+  return factory.createClient();
+}
+


### PR DESCRIPTION
Part of `oh-tab-ycg2` (keep bead in_progress).

- Shrink `Agent.ts` by extracting:
  - `createLlmClientFromSettings()` → `runtime/createLlmClientFromSettings.ts`
  - condensation LLM config resolution → `runtime/condensationLlmConfig.ts`
- Behavior-preserving refactor; tests unchanged.

Local checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored LLM configuration resolution and client initialization logic in the agent runtime.
  * Reorganized internal components into modular helper functions for improved code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->