### PR TITLE
oh-tab-7k8l: HAL voice_confirm uses profileId

### DIFF
--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -126,6 +126,7 @@ References:
 Settings:
 - `openhands.hal.enabled`: boolean (default `false`)
 - `openhands.hal.mode`: `bundled` | `tts_only` | `voice_confirm` (default: `tts_only`)
+- `openhands.hal.llmProfileId`: string (default `gemini-flash-hal`) — LLM profile used for `voice_confirm` classification
 - `openhands.hal.userName`: string (default: `Engel`) — used only for templated script lines in the HAL flow
 - API key:
   - Settings UI placeholder: `openhands.secrets.elevenLabsApiKey`
@@ -136,14 +137,11 @@ Settings:
 - `openhands.hal.volume`: 0.0–1.0
 - `openhands.hal.cache`: boolean (default `true`)
 - Gemini (only for `voice_confirm`):
-  - LLM profile id: `gemini-flash-hal` (seeded by default)
+  - LLM profile id: `gemini-flash-hal` (seeded by default; override with `openhands.hal.llmProfileId`)
     - Provider: `gemini`
     - Model (default): `gemini-2.5-flash`
     - Base URL (default): Gemini API base URL (allow proxies)
     - Configure model/baseUrl via the LLM Profiles UI by editing `gemini-flash-hal`.
-  - Fallback-only (if the profile cannot be loaded):
-    - `openhands.hal.gemini.model`
-    - `openhands.hal.gemini.baseUrl`
   - Settings UI placeholder: `openhands.secrets.geminiLlmApiKey`
   - Stored securely in SecretStorage: `GEMINI_API_KEY` (set via `openhands.setGeminiLlmApiKey`)
 

--- a/docs/llm_profiles_sot_migration.md
+++ b/docs/llm_profiles_sot_migration.md
@@ -43,7 +43,8 @@ Key code paths:
 
 ### HAL flows (Gemini classifier)
 - `src/webview/host/createWebviewMessageHandler.ts`
-  - Attempts to load `gemini-flash-hal` profile for `{ baseUrl, model }`, but still has legacy fallbacks (`settings.gemini.*` and `settings.llm.provider` for key selection).
+  - Uses `openhands.hal.llmProfileId` (default `gemini-flash-hal`) to load `{ baseUrl, model }`.
+  - Resolves API key via profile key → provider key → global fallback (no `settings.gemini.*` / `settings.llm.provider` fallbacks).
 
 ### Tests that assume raw settings
 - `tests/e2e/suite/llmSwitching.ts` and `tests/e2e/suite/llmProfiles.ts` currently exercise both:
@@ -85,5 +86,3 @@ Key code paths:
 
 - **Override allowlist:** should any settings remain global (outside profiles) in the final state (e.g. maxIterations is global, but should token budgets/temperature ever be global overrides)?
 - **Persistence semantics:** on restore, should we restore the last selected `profileId` only, or also preserve per-conversation overrides (once overrides are removed, this becomes simpler)?
-- **HAL legacy:** do we want to fully remove `settings.gemini.*` and always source HAL classifier config from a profile?
-

--- a/package.json
+++ b/package.json
@@ -289,17 +289,11 @@
             "order": 8,
             "markdownDescription": "Enable caching for generated ElevenLabs audio."
           },
-          "openhands.hal.gemini.model": {
+          "openhands.hal.llmProfileId": {
             "type": "string",
-            "default": "gemini-2.5-flash",
+            "default": "gemini-flash-hal",
             "order": 9,
-            "markdownDescription": "Gemini model used for `voice_confirm` classification."
-          },
-          "openhands.hal.gemini.baseUrl": {
-            "type": "string",
-            "default": "https://generativelanguage.googleapis.com/v1beta",
-            "order": 10,
-            "markdownDescription": "Gemini API base URL (default is Google AI Studio; allow proxies)."
+            "markdownDescription": "LLM profile id used for `voice_confirm` classification (expected Gemini provider)."
           }
         }
       },

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,5 +1,6 @@
 import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, ConversationSettings, ConfirmationSettings } from './SettingsAdapter';
 import type { HalMode } from '../shared/halTypes';
