### PR TITLE
oh-tab-vrr9: dedupe normalizeNonEmptyString

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ import { DEFAULT_HAL_STATE } from './shared/halDefaults';
 import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { maskSecretsInText } from './shared/maskSecrets';
 import { safeStringify } from './shared/safeStringify';
+import { normalizeNonEmptyString } from './shared/stringUtils';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, isValidPastedImageId } from './shared/pastedImages';
 import { cleanupPastedImages } from './shared/pastedImagesCleanup';
 import { transformEventForWebview as transformEventForWebviewWithPastedImages } from './conversation/host/transformEventForWebview';
@@ -231,11 +232,6 @@ async function summarizeWithLocalLlm(settings: OpenHandsSettings, prompt: string
     throw new Error('LLM returned an empty summary');
   }
   return trimmed;
-}
-
-function normalizeNonEmptyString(value: string | undefined | null): string | undefined {
-  const trimmed = typeof value === 'string' ? value.trim() : '';
-  return trimmed || undefined;
 }
 
 function resolveActiveEditorFilePath(editor: vscode.TextEditor | undefined): string | undefined {

--- a/src/extension/conversationStoreRoot.ts
+++ b/src/extension/conversationStoreRoot.ts
@@ -2,11 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-
-function normalizeNonEmptyString(value: string | undefined | null): string | undefined {
-  const trimmed = typeof value === 'string' ? value.trim() : '';
-  return trimmed || undefined;
-}
+import { normalizeNonEmptyString } from '../shared/stringUtils';
 
 function resolveConfiguredPath(p: string): string {
   const raw = p.trim();
@@ -70,4 +66,3 @@ export async function resolveConversationStoreRoot(params: {
   // Last resort: return tmp path even if we couldn't probe it; conversation may still run without persistence.
   return path.join(os.tmpdir(), 'openhands-conversations-vscode');
 }
-

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -2,6 +2,7 @@ import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, Conve
 import type { HalMode } from '../shared/halTypes';
 import { DEFAULT_HAL_LLM_PROFILE_ID } from '../shared/halDefaults';
 import { normalizeServerUrl } from '../shared/serverUrls';
+import { normalizeNonEmptyString } from '../shared/stringUtils';
 import { detectProviderFromBaseUrl, ensureDefaultProfiles, loadProfile } from '@openhands/agent-sdk-ts';
 
 export interface SavedServer {
@@ -71,11 +72,6 @@ const HAL_CONFIG_UPDATES: Array<[keyof HalSettings, string]> = [
   ['volume', 'openhands.hal.volume'],
   ['cache', 'openhands.hal.cache'],
 ];
-
-const normalizeNonEmptyString = (value: string | null | undefined): string | undefined => {
-  const trimmed = typeof value === 'string' ? value.trim() : '';
-  return trimmed || undefined;
-};
 
 const isSafeProfileId = (value: string): boolean => {
   if (!value.trim()) return false;

--- a/src/shared/stringUtils.ts
+++ b/src/shared/stringUtils.ts
@@ -1,5 +1,3 @@
 export function normalizeNonEmptyString(value: string | null | undefined): string | undefined {
-  const trimmed = typeof value === 'string' ? value.trim() : '';
-  return trimmed || undefined;
+  return value?.trim() || undefined;
 }
-

--- a/src/shared/stringUtils.ts
+++ b/src/shared/stringUtils.ts
@@ -1,0 +1,5 @@
+export function normalizeNonEmptyString(value: string | null | undefined): string | undefined {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || undefined;
+}
+


### PR DESCRIPTION
Bead: `oh-tab-vrr9`.

- Adds `src/shared/stringUtils.ts` with `normalizeNonEmptyString`.
- Removes duplicate implementations from `src/extension.ts`, `src/extension/conversationStoreRoot.ts`, and `src/settings/SettingsManager.ts`.

Local checks:
- `npm test`
- `npm run typecheck`
- `npm run lint`

Will wait for OrangeCastle approval before merge.