### PR TITLE
[oh-tab-ihgw] Webview: extract rendered event block

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -1,14 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
-  isSystemPromptEvent,
-  isActionEvent,
-  isObservationEvent,
-  isUserRejectObservation,
   isMessageEvent,
-  isAgentErrorEvent,
-  isConversationErrorEvent,
-  isPauseEvent,
-  isCondensation,
   type Event,
   type ActionEvent,
 } from '@openhands/agent-sdk-ts';
@@ -23,6 +15,7 @@ import { useStatusMessages } from './app/useStatusMessages';
 import { useHostMessages } from './app/useHostMessages';
 import { useConversationEvents } from './app/useConversationEvents';
 import { useLlmProfilesRequests } from './app/useLlmProfilesRequests';
+import { RenderedEventBlock } from './app/RenderedEventBlock';
 
 // Component imports
 import { Header } from './Header';
@@ -34,14 +27,6 @@ import { LlmProfilesView, type LlmProfilesViewOpenRequest } from './LlmProfilesV
 import type { HalPhase } from '../../shared/halTypes';
 import { HalOverlay } from './HalOverlay';
 import {
-  SystemPromptEventBlock,
-  ActionEventBlock,
-  ObservationEventBlock,
-  UserRejectBlock,
-  AgentErrorBlock,
-  ConversationErrorBlock,
-  CondensationBlock,
-  MessageEventBlock,
   StreamingMessageBlock,
 } from './EventBlock';
 import type { WebviewToHostMessage } from '../../shared/webviewMessages';
@@ -52,54 +37,6 @@ type WebviewPersistedState = {
   conversationId?: string;
   lastSeenSeq?: number;
 };
