### PR TITLE
SDK: extract tool message formatting (oh-tab-g9ys)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -48,6 +48,7 @@ import {
   sanitizeChatRequestForDebug,
   sanitizeMessageForDebug,
 } from './textSanitizers';
+import { formatToolMessageText } from './toolMessageFormatting';
 import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } from './createLlmClientFromSettings';
 import { CIRCULAR_REFERENCE_MARKER, deepTruncate, truncateToolMessage } from './toolResultTruncation';
@@ -261,65 +262,6 @@ export class Agent extends EventEmitter {
     return value;
   }
 
-  private formatToolMessageText(toolCall: ToolCall, result: unknown): string {
-    const toolName = toolCall.function.name;
-    const asRecord = (value: unknown): Record<string, unknown> | undefined =>
-      value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
-
-    if (toolName === 'terminal') {
-      const record = asRecord(result) ?? {};
-      const commandFromArgs = (() => {
-        const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
-        if (!rawArgs) return undefined;
-        try {
-          const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
-          return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
-        } catch {
-          return rawArgs;
-        }
-      })();
-      const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs;
-      const stdout = typeof record.stdout === 'string' ? record.stdout.trimEnd() : '';
-      const stderr = typeof record.stderr === 'string' ? record.stderr.trimEnd() : '';
-      const exitCode = typeof record.exit_code === 'number' ? record.exit_code : undefined;
-      const timedOut = record.timeout === true;
-
-      const parts: string[] = [];
-      if (command) {
-        parts.push(command.startsWith('$') ? command : `$ ${command}`);
-      }
-      const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
-      if (output) parts.push(output);
-      if (typeof exitCode === 'number') {
-        parts.push(`[Command finished with exit code ${exitCode}]`);
-      } else {
-        parts.push('[Command finished]');
-      }
-      if (timedOut) parts.push('[Command timed out]');
-      return parts.join('\n');
-    }
-
-    if (toolName === 'file_editor') {
-      const record = asRecord(result) ?? {};
-      const command = toOptionalNonEmptyString(record.command);
-      const targetPath = toOptionalNonEmptyString(record.path);
-      const headerParts = ['file_editor'];
-      if (command) headerParts.push(command);
-      if (targetPath) headerParts.push(targetPath);
-      const header = headerParts.join(' ');
-      const content = typeof record.new_content === 'string' ? record.new_content : record.new_content === null ? '<file removed>' : '';
-      return content ? `${header}\n${content}` : header;
-    }
-
-    if (typeof result === 'string') return result;
-    if (result === null || result === undefined) return String(result);
-    try {
-      return JSON.stringify(result, null, 2);
-    } catch {
-      return Object.prototype.toString.call(result);
-    }
-  }
-
   private async maybeSummarizeToolCall(toolCall: ToolCall, result: unknown): Promise<void> {
     if (!this.summarizeToolCallsEnabled) return;
     if (this.toolSummarizerFailed) return;
@@ -342,7 +284,7 @@ export class Agent extends EventEmitter {
     const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments) ?? '';
     const safeArgs = rawArgs ? redactAndTruncateArgs(rawArgs) : '';
 
-    const formatted = this.formatToolMessageText(toolCall, result);
+    const formatted = formatToolMessageText(toolCall, result);
     const masked = this.maskSecretsInText(formatted);
     const clipped = truncateToolMessage(masked, TOOL_SUMMARY_PROMPT_MAX_CHARS);
 
@@ -1316,7 +1258,7 @@ export class Agent extends EventEmitter {
       } as Event;
       this.events.push(observation);
 
-      const formatted = this.formatToolMessageText(toolCall, enrichedResult);
+      const formatted = formatToolMessageText(toolCall, enrichedResult);
       const masked = this.maskSecretsInText(formatted);
       const clipped = truncateToolMessage(masked);
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolMessageFormatting.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolMessageFormatting.ts
@@ -1,0 +1,62 @@
+import type { ToolCall } from '../types';
+import { toOptionalNonEmptyString } from './settingsUtils';
+
+export function formatToolMessageText(toolCall: ToolCall, result: unknown): string {
+  const toolName = toolCall.function.name;
+  const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+    value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+
+  if (toolName === 'terminal') {
+    const record = asRecord(result) ?? {};
+    const commandFromArgs = (() => {
+      const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
+      if (!rawArgs) return undefined;
+      try {
+        const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
+        return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
+      } catch {
+        return rawArgs;
+      }
+    })();
+    const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs;
+    const stdout = typeof record.stdout === 'string' ? record.stdout.trimEnd() : '';
+    const stderr = typeof record.stderr === 'string' ? record.stderr.trimEnd() : '';
+    const exitCode = typeof record.exit_code === 'number' ? record.exit_code : undefined;
+    const timedOut = record.timeout === true;
+
+    const parts: string[] = [];
+    if (command) {
+      parts.push(command.startsWith('$') ? command : `$ ${command}`);
+    }
+    const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
+    if (output) parts.push(output);
+    if (typeof exitCode === 'number') {
+      parts.push(`[Command finished with exit code ${exitCode}]`);
+    } else {
+      parts.push('[Command finished]');
+    }
+    if (timedOut) parts.push('[Command timed out]');
+    return parts.join('\n');
+  }
+
+  if (toolName === 'file_editor') {
+    const record = asRecord(result) ?? {};
+    const command = toOptionalNonEmptyString(record.command);
+    const targetPath = toOptionalNonEmptyString(record.path);
+    const headerParts = ['file_editor'];
+    if (command) headerParts.push(command);
+    if (targetPath) headerParts.push(targetPath);
+    const header = headerParts.join(' ');
+    const content = typeof record.new_content === 'string' ? record.new_content : record.new_content === null ? '<file removed>' : '';
+    return content ? `${header}\n${content}` : header;
+  }
+
+  if (typeof result === 'string') return result;
+  if (result === null || result === undefined) return String(result);
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return Object.prototype.toString.call(result);
+  }
+}
+


### PR DESCRIPTION
Bead: `oh-tab-g9ys`

- Extracted tool result → message text formatting into `packages/agent-sdk-ts/src/sdk/runtime/toolMessageFormatting.ts`.
- `Agent` now imports and uses `formatToolMessageText(...)` (no behavior change intended).

Tests:
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run typecheck`
