### PR TITLE
Webview: extract LlmProfilesPanelHeader (oh-tab-agno)

### DIFF
--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -4,6 +4,7 @@ import { useCloseOnEscapeAndOutsideClick } from './useCloseOnEscapeAndOutsideCli
 import { getVscodeApi } from '../shared/vscodeApi';
 import type { LlmProfileApiKeyStatusInfo, LlmProfileApiKeyStatusOverrides, WebviewToHostMessage } from '../../shared/webviewMessages';
 import { LlmProfileApiKeySection } from './llmProfilesView/LlmProfileApiKeySection';
+import { LlmProfilesPanelHeader } from './llmProfilesView/LlmProfilesPanelHeader';
 import { FieldError, FieldLabel, InputField, SelectField } from './llmProfilesView/fields';
 import {
   ADVANCED_FIELD_KEYS,
@@ -465,54 +466,17 @@ export function LlmProfilesView(props: {
         className="relative ml-auto w-full max-w-5xl h-full bg-[var(--vscode-editor-background)] border-l border-white/[0.08] shadow-2xl flex flex-col animate-slide-in-right"
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.08]">
-          <div className="flex items-center gap-2.5">
-            <div className="text-2xl" aria-label="OpenHands">
-              🙌
-            </div>
-            <h2 className="font-semibold text-base leading-tight text-stone-100">OpenHands - LLM Profiles</h2>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={startCreate}
-              className="h-9 w-9 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40 transition-all flex items-center justify-center"
-              aria-label="Create profile"
-              title="Create profile"
-            >
-              <span className="codicon codicon-add" />
-            </button>
-            <button
-              type="button"
-              onClick={handleDuplicateProfile}
-              disabled={mode !== 'edit' || !selectedProfileId || loadingProfile}
-              className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Duplicate profile"
-              title="Duplicate profile"
-            >
-              <span className="codicon codicon-copy" />
-            </button>
-            <button
-              type="button"
-              onClick={() => { void handleDeleteProfile(); }}
-              disabled={mode !== 'edit' || !selectedProfileId || loadingProfile || saving || deleting}
-              className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-              aria-label="Delete profile"
-              title="Delete profile"
-            >
-              <span className={`codicon codicon-${deleting ? 'loading' : 'trash'} ${deleting ? 'animate-spin' : ''}`} />
-            </button>
-            <button
-              type="button"
-              onClick={onClose}
-              className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
-              aria-label="Close profiles view"
-              title="Close"
-            >
-              <span className="codicon codicon-close" />
-            </button>
-          </div>
-        </div>
+        <LlmProfilesPanelHeader
+          mode={mode}
+          selectedProfileId={selectedProfileId}
+          loadingProfile={loadingProfile}
+          saving={saving}
+          deleting={deleting}
+          onCreate={startCreate}
+          onDuplicate={handleDuplicateProfile}
+          onDelete={handleDeleteProfile}
+          onClose={onClose}
+        />
 
         {/* Body */}
         <div className="flex-1 overflow-hidden flex">

--- a/src/webview-src/components/llmProfilesView/LlmProfilesPanelHeader.tsx
+++ b/src/webview-src/components/llmProfilesView/LlmProfilesPanelHeader.tsx
@@ -1,0 +1,70 @@
+import type { ProfileFormMode } from './formState';
+
+export function LlmProfilesPanelHeader(props: {
+  mode: ProfileFormMode;
+  selectedProfileId: string | null;
+  loadingProfile: boolean;
+  saving: boolean;
+  deleting: boolean;
+  onCreate: () => void;
+  onDuplicate: () => void;
+  onDelete: () => Promise<void>;
+  onClose: () => void;
+}) {
+  const { mode, selectedProfileId, loadingProfile, saving, deleting, onCreate, onDuplicate, onDelete, onClose } = props;
+
+  const duplicateDisabled = mode !== 'edit' || !selectedProfileId || loadingProfile;
+  const deleteDisabled = mode !== 'edit' || !selectedProfileId || loadingProfile || saving || deleting;
+
+  return (
+    <div className="flex items-center justify-between px-5 py-4 border-b border-white/[0.08]">
+      <div className="flex items-center gap-2.5">
+        <div className="text-2xl" aria-label="OpenHands">
+          🙌
+        </div>
+        <h2 className="font-semibold text-base leading-tight text-stone-100">OpenHands - LLM Profiles</h2>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onCreate}
+          className="h-9 w-9 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40 transition-all flex items-center justify-center"
+          aria-label="Create profile"
+          title="Create profile"
+        >
+          <span className="codicon codicon-add" />
+        </button>
+        <button
+          type="button"
+          onClick={onDuplicate}
+          disabled={duplicateDisabled}
+          className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="Duplicate profile"
+          title="Duplicate profile"
+        >
+          <span className="codicon codicon-copy" />
+        </button>
+        <button
+          type="button"
+          onClick={() => { void onDelete(); }}
+          disabled={deleteDisabled}
+          className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label="Delete profile"
+          title="Delete profile"
+        >
+          <span className={`codicon codicon-${deleting ? 'loading' : 'trash'} ${deleting ? 'animate-spin' : ''}`} />
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
+          aria-label="Close profiles view"
+          title="Close"
+        >
+          <span className="codicon codicon-close" />
+        </button>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
Bead: oh-tab-agno

Slice: extract the LLM Profiles panel header into its own component (behavior-preserving).

Tests:
- npx vitest run src/webview-src/__tests__/LlmProfilesView.test.tsx
- npm run lint
- npm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the LLM profiles panel header into a dedicated component to improve code maintainability and structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->