-
-/**
- * Event dispatcher: routes agent-sdk events to appropriate rendering components.
- */
-function EventBlock({
-  event,
-  index,
-  skills,
-}: {
-  event: Event;
-  index: number;
-  skills: { label: string; path: string }[];
-}) {
-  if (isSystemPromptEvent(event)) return <SystemPromptEventBlock event={event} index={index} skills={skills} />;
-  if (isActionEvent(event)) return <ActionEventBlock event={event} index={index} />;
-  if (isObservationEvent(event)) return <ObservationEventBlock event={event} index={index} />;
-  if (isUserRejectObservation(event)) return <UserRejectBlock event={event} index={index} />;
-  if (isMessageEvent(event)) {
-    const message = event.llm_message;
-    if (message?.role === 'tool') return null;
-    const hasRenderableContent = Array.isArray(message?.content)
-      ? message.content.some((item) => {
-        if (item.type === 'text') return item.text.trim().length > 0;
-        return true;
-      })
-      : false;
-    const hasToolCalls = Array.isArray(message?.tool_calls) && message.tool_calls.length > 0;
-    if (message?.role === 'assistant' && hasToolCalls && !hasRenderableContent) {
-      return null;
-    }
-    return <MessageEventBlock event={event} index={index} />;
-  }
-  if (isAgentErrorEvent(event)) return <AgentErrorBlock event={event} index={index} />;
-  if (isConversationErrorEvent(event)) return <ConversationErrorBlock event={event} index={index} />;
-  if (isPauseEvent(event)) return null; // Pause events only show in status bar
-  if (isCondensation(event)) return <CondensationBlock event={event} index={index} />;
-
-  // Fallback for unknown events
-  const safeKind = 'kind' in event && typeof event.kind === 'string' ? event.kind : 'unknown';
-  return (
-    <div className="bg-white/5 border-l-[3px] border-gray-500 p-4 rounded-lg my-3">
-      <div className="font-semibold mb-2">Unknown Event: {String(safeKind)}</div>
-      <pre className="font-mono text-xs overflow-auto bg-black/20 p-3 rounded">
-        {JSON.stringify(event ?? {}, null, 2)}
-      </pre>
-    </div>
-  );
-}
 
 /**
  * Main App component: React webview root for OpenHands extension.
@@ -791,7 +728,7 @@ export function App() {
         ) : (
           <>
             {events.map((ev, index) => (
-              <EventBlock key={ev.id} event={ev.event} index={index} skills={skills} />
+              <RenderedEventBlock key={ev.id} event={ev.event} index={index} skills={skills} />
             ))}
             {streamingContent !== null && (
               <StreamingMessageBlock content={streamingContent} />

--- a/src/webview-src/components/app/RenderedEventBlock.tsx
+++ b/src/webview-src/components/app/RenderedEventBlock.tsx
@@ -21,18 +21,16 @@ import {
   MessageEventBlock,
 } from '../EventBlock';
 
-/**
- * Event dispatcher: routes agent-sdk events to appropriate rendering components.
- */
-export function RenderedEventBlock({
-  event,
-  index,
-  skills,
-}: {
+type RenderedEventBlockProps = {
   event: Event;
   index: number;
   skills: { label: string; path: string }[];
-}) {
+};
+
+/**
+ * Event dispatcher: routes agent-sdk events to appropriate rendering components.
+ */
+export function RenderedEventBlock({ event, index, skills }: RenderedEventBlockProps) {
   if (isSystemPromptEvent(event)) return <SystemPromptEventBlock event={event} index={index} skills={skills} />;
   if (isActionEvent(event)) return <ActionEventBlock event={event} index={index} />;
   if (isObservationEvent(event)) return <ObservationEventBlock event={event} index={index} />;
@@ -68,4 +66,3 @@ export function RenderedEventBlock({
     </div>
   );
 }
-

--- a/src/webview-src/components/app/RenderedEventBlock.tsx
+++ b/src/webview-src/components/app/RenderedEventBlock.tsx
@@ -1,0 +1,71 @@
+import {
+  isSystemPromptEvent,
+  isActionEvent,
+  isObservationEvent,
+  isUserRejectObservation,
+  isMessageEvent,
+  isAgentErrorEvent,
+  isConversationErrorEvent,
+  isPauseEvent,
+  isCondensation,
+  type Event,
+} from '@openhands/agent-sdk-ts';
+import {
+  SystemPromptEventBlock,
+  ActionEventBlock,
+  ObservationEventBlock,
+  UserRejectBlock,
+  AgentErrorBlock,
+  ConversationErrorBlock,
+  CondensationBlock,
+  MessageEventBlock,
+} from '../EventBlock';
+
+/**
+ * Event dispatcher: routes agent-sdk events to appropriate rendering components.
+ */
+export function RenderedEventBlock({
+  event,
+  index,
+  skills,
+}: {
+  event: Event;
+  index: number;
+  skills: { label: string; path: string }[];
+}) {
+  if (isSystemPromptEvent(event)) return <SystemPromptEventBlock event={event} index={index} skills={skills} />;
+  if (isActionEvent(event)) return <ActionEventBlock event={event} index={index} />;
+  if (isObservationEvent(event)) return <ObservationEventBlock event={event} index={index} />;
+  if (isUserRejectObservation(event)) return <UserRejectBlock event={event} index={index} />;
+  if (isMessageEvent(event)) {
+    const message = event.llm_message;
+    if (message?.role === 'tool') return null;
+    const hasRenderableContent = Array.isArray(message?.content)
+      ? message.content.some((item) => {
+        if (item.type === 'text') return item.text.trim().length > 0;
+        return true;
+      })
+      : false;
+    const hasToolCalls = Array.isArray(message?.tool_calls) && message.tool_calls.length > 0;
+    if (message?.role === 'assistant' && hasToolCalls && !hasRenderableContent) {
+      return null;
+    }
+    return <MessageEventBlock event={event} index={index} />;
+  }
+  if (isAgentErrorEvent(event)) return <AgentErrorBlock event={event} index={index} />;
+  if (isConversationErrorEvent(event)) return <ConversationErrorBlock event={event} index={index} />;
+  if (isPauseEvent(event)) return null; // Pause events only show in status bar
+  if (isCondensation(event)) return <CondensationBlock event={event} index={index} />;
+
+  // Fallback for unknown events
+  const safeKind = 'kind' in event && typeof event.kind === 'string' ? event.kind : 'unknown';
+  return (
+    <div className="bg-white/5 border-l-[3px] border-gray-500 p-4 rounded-lg my-3">
+      <div className="font-semibold mb-2">Unknown Event: {String(safeKind)}</div>
+      <pre className="font-mono text-xs overflow-auto bg-black/20 p-3 rounded">
+        {JSON.stringify(event ?? {}, null, 2)}
+      </pre>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Bead: oh-tab-ihgw

Small, behavior-preserving App.tsx refactor:
- Move the event->component dispatch logic out of `src/webview-src/components/App.tsx` into `src/webview-src/components/app/RenderedEventBlock.tsx`.
- No functional changes; tests remain green.
