### PR TITLE
refactor(runtime): rename AgentOrchestrator to LLMStreamer

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -68,7 +68,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
   - `LocalConversation` - in-process agent execution
   - `RemoteConversation` - WebSocket to agent-server
 - **Context Layer** - AgentContext, Skills
-- **Runtime Layer** - AgentOrchestrator, EventLog, ConversationState
+- **Runtime Layer** - LLMStreamer, EventLog, ConversationState
 - **LLM Layer** - Anthropic, OpenAI-compatible clients
 - **Tools Layer** - Terminal, FileEditor, TaskTracker, Browser, Glob, Grep, BrowserUse, PlanningFileEditor, Delegate
 

--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -35,7 +35,7 @@ The SDK follows these core principles:
 │                 │                                         │
 │  ┌──────────────┴──────────────────────────────────┐    │
 │  │         Runtime Layer (Orchestration)            │    │
-│  │  AgentOrchestrator │ EventLog │ State │ Locks   │    │
+│  │  LLMStreamer │ EventLog │ State │ Locks   │    │
 │  └──────────────┬──────────────────────────────────┘    │
 │                 │                                         │
 │  ┌──────────────┴──────────────┬─────────────────┐      │
@@ -114,10 +114,10 @@ interface ConversationInstance {
 
 **Purpose**: In-memory agent execution within VS Code without an external agent-server.
 
-**Status**: Local execution path that runs the full agent loop directly inside VS Code using `AgentOrchestrator`, built-in tools, and `LocalWorkspace`.
+**Status**: Local execution path that runs the full agent loop directly inside VS Code using `LLMStreamer`, built-in tools, and `LocalWorkspace`.
 
 **Features**:
-- Runs agent orchestration locally using `AgentOrchestrator`
+- Runs agent orchestration locally using `LLMStreamer`
 - EventEmitter-based event dispatching
 - Manages tool execution with `LocalWorkspace`
 - Terminal events for VS Code integrated terminal
@@ -465,7 +465,7 @@ Third-party files supported:
 
 The runtime layer coordinates agent execution, manages conversation state, and orchestrates LLM interactions.
 
-### AgentOrchestrator
+### LLMStreamer
 
 **Purpose**: Manages the Conversation using the LLMClient with streaming support.
 
@@ -477,12 +477,12 @@ The runtime layer coordinates agent execution, manages conversation state, and o
 
 **Usage Example**:
 ```typescript
-import { AgentOrchestrator, LLMFactory } from '@openhands/agent-sdk-ts';
+import { LLMStreamer, LLMFactory } from '@openhands/agent-sdk-ts';
 
 const client = await new LLMFactory({ provider: 'anthropic', model: 'claude-sonnet-4-20250514' }).createClient();
-const orchestrator = new AgentOrchestrator(client);
+const streamer = new LLMStreamer(client);
 
-const response = await orchestrator.runChat({
+const response = await streamer.runChat({
   systemPrompt: 'You are a code assistant.',
   messages: [
     { role: 'user', content: [{ type: 'text', text: 'Write a hello world function' }] }
@@ -514,7 +514,7 @@ return { message, usage }
 
 ### Agent (TS SDK)
 
-**Purpose**: Elevates `AgentOrchestrator` into a full agent loop that mirrors the Python SDK's local execution flow.
+**Purpose**: Elevates `LLMStreamer` into a full agent loop that mirrors the Python SDK's local execution flow.
 
 **Key Responsibilities**:
 - Emit `SystemPromptEvent` up front with tool definitions
@@ -1536,7 +1536,7 @@ For advanced use cases requiring direct control:
 
 ```typescript
 import {
-  AgentOrchestrator,
+  LLMStreamer,
   LLMFactory,
   EventLog,
   ConversationState,
@@ -1553,7 +1553,7 @@ const client = await new LLMFactory({ provider: 'anthropic', model: 'claude-sonn
 
 const eventLog = new EventLog();
 const state = new ConversationState(eventLog);
-const orchestrator = new AgentOrchestrator(client, { events: eventLog, state });
+const streamer = new LLMStreamer(client, { events: eventLog, state });
 
 // Tools
 const workspace = new LocalWorkspace('/workspace');
@@ -1563,7 +1563,7 @@ const fileEditor = new FileEditorTool();
 const toolContext = { workspace, events: eventLog, secrets };
 
 // Execute agent
-const response = await orchestrator.runChat({
+const response = await streamer.runChat({
   systemPrompt: 'You are a helpful assistant.',
   messages: conversation.messages,
   tools: [

--- a/packages/agent-sdk-ts/AGENTS.md
+++ b/packages/agent-sdk-ts/AGENTS.md
@@ -57,7 +57,7 @@ Skills are loaded from:
 ### 3. Runtime Layer (`src/runtime/`)
 Agent execution and state management:
 
-- **`AgentOrchestrator`** - Core orchestration layer that manages LLM streaming, tool calls, and conversation flow
+- **`LLMStreamer`** - Core orchestration layer that manages LLM streaming, tool calls, and conversation flow
   - Handles streaming chat completions from LLM providers
   - Accumulates text, reasoning content, and tool calls from stream chunks
   - Updates conversation state in real-time
@@ -356,7 +356,7 @@ conversation.disconnect();
 ### Local vs Remote Mode
 
 ```typescript
-// Local mode - runs the orchestrator in-process against the VS Code workspace
+// Local mode - runs the streamer in-process against the VS Code workspace
 const localConversation = Conversation({
   settings: { /* ... */ },
   workspaceRoot: '/workspace',
@@ -386,16 +386,16 @@ const config: LLMConfiguration = {
 const client = await new LLMFactory(config).createClient();
 ```
 
-### Using AgentOrchestrator (Low-Level)
+### Using LLMStreamer (Low-Level)
 
 For direct orchestration without the Conversation wrapper:
 
 ```typescript
-import { AgentOrchestrator } from '@openhands/agent-sdk-ts';
+import { LLMStreamer } from '@openhands/agent-sdk-ts';
 
-const orchestrator = new AgentOrchestrator(client);
+const streamer = new LLMStreamer(client);
 
-const response = await orchestrator.runChat({
+const response = await streamer.runChat({
   systemPrompt: 'You are a helpful assistant.',
   messages: [{ role: 'user', content: [{ type: 'text', text: 'Hello!' }] }],
 });

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -16,7 +16,7 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 
 | Module | Python | TypeScript | Notes |
 |--------|--------|-----------|-------|
-| agent/ | ✓ `Agent`, `AgentBase` | ✓ `Agent` in runtime/ | TS has separate `AgentOrchestrator` |
+| agent/ | ✓ `Agent`, `AgentBase` | ✓ `Agent` in runtime/ | TS has separate `LLMStreamer` |
 | context/ | ✓ | ✓ | Similar skill/context handling |
 | conversation/ | ✓ | ✓ | Both have Local/Remote variants |
 | critic/ | ✓ | ✗ | Evaluation framework, Python only (not planned) |
@@ -64,7 +64,7 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 
 ### Features in TypeScript but NOT in Python
 
-1. **AgentOrchestrator** - Separate orchestration layer (Python has this in Agent class)
+1. **LLMStreamer** - Separate orchestration layer (Python has this in Agent class)
 
 2. **LLM Profiles System** - Profile-based provider management, native clients (Anthropic, OpenAI-compatible, Gemini)
 
@@ -405,7 +405,7 @@ Python's RemoteConversation has significantly more features than TypeScript's im
 
 ### TypeScript shape
 
-- `Agent` wraps `AgentOrchestrator`
+- `Agent` wraps `LLMStreamer`
   - Builds/attaches `EventLog`, `ConversationState`, `SecretRegistry`
   - Optional tools/LLM client and optional `AgentContext`
 - Methods: `run`, `pause/resume`, `cancel`, `approveAction/rejectAction`
@@ -441,7 +441,7 @@ classDiagram
       +run()
       +pause()/resume()/cancel()
       +approveAction()/rejectAction()
-      -AgentOrchestrator
+      -LLMStreamer
       -ConversationState (in-memory)
       -EventLog (in-memory)
       -SecretRegistry (in-memory)
@@ -453,7 +453,7 @@ classDiagram
 
 ### Source references
 - Python: openhands/sdk/agent/base.py AgentBase; openhands/sdk/agent/agent.py Agent; openhands/sdk/conversation/state.py ConversationState; openhands/sdk/conversation/conversation.py Conversation factory glue.
-- TypeScript: packages/agent-sdk-ts/src/sdk/runtime/Agent.ts Agent; packages/agent-sdk-ts/src/sdk/runtime/AgentOrchestrator.ts AgentOrchestrator; packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts ConversationState; packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts SecretRegistry.
+- TypeScript: packages/agent-sdk-ts/src/sdk/runtime/Agent.ts Agent; packages/agent-sdk-ts/src/sdk/runtime/LLMStreamer.ts LLMStreamer; packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts ConversationState; packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts SecretRegistry.
 
 ## AgentContext and skills
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.streamer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.streamer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { AgentOrchestrator } from '../runtime';
+import { LLMStreamer } from '../runtime';
 import { DEFAULT_RETRY_OPTIONS, OpenAICompatibleClient, OpenAIResponsesClient, GeminiClient, LLMFactory, LLMCredentialProvider } from '../llm';
 import type { ChatCompletionRequest, LLMConfiguration } from '../llm';
 import { ConversationState, EventLog, SecretRegistry } from '../runtime';
@@ -42,9 +42,9 @@ describe('OpenAICompatibleClient streaming', () => {
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
     const state = new ConversationState({ eventLog: new EventLog() });
     const client = new OpenAICompatibleClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client, { state });
+    const streamer = new LLMStreamer(client, { state });
 
-    const response = await orchestrator.runChat(buildRequest());
+    const response = await streamer.runChat(buildRequest());
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.message.content[0]).toEqual({ type: 'text', text: 'Hello' });
@@ -72,13 +72,13 @@ describe('OpenAICompatibleClient streaming', () => {
 
     const state = new ConversationState({ eventLog: new EventLog() });
     const client = new OpenAICompatibleClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client, { state });
+    const streamer = new LLMStreamer(client, { state });
 
-    const response1 = await orchestrator.runChat(buildRequest());
+    const response1 = await streamer.runChat(buildRequest());
     expect(response1.message.content[0]).toEqual({ type: 'text', text: 'Hello' });
     expect(state.snapshot.values.llm_stream).toBe('Hello');
 
-    const response2 = await orchestrator.runChat(buildRequest());
+    const response2 = await streamer.runChat(buildRequest());
     expect(response2.message.content[0]).toEqual({ type: 'text', text: 'Bye' });
     expect(state.snapshot.values.llm_stream).toBe('Bye');
 
@@ -97,8 +97,8 @@ describe('OpenAICompatibleClient streaming', () => {
       'retry-key',
       { ...DEFAULT_RETRY_OPTIONS, baseDelayMs: 0, maxDelayMs: 0 },
     );
-    const orchestrator = new AgentOrchestrator(client);
-    const response = await orchestrator.runChat(buildRequest());
+    const streamer = new LLMStreamer(client);
+    const response = await streamer.runChat(buildRequest());
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(response.message.content[0].type).toBe('text');
@@ -107,9 +107,9 @@ describe('OpenAICompatibleClient streaming', () => {
   it('propagates failure after retries', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse('error', 500));
     const client = new OpenAICompatibleClient(baseConfig, 'bad-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    await expect(orchestrator.runChat(buildRequest())).rejects.toThrow(/LLM request failed/);
+    await expect(streamer.runChat(buildRequest())).rejects.toThrow(/LLM request failed/);
   });
 });
 
@@ -132,9 +132,9 @@ describe('GeminiClient streaming', () => {
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
     const state = new ConversationState({ eventLog: new EventLog() });
     const client = new GeminiClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client, { state });
+    const streamer = new LLMStreamer(client, { state });
 
-    const response = await orchestrator.runChat(buildRequest());
+    const response = await streamer.runChat(buildRequest());
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(response.message.content[0]).toEqual({ type: 'text', text: 'Hello' });
@@ -160,8 +160,8 @@ describe('GeminiClient streaming', () => {
       'retry-key',
       { ...DEFAULT_RETRY_OPTIONS, baseDelayMs: 0, maxDelayMs: 0 },
     );
-    const orchestrator = new AgentOrchestrator(client);
-    const response = await orchestrator.runChat(buildRequest());
+    const streamer = new LLMStreamer(client);
+    const response = await streamer.runChat(buildRequest());
 
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(response.message.content[0].type).toBe('text');
@@ -170,9 +170,9 @@ describe('GeminiClient streaming', () => {
   it('propagates failure after retries', async () => {
     vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse('error', 500));
     const client = new GeminiClient(baseConfig, 'bad-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    await expect(orchestrator.runChat(buildRequest())).rejects.toThrow(/LLM request failed/);
+    await expect(streamer.runChat(buildRequest())).rejects.toThrow(/LLM request failed/);
   });
 });
 
@@ -213,9 +213,9 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
     const client = new OpenAIResponsesClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    const response = await orchestrator.runChat(buildRequest());
+    const response = await streamer.runChat(buildRequest());
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(String(fetchMock.mock.calls[0]?.[0] ?? '')).toContain('/responses');
@@ -244,9 +244,9 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
     const client = new OpenAIResponsesClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    await orchestrator.runChat({
+    await streamer.runChat({
       systemPrompt: 'you are a test harness',
       messages: [
         { role: 'user', content: [{ type: 'text', text: 'hello' }] },
@@ -280,9 +280,9 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
     const client = new OpenAIResponsesClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    await orchestrator.runChat({
+    await streamer.runChat({
       systemPrompt: 'you are a test harness',
       messages: [
         { role: 'user', content: [{ type: 'text', text: 'hello' }] },
@@ -327,10 +327,10 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
     const client = new OpenAIResponsesClient(baseConfig, 'test-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
     const encryptedContent = 'encrypted\n';
-    await orchestrator.runChat({
+    await streamer.runChat({
       systemPrompt: 'you are a test harness',
       messages: [
         { role: 'user', content: [{ type: 'text', text: 'hello' }] },
@@ -367,9 +367,9 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
     const client = new OpenAIResponsesClient({ ...baseConfig, reasoningEffort: 'medium', reasoningSummary: 'detailed' }, 'test-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    await orchestrator.runChat(buildRequest());
+    await streamer.runChat(buildRequest());
 
     const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
     const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
@@ -390,9 +390,9 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 
     const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
     const client = new OpenAIResponsesClient({ ...baseConfig, reasoningEffort: 'none', reasoningSummary: 'detailed' }, 'test-key');
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    await orchestrator.runChat(buildRequest());
+    await streamer.runChat(buildRequest());
 
     const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
     const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
@@ -458,9 +458,9 @@ describe('LLMFactory integration', () => {
   maybeIt('streams from OpenAI with real credentials', async () => {
     const factory = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', maxOutputTokens: 8 });
     const client = await factory.createClient();
-    const orchestrator = new AgentOrchestrator(client);
+    const streamer = new LLMStreamer(client);
 
-    const result = await orchestrator.runChat({
+    const result = await streamer.runChat({
       systemPrompt: 'You are a concise bot',
       messages: [{ role: 'user', content: [{ type: 'text', text: 'Say hello in one short sentence.' }] }],
     });

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.api-key-precedence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/factory.api-key-precedence.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
 import { LLMFactory } from '..';
 import { SecretRegistry } from '../../runtime/SecretRegistry';
 
@@ -10,6 +10,22 @@ class TrackingSecretRegistry extends SecretRegistry {
     return super.get(name);
   }
 }
+
+let originalOpenaiKey: string | undefined;
+let originalLitellmKey: string | undefined;
+
+beforeEach(() => {
+  // Ensure environment variables do not interfere with precedence tests
+  originalOpenaiKey = process.env.OPENAI_API_KEY;
+  originalLitellmKey = process.env.LITELLM_API_KEY;
+  delete process.env.OPENAI_API_KEY;
+  delete process.env.LITELLM_API_KEY;
+});
+
+afterEach(() => {
+  if (originalOpenaiKey === undefined) delete process.env.OPENAI_API_KEY; else process.env.OPENAI_API_KEY = originalOpenaiKey;
+  if (originalLitellmKey === undefined) delete process.env.LITELLM_API_KEY; else process.env.LITELLM_API_KEY = originalLitellmKey;
+});
 
 describe('LLMFactory API key precedence', () => {
   it('prefers provider-specific key over openhands.llmApiKey (openai)', async () => {

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -176,7 +176,7 @@ const mapChunkToStream = (chunk: OpenAIStreamChunk, accumulator: OpenAIToolCallA
         name: call.function?.name,
         arguments: call.function?.arguments,
       });
-      // Yield only the delta, not accumulated arguments (orchestrator will accumulate)
+      // Yield only the delta, not accumulated arguments (streamer will accumulate)
       deltas.push({
         type: 'tool_call_delta',
         id: result.current.id,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { randomUUID } from 'crypto';
 import path from 'path';
-import { AgentOrchestrator } from './AgentOrchestrator';
+import { LLMStreamer } from './LLMStreamer';
 import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
@@ -114,7 +114,7 @@ export class Agent extends EventEmitter {
   private readonly confirmation: ConfirmationPolicy;
   private readonly lock = new AsyncLock();
   private llmClientPromise?: Promise<LLMClient>;
-  private orchestratorPromise?: Promise<AgentOrchestrator>;
+  private streamerPromise?: Promise<LLMStreamer>;
   private paused = false;
   private cancelled = false;
   private finished = false;
@@ -401,7 +401,7 @@ export class Agent extends EventEmitter {
 
       // Force the next run to rebuild the LLM client from updated settings.
       this.llmClientPromise = undefined;
-      this.orchestratorPromise = undefined;
+      this.streamerPromise = undefined;
       return Promise.resolve();
     });
   }
@@ -596,16 +596,16 @@ export class Agent extends EventEmitter {
     }
 
     const maxIterations = this.clampMaxIterations();
-    let orchestrator: AgentOrchestrator;
+    let streamer: LLMStreamer;
     try {
-      orchestrator = await this.getOrchestrator();
+      streamer = await this.getStreamer();
     } catch (error) {
       const classified = classifyError(error, { stage: 'llm_init' });
       this.events.push(this.toConversationErrorEvent(error, { code: classified.code }));
       this.state.setStatus('IDLE');
       // Allow a future retry after settings/secrets are updated.
       this.llmClientPromise = undefined;
-      this.orchestratorPromise = undefined;
+      this.streamerPromise = undefined;
       return undefined;
     }
     let lastAssistantMessage: Message | undefined;
@@ -613,7 +613,7 @@ export class Agent extends EventEmitter {
     while (!this.paused && !this.pendingAction && !this.cancelled && !this.finished && this.state.snapshot.iteration < maxIterations) {
       this.state.setStatus('RUNNING');
       const llmConfig = this.getEffectiveLlmConfigForCondensation();
-      let response: Awaited<ReturnType<AgentOrchestrator['runChat']>> | undefined;
+      let response: Awaited<ReturnType<LLMStreamer['runChat']>> | undefined;
 
       // Condensation is token-budget based: before calling the LLM (and again if we hit a context-limit
       // error), we may summarize the conversation to shrink the next request.
@@ -674,7 +674,7 @@ export class Agent extends EventEmitter {
         }
 
         try {
-          const result = await orchestrator.runChat(request);
+          const result = await streamer.runChat(request);
           response = result;
           if (this.debug) {
             try {
@@ -1068,15 +1068,15 @@ export class Agent extends EventEmitter {
     return this.llmClientPromise;
   }
 
-  private async getOrchestrator(): Promise<AgentOrchestrator> {
-    if (!this.orchestratorPromise) {
-      this.orchestratorPromise = (async () => {
+  private async getStreamer(): Promise<LLMStreamer> {
+    if (!this.streamerPromise) {
+      this.streamerPromise = (async () => {
         const client = await this.getPrimaryLlmClient();
-        return new AgentOrchestrator(client, { events: this.events, state: this.state });
+        return new LLMStreamer(client, { events: this.events, state: this.state });
       })();
     }
 
-    return this.orchestratorPromise;
+    return this.streamerPromise;
   }
 
   private createLlmClientFromSettings(): Promise<LLMClient> {

--- a/packages/agent-sdk-ts/src/sdk/runtime/LLMStreamer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/LLMStreamer.ts
@@ -3,16 +3,16 @@ import { ConversationState } from './ConversationState';
 import type { ChatCompletionRequest, LLMClient, LLMResponse, LLMStreamChunk } from '../llm';
 import type { Message, ToolCall } from '../types';
 
-export interface AgentOrchestratorOptions {
+export interface LLMStreamerOptions {
   events?: EventLog;
   state?: ConversationState;
 }
 
-export class AgentOrchestrator {
+export class LLMStreamer {
   private readonly events: EventLog;
   private readonly state: ConversationState;
 
-  constructor(private readonly llm: LLMClient, options: AgentOrchestratorOptions = {}) {
+  constructor(private readonly llm: LLMClient, options: LLMStreamerOptions = {}) {
     this.events = options.events ?? new EventLog();
     this.state = options.state ?? new ConversationState({ eventLog: this.events });
     this.state.attachEventLog(this.events);

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
@@ -31,6 +31,9 @@ describe('Agent profile api key selection', () => {
 
       const secrets = new SecretRegistry();
       secrets.set('openhands.llmProfileApiKey.p1', 'sk-profile');
+      // Avoid interference from OPENAI_API_KEY if present in CI env
+      const originalOpenai = process.env.OPENAI_API_KEY;
+      delete process.env.OPENAI_API_KEY;
 
       let authorization: string | undefined;
       const originalFetch = globalThis.fetch;
@@ -71,6 +74,7 @@ describe('Agent profile api key selection', () => {
         }
       } finally {
         globalThis.fetch = originalFetch;
+        process.env.OPENAI_API_KEY = originalOpenai;
       }
 
       expect(authorization).toBe('Bearer sk-profile');
@@ -105,6 +109,9 @@ describe('Agent profile api key selection', () => {
       });
 
       const secrets = new SecretRegistry();
+      // Avoid interference from OPENAI_API_KEY if present in CI env
+      const originalOpenai = process.env.OPENAI_API_KEY;
+      delete process.env.OPENAI_API_KEY;
 
       let authorization: string | undefined;
       const originalFetch = globalThis.fetch;
@@ -145,6 +152,7 @@ describe('Agent profile api key selection', () => {
         }
       } finally {
         globalThis.fetch = originalFetch;
+        process.env.OPENAI_API_KEY = originalOpenai;
       }
 
       expect(authorization).toBe('Bearer sk-global');

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
@@ -74,7 +74,7 @@ describe('Agent profile api key selection', () => {
         }
       } finally {
         globalThis.fetch = originalFetch;
-        process.env.OPENAI_API_KEY = originalOpenai;
+        if (originalOpenai === undefined) delete process.env.OPENAI_API_KEY; else process.env.OPENAI_API_KEY = originalOpenai;
       }
 
       expect(authorization).toBe('Bearer sk-profile');
@@ -152,7 +152,7 @@ describe('Agent profile api key selection', () => {
         }
       } finally {
         globalThis.fetch = originalFetch;
-        process.env.OPENAI_API_KEY = originalOpenai;
+        if (originalOpenai === undefined) delete process.env.OPENAI_API_KEY; else process.env.OPENAI_API_KEY = originalOpenai;
       }
 
       expect(authorization).toBe('Bearer sk-global');

--- a/packages/agent-sdk-ts/src/sdk/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/index.ts
@@ -3,7 +3,7 @@ export * from './ConversationState';
 export * from './SecretRegistry';
 export * from './AsyncLock';
 export * from './Agent';
-export * from './AgentOrchestrator';
+export * from './LLMStreamer';
 export * from './persistence';
 export * from './ConversationStats';
 export * from './fileDiffSummarizer';

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -19,6 +19,21 @@ class MemoryAdapter implements SettingsAdapter {
 }
 
 describe('SettingsManager', () => {
+  const originalOpenaiKey = process.env.OPENAI_API_KEY;
+  const originalAnthropicKey = process.env.ANTHROPIC_API_KEY;
+  const originalGeminiKey = process.env.GEMINI_API_KEY;
+
+  beforeEach(() => {
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.GEMINI_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalOpenaiKey === undefined) delete process.env.OPENAI_API_KEY; else process.env.OPENAI_API_KEY = originalOpenaiKey;
+    if (originalAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY; else process.env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    if (originalGeminiKey === undefined) delete process.env.GEMINI_API_KEY; else process.env.GEMINI_API_KEY = originalGeminiKey;
+  });
   let a: MemoryAdapter;
   let mgr: SettingsManager;
   let tmpDir = '';


### PR DESCRIPTION
Summary
- Rename AgentOrchestrator to LLMStreamer to better reflect purpose (LLM streaming and state updates rather than orchestration)
- Introduce LLMStreamerOptions (renamed from AgentOrchestratorOptions)
- Update Agent to use LLMStreamer (streamerPromise, getStreamer)
- Update test suite and docs accordingly

Changes
- Code:
  - packages/agent-sdk-ts/src/sdk/runtime/AgentOrchestrator.ts -> LLMStreamer.ts
  - Updated imports/usages throughout runtime (Agent.ts) and test files
  - Barrel export updated (runtime/index.ts)
- Tests:
  - Renamed llm.orchestrator.test.ts -> llm.streamer.test.ts
  - Adjusted references from AgentOrchestrator to LLMStreamer
  - Hardened API key precedence/profile tests against env leakage to keep suite deterministic
- Docs:
  - Replaced references in AGENTS.md, docs/agent-sdk-architecture.md, docs/PRD.md, and python-parity.md
  - Adjusted wording ("streamer") where applicable

Validation
- Ran full workspace test suite: all tests passing locally

Backward compatibility
- This is a rename within the TS SDK in this repo. Public import path stays `@openhands/agent-sdk-ts` with runtime barrel continuing to export the class (now as LLMStreamer). Any consumers in this repo updated accordingly.

Closes #548

Notes
- No runtime behavior changes beyond class name and related identifiers.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/47fdf41e77d54e11b77b121e493ce9bc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Renamed core orchestration component from `AgentOrchestrator` to `LLMStreamer` in the TypeScript SDK. Update your imports and instantiation code accordingly.

* **Documentation**
  * Updated all architecture and usage documentation to reflect the new `LLMStreamer` component and provide updated code examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->