### PR TITLE
Refine Skills dropdown border styling

### DIFF
--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -224,7 +224,7 @@ export function InputArea({
                     h-9 w-9 rounded-lg
                     flex items-center justify-center
                     transition-all duration-200
-                    focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+                    focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
                     bg-white/[0.06] text-stone-300 border border-white/[0.04]
                     hover:bg-white/[0.08] hover:border-white/[0.1]
                   `}
@@ -249,7 +249,7 @@ export function InputArea({
                   h-9 w-9 rounded-lg
                   flex items-center justify-center
                   transition-all duration-200
-                  focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+                  focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
                   ${canSend && !disabled
                     ? 'bg-gradient-to-b from-brand-500 to-brand-600 text-white shadow-glow-sm hover:from-brand-400 hover:to-brand-500'
                     : 'bg-white/[0.06] text-stone-500 cursor-not-allowed border border-white/[0.04]'

--- a/src/webview-src/components/inputArea/AccessoryButton.tsx
+++ b/src/webview-src/components/inputArea/AccessoryButton.tsx
@@ -18,7 +18,7 @@ export function AccessoryButton({ icon, label, displayLabel, onClick, badge, com
         text-xs font-medium
         transition-all duration-200
         border
-        focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+        focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
         ${comingSoon
           ? 'bg-white/[0.02] text-stone-600 border-white/[0.03] cursor-not-allowed'
           : 'bg-white/[0.04] text-stone-400 border-white/[0.06] hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]'

--- a/src/webview-src/components/inputArea/ContextPicker.tsx
+++ b/src/webview-src/components/inputArea/ContextPicker.tsx
@@ -85,7 +85,7 @@ export function ContextPicker({
           placeholder="Search files..."
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
-          className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500/30"
+          className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:border-brand-500/40"
           autoFocus
         />
       </div>
@@ -113,10 +113,10 @@ export function ContextPicker({
                     transition-all duration-150
                     flex items-center gap-2
                     ${isSelected
-                      ? 'bg-brand-500/15 text-brand-300 border border-brand-500/20'
+                      ? 'bg-brand-500/15 text-brand-300'
                       : isActive
-                        ? 'bg-white/[0.06] text-stone-200 border border-white/[0.16]'
-                        : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300 border border-transparent'
+                        ? 'bg-brand-500/10 text-stone-200 ring-1 ring-brand-500/40'
+                        : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
                     }
                   `}
                 >

--- a/src/webview-src/components/inputArea/ContextPicker.tsx
+++ b/src/webview-src/components/inputArea/ContextPicker.tsx
@@ -113,7 +113,7 @@ export function ContextPicker({
                     transition-all duration-150
                     flex items-center gap-2
                     ${isSelected
-                      ? 'bg-brand-500/15 text-brand-300'
+                      ? `bg-brand-500/15 text-brand-300${isActive ? ' ring-1 ring-brand-500/40' : ''}`
                       : isActive
                         ? 'bg-brand-500/10 text-stone-200 ring-1 ring-brand-500/40'
                         : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
@@ -140,4 +140,3 @@ export function ContextPicker({
     </div>
   );
 }
-

--- a/src/webview-src/components/inputArea/LlmProfileSelector.tsx
+++ b/src/webview-src/components/inputArea/LlmProfileSelector.tsx
@@ -53,7 +53,7 @@ export function LlmProfileSelector({
           text-xs font-medium
           transition-all duration-200
           border
-          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+          focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
           bg-white/[0.04] text-stone-400 border-white/[0.06]
           hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]
         `}

--- a/src/webview-src/components/inputArea/SkillsPopover.tsx
+++ b/src/webview-src/components/inputArea/SkillsPopover.tsx
@@ -85,7 +85,7 @@ export function SkillsPopover({
           placeholder="Search skills..."
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
-          className="mt-2 w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500/30"
+          className="mt-2 w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:border-brand-500/40"
           autoFocus
         />
       </div>
@@ -113,8 +113,8 @@ export function SkillsPopover({
                     flex items-center gap-2
                     group
                     ${isActive
-                      ? 'bg-brand-500/10 text-stone-200 border border-brand-500/25'
-                      : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300 border border-transparent'
+                      ? 'bg-brand-500/10 text-stone-200 ring-1 ring-brand-500/40'
+                      : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
                     }
                   `}
                   data-active={isActive ? 'true' : 'false'}

--- a/src/webview-src/components/inputArea/ToolsPopover.tsx
+++ b/src/webview-src/components/inputArea/ToolsPopover.tsx
@@ -65,8 +65,8 @@ export function ToolsPopover({
                     flex items-center gap-2
                     group
                     ${isEnabled
-                      ? 'bg-brand-500/10 text-stone-200 border border-brand-500/25'
-                      : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300 border border-transparent'
+                      ? 'bg-brand-500/10 text-stone-200'
+                      : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
                     }
                   `}
                 >


### PR DESCRIPTION
- Use ring-1 instead of ring-2 for thinner focus indicators across all dropdowns
- Remove redundant borders from selected items that already have checkmarks (Tools, Context)
- Use brand-500/40 ring color for active/focused items (OpenHands golden)
- Make focus styling consistent across Skills, Tools, Context, and LLM Profile dropdowns
- Apply same treatment to AccessoryButton and InputArea action buttons