+import { DEFAULT_HAL_LLM_PROFILE_ID } from '../shared/halDefaults';
 import { normalizeServerUrl } from '../shared/serverUrls';
 import { detectProviderFromBaseUrl, ensureDefaultProfiles, loadProfile } from '@openhands/agent-sdk-ts';
 
@@ -47,7 +48,7 @@ const DEFAULTS: OpenHandsSettings = {
   agent: { enableSecurityAnalyzer: true, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
-  hal: { enabled: false, mode: 'tts_only', llmProfileId: 'gemini-flash-hal', userName: 'Engel', volume: 1, cache: true },
+  hal: { enabled: false, mode: 'tts_only', llmProfileId: DEFAULT_HAL_LLM_PROFILE_ID, userName: 'Engel', volume: 1, cache: true },
   secrets: {}
 };
 
@@ -303,7 +304,7 @@ export class SettingsManager {
         DEFAULTS.hal.mode
       ),
       llmProfileId: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.hal.llmProfileId', DEFAULTS.hal.llmProfileId) ?? DEFAULTS.hal.llmProfileId
+        this.adapter.get<string | null>('openhands.hal.llmProfileId', DEFAULTS.hal.llmProfileId)
       ) ?? DEFAULTS.hal.llmProfileId,
       userName: normalizeNonEmptyString(
         this.adapter.get<string | null>('openhands.hal.userName', DEFAULTS.hal.userName) ?? DEFAULTS.hal.userName

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -11,6 +11,7 @@ export interface SavedServer {
 export type HalSettings = {
   enabled: boolean;
   mode: HalMode;
+  llmProfileId: string;
   userName: string;
   voiceAId?: string;
   voiceUserId?: string;
@@ -19,18 +20,12 @@ export type HalSettings = {
   cache: boolean;
 };
 
-export type GeminiSettings = {
-  model: string;
-  baseUrl: string;
-};
-
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
   hal: HalSettings;
-  gemini: GeminiSettings;
   servers: SavedServer[];
   secrets: {
     sessionApiKey?: string;
@@ -52,8 +47,7 @@ const DEFAULTS: OpenHandsSettings = {
   agent: { enableSecurityAnalyzer: true, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
-  hal: { enabled: false, mode: 'tts_only', userName: 'Engel', volume: 1, cache: true },
-  gemini: { model: 'gemini-2.5-flash', baseUrl: 'https://generativelanguage.googleapis.com/v1beta' },
+  hal: { enabled: false, mode: 'tts_only', llmProfileId: 'gemini-flash-hal', userName: 'Engel', volume: 1, cache: true },
   secrets: {}
 };
 
@@ -68,6 +62,7 @@ const DEFAULT_LLM_PROFILE_ID_BY_API_KEY: Array<{ secretKey: string; profileId: s
 const HAL_CONFIG_UPDATES: Array<[keyof HalSettings, string]> = [
   ['enabled', 'openhands.hal.enabled'],
   ['mode', 'openhands.hal.mode'],
+  ['llmProfileId', 'openhands.hal.llmProfileId'],
   ['userName', 'openhands.hal.userName'],
   ['voiceAId', 'openhands.hal.voiceAId'],
   ['voiceUserId', 'openhands.hal.voiceUserId'],
@@ -307,6 +302,9 @@ export class SettingsManager {
         this.adapter.get<unknown>('openhands.hal.mode', DEFAULTS.hal.mode) ?? DEFAULTS.hal.mode,
         DEFAULTS.hal.mode
       ),
+      llmProfileId: normalizeNonEmptyString(
+        this.adapter.get<string | null>('openhands.hal.llmProfileId', DEFAULTS.hal.llmProfileId) ?? DEFAULTS.hal.llmProfileId
+      ) ?? DEFAULTS.hal.llmProfileId,
       userName: normalizeNonEmptyString(
         this.adapter.get<string | null>('openhands.hal.userName', DEFAULTS.hal.userName) ?? DEFAULTS.hal.userName
       ) ?? DEFAULTS.hal.userName,
@@ -318,14 +316,6 @@ export class SettingsManager {
         DEFAULTS.hal.volume
       ),
       cache: this.adapter.get<boolean>('openhands.hal.cache', DEFAULTS.hal.cache) ?? DEFAULTS.hal.cache,
-    };
-    const gemini: GeminiSettings = {
-      model: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.hal.gemini.model', DEFAULTS.gemini.model) ?? DEFAULTS.gemini.model
-      ) ?? DEFAULTS.gemini.model,
-      baseUrl: normalizeNonEmptyString(
-        this.adapter.get<string | null>('openhands.hal.gemini.baseUrl', DEFAULTS.gemini.baseUrl) ?? DEFAULTS.gemini.baseUrl
-      ) ?? DEFAULTS.gemini.baseUrl,
     };
     const secrets = {
       sessionApiKey: await this.adapter.getSecret('openhands.sessionApiKey'),
@@ -339,7 +329,7 @@ export class SettingsManager {
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
       customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
     };
-    return { serverUrl, servers, llm, agent, conversation, confirmation, hal, gemini, secrets };
+    return { serverUrl, servers, llm, agent, conversation, confirmation, hal, secrets };
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
@@ -391,15 +381,6 @@ export class SettingsManager {
       for (const [key, configKey] of HAL_CONFIG_UPDATES) {
         const value = partial.hal[key];
         if (value !== undefined) ops.push(this.adapter.update(configKey, value, target));
-      }
-    }
-
-    if (partial.gemini) {
-      if (partial.gemini.model !== undefined) {
-        ops.push(this.adapter.update('openhands.hal.gemini.model', partial.gemini.model, target));
-      }
-      if (partial.gemini.baseUrl !== undefined) {
-        ops.push(this.adapter.update('openhands.hal.gemini.baseUrl', partial.gemini.baseUrl, target));
       }
     }
 

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -173,7 +173,7 @@ describe('SettingsManager', () => {
     expect(s.hal.cache).toBe(false);
     expect(s.secrets.sessionApiKey).toBe('sess');
     expect(s.secrets.llmApiKey).toBe('key');
-    // HAL no longer uses a separate Gemini key; it relies on GEMINI_API_KEY/global LLM key.
+    // HAL voice_confirm does not have a separate Gemini secret setting; it relies on profile/provider/global keys.
   });
 
   it('sanitizes invalid HAL mode and clamps volume', async () => {

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -50,14 +50,13 @@ describe('SettingsManager', () => {
     expect(s.agent.debug).toBe(false);
     expect(s.hal.enabled).toBe(false);
     expect(s.hal.mode).toBe('tts_only');
+    expect(s.hal.llmProfileId).toBe('gemini-flash-hal');
     expect(s.hal.userName).toBe('Engel');
     expect(s.hal.voiceAId).toBeUndefined();
     expect(s.hal.voiceUserId).toBeUndefined();
     expect(s.hal.modelId).toBeUndefined();
     expect(s.hal.volume).toBe(1);
     expect(s.hal.cache).toBe(true);
-    expect(s.gemini.model).toBe('gemini-2.5-flash');
-    expect(s.gemini.baseUrl).toBe('https://generativelanguage.googleapis.com/v1beta');
   });
 
   it('selects gpt-5-mini when OPENAI_API_KEY is present', async () => {
@@ -139,16 +138,13 @@ describe('SettingsManager', () => {
       hal: {
         enabled: true,
         mode: 'voice_confirm',
+        llmProfileId: 'gemini-flash-hal',
         userName: 'Alice',
         voiceAId: 'voice_hal',
         voiceUserId: 'voice_user',
         modelId: 'eleven_turbo_v2',
         volume: 0.25,
         cache: false,
-      },
-      gemini: {
-        model: 'gemini-2.5-pro',
-        baseUrl: 'https://proxy.example.com/v1beta',
       },
       secrets: { sessionApiKey: 'sess', llmApiKey: 'key' }
     });
@@ -168,14 +164,13 @@ describe('SettingsManager', () => {
     expect(s.confirmation.confirmUnknown).toBe(false);
     expect(s.hal.enabled).toBe(true);
     expect(s.hal.mode).toBe('voice_confirm');
+    expect(s.hal.llmProfileId).toBe('gemini-flash-hal');
     expect(s.hal.userName).toBe('Alice');
     expect(s.hal.voiceAId).toBe('voice_hal');
     expect(s.hal.voiceUserId).toBe('voice_user');
     expect(s.hal.modelId).toBe('eleven_turbo_v2');
     expect(s.hal.volume).toBe(0.25);
     expect(s.hal.cache).toBe(false);
-    expect(s.gemini.model).toBe('gemini-2.5-pro');
-    expect(s.gemini.baseUrl).toBe('https://proxy.example.com/v1beta');
     expect(s.secrets.sessionApiKey).toBe('sess');
     expect(s.secrets.llmApiKey).toBe('key');
     // HAL no longer uses a separate Gemini key; it relies on GEMINI_API_KEY/global LLM key.

--- a/src/shared/halDefaults.ts
+++ b/src/shared/halDefaults.ts
@@ -10,3 +10,4 @@ export const DEFAULT_HAL_STATE: HalStateSnapshot = {
   lastError: null,
 };
 
+export const DEFAULT_HAL_LLM_PROFILE_ID = 'gemini-flash-hal';

--- a/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
@@ -75,4 +75,62 @@ describe('createWebviewMessageHandler (HAL voice_confirm profile)', () => {
       apiKey: 'secret',
     }));
   });
+
+  it('prefers per-profile API key over provider key when both are set', async () => {
+    const cfg = {
+      get: vi.fn((key: string, defaultValue?: unknown) => defaultValue),
+      inspect: vi.fn(() => ({})),
+      update: vi.fn(async () => undefined),
+    };
+
+    (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
+
+    const context = {
+      secrets: {
+        get: vi.fn(async () => undefined),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      },
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    const secretRegistryGet = vi.fn(async (key: string) => {
+      if (key === 'openhands.llmProfileApiKey.gemini-flash-hal') return 'profile-secret';
+      if (key === 'GEMINI_API_KEY') return 'provider-secret';
+      return undefined;
+    });
+
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context,
+      host: { postMessage },
+      secretRegistry: { get: secretRegistryGet } as any,
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp/openhands-conversations',
+      setWebviewReadyState: () => undefined,
+      setLastKnownLlmLabel: () => undefined,
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => undefined,
+      onRenderedEventsResponse: () => undefined,
+      onUiStateResponse: () => undefined,
+      onHalStateResponse: () => undefined,
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => undefined,
+    });
+
+    await handler({
+      type: 'halVoiceConfirmRequest',
+      requestId: 'r1',
+      mimeType: 'audio/wav',
+      audioBase64: 'Zm9v',
+    });
+
+    const { classifyHalVoiceDecision } = await import('../../../hal/gemini/decisionClassifier');
+    expect(classifyHalVoiceDecision).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: 'profile-secret',
+    }));
+  });
 });

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import * as childProcess from 'child_process';
-import { assertValidProfileId, detectProviderFromBaseUrl, LLMProfileValidationError, type LLMProvider, type SecretRegistry } from '@openhands/agent-sdk-ts';
+import { assertValidProfileId, DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMProfileValidationError, type LLMProvider, type SecretRegistry } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
@@ -972,42 +972,77 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         const settings = await settingsMgr.get();
 
-        const halGeminiConfig = (() => {
-          let baseUrl = settings.gemini.baseUrl;
-          let model = settings.gemini.model;
+        const defaultHalProfileId = 'gemini-flash-hal';
+        const configuredHalProfileId = typeof settings.hal.llmProfileId === 'string'
+          ? settings.hal.llmProfileId.trim()
+          : '';
+        const halProfileId = (() => {
+          if (!configuredHalProfileId) return defaultHalProfileId;
           try {
-            const profile = llmProfilesStore.loadProfile('gemini-flash-hal', llmProfileStoreOptions());
-            const baseUrlFromProfile = typeof profile.config.baseUrl === 'string' ? profile.config.baseUrl.trim() : '';
-            const modelFromProfile = typeof profile.config.model === 'string' ? profile.config.model.trim() : '';
-            if (baseUrlFromProfile) baseUrl = baseUrlFromProfile;
-            if (modelFromProfile) model = modelFromProfile;
+            validateProfileId(configuredHalProfileId);
+            return configuredHalProfileId;
           } catch (err) {
             const reason = err instanceof Error ? err.message : String(err);
-            outputChannel?.appendLine(`[hal] Failed to load gemini-flash-hal profile; falling back to settings: ${reason}`);
+            outputChannel?.appendLine(`[hal] Invalid HAL llmProfileId '${configuredHalProfileId}'; using '${defaultHalProfileId}': ${reason}`);
+            return defaultHalProfileId;
           }
-          return { baseUrl, model };
         })();
 
-        // Use the global Gemini provider key for HAL as well.
-        // Preference order:
-        // 1) SecretRegistry (VS Code SecretStorage key 'GEMINI_API_KEY', then process.env.GEMINI_API_KEY)
-        // 2) If the active LLM provider is Gemini, fall back to the generic llmApiKey
-        let halGeminiKey = '';
+        let halProfile: ReturnType<typeof llmProfilesStore.loadProfile> | undefined;
         try {
-          const maybe = deps.secretRegistry ? await deps.secretRegistry.get('GEMINI_API_KEY') : undefined;
-          if (typeof maybe === 'string' && maybe.trim()) halGeminiKey = maybe.trim();
-        } catch {
-          // ignore
+          halProfile = llmProfilesStore.loadProfile(halProfileId, llmProfileStoreOptions());
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error: reason });
+          outputChannel?.appendLine(`[hal] Failed to load HAL LLM profile '${halProfileId}': ${reason}`);
+          break;
         }
-        if (!halGeminiKey && settings.llm.provider === 'gemini') {
-          const mainKey = settings.secrets.llmApiKey;
-          if (typeof mainKey === 'string' && mainKey.trim()) halGeminiKey = mainKey.trim();
+
+        const model = typeof halProfile.config.model === 'string' ? halProfile.config.model.trim() : '';
+        const baseUrlFromProfile = typeof halProfile.config.baseUrl === 'string' ? halProfile.config.baseUrl.trim() : '';
+        const provider = halProfile.config.provider ?? detectProviderFromBaseUrl(baseUrlFromProfile);
+        if (provider !== 'gemini') {
+          const error = `HAL voice_confirm requires a Gemini profile (got provider '${provider}').`;
+          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error });
+          outputChannel?.appendLine(`[hal] ${error}`);
+          break;
+        }
+
+        const baseUrl = baseUrlFromProfile || DEFAULT_PROVIDER_BASE_URLS.gemini;
+
+        const getStoredSecret = async (key: string): Promise<string | undefined> => {
+          const trimmedKey = key.trim();
+          if (!trimmedKey) return undefined;
+          try {
+            const resolved = deps.secretRegistry
+              ? await deps.secretRegistry.get(trimmedKey)
+              : (process.env[trimmedKey] ?? (await context.secrets.get(trimmedKey)));
+            const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
+            return trimmedValue || undefined;
+          } catch {
+            return undefined;
+          }
+        };
+
+        const keyOrder = [
+          getProfileApiKeySecretKey(halProfileId),
+          getProviderApiKeyName(provider),
+          'openhands.llmApiKey',
+          'LLM_API_KEY',
+        ];
+        let halGeminiKey: string | undefined;
+        for (const key of keyOrder) {
+          const candidate = await getStoredSecret(key);
+          if (candidate) {
+            halGeminiKey = candidate;
+            break;
+          }
         }
 
         const result = await classifyHalVoiceDecision({
-          baseUrl: halGeminiConfig.baseUrl,
-          apiKey: halGeminiKey,
-          model: halGeminiConfig.model,
+          baseUrl,
+          apiKey: halGeminiKey ?? '',
+          model,
           mimeType: message.mimeType,
           audioBase64: message.audioBase64,
         });

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -10,6 +10,7 @@ import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
 import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
 import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
 import { getHalDialogueLinesForMode } from '../../shared/halScript';
+import { DEFAULT_HAL_LLM_PROFILE_ID } from '../../shared/halDefaults';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
 import { MAX_PASTED_IMAGE_BYTES } from '../../shared/pasteLimits';
@@ -202,13 +203,22 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       || value === 'gemini';
   };
 
-  const hasStoredSecret = async (key: string): Promise<boolean> => {
+  const getStoredSecret = async (key: string): Promise<string | undefined> => {
     const trimmedKey = key.trim();
-    if (!trimmedKey) return false;
-    const resolved = deps.secretRegistry
-      ? await deps.secretRegistry.get(trimmedKey)
-      : (process.env[trimmedKey] ?? (await context.secrets.get(trimmedKey)));
-    return typeof resolved === 'string' && resolved.trim().length > 0;
+    if (!trimmedKey) return undefined;
+    try {
+      const resolved = deps.secretRegistry
+        ? await deps.secretRegistry.get(trimmedKey)
+        : (process.env[trimmedKey] ?? (await context.secrets.get(trimmedKey)));
+      const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
+      return trimmedValue || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const hasStoredSecret = async (key: string): Promise<boolean> => {
+    return Boolean(await getStoredSecret(key));
   };
 
   const getElevenlabsTtsGate = (): TtsConversationGate => {
@@ -972,7 +982,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         const settings = await settingsMgr.get();
 
-        const defaultHalProfileId = 'gemini-flash-hal';
+        const defaultHalProfileId = DEFAULT_HAL_LLM_PROFILE_ID;
         const configuredHalProfileId = typeof settings.hal.llmProfileId === 'string'
           ? settings.hal.llmProfileId.trim()
           : '';
@@ -1009,20 +1019,6 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         }
 
         const baseUrl = baseUrlFromProfile || DEFAULT_PROVIDER_BASE_URLS.gemini;
-
-        const getStoredSecret = async (key: string): Promise<string | undefined> => {
-          const trimmedKey = key.trim();
-          if (!trimmedKey) return undefined;
-          try {
-            const resolved = deps.secretRegistry
-              ? await deps.secretRegistry.get(trimmedKey)
-              : (process.env[trimmedKey] ?? (await context.secrets.get(trimmedKey)));
-            const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
-            return trimmedValue || undefined;
-          } catch {
-            return undefined;
-          }
-        };
 
         const keyOrder = [
           getProfileApiKeySecretKey(halProfileId),


### PR DESCRIPTION
Bead: oh-tab-7k8l

HAL `voice_confirm` now resolves model/baseUrl + API key from a dedicated LLM profileId (default `gemini-flash-hal`) instead of legacy `openhands.hal.gemini.*` settings + bespoke key fallback.

Changes:
- Adds `openhands.hal.llmProfileId` (default `gemini-flash-hal`).
- Removes `openhands.hal.gemini.model` / `openhands.hal.gemini.baseUrl`.
- Voice confirm key precedence now matches profile behavior: per-profile key → provider key → global fallback.

Tests:
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an LLM profile ID setting to select the model used for voice confirmation.

* **Bug Fixes**
  * Profile-specific API keys now take precedence over provider/global keys.
  * Added validation and clearer errors when an invalid profile or provider is selected.

* **Chores**
  * Default voice-confirmation profile updated to gemini-flash-hal.
  * Removed legacy Gemini model/base-url settings and updated docs/tests accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->