### PR TITLE
[oh-tab-susv] HAL: rename ElevenLabs key to HAL TTS key

### DIFF
--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -129,8 +129,8 @@ Settings:
 - `openhands.hal.llmProfileId`: string (default `gemini-flash-hal`) — LLM profile used for `voice_confirm` classification
 - `openhands.hal.userName`: string (default: `Engel`) — used only for templated script lines in the HAL flow
 - API key:
-  - Settings UI placeholder: `openhands.secrets.elevenLabsApiKey`
-  - Stored securely in SecretStorage: `openhands.elevenLabsApiKey` (already implemented)
+  - Settings UI placeholder: `openhands.hal.ttsApiKey`
+  - Stored securely in SecretStorage: `openhands.hal.ttsApiKey`
 - `openhands.hal.voiceAId`: string (`voice_hal` / HAL voice id)
 - `openhands.hal.voiceUserId`: string (`voice_user` / user voice id; used for `tts_only`)
 - `openhands.hal.modelId`: e.g. `eleven_turbo_v2` (optional)

--- a/package.json
+++ b/package.json
@@ -262,7 +262,7 @@
             "default": "",
             "order": 4,
             "editPresentation": "singlelineText",
-            "markdownDescription": "**To set your HAL TTS API key securely:**\n\n[🔑 Configure HAL TTS API Key](command:openhands.setHalTtsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Currently used for the ElevenLabs backend.)_"
+            "markdownDescription": "**To set your HAL TTS API key securely:**\n\n[🔑 Configure HAL TTS API Key](command:openhands.setHalTtsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Used for HAL voice synthesis (backend currently ElevenLabs).)_"
           },
           "openhands.hal.voiceAId": {
             "type": "string",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "onCommand:openhands.setGeminiLlmApiKey",
     "onCommand:openhands.setSessionApiKey",
     "onCommand:openhands.setGithubToken",
-    "onCommand:openhands.setElevenLabsApiKey",
+    "onCommand:openhands.setHalTtsApiKey",
 
     "onCommand:openhands.setCustomSecret1",
     "onCommand:openhands.setCustomSecret2",
@@ -94,8 +94,8 @@
         "title": "OpenHands: Set GitHub Token"
       },
       {
-        "command": "openhands.setElevenLabsApiKey",
-        "title": "OpenHands: Set ElevenLabs API Key"
+        "command": "openhands.setHalTtsApiKey",
+        "title": "OpenHands: Set HAL TTS API Key"
       },
 
       {
@@ -257,28 +257,35 @@
             "order": 3,
             "markdownDescription": "User name used only in templated HAL script lines."
           },
