### PR TITLE
Webview: extract useWebviewReady hook (oh-tab-ihgw)

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -15,6 +15,7 @@ import { useStatusMessages } from './app/useStatusMessages';
 import { useHostMessages } from './app/useHostMessages';
 import { useConversationEvents } from './app/useConversationEvents';
 import { useLlmProfilesRequests } from './app/useLlmProfilesRequests';
+import { useWebviewReady } from './app/useWebviewReady';
 import { ConversationPane } from './app/ConversationPane';
 import { ConversationInputDock } from './app/ConversationInputDock';
 
@@ -28,11 +29,6 @@ import { HalOverlay } from './HalOverlay';
 import type { WebviewToHostMessage } from '../../shared/webviewMessages';
 
 type RenderedEvent = { id: number; event: Event };
-
-type WebviewPersistedState = {
-  conversationId?: string;
-  lastSeenSeq?: number;
-};
 
 /**
  * Main App component: React webview root for OpenHands extension.
@@ -255,37 +251,7 @@ export function App() {
     setConversationTotals,
   });
 
-  // Signal webview is ready on mount
-  useEffect(() => {
-    const vscodeApi = getVscodeApi();
-    let didRequestSkills = false;
-    let didRequestTools = false;
-    const sendReady = () => {
-      const state = vscodeApi.getState?.<WebviewPersistedState>() ?? {};
-      const payload: WebviewToHostMessage = { type: 'webviewReady' };
-      if (typeof state.conversationId === 'string') payload.conversationId = state.conversationId;
-      if (typeof state.lastSeenSeq === 'number') payload.lastSeenSeq = state.lastSeenSeq;
-      postMessage(payload);
-      if (!didRequestSkills) {
-        didRequestSkills = true;
-        postMessage({ type: 'requestSkills' });
-      }
-      if (!didRequestTools) {
-        didRequestTools = true;
-        postMessage({ type: 'requestTools' });
-      }
-    };
-
-    sendReady();
-
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        sendReady();
-      }
-    };
-    document.addEventListener('visibilitychange', onVisibilityChange);
-    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
-  }, [postMessage]);
+  useWebviewReady({ postMessage });
 
   useHostMessages({
     applyHalSettings,

--- a/src/webview-src/components/app/useWebviewReady.ts
+++ b/src/webview-src/components/app/useWebviewReady.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { getVscodeApi } from '../../shared/vscodeApi';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+
+type WebviewPersistedState = {
+  conversationId?: string;
+  lastSeenSeq?: number;
+};
+
+export function useWebviewReady({ postMessage }: { postMessage: (message: WebviewToHostMessage) => void }) {
+  useEffect(() => {
+    const vscodeApi = getVscodeApi();
+    let didRequestSkills = false;
+    let didRequestTools = false;
+
+    const sendReady = () => {
+      const state = vscodeApi.getState?.<WebviewPersistedState>() ?? {};
+      const payload: WebviewToHostMessage = { type: 'webviewReady' };
+      if (typeof state.conversationId === 'string') payload.conversationId = state.conversationId;
+      if (typeof state.lastSeenSeq === 'number') payload.lastSeenSeq = state.lastSeenSeq;
+      postMessage(payload);
+      if (!didRequestSkills) {
+        didRequestSkills = true;
+        postMessage({ type: 'requestSkills' });
+      }
+      if (!didRequestTools) {
+        didRequestTools = true;
+        postMessage({ type: 'requestTools' });
+      }
+    };
+
+    sendReady();
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        sendReady();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, [postMessage]);
+}
+


### PR DESCRIPTION
Small `oh-tab-ihgw` slice: extracts the “webviewReady + visibilitychange resend” effect from `App.tsx` into a dedicated hook.

- New hook: `src/webview-src/components/app/useWebviewReady.ts`
- Removes the local `WebviewPersistedState` type + effect block from `App.tsx`.

Tests:
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated webview initialization logic into a dedicated hook for improved maintainability.
  * Removed persistence of conversation state across sessions—conversation ID and sequence data will no longer be retained when the webview closes and reopens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->