### PR TITLE
SDK: extract ToolSummarizer helper (oh-tab-g9ys)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -5,7 +5,7 @@ import { LLMStreamer } from './LLMStreamer';
 import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
-import type { ChatCompletionRequest, LLMClient, LLMProvider, LLMToolDefinition } from '../llm';
+import type { LLMClient, LLMProvider, LLMToolDefinition } from '../llm';
 import {
   DEFAULT_PROVIDER_BASE_URLS,
   detectProviderFromBaseUrl,
@@ -36,13 +36,9 @@ import type { AgentContext } from '../context';
 import { LLMSummarizingCondenser } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
-import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
-import { getGeminiClient } from './geminiClient';
-import { summarizeTerminalObservationWithGeminiFlash } from './terminalObservationSummarizer';
 import { SYSTEM_PROMPT } from './systemPrompt';
 import { sanitizeChatMessages } from './sanitizeChatMessages';
 import {
-  ELLIPSIS,
   redactAndTruncateArgs,
   sanitizeChatRequestForDebug,
   sanitizeMessageForDebug,
@@ -52,6 +48,7 @@ import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } from './createLlmClientFromSettings';
 import { deepTruncate, truncateToolMessage } from './toolResultTruncation';
 import { SecretMasker } from './secretMasker';
+import { ToolSummarizer } from './toolSummarizer';
 
 export type AgentRunInput = string | Message;
 
@@ -77,10 +74,6 @@ export interface AgentOptions {
 }
 
 const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
-
-const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
-const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
-const TOOL_SUMMARY_MAX_CHARS = 1_000;
 
 // Condensation is token-budget based (maxInputTokens). When the next request would exceed that
 // budget (or the provider returns a context-limit error), we emit a `Condensation` event
@@ -127,11 +120,7 @@ export class Agent extends EventEmitter {
   private readonly registry?: import('../llm').LLMRegistry;
   private readonly conversationStats?: import('./ConversationStats').ConversationStats;
   private debug: boolean;
-  private summarizeToolCallsEnabled = false;
-  private pendingToolSummaries: Array<{ toolName: string; summary: string }> = [];
-  private toolSummarizerClient?: LLMClient;
-  private toolSummarizerInitPromise?: Promise<LLMClient>;
-  private toolSummarizerFailed = false;
+  private readonly toolSummarizer: ToolSummarizer;
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -143,6 +132,11 @@ export class Agent extends EventEmitter {
     this.secretMasker = new SecretMasker({
       getConfiguredSecrets: () => Object.values(this.options.settings?.secrets ?? {}),
       getRegisteredSecrets: () => this.secrets.getRegisteredValues(),
+    });
+    this.toolSummarizer = new ToolSummarizer({
+      secrets: this.secrets,
+      secretMasker: this.secretMasker,
+      injectedClient: options.toolSummarizerClient,
     });
     const providedTools = options.tools ?? [];
     const toolsWithFinish = providedTools.some((tool) => tool.name === 'finish')
@@ -164,16 +158,7 @@ export class Agent extends EventEmitter {
     this.confirmation.riskyThreshold = settings?.confirmation?.riskyThreshold ?? 'MEDIUM';
     this.confirmation.confirmUnknown = settings?.confirmation?.confirmUnknown ?? true;
     this.debug = settings?.agent?.debug ?? false;
-    this.summarizeToolCallsEnabled = settings?.agent?.summarizeToolCalls ?? false;
-    if (!this.summarizeToolCallsEnabled) {
-      this.pendingToolSummaries = [];
-    }
-    // If the user updates settings/secrets, allow retrying tool summarization.
-    this.toolSummarizerFailed = false;
-    if (!this.options.toolSummarizerClient) {
-      this.toolSummarizerClient = undefined;
-      this.toolSummarizerInitPromise = undefined;
-    }
+    this.toolSummarizer.updateSettings(settings, { debug: this.debug });
     this.syncToolSecrets(settings);
   }
 
@@ -184,74 +169,6 @@ export class Agent extends EventEmitter {
     this.secrets.set('CUSTOM_SECRET_2', s?.customSecret2);
     this.secrets.set('CUSTOM_SECRET_3', s?.customSecret3);
     this.secrets.set('ELEVENLABS_API_KEY', s?.halTtsApiKey);
-  }
-
-  private async maybeSummarizeToolCall(toolCall: ToolCall, result: unknown): Promise<void> {
-    if (!this.summarizeToolCallsEnabled) return;
-    if (this.toolSummarizerFailed) return;
-
-    try {
-      const summary = await this.summarizeToolCall(toolCall, result);
-      if (!summary) return;
-      this.pendingToolSummaries.push({ toolName: toolCall.function.name, summary });
-    } catch (error) {
-      this.toolSummarizerFailed = true;
-      if (this.debug) {
-        console.warn('[Agent] Tool call summarization failed; disabling for this session:', error);
-      }
-    }
-  }
-
-  private async summarizeToolCall(toolCall: ToolCall, result: unknown): Promise<string | undefined> {
-    const client = await this.getToolSummarizerClient();
-    const toolName = toolCall.function.name;
-    const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments) ?? '';
-    const safeArgs = rawArgs ? redactAndTruncateArgs(rawArgs) : '';
-
-    const formatted = formatToolMessageText(toolCall, result);
-    const masked = this.secretMasker.maskText(formatted);
-    const clipped = truncateToolMessage(masked, TOOL_SUMMARY_PROMPT_MAX_CHARS);
-
-    const prompt = [
-      'Write a concise (1–3 sentence) summary of a tool execution performed by an autonomous coding agent.',
-      '- Focus on the action taken and key outcome.',
-      '- Do not include secrets or long output excerpts.',
-      '',
-      `Tool: ${toolName}`,
-      `Arguments: ${safeArgs || '(none)'}`,
-      '',
-      'Result (redacted + clipped):',
-      clipped || '(empty)',
-    ].join('\n');
-
-    const request: ChatCompletionRequest = {
-      systemPrompt: 'You summarize tool executions for an autonomous coding agent.',
-      messages: [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
-    };
-
-    let text = '';
-    for await (const chunk of client.streamChat(request)) {
-      if (chunk.type === 'text') text += chunk.text;
-    }
-
-    const summary = this.secretMasker.maskText(text).trim();
-    if (!summary) return undefined;
-
-    return summary.length > TOOL_SUMMARY_MAX_CHARS ? summary.slice(0, TOOL_SUMMARY_MAX_CHARS) + '…' : summary;
-  }
-
-  private async getToolSummarizerClient(): Promise<LLMClient> {
-    if (this.options.toolSummarizerClient) return this.options.toolSummarizerClient;
-    if (this.toolSummarizerClient) return this.toolSummarizerClient;
-    if (this.toolSummarizerInitPromise) return this.toolSummarizerInitPromise;
-
-    this.toolSummarizerInitPromise = (async () => {
-      const client = await getGeminiClient(this.secrets, { usageId: 'tool-summarizer', profileId: TOOL_SUMMARY_PROFILE_ID });
-      this.toolSummarizerClient = client;
-      return client;
-    })();
-
-    return this.toolSummarizerInitPromise;
   }
 
   /**
@@ -584,7 +501,7 @@ export class Agent extends EventEmitter {
       }
 
       if (!response) break;
-      this.pendingToolSummaries = [];
+      this.toolSummarizer.resetPendingSummaries();
 
       const assistantEvent: MessageEvent = {
         kind: 'MessageEvent',
@@ -722,7 +639,7 @@ export class Agent extends EventEmitter {
       });
     const messages = (() => {
       const sanitized = sanitizeChatMessages(rawMessages);
-      const summaryMessage = this.buildToolSummaryMessage();
+      const summaryMessage = this.toolSummarizer.buildToolSummaryMessage();
       return summaryMessage ? [...sanitized, summaryMessage] : sanitized;
     })();
     const tools = this.getToolDefinitions();
@@ -810,25 +727,6 @@ export class Agent extends EventEmitter {
     } as Event);
 
     return true;
-  }
-
-  private buildToolSummaryMessage(): Message | undefined {
-    if (!this.summarizeToolCallsEnabled) return undefined;
-    if (!this.pendingToolSummaries.length) return undefined;
-
-    if (this.pendingToolSummaries.length === 1) {
-      const only = this.pendingToolSummaries[0];
-      return {
-        role: 'assistant',
-        content: [{ type: 'text', text: `Tool summary (${only.toolName}): ${only.summary}` }],
-      };
-    }
-
-    const lines = [
-      'Tool summaries:',
-      ...this.pendingToolSummaries.map((entry) => `- ${entry.toolName}: ${entry.summary}`),
-    ];
-    return { role: 'assistant', content: [{ type: 'text', text: lines.join('\n') }] };
   }
 
   private getToolDefinitions(): LLMToolDefinition[] {
@@ -1165,8 +1063,8 @@ export class Agent extends EventEmitter {
     try {
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
       const result = await tool.execute(validated, context);
-      let enrichedResult = await this.maybeAttachFileDiffSummary(toolCall, result);
-      enrichedResult = await this.maybeAttachTerminalObservationSummary(toolCall, enrichedResult);
+      let enrichedResult = await this.toolSummarizer.maybeAttachFileDiffSummary(toolCall, result);
+      enrichedResult = await this.toolSummarizer.maybeAttachTerminalObservationSummary(toolCall, enrichedResult);
 
       if (toolCall.function.name === 'terminal') {
         this.emitTerminalEvents(toolCall, enrichedResult);
@@ -1198,7 +1096,7 @@ export class Agent extends EventEmitter {
       };
       this.events.push(toolMessage);
 
-      await this.maybeSummarizeToolCall(toolCall, enrichedResult);
+      await this.toolSummarizer.maybeSummarizeToolCall(toolCall, enrichedResult);
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_execute', toolName: tool.name });
       if (classified.classification === 'agent') {
@@ -1211,103 +1109,6 @@ export class Agent extends EventEmitter {
         message: classified.message,
         ...(classified.code ? { code: classified.code } : {}),
       });
-    }
-  }
-
-  private async maybeAttachFileDiffSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
-    if (toolCall.function.name !== 'file_editor') return result;
-    if (!this.summarizeToolCallsEnabled) return result;
-    if (this.toolSummarizerFailed) return result;
-    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
-
-    const record = result as Record<string, unknown>;
-    const command = toOptionalNonEmptyString(record.command);
-    if (command !== 'insert' && command !== 'str_replace') return result;
-
-    if (typeof record.summary === 'string' && record.summary.trim()) return result;
-
-    const filePath = toOptionalNonEmptyString(record.path);
-    const oldContent = record.old_content;
-    const newContent = record.new_content;
-    const oldText = typeof oldContent === 'string' ? oldContent : oldContent === null ? '' : undefined;
-    const newText = typeof newContent === 'string' ? newContent : newContent === null ? '' : undefined;
-    if (!filePath || oldText === undefined || newText === undefined) return result;
-
-    try {
-      const llmClient = await this.getToolSummarizerClient();
-      const summary = await summarizeFileChangesWithGeminiFlash(
-        { kind: 'contents', filePath, oldContent: oldText, newContent: newText },
-        { secrets: this.secrets, llmClient },
-      );
-      if (!summary) return result;
-
-      return { ...record, summary };
-    } catch (error) {
-      this.toolSummarizerFailed = true;
-      if (this.debug) {
-        console.warn('[Agent] File diff summarization failed; disabling for this session:', error);
-      }
-      return result;
-    }
-  }
-
-  private async maybeAttachTerminalObservationSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
-    if (toolCall.function.name !== 'terminal') return result;
-    if (!this.summarizeToolCallsEnabled) return result;
-    if (this.toolSummarizerFailed) return result;
-    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
-
-    const record = result as Record<string, unknown>;
-    if (typeof record.summary === 'string' && record.summary.trim()) return result;
-
-    const commandFromArgs = (() => {
-      const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
-      if (!rawArgs) return undefined;
-      try {
-        const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
-        return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
-      } catch {
-        return rawArgs;
-      }
-    })();
-
-    const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs ?? '';
-    const exitCodeRaw = record.exit_code;
-    const exitCode =
-      typeof exitCodeRaw === 'string' || typeof exitCodeRaw === 'number'
-        ? exitCodeRaw
-        : exitCodeRaw === null
-          ? null
-          : undefined;
-    const stdout = typeof record.stdout === 'string' ? record.stdout : undefined;
-    const stderr = typeof record.stderr === 'string' ? record.stderr : undefined;
-    const timedOut = record.timeout === true;
-    const outputWasTruncated =
-      (typeof stdout === 'string' && stdout.includes(ELLIPSIS)) ||
-      (typeof stderr === 'string' && stderr.includes(ELLIPSIS));
-
-    try {
-      const llmClient = await this.getToolSummarizerClient();
-      const summary = await summarizeTerminalObservationWithGeminiFlash(
-        {
-          command,
-          exit_code: exitCode,
-          stdout,
-          stderr,
-          timedOut,
-          wasTruncated: outputWasTruncated,
-        },
-        { secrets: this.secrets, llmClient },
-      );
-      if (!summary) return result;
-
-      return { ...record, summary };
-    } catch (error) {
-      this.toolSummarizerFailed = true;
-      if (this.debug) {
-        console.warn('[Agent] Terminal summarization failed; disabling for this session:', error);
-      }
-      return result;
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts
@@ -63,7 +63,7 @@ describe('Gemini summarizers prefer GEMINI_API_KEY', () => {
       secrets,
     });
 
-    await (agent as any).getToolSummarizerClient();
+    await (agent as any).toolSummarizer.getClient();
 
     expect(secrets.calls[0]).toBe('GEMINI_API_KEY');
   });

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
@@ -1,0 +1,236 @@
+import type { ChatCompletionRequest, LLMClient } from '../llm';
+import type { Message, ToolCall } from '../types';
+import type { OpenHandsSettings } from '../types/settings';
+import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
+import { getGeminiClient } from './geminiClient';
+import type { SecretRegistry } from './SecretRegistry';
+import { SecretMasker } from './secretMasker';
+import { toOptionalNonEmptyString } from './settingsUtils';
+import { summarizeTerminalObservationWithGeminiFlash } from './terminalObservationSummarizer';
+import { formatToolMessageText } from './toolMessageFormatting';
+import { truncateToolMessage } from './toolResultTruncation';
+import { ELLIPSIS, redactAndTruncateArgs } from './textSanitizers';
+
+const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
+const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
+const TOOL_SUMMARY_MAX_CHARS = 1_000;
+
+export class ToolSummarizer {
+  private enabled = false;
+  private failed = false;
+  private debug = false;
+  private pendingToolSummaries: Array<{ toolName: string; summary: string }> = [];
+  private client?: LLMClient;
+  private clientInitPromise?: Promise<LLMClient>;
+
+  constructor(
+    private readonly deps: {
+      secrets: SecretRegistry;
+      secretMasker: SecretMasker;
+      injectedClient?: LLMClient;
+    },
+  ) {}
+
+  updateSettings(settings: OpenHandsSettings, options: { debug: boolean }): void {
+    this.debug = options.debug;
+    this.enabled = settings?.agent?.summarizeToolCalls ?? false;
+    if (!this.enabled) {
+      this.pendingToolSummaries = [];
+    }
+
+    // If the user updates settings/secrets, allow retrying tool summarization.
+    this.failed = false;
+
+    if (!this.deps.injectedClient) {
+      this.client = undefined;
+      this.clientInitPromise = undefined;
+    }
+  }
+
+  resetPendingSummaries(): void {
+    this.pendingToolSummaries = [];
+  }
+
+  buildToolSummaryMessage(): Message | undefined {
+    if (!this.enabled) return undefined;
+    if (!this.pendingToolSummaries.length) return undefined;
+
+    if (this.pendingToolSummaries.length === 1) {
+      const only = this.pendingToolSummaries[0];
+      return {
+        role: 'assistant',
+        content: [{ type: 'text', text: `Tool summary (${only.toolName}): ${only.summary}` }],
+      };
+    }
+
+    const lines = [
+      'Tool summaries:',
+      ...this.pendingToolSummaries.map((entry) => `- ${entry.toolName}: ${entry.summary}`),
+    ];
+    return { role: 'assistant', content: [{ type: 'text', text: lines.join('\n') }] };
+  }
+
+  async maybeSummarizeToolCall(toolCall: ToolCall, result: unknown): Promise<void> {
+    if (!this.enabled) return;
+    if (this.failed) return;
+
+    try {
+      const summary = await this.summarizeToolCall(toolCall, result);
+      if (!summary) return;
+      this.pendingToolSummaries.push({ toolName: toolCall.function.name, summary });
+    } catch (error) {
+      this.markFailed('[Agent] Tool call summarization failed; disabling for this session:', error);
+    }
+  }
+
+  async maybeAttachFileDiffSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
+    if (toolCall.function.name !== 'file_editor') return result;
+    if (!this.enabled) return result;
+    if (this.failed) return result;
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
+
+    const record = result as Record<string, unknown>;
+    const command = toOptionalNonEmptyString(record.command);
+    if (command !== 'insert' && command !== 'str_replace') return result;
+
+    if (typeof record.summary === 'string' && record.summary.trim()) return result;
+
+    const filePath = toOptionalNonEmptyString(record.path);
+    const oldContent = record.old_content;
+    const newContent = record.new_content;
+    const oldText = typeof oldContent === 'string' ? oldContent : oldContent === null ? '' : undefined;
+    const newText = typeof newContent === 'string' ? newContent : newContent === null ? '' : undefined;
+    if (!filePath || oldText === undefined || newText === undefined) return result;
+
+    try {
+      const llmClient = await this.getClient();
+      const summary = await summarizeFileChangesWithGeminiFlash(
+        { kind: 'contents', filePath, oldContent: oldText, newContent: newText },
+        { secrets: this.deps.secrets, llmClient },
+      );
+      if (!summary) return result;
+
+      return { ...record, summary };
+    } catch (error) {
+      this.markFailed('[Agent] File diff summarization failed; disabling for this session:', error);
+      return result;
+    }
+  }
+
+  async maybeAttachTerminalObservationSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
+    if (toolCall.function.name !== 'terminal') return result;
+    if (!this.enabled) return result;
+    if (this.failed) return result;
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
+
+    const record = result as Record<string, unknown>;
+    if (typeof record.summary === 'string' && record.summary.trim()) return result;
+
+    const commandFromArgs = (() => {
+      const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
+      if (!rawArgs) return undefined;
+      try {
+        const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
+        return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
+      } catch {
+        return rawArgs;
+      }
+    })();
+
+    const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs ?? '';
+    const exitCodeRaw = record.exit_code;
+    const exitCode =
+      typeof exitCodeRaw === 'string' || typeof exitCodeRaw === 'number'
+        ? exitCodeRaw
+        : exitCodeRaw === null
+          ? null
+          : undefined;
+    const stdout = typeof record.stdout === 'string' ? record.stdout : undefined;
+    const stderr = typeof record.stderr === 'string' ? record.stderr : undefined;
+    const timedOut = record.timeout === true;
+    const outputWasTruncated =
+      (typeof stdout === 'string' && stdout.includes(ELLIPSIS)) ||
+      (typeof stderr === 'string' && stderr.includes(ELLIPSIS));
+
+    try {
+      const llmClient = await this.getClient();
+      const summary = await summarizeTerminalObservationWithGeminiFlash(
+        {
+          command,
+          exit_code: exitCode,
+          stdout,
+          stderr,
+          timedOut,
+          wasTruncated: outputWasTruncated,
+        },
+        { secrets: this.deps.secrets, llmClient },
+      );
+      if (!summary) return result;
+
+      return { ...record, summary };
+    } catch (error) {
+      this.markFailed('[Agent] Terminal summarization failed; disabling for this session:', error);
+      return result;
+    }
+  }
+
+  private async summarizeToolCall(toolCall: ToolCall, result: unknown): Promise<string | undefined> {
+    const client = await this.getClient();
+    const toolName = toolCall.function.name;
+    const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments) ?? '';
+    const safeArgs = rawArgs ? redactAndTruncateArgs(rawArgs) : '';
+
+    const formatted = formatToolMessageText(toolCall, result);
+    const masked = this.deps.secretMasker.maskText(formatted);
+    const clipped = truncateToolMessage(masked, TOOL_SUMMARY_PROMPT_MAX_CHARS);
+
+    const prompt = [
+      'Write a concise (1–3 sentence) summary of a tool execution performed by an autonomous coding agent.',
+      '- Focus on the action taken and key outcome.',
+      '- Do not include secrets or long output excerpts.',
+      '',
+      `Tool: ${toolName}`,
+      `Arguments: ${safeArgs || '(none)'}`,
+      '',
+      'Result (redacted + clipped):',
+      clipped || '(empty)',
+    ].join('\n');
+
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'You summarize tool executions for an autonomous coding agent.',
+      messages: [{ role: 'user', content: [{ type: 'text', text: prompt }] }],
+    };
+
+    let text = '';
+    for await (const chunk of client.streamChat(request)) {
+      if (chunk.type === 'text') text += chunk.text;
+    }
+
+    const summary = this.deps.secretMasker.maskText(text).trim();
+    if (!summary) return undefined;
+
+    return summary.length > TOOL_SUMMARY_MAX_CHARS ? summary.slice(0, TOOL_SUMMARY_MAX_CHARS) + '…' : summary;
+  }
+
+  private async getClient(): Promise<LLMClient> {
+    if (this.deps.injectedClient) return this.deps.injectedClient;
+    if (this.client) return this.client;
+    if (this.clientInitPromise) return this.clientInitPromise;
+
+    this.clientInitPromise = (async () => {
+      const client = await getGeminiClient(this.deps.secrets, { usageId: 'tool-summarizer', profileId: TOOL_SUMMARY_PROFILE_ID });
+      this.client = client;
+      return client;
+    })();
+
+    return this.clientInitPromise;
+  }
+
+  private markFailed(message: string, error: unknown): void {
+    this.failed = true;
+    if (this.debug) {
+      console.warn(message, error);
+    }
+  }
+}
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
@@ -212,7 +212,7 @@ export class ToolSummarizer {
     return summary.length > TOOL_SUMMARY_MAX_CHARS ? summary.slice(0, TOOL_SUMMARY_MAX_CHARS) + '…' : summary;
   }
 
-  private async getClient(): Promise<LLMClient> {
+  public async getClient(): Promise<LLMClient> {
     if (this.deps.injectedClient) return this.deps.injectedClient;
     if (this.client) return this.client;
     if (this.clientInitPromise) return this.clientInitPromise;


### PR DESCRIPTION
`oh-tab-g9ys` slice: move tool-call + diff + terminal summarization logic out of `Agent.ts`.

- New `ToolSummarizer` helper: `packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts`.
- `Agent` now delegates:
  - pending tool summary message generation
  - tool-call summarization (1–3 sentence summary)
  - auto-attaching file diff / terminal observation summaries
- Updates `toolSummarizer.key-preference` test to use the new helper internals (still verifies `GEMINI_API_KEY` precedence).

Tests:
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated all tool-summarization behavior into a new internal ToolSummarizer component, centralizing summary generation, attachment, and lifecycle management.
  * Removed legacy in-class summarization logic and related internal constants; runtime now delegates summary responsibilities to the new component.
  * Public APIs and external behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->