### PR TITLE
[oh-tab-b7qq] Extension: extract pasted images cleanup scheduler

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,8 +8,7 @@ import { DEFAULT_HAL_STATE } from './shared/halDefaults';
 import { resolveConfiguredLlmLabel } from './shared/llmProfiles';
 import { maskSecretsInText } from './shared/maskSecrets';
 import { safeStringify } from './shared/safeStringify';
-import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, isValidPastedImageId } from './shared/pastedImages';
-import { cleanupPastedImages } from './shared/pastedImagesCleanup';
+import { getGlobalStorageBaseDir } from './shared/pastedImages';
 import { transformEventForWebview as transformEventForWebviewWithPastedImages } from './conversation/host/transformEventForWebview';
 import { ConversationEventBacklog, type BufferedConversationEvent } from './conversation/eventBacklog';
 import { OpenHandsTerminalLogPseudoterminal } from './terminal/OpenHandsTerminalLogPseudoterminal';
@@ -20,6 +19,7 @@ import { createDevBridgeLogger, createMaskedOutputChannel } from './extension/de
 import { createFileEditNoteTracker } from './extension/fileEditNote';
 import { getGitHeadDiffSummaryForFile, resolveGitContext } from './extension/gitDiffSummary';
 import { resolveConversationStoreRoot } from './extension/conversationStoreRoot';
