### PR TITLE
oh-tab-b7qq: extract git diff helpers

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
-import * as childProcess from 'child_process';
 import * as path from 'path';
 import * as os from 'os';
 import { SettingsManager, type OpenHandsSettings } from './settings/SettingsManager';
@@ -18,6 +17,7 @@ import { OpenHandsTerminalLogPseudoterminal } from './terminal/OpenHandsTerminal
 import { registerDiagnosticsCommands, type RenderedEventsInfo, type UiStateSnapshot } from './dev/registerDiagnosticsCommands';
 import type { HostToWebviewMessage } from './shared/webviewMessages';
 import { resolveLocalTools } from './shared/localTools';
+import { getGitHeadDiffSummaryForFile, resolveGitContext } from './extension/gitDiffSummary';
 import {
   AgentContext,
   Conversation,
@@ -241,64 +241,6 @@ function flushConversationEventBacklog(params: {
 function renderError(err: unknown): string {
   const rendered = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
   return maskSecretsInText(rendered, secretRegistry);
-}
-
-function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    childProcess.execFile(command, args, { cwd }, (err, stdout, stderr) => {
-      if (err) {
-        const message = typeof stderr === 'string' && stderr.trim().length > 0 ? stderr.trim() : err.message;
-        reject(new Error(message));
-        return;
-      }
-      resolve(typeof stdout === 'string' ? stdout : String(stdout));
-    });
-  });
-}
-
-async function getGitHeadDiffSummaryForFile(filePath: string): Promise<string> {
-  const cwd = path.dirname(filePath);
-  let root: string;
-  try {
-    root = (await execFileText('git', ['rev-parse', '--show-toplevel'], cwd)).trim();
-  } catch {
-    return '(no HEAD available)';
-  }
-
-  const relative = path.relative(root, filePath);
-  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
-    return '(no HEAD available)';
-  }
-
-  const isTracked = await execFileText('git', ['ls-files', '--error-unmatch', '--', relative], root)
-    .then(() => true)
-    .catch(() => false);
-  if (!isTracked) {
-    return '(no HEAD available: untracked file)';
-  }
-
-  try {
-    const stat = await execFileText('git', ['diff', '--no-color', '--stat', 'HEAD', '--', relative], root);
-    const trimmed = stat.trim();
-    if (!trimmed) return '(no changes vs HEAD)';
-    const maxChars = 2000;
-    return trimmed.length > maxChars ? `${trimmed.slice(0, maxChars)}\n…(truncated)` : trimmed;
-  } catch {
-    return '(no HEAD available)';
-  }
-}
-
-async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ repoName: string; branchName: string }> {
-  const fallbackRepo = workspaceRoot ? path.basename(workspaceRoot) : 'unknown';
-  if (!workspaceRoot) return { repoName: fallbackRepo, branchName: 'unknown' };
-
-  try {
-    const root = (await execFileText('git', ['rev-parse', '--show-toplevel'], workspaceRoot)).trim();
-    const branch = (await execFileText('git', ['rev-parse', '--abbrev-ref', 'HEAD'], root)).trim();
-    return { repoName: path.basename(root) || fallbackRepo, branchName: branch || 'unknown' };
-  } catch {
-    return { repoName: fallbackRepo, branchName: 'unknown' };
-  }
 }
 
 async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string, secrets: SecretRegistry): Promise<string> {

--- a/src/extension/gitDiffSummary.ts
+++ b/src/extension/gitDiffSummary.ts
@@ -1,0 +1,60 @@
+import * as childProcess from 'child_process';
+import * as path from 'path';
+
+function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(command, args, { cwd }, (err, stdout, stderr) => {
+      if (err) {
+        const message = typeof stderr === 'string' && stderr.trim().length > 0 ? stderr.trim() : err.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve(typeof stdout === 'string' ? stdout : String(stdout));
+    });
+  });
+}
+
+export async function getGitHeadDiffSummaryForFile(filePath: string): Promise<string> {
+  const cwd = path.dirname(filePath);
+  let root: string;
+  try {
+    root = (await execFileText('git', ['rev-parse', '--show-toplevel'], cwd)).trim();
+  } catch {
+    return '(no HEAD available)';
+  }
+
+  const relative = path.relative(root, filePath);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return '(no HEAD available)';
+  }
+
+  const isTracked = await execFileText('git', ['ls-files', '--error-unmatch', '--', relative], root)
+    .then(() => true)
+    .catch(() => false);
+  if (!isTracked) {
+    return '(no HEAD available: untracked file)';
+  }
+
+  try {
+    const stat = await execFileText('git', ['diff', '--no-color', '--stat', 'HEAD', '--', relative], root);
+    const trimmed = stat.trim();
+    if (!trimmed) return '(no changes vs HEAD)';
+    const maxChars = 2000;
+    return trimmed.length > maxChars ? `${trimmed.slice(0, maxChars)}\n…(truncated)` : trimmed;
+  } catch {
+    return '(no HEAD available)';
+  }
+}
+
+export async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ repoName: string; branchName: string }> {
+  const fallbackRepo = workspaceRoot ? path.basename(workspaceRoot) : 'unknown';
+  if (!workspaceRoot) return { repoName: fallbackRepo, branchName: 'unknown' };
+
+  try {
+    const root = (await execFileText('git', ['rev-parse', '--show-toplevel'], workspaceRoot)).trim();
+    const branch = (await execFileText('git', ['rev-parse', '--abbrev-ref', 'HEAD'], root)).trim();
+    return { repoName: path.basename(root) || fallbackRepo, branchName: branch || 'unknown' };
+  } catch {
+    return { repoName: fallbackRepo, branchName: 'unknown' };
+  }
+}


### PR DESCRIPTION
Bead: oh-tab-b7qq

This is the first behavior-preserving slice of splitting `src/extension.ts`.

**Changes**
- Extract git helper functions into `src/extension/gitDiffSummary.ts`.
- Update `src/extension.ts` to import and use `getGitHeadDiffSummaryForFile` and `resolveGitContext`.

**Verification**
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of Git integration components for improved code structure and maintainability. No impact on user-facing functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->