### PR TITLE
oh-tab-b7qq: extract conversation store root

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { SettingsManager, type OpenHandsSettings } from './settings/SettingsManager';
@@ -20,6 +19,7 @@ import { resolveLocalTools } from './shared/localTools';
 import { createDevBridgeLogger, createMaskedOutputChannel } from './extension/devBridgeLogger';
 import { createFileEditNoteTracker } from './extension/fileEditNote';
 import { getGitHeadDiffSummaryForFile, resolveGitContext } from './extension/gitDiffSummary';
+import { resolveConversationStoreRoot } from './extension/conversationStoreRoot';
 import {
   AgentContext,
   Conversation,
@@ -253,63 +253,6 @@ function syncActiveEditorSystemMessageSuffix(editor: vscode.TextEditor | undefin
     : undefined;
 }
 
-function resolveConfiguredPath(p: string): string {
-  const raw = p.trim();
-  if (raw.startsWith('~/') || raw === '~') {
-    const suffix = raw === '~' ? '' : raw.slice(2);
-    return path.join(os.homedir(), suffix);
-  }
-  if (raw.startsWith('~\\')) {
-    return path.join(os.homedir(), raw.slice(2));
-  }
-  if (path.isAbsolute(raw)) return raw;
-  // Prefer homedir-relative resolution so behavior is stable even with no workspace open.
-  return path.resolve(os.homedir(), raw);
-}
-
-async function ensureWritableDirectory(dir: string): Promise<void> {
-  await fs.mkdir(dir, { recursive: true });
-  const probe = path.join(dir, `.openhands-write-probe-${process.pid}-${Date.now()}`);
-  await fs.writeFile(probe, 'ok', 'utf8');
-  await fs.unlink(probe);
-}
-
-async function resolveConversationStoreRoot(context: vscode.ExtensionContext): Promise<string> {
-  const cfg = vscode.workspace.getConfiguration();
-  const configured = normalizeNonEmptyString(cfg.get<string>('openhands.conversation.storeRoot'));
-
-  const candidates: Array<{ label: string; dir: string }> = [];
-  if (configured) candidates.push({ label: 'setting openhands.conversation.storeRoot', dir: resolveConfiguredPath(configured) });
-
-  try {
-    candidates.push({ label: 'default ~/.openhands/conversations-vscode', dir: path.join(os.homedir(), '.openhands', 'conversations-vscode') });
-  } catch (err) {
-    outputChannel?.appendLine(`[storage] Failed to compute home dir default: ${renderError(err)}`);
-  }
-
-  const globalStorage = (context as unknown as { globalStorageUri?: vscode.Uri }).globalStorageUri?.fsPath;
-  if (globalStorage) {
-    candidates.push({ label: 'VS Code globalStorageUri', dir: path.join(globalStorage, 'conversations') });
-  }
-
-  candidates.push({ label: 'os.tmpdir()', dir: path.join(os.tmpdir(), 'openhands-conversations-vscode') });
-
-  for (const candidate of candidates) {
-    try {
-      await ensureWritableDirectory(candidate.dir);
-      if (candidate.dir !== candidates[0]?.dir) {
-        outputChannel?.appendLine(`[storage] Using conversation store root: ${candidate.dir} (${candidate.label})`);
-      }
-      return candidate.dir;
-    } catch (err) {
-      outputChannel?.appendLine(`[storage] Cannot use ${candidate.label} (${candidate.dir}): ${renderError(err)}`);
-    }
-  }
-
-  // Last resort: return tmp path even if we couldn't probe it; conversation may still run without persistence.
-  return path.join(os.tmpdir(), 'openhands-conversations-vscode');
-}
-
 /**
  * Initialize the OpenHands extension: create logging channel and chat webview, register commands and configuration handlers, and wire up terminal, conversation, and secret-management behavior.
  *
@@ -352,7 +295,8 @@ export function activate(context: vscode.ExtensionContext) {
         getConversation: () => conversation,
         getConversationMode: () => conversationMode,
         getConversationStoreRoot: () => conversationStoreRoot,
-        resolveConversationStoreRoot: () => resolveConversationStoreRoot(context),
+        resolveConversationStoreRoot: () =>
+          resolveConversationStoreRoot({ context, getOutputChannel: () => outputChannel, renderError }),
         setWebviewReadyState: (conversationId, lastSeenSeq) => {
           chatWebviewReady = true;
           chatLastConversationId = conversationId;
@@ -571,7 +515,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       const persistenceDir =
         desiredMode === 'local'
-          ? await resolveConversationStoreRoot(context).catch((err: unknown) => {
+          ? await resolveConversationStoreRoot({ context, getOutputChannel: () => outputChannel, renderError }).catch((err: unknown) => {
               outputChannel?.appendLine(`[storage] Failed to resolve conversation store root: ${renderError(err)}`);
               return path.join(os.tmpdir(), 'openhands-conversations-vscode');
             })

--- a/src/extension/conversationStoreRoot.ts
+++ b/src/extension/conversationStoreRoot.ts
@@ -1,0 +1,73 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+function normalizeNonEmptyString(value: string | undefined | null): string | undefined {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || undefined;
+}
+
+function resolveConfiguredPath(p: string): string {
+  const raw = p.trim();
+  if (raw.startsWith('~/') || raw === '~') {
+    const suffix = raw === '~' ? '' : raw.slice(2);
+    return path.join(os.homedir(), suffix);
+  }
+  if (raw.startsWith('~\\')) {
+    return path.join(os.homedir(), raw.slice(2));
+  }
+  if (path.isAbsolute(raw)) return raw;
+  // Prefer homedir-relative resolution so behavior is stable even with no workspace open.
+  return path.resolve(os.homedir(), raw);
+}
+
+async function ensureWritableDirectory(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+  const probe = path.join(dir, `.openhands-write-probe-${process.pid}-${Date.now()}`);
+  await fs.writeFile(probe, 'ok', 'utf8');
+  await fs.unlink(probe);
+}
+
+export async function resolveConversationStoreRoot(params: {
+  context: vscode.ExtensionContext;
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  renderError: (err: unknown) => string;
+}): Promise<string> {
+  const cfg = vscode.workspace.getConfiguration();
+  const configured = normalizeNonEmptyString(cfg.get<string>('openhands.conversation.storeRoot'));
+
+  const candidates: Array<{ label: string; dir: string }> = [];
+  if (configured) {
+    candidates.push({ label: 'setting openhands.conversation.storeRoot', dir: resolveConfiguredPath(configured) });
+  }
+
+  try {
+    candidates.push({ label: 'default ~/.openhands/conversations-vscode', dir: path.join(os.homedir(), '.openhands', 'conversations-vscode') });
+  } catch (err) {
+    params.getOutputChannel()?.appendLine(`[storage] Failed to compute home dir default: ${params.renderError(err)}`);
+  }
+
+  const globalStorage = (params.context as unknown as { globalStorageUri?: vscode.Uri }).globalStorageUri?.fsPath;
+  if (globalStorage) {
+    candidates.push({ label: 'VS Code globalStorageUri', dir: path.join(globalStorage, 'conversations') });
+  }
+
+  candidates.push({ label: 'os.tmpdir()', dir: path.join(os.tmpdir(), 'openhands-conversations-vscode') });
+
+  for (const candidate of candidates) {
+    try {
+      await ensureWritableDirectory(candidate.dir);
+      if (candidate.dir !== candidates[0]?.dir) {
+        params.getOutputChannel()?.appendLine(`[storage] Using conversation store root: ${candidate.dir} (${candidate.label})`);
+      }
+      return candidate.dir;
+    } catch (err) {
+      params.getOutputChannel()?.appendLine(`[storage] Cannot use ${candidate.label} (${candidate.dir}): ${params.renderError(err)}`);
+    }
+  }
+
+  // Last resort: return tmp path even if we couldn't probe it; conversation may still run without persistence.
+  return path.join(os.tmpdir(), 'openhands-conversations-vscode');
+}
+


### PR DESCRIPTION
Bead: oh-tab-b7qq

Next small, behavior-preserving slice of splitting `src/extension.ts`.

**Changes**
- New `src/extension/conversationStoreRoot.ts`: `resolveConversationStoreRoot(...)` plus internal helpers.
- `src/extension.ts` now calls into the module for conversation persistence directory resolution.

**Verification**
- `npm test`
- `npm run typecheck`
- `npm run lint`