+import { createPastedImagesCleanupScheduler } from './extension/pastedImagesCleanupScheduler';
 import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import {
@@ -64,6 +64,14 @@ const MAX_EVENT_BACKLOG = 2000;
 const MAX_PASTED_IMAGES_STORAGE_FILES = 2000;
 const MAX_PASTED_IMAGES_STORAGE_BYTES = 200 * 1024 * 1024;
 const eventBacklog = new ConversationEventBacklog({ maxSize: MAX_EVENT_BACKLOG });
+const pastedImagesCleanupScheduler = createPastedImagesCleanupScheduler({
+  iterBacklog: () => eventBacklog.iter(),
+  getBaseDir: () => pastedImagesBaseDir,
+  maxFiles: MAX_PASTED_IMAGES_STORAGE_FILES,
+  maxBytes: MAX_PASTED_IMAGES_STORAGE_BYTES,
+  log: (line) => outputChannel?.appendLine(line),
+  renderError,
+});
 // Buffer of test events sent via _sendTestEvent (used as fallback in E2E query)
 const MAX_TEST_EVENTS = MAX_EVENT_BACKLOG;
 const sentTestEvents: Event[] = [];
@@ -83,85 +91,13 @@ function markPrintedExitFor(commandId: string): void {
   if (oldest) printedExitFor.delete(oldest);
 }
 
-let pastedImagesCleanupInFlight: Promise<void> | undefined;
-let pastedImagesCleanupQueued = false;
-const OPENHANDS_IMAGE_ID_REGEX = new RegExp(`${OPENHANDS_IMAGE_URL_PREFIX}([a-f0-9]{16}\\.[a-z0-9]+)`, 'g');
-
-function messageHasPastedImages(event: Event): boolean {
-  if (event.kind !== 'MessageEvent') return false;
-  const content = (event as unknown as { llm_message?: { content?: unknown } }).llm_message?.content;
-  if (!Array.isArray(content)) return false;
-  for (const item of content) {
-    if (!item || (item as { type?: unknown }).type !== 'text') continue;
-    const text = (item as { text?: unknown }).text;
-    if (typeof text === 'string' && text.includes(OPENHANDS_IMAGE_URL_PREFIX)) return true;
-  }
-  return false;
-}
-
-function collectReferencedPastedImageIdsFromBacklog(): Set<string> {
-  const imageIds = new Set<string>();
-  for (const item of eventBacklog.iter()) {
-    const event = item.event;
-    if (event.kind !== 'MessageEvent') continue;
-    const content = (event as unknown as { llm_message?: { content?: unknown } }).llm_message?.content;
-    if (!Array.isArray(content)) continue;
-
-    for (const part of content) {
-      if (!part || (part as { type?: unknown }).type !== 'text') continue;
-      const text = (part as { text?: unknown }).text;
-      if (typeof text !== 'string' || !text.includes(OPENHANDS_IMAGE_URL_PREFIX)) continue;
-
-      for (const match of text.matchAll(OPENHANDS_IMAGE_ID_REGEX)) {
-        const imageId = match[1];
-        if (typeof imageId === 'string' && isValidPastedImageId(imageId)) {
-          imageIds.add(imageId);
-        }
-      }
-    }
-  }
-  return imageIds;
-}
-
-function schedulePastedImagesCleanup(): void {
-  if (pastedImagesCleanupInFlight) {
-    pastedImagesCleanupQueued = true;
-    return;
-  }
-
-  pastedImagesCleanupInFlight = (async () => {
-    try {
-      const keepImageIds = collectReferencedPastedImageIdsFromBacklog();
-      await cleanupPastedImages({
-        baseDir: pastedImagesBaseDir,
-        keepImageIds,
-        maxFiles: MAX_PASTED_IMAGES_STORAGE_FILES,
-        maxBytes: MAX_PASTED_IMAGES_STORAGE_BYTES,
-        log: (line) => outputChannel?.appendLine(line),
-      });
-    } catch (err) {
-      outputChannel?.appendLine(`[pasted-images] Cleanup failed: ${renderError(err)}`);
-    } finally {
-      pastedImagesCleanupInFlight = undefined;
-    }
-  })()
-    .finally(() => {
-      if (pastedImagesCleanupQueued) {
-        pastedImagesCleanupQueued = false;
-        schedulePastedImagesCleanup();
-      }
-    });
-}
-
 function resetConversationEventBacklog(conversationId: string | undefined) {
   eventBacklog.reset(conversationId);
 }
 
 function bufferConversationEvent(event: Event): number {
   const seq = eventBacklog.push(event);
-  if (messageHasPastedImages(event)) {
-    schedulePastedImagesCleanup();
-  }
+  pastedImagesCleanupScheduler.handleBufferedEvent(event);
   return seq;
 }
 

--- a/src/extension/pastedImagesCleanupScheduler.ts
+++ b/src/extension/pastedImagesCleanupScheduler.ts
@@ -1,0 +1,93 @@
+import type { Event } from '@openhands/agent-sdk-ts';
+import type { BufferedConversationEvent } from '../conversation/eventBacklog';
+import { OPENHANDS_IMAGE_URL_PREFIX, isValidPastedImageId } from '../shared/pastedImages';
+import { cleanupPastedImages } from '../shared/pastedImagesCleanup';
+
+type SchedulerParams = {
+  iterBacklog: () => Iterable<BufferedConversationEvent>;
+  getBaseDir: () => string;
+  maxFiles: number;
+  maxBytes: number;
+  log: (line: string) => void;
+  renderError: (err: unknown) => string;
+};
+
+const OPENHANDS_IMAGE_ID_REGEX = new RegExp(`${OPENHANDS_IMAGE_URL_PREFIX}([a-f0-9]{16}\\.[a-z0-9]+)`, 'g');
+
+function messageHasPastedImages(event: Event): boolean {
+  if (event.kind !== 'MessageEvent') return false;
+  const content = (event as unknown as { llm_message?: { content?: unknown } }).llm_message?.content;
+  if (!Array.isArray(content)) return false;
+  for (const item of content) {
+    if (!item || (item as { type?: unknown }).type !== 'text') continue;
+    const text = (item as { text?: unknown }).text;
+    if (typeof text === 'string' && text.includes(OPENHANDS_IMAGE_URL_PREFIX)) return true;
+  }
+  return false;
+}
+
+function collectReferencedPastedImageIdsFromBacklog(iterBacklog: SchedulerParams['iterBacklog']): Set<string> {
+  const imageIds = new Set<string>();
+  for (const item of iterBacklog()) {
+    const event = item.event;
+    if (event.kind !== 'MessageEvent') continue;
+    const content = (event as unknown as { llm_message?: { content?: unknown } }).llm_message?.content;
+    if (!Array.isArray(content)) continue;
+
+    for (const part of content) {
+      if (!part || (part as { type?: unknown }).type !== 'text') continue;
+      const text = (part as { text?: unknown }).text;
+      if (typeof text !== 'string' || !text.includes(OPENHANDS_IMAGE_URL_PREFIX)) continue;
+
+      for (const match of text.matchAll(OPENHANDS_IMAGE_ID_REGEX)) {
+        const imageId = match[1];
+        if (typeof imageId === 'string' && isValidPastedImageId(imageId)) {
+          imageIds.add(imageId);
+        }
+      }
+    }
+  }
+  return imageIds;
+}
+
+export function createPastedImagesCleanupScheduler(params: SchedulerParams) {
+  let cleanupInFlight: Promise<void> | undefined;
+  let cleanupQueued = false;
+
+  const schedule = (): void => {
+    if (cleanupInFlight) {
+      cleanupQueued = true;
+      return;
+    }
+
+    cleanupInFlight = (async () => {
+      try {
+        const keepImageIds = collectReferencedPastedImageIdsFromBacklog(params.iterBacklog);
+        await cleanupPastedImages({
+          baseDir: params.getBaseDir(),
+          keepImageIds,
+          maxFiles: params.maxFiles,
+          maxBytes: params.maxBytes,
+          log: params.log,
+        });
+      } catch (err) {
+        params.log(`[pasted-images] Cleanup failed: ${params.renderError(err)}`);
+      } finally {
+        cleanupInFlight = undefined;
+      }
+    })().finally(() => {
+      if (cleanupQueued) {
+        cleanupQueued = false;
+        schedule();
+      }
+    });
+  };
+
+  const handleBufferedEvent = (event: Event): void => {
+    if (!messageHasPastedImages(event)) return;
+    schedule();
+  };
+
+  return { handleBufferedEvent };
+}
+


### PR DESCRIPTION
Bead: oh-tab-b7qq

Small, behavior-preserving extraction:
- Move pasted-images cleanup scheduling + referenced-id scanning out of `src/extension.ts` into `src/extension/pastedImagesCleanupScheduler.ts`.
- `bufferConversationEvent` now just pushes to backlog and calls `pastedImagesCleanupScheduler.handleBufferedEvent(event)`.

Local: `npm test`, `npm run typecheck`, `npm run lint` all green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized pasted image cleanup handling into a centralized scheduler for improved code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->