### PR TITLE
Extension: extract HAL settings change handler (oh-tab-b7qq)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { registerExplainSelectionCommand } from './extension/explainSelectionCom
 import { createPastedImagesCleanupScheduler } from './extension/pastedImagesCleanupScheduler';
 import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
+import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import {
   AgentContext,
   Conversation,
@@ -610,20 +611,16 @@ export function activate(context: vscode.ExtensionContext) {
     getOutputChannel: () => outputChannel,
     renderError,
   });
+  const onHalConfigurationChange = createHalConfigurationChangeHandler({
+    context,
+    getChatView: () => chatView,
+    isChatWebviewReady: () => chatWebviewReady,
+    getOutputChannel: () => outputChannel,
+    renderError,
+  });
   const onConfigurationChange = async (e: vscode.ConfigurationChangeEvent) => {
     await onConfigurationChangeBase(e);
-
-    if (e.affectsConfiguration('openhands.hal')) {
-      try {
-        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-        const settings = await settingsMgr.get();
-        if (chatView && chatWebviewReady) {
-          void chatView.webview.postMessage({ type: 'halSettings', hal: settings.hal } satisfies HostToWebviewMessage);
-        }
-      } catch (err: unknown) {
-        outputChannel?.appendLine(`[settings] Failed to apply HAL settings update: ${renderError(err)}`);
-      }
-    }
+    await onHalConfigurationChange(e);
   };
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(onConfigurationChange));
 

--- a/src/extension/halConfigurationChangeHandler.ts
+++ b/src/extension/halConfigurationChangeHandler.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { SettingsManager } from '../settings/SettingsManager';
+import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
+import type { HostToWebviewMessage } from '../shared/webviewMessages';
+
+export type HalConfigurationChangeHandlerDeps = {
+  context: vscode.ExtensionContext;
+  getChatView: () => vscode.WebviewView | undefined;
+  isChatWebviewReady: () => boolean;
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  renderError: (err: unknown) => string;
+};
+
+export function createHalConfigurationChangeHandler(deps: HalConfigurationChangeHandlerDeps) {
+  return async (e: vscode.ConfigurationChangeEvent) => {
+    if (!e.affectsConfiguration('openhands.hal')) return;
+
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+      const settings = await settingsMgr.get();
+      const chatView = deps.getChatView();
+      if (chatView && deps.isChatWebviewReady()) {
+        void chatView.webview.postMessage({ type: 'halSettings', hal: settings.hal } satisfies HostToWebviewMessage);
+      }
+    } catch (err: unknown) {
+      deps.getOutputChannel()?.appendLine(`[settings] Failed to apply HAL settings update: ${deps.renderError(err)}`);
+    }
+  };
+}
+


### PR DESCRIPTION
Bead: oh-tab-b7qq

Slice: extract the HAL settings config-change handling out of `src/extension.ts` into `src/extension/halConfigurationChangeHandler.ts` (behavior-preserving).

Tests:
- `npx vitest run src/__tests__/extension.test.ts`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized HAL configuration change handling for improved chat interface synchronization and enhanced error reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->