-          "openhands.hal.voiceAId": {
+          "openhands.hal.ttsApiKey": {
             "type": "string",
             "default": "",
             "order": 4,
-            "markdownDescription": "ElevenLabs voice ID for HAL (voice A)."
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**To set your HAL TTS API key securely:**\n\n[🔑 Configure HAL TTS API Key](command:openhands.setHalTtsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Currently used for the ElevenLabs backend.)_"
+          },
+          "openhands.hal.voiceAId": {
+            "type": "string",
+            "default": "",
+            "order": 5,
+            "markdownDescription": "TTS voice ID for HAL (voice A). (For the ElevenLabs backend, this is an ElevenLabs voice ID.)"
           },
           "openhands.hal.voiceUserId": {
             "type": "string",
             "default": "",
-            "order": 5,
-            "markdownDescription": "ElevenLabs voice ID for the user (voice B, used in `tts_only` mode)."
+            "order": 6,
+            "markdownDescription": "TTS voice ID for the user (voice B, used in `tts_only` mode). (For the ElevenLabs backend, this is an ElevenLabs voice ID.)"
           },
           "openhands.hal.modelId": {
             "type": "string",
             "default": "",
-            "order": 6,
-            "markdownDescription": "Optional ElevenLabs model id (e.g., `eleven_turbo_v2`)."
+            "order": 7,
+            "markdownDescription": "Optional TTS model id (ElevenLabs example: `eleven_turbo_v2`)."
           },
           "openhands.hal.volume": {
             "type": "number",
             "default": 1,
-            "order": 7,
+            "order": 8,
             "minimum": 0,
             "maximum": 1,
             "markdownDescription": "Playback volume (0.0–1.0)."
@@ -286,13 +293,13 @@
           "openhands.hal.cache": {
             "type": "boolean",
             "default": true,
-            "order": 8,
-            "markdownDescription": "Enable caching for generated ElevenLabs audio."
+            "order": 9,
+            "markdownDescription": "Enable caching for generated HAL TTS audio."
           },
           "openhands.hal.llmProfileId": {
             "type": "string",
             "default": "gemini-flash-hal",
-            "order": 9,
+            "order": 10,
             "markdownDescription": "LLM profile id used for `voice_confirm` classification (expected Gemini provider)."
           }
         }
@@ -408,14 +415,6 @@
             "order": 7,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your Gemini API key securely:**\n\n[🔑 Configure Gemini API Key](command:openhands.setGeminiLlmApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `GEMINI_API_KEY`.)_"
-          },
-
-          "openhands.secrets.elevenLabsApiKey": {
-            "type": "string",
-            "default": "",
-            "order": 9,
-            "editPresentation": "singlelineText",
-            "markdownDescription": "**To set your ElevenLabs API key securely:**\n\n[🔑 Configure ElevenLabs API Key](command:openhands.setElevenLabsApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json)_"
           },
           "openhands.secrets.customSecret1": {
             "type": "string",

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -167,7 +167,7 @@ describe('RemoteConversation', () => {
       settings: {
         ...baseSettings,
         secrets: {
-          elevenLabsApiKey: 'xi-example123',
+          halTtsApiKey: 'xi-example123',
           githubToken: 'ghp_example123',
           customSecret1: 'secret-1',
           customSecret2: 'secret-2',
@@ -351,7 +351,7 @@ describe('RemoteConversation', () => {
       settings: {
         ...baseSettings,
         secrets: {
-          elevenLabsApiKey: 'xi-example123',
+          halTtsApiKey: 'xi-example123',
           githubToken: 123 as any,
           customSecret1: {} as any,
           customSecret2: '   ' as any,

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -217,7 +217,7 @@ export class RemoteConversation extends EventEmitter {
         const secret = toStaticSecret(value);
         if (secret) typedSecrets[key] = secret;
       };
-      maybeSetSecret('ELEVENLABS_API_KEY', s?.secrets.elevenLabsApiKey);
+      maybeSetSecret('ELEVENLABS_API_KEY', s?.secrets.halTtsApiKey);
       maybeSetSecret('GITHUB_TOKEN', s?.secrets.githubToken);
       maybeSetSecret('CUSTOM_SECRET_1', s?.secrets.customSecret1);
       maybeSetSecret('CUSTOM_SECRET_2', s?.secrets.customSecret2);

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -220,7 +220,7 @@ export class Agent extends EventEmitter {
     this.secrets.set('CUSTOM_SECRET_1', s?.customSecret1);
     this.secrets.set('CUSTOM_SECRET_2', s?.customSecret2);
     this.secrets.set('CUSTOM_SECRET_3', s?.customSecret3);
-    this.secrets.set('ELEVENLABS_API_KEY', s?.elevenLabsApiKey);
+    this.secrets.set('ELEVENLABS_API_KEY', s?.halTtsApiKey);
   }
 
   private getSecretValuesForMasking(): string[] {

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -104,7 +104,7 @@ export type OpenHandsSettings = ServerSettings & {
     awsAccessKeyId?: string;
     awsSecretAccessKey?: string;
     githubToken?: string;
-    elevenLabsApiKey?: string;
+    halTtsApiKey?: string;
     customSecret1?: string;
     customSecret2?: string;
     customSecret3?: string;

--- a/src/extension/secretCommands.ts
+++ b/src/extension/secretCommands.ts
@@ -35,7 +35,7 @@ async function syncSecretStatusIndicators(params: { context: vscode.ExtensionCon
 
     { key: 'openhands.secrets.sessionApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.sessionApiKey) },
     { key: 'openhands.secrets.githubToken', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.githubToken) },
-    { key: 'openhands.secrets.elevenLabsApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.elevenLabsApiKey) },
+    { key: 'openhands.hal.ttsApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.halTtsApiKey) },
     { key: 'openhands.secrets.customSecret1', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret1) },
     { key: 'openhands.secrets.customSecret2', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret2) },
     { key: 'openhands.secrets.customSecret3', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret3) },
@@ -289,14 +289,14 @@ export function registerSecretCommands(params: {
     errorPrefix: 'Failed to save GitHub token',
   });
 
-  const setElevenLabsApiKey = registerSecretCommand('openhands.setElevenLabsApiKey', {
-    title: 'ElevenLabs API Key',
-    secretKey: 'elevenLabsApiKey',
-    prompt: 'Enter your ElevenLabs API key. It will be stored securely in VS Code SecretStorage.',
+  const setHalTtsApiKey = registerSecretCommand('openhands.setHalTtsApiKey', {
+    title: 'HAL TTS API Key',
+    secretKey: 'halTtsApiKey',
+    prompt: 'Enter your HAL TTS API key. It will be stored securely in VS Code SecretStorage (currently used for the ElevenLabs backend).',
     placeHolder: 'xi-...',
-    successMessage: 'ElevenLabs API key saved securely.',
-    clearedMessage: 'ElevenLabs API key cleared.',
-    errorPrefix: 'Failed to save ElevenLabs API key',
+    successMessage: 'HAL TTS API key saved securely.',
+    clearedMessage: 'HAL TTS API key cleared.',
+    errorPrefix: 'Failed to save HAL TTS API key',
   });
 
   const setCustomSecret1 = registerSecretCommand('openhands.setCustomSecret1', {
@@ -337,7 +337,7 @@ export function registerSecretCommands(params: {
     setGeminiLlmApiKey,
     setSessionApiKey,
     setGithubToken,
-    setElevenLabsApiKey,
+    setHalTtsApiKey,
     setCustomSecret1,
     setCustomSecret2,
     setCustomSecret3,

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -35,7 +35,7 @@ export type OpenHandsSettings = ServerSettings & {
     awsAccessKeyId?: string;
     awsSecretAccessKey?: string;
     githubToken?: string;
-    elevenLabsApiKey?: string;
+    halTtsApiKey?: string;
     customSecret1?: string;
     customSecret2?: string;
     customSecret3?: string;
@@ -320,7 +320,7 @@ export class SettingsManager {
       awsAccessKeyId: await this.adapter.getSecret('openhands.awsAccessKeyId'),
       awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
       githubToken: await this.adapter.getSecret('openhands.githubToken'),
-      elevenLabsApiKey: await this.adapter.getSecret('openhands.elevenLabsApiKey'),
+      halTtsApiKey: await this.adapter.getSecret('openhands.hal.ttsApiKey'),
 
       customSecret1: await this.adapter.getSecret('openhands.customSecret1'),
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
@@ -397,8 +397,8 @@ export class SettingsManager {
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'githubToken')) {
         ops.push(this.adapter.storeSecret('openhands.githubToken', partial.secrets.githubToken));
       }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'elevenLabsApiKey')) {
-        ops.push(this.adapter.storeSecret('openhands.elevenLabsApiKey', partial.secrets.elevenLabsApiKey));
+      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'halTtsApiKey')) {
+        ops.push(this.adapter.storeSecret('openhands.hal.ttsApiKey', partial.secrets.halTtsApiKey));
       }
 
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret1')) {

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -248,7 +248,7 @@ describe('SettingsManager', () => {
     await mgr.update({
       secrets: {
         githubToken: 'ghp_example123',
-        elevenLabsApiKey: 'xi-example123',
+        halTtsApiKey: 'xi-example123',
         customSecret1: 'secret-1',
         customSecret2: 'secret-2',
         customSecret3: 'secret-3',
@@ -257,7 +257,7 @@ describe('SettingsManager', () => {
 
     const s = await mgr.get();
     expect(s.secrets.githubToken).toBe('ghp_example123');
-    expect(s.secrets.elevenLabsApiKey).toBe('xi-example123');
+    expect(s.secrets.halTtsApiKey).toBe('xi-example123');
     expect(s.secrets.customSecret1).toBe('secret-1');
     expect(s.secrets.customSecret2).toBe('secret-2');
     expect(s.secrets.customSecret3).toBe('secret-3');
@@ -267,7 +267,7 @@ describe('SettingsManager', () => {
     await mgr.update({
       secrets: {
         githubToken: 'ghp_example123',
-        elevenLabsApiKey: 'xi-example123',
+        halTtsApiKey: 'xi-example123',
         customSecret1: 'secret-1',
         customSecret2: 'secret-2',
         customSecret3: 'secret-3',
@@ -276,7 +276,7 @@ describe('SettingsManager', () => {
 
     let s = await mgr.get();
     expect(s.secrets.githubToken).toBe('ghp_example123');
-    expect(s.secrets.elevenLabsApiKey).toBe('xi-example123');
+    expect(s.secrets.halTtsApiKey).toBe('xi-example123');
     expect(s.secrets.customSecret1).toBe('secret-1');
     expect(s.secrets.customSecret2).toBe('secret-2');
     expect(s.secrets.customSecret3).toBe('secret-3');
@@ -284,7 +284,7 @@ describe('SettingsManager', () => {
     await mgr.update({
       secrets: {
         githubToken: undefined,
-        elevenLabsApiKey: undefined,
+        halTtsApiKey: undefined,
         customSecret1: undefined,
         customSecret2: undefined,
         customSecret3: undefined,
@@ -293,7 +293,7 @@ describe('SettingsManager', () => {
 
     s = await mgr.get();
     expect(s.secrets.githubToken).toBeUndefined();
-    expect(s.secrets.elevenLabsApiKey).toBeUndefined();
+    expect(s.secrets.halTtsApiKey).toBeUndefined();
     expect(s.secrets.customSecret1).toBeUndefined();
     expect(s.secrets.customSecret2).toBeUndefined();
     expect(s.secrets.customSecret3).toBeUndefined();

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -716,7 +716,7 @@ export function useHalFlow(deps: {
 
     const shouldNotify = (payload as { shouldNotify?: unknown } | undefined)?.shouldNotify === true;
     const error = (payload as { error?: unknown } | undefined)?.error;
-    const message = typeof error === 'string' && error.trim() ? error.trim() : 'ElevenLabs TTS failed';
+    const message = typeof error === 'string' && error.trim() ? error.trim() : 'HAL TTS failed';
     const convoId = deps.conversationIdRef.current;
     if (convoId) setHalDisabledConversationId(convoId);
 

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -945,7 +945,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           break;
         }
 
-        const apiKey = settings.secrets.elevenLabsApiKey ?? '';
+        const apiKey = settings.secrets.halTtsApiKey ?? '';
         const voiceId = line.voice === 'voice_hal' ? (settings.hal.voiceAId ?? '') : (settings.hal.voiceUserId ?? '');
 
         const result = await getElevenlabsTtsGate().synthesize({


### PR DESCRIPTION
Bead: oh-tab-susv

- Rename user-facing command + settings from ElevenLabs branding to HAL-first (`openhands.hal.ttsApiKey`).
- Rename SecretStorage key to `openhands.hal.ttsApiKey`.
- Keep backend env var name `ELEVENLABS_API_KEY` (implementation unchanged).

No backwards-compat is required for old keys/command ids (feature not shipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Changes**
  * Renamed TTS API key configuration from ElevenLabs to HAL TTS
  * Updated API key setting location to `openhands.hal.ttsApiKey`
  * Updated command name from "Set ElevenLabs API Key" to "Set HAL TTS API Key"
  * Reorganized HAL configuration schema with updated property mappings
  * Updated error messaging for HAL TTS failures

* **Documentation**
  * Updated configuration documentation to reflect HAL TTS terminology

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->