### PR TITLE
oh-tab-yws8: apply profile selection + reduce error detail

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.error-detail.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.error-detail.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { Agent, EventLog } from '../runtime';
+import type { OpenHandsSettings } from '../types/settings';
+import { isConversationErrorEvent } from '../types';
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-error-detail-'));
+
+const baseSettings: OpenHandsSettings = {
+  llm: { provider: 'openai', model: 'gpt-5-mini' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+describe('ConversationErrorEvent details', () => {
+  it('does not include internal LLM context in the error detail by default', async () => {
+    const originalOpenAIKey = process.env.OPENAI_API_KEY;
+    const originalLlmKey = process.env.LLM_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.LLM_API_KEY;
+
+    try {
+      const log = new EventLog();
+      const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot: createWorkspaceRoot() });
+      await agent.run('hi');
+
+      const errorEvent = log.list().find(isConversationErrorEvent);
+      expect(errorEvent?.detail).toContain('Missing API key');
+      expect(errorEvent?.detail).not.toContain('mode=');
+      expect(errorEvent?.detail).not.toContain('llm.');
+    } finally {
+      if (originalOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = originalOpenAIKey;
+      if (originalLlmKey === undefined) delete process.env.LLM_API_KEY;
+      else process.env.LLM_API_KEY = originalLlmKey;
+    }
+  });
+
+  it('includes internal LLM context in the error detail when agent.debug=true', async () => {
+    const originalOpenAIKey = process.env.OPENAI_API_KEY;
+    const originalLlmKey = process.env.LLM_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.LLM_API_KEY;
+
+    try {
+      const log = new EventLog();
+      const agent = new Agent({
+        settings: { ...baseSettings, agent: { debug: true } },
+        events: log,
+        workspaceRoot: createWorkspaceRoot(),
+      });
+      await agent.run('hi');
+
+      const errorEvent = log.list().find(isConversationErrorEvent);
+      expect(errorEvent?.detail).toContain('Missing API key');
+      expect(errorEvent?.detail).toContain('mode=local');
+      expect(errorEvent?.detail).toContain('llm.provider=');
+    } finally {
+      if (originalOpenAIKey === undefined) delete process.env.OPENAI_API_KEY;
+      else process.env.OPENAI_API_KEY = originalOpenAIKey;
+      if (originalLlmKey === undefined) delete process.env.LLM_API_KEY;
+      else process.env.LLM_API_KEY = originalLlmKey;
+    }
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1134,47 +1134,51 @@ export class Agent extends EventEmitter {
   private toConversationErrorEvent(error: unknown, options?: { code?: string; message?: string }): Event {
     const message = options?.message ?? stringifyErrorWithCause(error);
     const code = options?.code ?? classifyConversationErrorCode(message);
-    const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
-    const profileId = toOptionalNonEmptyString(this.options.settings?.llm?.profileId);
-    const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
-    const configuredProvider = this.options.settings?.llm?.provider ?? undefined;
-    const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
-    const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
-    const configuredApiKey = toOptionalNonEmptyString(this.options.settings?.secrets?.llmApiKey);
-    const hasInlineApiKey =
-      typeof configuredApiKey === 'string' && !/^[A-Z0-9_]+$/.test(configuredApiKey);
-    const apiKeyStatus = configuredApiKey ? (hasInlineApiKey ? 'inline' : 'reference') : 'unset';
-    const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
-    const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
+    const detail = (() => {
+      if (!this.debug) return message;
 
-    const contextParts = [
-      `mode=${mode}`,
-      `llm.model=${model ?? '(unset)'}`,
-      `llm.provider=${provider}`,
-      `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
-      `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
-      `llm.apiKey=${apiKeyStatus}`,
-    ];
-    if (profileId) {
-      contextParts.push(`llm.profileId=${profileId}`);
+      const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
+      const profileId = toOptionalNonEmptyString(this.options.settings?.llm?.profileId);
+      const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
+      const configuredProvider = this.options.settings?.llm?.provider ?? undefined;
+      const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
+      const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
+      const configuredApiKey = toOptionalNonEmptyString(this.options.settings?.secrets?.llmApiKey);
+      const hasInlineApiKey =
+        typeof configuredApiKey === 'string' && !/^[A-Z0-9_]+$/.test(configuredApiKey);
+      const apiKeyStatus = configuredApiKey ? (hasInlineApiKey ? 'inline' : 'reference') : 'unset';
+      const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
+      const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
 
-      if (isSafeProfileId(profileId)) {
-        try {
-          const profile = loadProfile(profileId);
-          const profileModel = toOptionalNonEmptyString(profile.config.model);
-          const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
-          const effectiveProfileProvider =
-            profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
-          contextParts.push(`llm.effectiveProvider=${effectiveProfileProvider}`);
-          contextParts.push(`llm.effectiveModel=${profileModel ?? '(unset)'}`);
-        } catch {
-          // best-effort: profile may be missing or unreadable
+      const contextParts = [
+        `mode=${mode}`,
+        `llm.model=${model ?? '(unset)'}`,
+        `llm.provider=${provider}`,
+        `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
+        `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
+        `llm.apiKey=${apiKeyStatus}`,
+      ];
+      if (profileId) {
+        contextParts.push(`llm.profileId=${profileId}`);
+
+        if (isSafeProfileId(profileId)) {
+          try {
+            const profile = loadProfile(profileId);
+            const profileModel = toOptionalNonEmptyString(profile.config.model);
+            const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
+            const effectiveProfileProvider =
+              profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
+            contextParts.push(`llm.effectiveProvider=${effectiveProfileProvider}`);
+            contextParts.push(`llm.effectiveModel=${profileModel ?? '(unset)'}`);
+          } catch {
+            // best-effort: profile may be missing or unreadable
+          }
         }
       }
-    }
-    if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
+      if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
 
-    const detail = `${message} (${contextParts.join(', ')})`;
+      return `${message} (${contextParts.join(', ')})`;
+    })();
     return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail } as Event;
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
@@ -155,7 +155,7 @@ describe('Agent profile api key selection', () => {
     }
   });
 
-  it('includes effective provider/model in ConversationErrorEvent detail when profileId is set', async () => {
+  it('includes effective provider/model in ConversationErrorEvent detail when debug is enabled and profileId is set', async () => {
     const tmpHome = makeTempDir('agent-profile-error-detail-');
     const originalHome = process.env.HOME;
     const originalUserProfile = process.env.USERPROFILE;
@@ -179,6 +179,7 @@ describe('Agent profile api key selection', () => {
         workspaceRoot: tmpHome,
         settings: {
           // Raw settings are misleading when profileId is set; detail should include effective profile values.
+          agent: { debug: true },
           llm: { profileId: 'p1', provider: 'openai', model: 'gpt-4o-mini' },
           secrets: {},
         } as any,

--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as vscode from 'vscode';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -9,6 +10,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
   let tmpDir = '';
 
   beforeEach(async () => {
+    (vscode as any).__resetMocks();
     vi.clearAllMocks();
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-llm-profiles-'));
   });
@@ -19,7 +21,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     }
   });
 
-  const createHandler = () => {
+  const createHandler = (options?: { conversation?: any }) => {
     const postMessage = vi.fn(async () => true);
     const secretValues = new Map<string, string>();
     const secrets = {
@@ -36,7 +38,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       context: { globalStorageUri: { fsPath: tmpDir }, secrets } as any,
       host: { postMessage },
       secretRegistry,
-      getConversation: () => undefined,
+      getConversation: () => options?.conversation,
       getConversationMode: () => 'local',
       getConversationStoreRoot: () => undefined,
       resolveConversationStoreRoot: async () => tmpDir,
@@ -160,5 +162,15 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     expect(secrets.delete).toHaveBeenCalledWith(key);
     await expect(secretRegistry.get(key)).resolves.toBeUndefined();
     await expect(fs.stat(path.join(tmpDir, 'a.json'))).rejects.toThrow();
+  });
+
+  it('applies selected LLM profileId to the active conversation immediately', async () => {
+    const conversation = { getStatus: () => 'online', setSettings: vi.fn() };
+    const { handler } = createHandler({ conversation });
+
+    await handler({ type: 'setLlmProfileId', profileId: 'test-gpt-4' });
+
+    expect(conversation.setSettings).toHaveBeenCalledTimes(1);
+    expect(conversation.setSettings.mock.calls[0]?.[0]?.llm?.profileId).toBe('test-gpt-4');
   });
 });

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -530,6 +530,12 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         await settingsMgr.update({ llm: { profileId } });
 
         const updated = await settingsMgr.get();
+        try {
+          conversation?.setSettings(updated);
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          outputChannel?.appendLine(`[settings] Failed to apply profile selection to active conversation: ${reason}`);
+        }
         deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(updated));
 
         void host.postMessage({


### PR DESCRIPTION
Fixes bead oh-tab-yws8.

- Apply LLM profile selection to the active conversation immediately (avoids race with VS Code config-change propagation).
- Make ConversationErrorEvent.detail user-focused by default; include internal llm context only when openhands.agent.debug=true.
- Add unit coverage for both behaviors.

Local checks: npm test, npm run typecheck, npm run lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * LLM profile selection now automatically applies to the active conversation.

* **Improvements**
  * Error messages are now less verbose in production mode, with detailed debug information only displayed when debug mode is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->