### PR TITLE
oh-tab-ycg2: dedupe runtime settings helpers

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -49,6 +49,7 @@ import {
   sanitizeMessageForDebug,
   truncateString,
 } from './textSanitizers';
+import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } from './createLlmClientFromSettings';
 
 export type AgentRunInput = string | Message;
@@ -107,19 +108,6 @@ function deepTruncate(value: unknown, seen = new WeakSet<object>()): unknown {
     return out;
   }
   return value;
-}
-
-function toOptionalNonEmptyString(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function isSafeProfileId(profileId: string): boolean {
-  if (!profileId.trim()) return false;
-  if (profileId !== profileId.trim()) return false;
-  if (profileId.includes('/') || profileId.includes('\\')) return false;
-  return /^[a-zA-Z0-9._-]+$/.test(profileId);
 }
 
 function truncateToolMessage(text: string, maxChars = TOOL_MESSAGE_MAX_CHARS): string {

--- a/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
@@ -5,19 +5,7 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { ConversationState } from './ConversationState';
 import type { ConversationStats } from './ConversationStats';
 import type { SecretRegistry } from './SecretRegistry';
-
-const toOptionalNonEmptyString = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-};
-
-const isSafeProfileId = (profileId: string): boolean => {
-  if (!profileId.trim()) return false;
-  if (profileId !== profileId.trim()) return false;
-  if (profileId.includes('/') || profileId.includes('\\')) return false;
-  return /^[a-zA-Z0-9._-]+$/.test(profileId);
-};
+import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 
 export function createLlmClientFromSettings(params: {
   settings: OpenHandsSettings;
@@ -87,4 +75,3 @@ export function createLlmClientFromSettings(params: {
 
   return factory.createClient();
 }
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import type { AgentState } from './ConversationState';
 import type { Event } from '../types';
 import type { LLMProvider, OpenAIChatApi, ReasoningSummary } from '../llm/types';
+import { toOptionalNonEmptyString } from './settingsUtils';
 
 export type PersistedLlmConfig = {
   profileId?: string;
@@ -26,12 +27,6 @@ export type PersistedLlmConfig = {
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value);
-
-const toOptionalNonEmptyString = (value: unknown): string | undefined => {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-};
 
 const toOptionalFiniteNumber = (value: unknown): number | undefined => {
   if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/settingsUtils.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/settingsUtils.ts
@@ -1,0 +1,17 @@
+import { assertValidProfileId } from '../llm/profiles';
+
+export const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+export const isSafeProfileId = (profileId: string): boolean => {
+  try {
+    assertValidProfileId(profileId);
+    return true;
+  } catch {
+    return false;
+  }
+};
+


### PR DESCRIPTION
Bead: oh-tab-ycg2

Refactor-only: reduce duplicated settings helpers in the SDK runtime.

Changes:
- Add `packages/agent-sdk-ts/src/sdk/runtime/settingsUtils.ts`.
- Move `toOptionalNonEmptyString` + `isSafeProfileId` out of `Agent.ts`/`createLlmClientFromSettings.ts`/`persistence.ts`.
- `isSafeProfileId` now delegates to `assertValidProfileId` (via `../llm/profiles`) to keep validation rules consistent.

Tests:
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal settings utilities into a dedicated module for improved code organization and reusability.

* **Chores**
  * Enhanced LLM client configuration with support for secrets management, custom registries, and conversation metrics tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->