### PR TITLE
[oh-tab-gger] Align dropdown styling + placement in LLM Profiles

### DIFF
--- a/docs/llm_profiles.md
+++ b/docs/llm_profiles.md
@@ -1,0 +1,139 @@
+# LLM Profiles (Spec)
+
+This document specifies the intended behavior for **LLM Profiles** in both the **Conversation View** (selection/use) and the **LLM Profiles View** (create/edit/manage).
+
+Related docs:
+- `docs/llm_profiles_sot_migration.md` (single-source-of-truth migration plan)
+- `docs/settings_prd.md` (settings + storage overview)
+
+## Goals
+
+- **Profiles are the single source of truth** for the main agent LLM configuration (provider/model/baseUrl and generation params).
+- The user can **switch profiles at runtime**; the change applies to the **next** LLM request only (in-flight requests keep streaming).
+- Profiles are a **local-only** concept in VS Code:
+  - Local mode: the SDK resolves `profileId` locally and uses it directly.
+  - Remote mode: the extension resolves `profileId` locally and **expands** it into server-supported `agent.llm` fields (do not send `profile_id` until the agent-server supports it).
+
+Non-goals:
+- “Freezing”/diffing the agent state (`diff_from_deserialized`, etc.) is explicitly out of scope.
+
+## Storage
+
+### Profile files
+
+- Profiles live on disk as JSON files under:
+  - `~/.openhands/llm-profiles/<profileId>.json`
+  - Source of truth constant: `packages/agent-sdk-ts/src/sdk/llm/profiles.ts` (`DEFAULT_LLM_PROFILES_DIR`)
+- `profileId` is the **filename stem** and must be a safe filename:
+  - Non-empty, trimmed
+  - No path separators
+  - Regex: `^[a-zA-Z0-9._-]+$`
+  - Validator: `assertValidProfileId()` in `packages/agent-sdk-ts/src/sdk/llm/profiles.ts`
+
+### Secrets (API keys)
+
+API keys are not stored in settings.json or in profile JSON files. They live in VS Code `SecretStorage`.
+
+SecretStorage keys:
+- **Provider-global keys** (shared defaults; shown in Settings under `OpenHands: Secrets`):
+  - `OPENAI_API_KEY`
+  - `ANTHROPIC_API_KEY`
+  - `OPENROUTER_API_KEY`
+  - `LITELLM_API_KEY`
+  - `GEMINI_API_KEY`
+- **Per-profile override key** (only when “Override for this profile” is enabled):
+  - `openhands.llmProfileApiKey.<profileId>`
+
+Key precedence for a given profile:
+1. If “Override for this profile” is enabled and `openhands.llmProfileApiKey.<profileId>` exists, use it.
+2. Otherwise use the provider-global key for the profile’s selected provider (e.g. `LITELLM_API_KEY` when provider is `litellm_proxy`).
+3. If no key is available, the request should fail with a clear user-facing error and a hint to set a key in `OpenHands: Secrets` or via the profile override UI.
+
+Important: key selection is **provider-driven**, not “model-family-driven”. For example, if provider is `litellm_proxy`, do **not** use `OPENAI_API_KEY` even if the model string starts with `gpt-`.
+
+## Profile schema (UI-facing)
+
+Profiles are edited via form fields (no raw JSON editing in the UI).
+
+Core fields:
+- Name (maps to `profileId`; required; immutable after create)
+- Provider (e.g. `openai`, `anthropic`, `openrouter`, `litellm_proxy`, `gemini`)
+- Model (string; required)
+- Base URL (optional; defaults by provider)
+- OpenAI API Mode (OpenAI only): `chat_completions` | `responses`
+- Generation params: temperature, topP, topK, maxInputTokens, maxOutputTokens, timeoutSeconds
+- OpenAI reasoning (when applicable): reasoningEffort, reasoningSummary
+- Headers (advanced; optional)
+
+## Conversation View (select + apply)
+
+### Selection behavior
+
+- The profile dropdown shows the **currently selected** `profileId`.
+- When the user selects a profile from the dropdown:
+  - The dropdown closes immediately.
+  - The selected item (checkmark + optional gear icon while open) updates to the newly selected `profileId`.
+  - The next LLM request uses the newly selected profile’s resolved configuration.
+
+### Runtime switching semantics
+
+- Switching profiles mid-conversation:
+  - Applies to the **next** LLM request (no interruption of in-flight streaming).
+  - Uses the newly selected profile for subsequent requests (until changed again).
+
+### Consistency requirement (critical)
+
+These three must always match (no “snap back to session default”):
+1. The profileId displayed in Conversation View (closed dropdown).
+2. The profile item that is checkmarked when the Conversation View dropdown is open.
+3. The profileId that is actually used to resolve the LLM configuration for the next request.
+
+## LLM Profiles View (create + edit + manage)
+
+### Profile picker + form
+
+- The view includes a profile selector (dropdown) with:
+  - Existing profiles
+  - “New Profile…” (clears the form and enables editing the Name field)
+- When editing an existing profile:
+  - The Name (`profileId`) field is disabled (since it is the filename).
+  - Saving changes must keep the form showing the **same profile** that was edited (do not switch to some default profile after Save).
+
+### Save / Close (dirty-state)
+
+- The view tracks whether the form has unsaved changes (“dirty”).
+  - Clean:
+    - Save is disabled/inactive
+    - Cancel button label reads “Close”
+  - Dirty:
+    - Save is enabled
+    - Cancel button label reads “Cancel” (and cancels changes + closes)
+
+### Delete (when present)
+
+- Deleting a profile:
+  - Must prompt for confirmation (in-webview modal matching `ConfirmationPrompt` styling).
+  - On confirm:
+    - Deletes `~/.openhands/llm-profiles/<profileId>.json`
+    - Deletes the per-profile override secret `openhands.llmProfileApiKey.<profileId>` (provider-global keys remain untouched)
+    - Refreshes the list and loads another existing profile (or “New Profile…” state if none exist)
+
+### Provider key UX
+
+- If a provider-global key exists for the selected provider, the UI should “recognize” it and show a simple indicator (e.g. green check), with an option to “Override for this profile”.
+- The UI should not display env-var-like key names as primary user text (avoid “Using OPENAI_API_KEY” style messaging in the main flow).
+
+## Error handling + logging
+
+User-facing errors (EventBlocks / status bar) should include:
+- HTTP status + provider error message (e.g. “invalid model ID”)
+- A short actionable hint when possible (e.g. “Check the profile’s provider/model or set the provider API key in OpenHands: Secrets.”)
+
+User-facing errors should **not** include internal diagnostic fields like:
+- effectiveBaseUrl / effectiveProvider / effectiveModel
+- inline/apiKey markers
+- mode=local / profileId echoing unless it helps the user (prefer a simple “Selected profile: <id>” if needed)
+
+Internal diagnostics (full request payload, effective resolution details) belong in:
+- Debug logs / Output channel gated behind a debug setting, not in normal UI error blocks.
+

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -903,13 +903,12 @@ describe('App - Advanced Test Coverage', () => {
 
       postToWindow({ type: 'event', event: action });
 
-      await waitFor(() => {
-        const badge = screen.getByText('high');
-        expect(badge).toBeInTheDocument();
-        expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed high risk for this action.');
-        expect(badge.className).toContain('bg-red-500/15');
+        await waitFor(() => {
+          const badge = screen.getByText('high');
+          expect(badge).toBeInTheDocument();
+          expect(badge.className).toContain('bg-red-500/15');
+        });
       });
-    });
 
     it('displays MEDIUM security risk badge', async () => {
       render(<App />);
@@ -921,13 +920,12 @@ describe('App - Advanced Test Coverage', () => {
 
       postToWindow({ type: 'event', event: action });
 
-      await waitFor(() => {
-        const badge = screen.getByText('medium');
-        expect(badge).toBeInTheDocument();
-        expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed medium risk for this action.');
-        expect(badge.className).toContain('bg-amber-500/15');
+        await waitFor(() => {
+          const badge = screen.getByText('medium');
+          expect(badge).toBeInTheDocument();
+          expect(badge.className).toContain('bg-amber-500/15');
+        });
       });
-    });
 
     it('displays LOW security risk badge', async () => {
       render(<App />);
@@ -942,7 +940,6 @@ describe('App - Advanced Test Coverage', () => {
       await waitFor(() => {
         const badge = screen.getByText('low');
         expect(badge).toBeInTheDocument();
-        expect(badge.closest('[title]')).toHaveAttribute('title', 'The model assessed low risk for this action.');
         expect(badge.className).toContain('bg-stone-500/15');
       });
     });

--- a/src/webview-src/__tests__/App.confirmation.test.tsx
+++ b/src/webview-src/__tests__/App.confirmation.test.tsx
@@ -59,7 +59,6 @@ describe('App - Confirmation Flow', () => {
     expect(scope.getAllByText(/terminal/i).length).toBeGreaterThanOrEqual(1);
     const riskBadge = scope.getByText(/high risk/);
     expect(riskBadge).toBeInTheDocument();
-    expect(riskBadge.closest('[title]')).toHaveAttribute('title', 'The model assessed high risk for this action.');
     expect(riskBadge.className).toContain('bg-red-500/15');
     expect(scope.getByText(/Reasoning/)).toBeInTheDocument();
   });

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -459,6 +459,7 @@ describe('App toolbar interactions', () => {
 
     const searchInput = await screen.findByPlaceholderText('Search skills...');
     fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
     fireEvent.keyDown(searchInput, { key: 'Enter' });
 
     await waitFor(() => {

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -452,7 +452,23 @@ describe('LLM Profiles view', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show advanced settings' }));
     expect(await screen.findByRole('spinbutton', { name: 'Max output tokens (numeric input)' })).toHaveValue(2048);
 
-    expect(screen.getByText('Use provider key')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(getLastPostedOfType('llmProfileApiKeyStatusRequest')).toBeTruthy();
+    });
+
+    const statusRequest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
+    postToWindow({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId: statusRequest.requestId,
+      ok: true,
+      profileId: statusRequest.profileId,
+      hasKey: true,
+      hasProfileKey: false,
+      hasProviderKey: true,
+      providerKeyName: 'OPENAI_API_KEY',
+    });
+
+    expect(await screen.findByLabelText('Provider key configured')).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: 'Override for this profile' })).not.toBeChecked();
     expect(screen.queryByLabelText('API key override')).toBeNull();
   });

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { App } from '../components/App';
 import { postToWindow } from './testUtils';
 
@@ -13,6 +13,16 @@ const getLastPostedOfType = (type: string): any | null => {
     if (candidate?.type === type) return candidate;
   }
   return null;
+};
+
+const selectDropdownOption = async (controlLabel: string, optionLabel: string) => {
+  const control = await screen.findByLabelText(controlLabel);
+  await waitFor(() => expect(control).not.toBeDisabled());
+
+  fireEvent.click(control);
+
+  const listbox = await screen.findByRole('listbox', { name: controlLabel });
+  fireEvent.click(within(listbox).getByRole('option', { name: optionLabel }));
 };
 
 describe('LLM Profiles view', () => {
@@ -79,7 +89,7 @@ describe('LLM Profiles view', () => {
     });
 
     const profileSelect = await screen.findByLabelText('Profile');
-    expect(profileSelect).toHaveValue('gpt-5');
+    expect(profileSelect).toHaveTextContent('gpt-5');
     expect(await screen.findByText('Edit profile')).toBeInTheDocument();
   });
 
@@ -98,9 +108,7 @@ describe('LLM Profiles view', () => {
 
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileSelect = await screen.findByLabelText('Profile');
-    await waitFor(() => expect(profileSelect).not.toBeDisabled());
-    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+    await selectDropdownOption('Profile', 'gpt-5');
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -195,9 +203,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileSelect = await screen.findByLabelText('Profile');
-    await waitFor(() => expect(profileSelect).not.toBeDisabled());
-    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+    await selectDropdownOption('Profile', 'gpt-5');
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -232,7 +238,7 @@ describe('LLM Profiles view', () => {
     expect(screen.queryByText('Using OPENAI_API_KEY')).toBeNull();
     expect(await screen.findByLabelText('Provider key configured')).toBeInTheDocument();
 
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'litellm_proxy' } });
+    await selectDropdownOption('Provider', 'litellm_proxy');
 
     await waitFor(() => {
       const latest = getLastPostedOfType('llmProfileApiKeyStatusRequest');
@@ -364,9 +370,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileSelect = await screen.findByLabelText('Profile');
-    await waitFor(() => expect(profileSelect).not.toBeDisabled());
-    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+    await selectDropdownOption('Profile', 'gpt-5');
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -408,9 +412,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileSelect = await screen.findByLabelText('Profile');
-    await waitFor(() => expect(profileSelect).not.toBeDisabled());
-    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+    await selectDropdownOption('Profile', 'gpt-5');
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -468,9 +470,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileSelect = await screen.findByLabelText('Profile');
-    await waitFor(() => expect(profileSelect).not.toBeDisabled());
-    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+    await selectDropdownOption('Profile', 'gpt-5');
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -531,7 +531,7 @@ describe('LLM Profiles view', () => {
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
     fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    await selectDropdownOption('Provider', 'openai');
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
@@ -562,7 +562,7 @@ describe('LLM Profiles view', () => {
 
     fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'gpt-5' } });
     fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'gpt-5' } });
-    fireEvent.change(screen.getByLabelText('Provider'), { target: { value: 'openai' } });
+    await selectDropdownOption('Provider', 'openai');
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Override for this profile' }));
     fireEvent.change(await screen.findByLabelText('API key override'), { target: { value: 'sk-test' } });
@@ -626,9 +626,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: ['gpt-5'] });
 
-    const profileSelect = await screen.findByLabelText('Profile');
-    await waitFor(() => expect(profileSelect).not.toBeDisabled());
-    fireEvent.change(profileSelect, { target: { value: 'gpt-5' } });
+    await selectDropdownOption('Profile', 'gpt-5');
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileLoadRequest')).toBeTruthy();
@@ -681,9 +679,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
 
-    const providerSelect = screen.getByLabelText('Provider');
-
-    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+    await selectDropdownOption('Provider', 'openai');
 
     fireEvent.click(await screen.findByRole('button', { name: 'Provider docs' }));
 
@@ -693,7 +689,7 @@ describe('LLM Profiles view', () => {
 
     expect(getLastPostedOfType('openMarkdownLink')?.href).toBe('https://platform.openai.com/docs');
 
-    fireEvent.change(providerSelect, { target: { value: 'openrouter' } });
+    await selectDropdownOption('Provider', 'openrouter');
     fireEvent.click(screen.getByRole('button', { name: 'Provider docs' }));
 
     await waitFor(() => {
@@ -714,9 +710,7 @@ describe('LLM Profiles view', () => {
     const listRequest = getLastPostedOfType('llmProfilesListRequest');
     postToWindow({ type: 'llmProfilesListResponse', requestId: listRequest.requestId, ok: true, profiles: [] });
 
-    const providerSelect = screen.getByLabelText('Provider');
-
-    fireEvent.change(providerSelect, { target: { value: 'openai' } });
+    await selectDropdownOption('Provider', 'openai');
 
     fireEvent.click(await screen.findByRole('button', { name: 'Get OpenAI API Key' }));
 

--- a/src/webview-src/__tests__/LlmProfilesView.test.tsx
+++ b/src/webview-src/__tests__/LlmProfilesView.test.tsx
@@ -149,7 +149,7 @@ describe('LLM Profiles view', () => {
 
     const apiKeyInput = await screen.findByLabelText('API key override');
     fireEvent.change(apiKeyInput, { target: { value: 'sk-test' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Save key' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save API key' }));
 
     await waitFor(() => {
       expect(getLastPostedOfType('llmProfileApiKeySetRequest')).toBeTruthy();

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -314,7 +314,6 @@ describe('Agent-SDK event rendering', () => {
     const button = await screen.findByRole('button', { name: 'View diff for /tmp/nested/README.md' });
     expect(button).toHaveTextContent('README.md');
     expect(button).not.toHaveTextContent('/tmp/nested/README.md');
-    expect(button).toHaveAttribute('title', 'View diff for /tmp/nested/README.md');
     fireEvent.click(button);
 
     expect(mockApi.postMessage).toHaveBeenCalledWith(

--- a/src/webview-src/components/ConfirmationPrompt.tsx
+++ b/src/webview-src/components/ConfirmationPrompt.tsx
@@ -182,7 +182,7 @@ export function ConfirmationPrompt({
                 onChange={(e) => setRejectReason(e.target.value)}
                 placeholder="Reason for rejection (optional)"
                 rows={3}
-                className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 resize-none focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500/30"
+                className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 resize-none focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]"
                 autoFocus
               />
             </div>
@@ -206,14 +206,14 @@ export function ConfirmationPrompt({
                 <button
                   onClick={handleCancel}
                   disabled={isSubmitting}
-                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
                 >
                   Cancel
                 </button>
                 <button
                   onClick={handleReject}
                   disabled={isSubmitting}
-                  className="px-4 py-2 rounded-lg bg-red-500/15 hover:bg-red-500/25 text-red-300 text-sm font-medium transition-all border border-red-400/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2 rounded-lg bg-red-500/15 hover:bg-red-500/25 text-red-300 text-sm font-medium transition-all border border-red-400/30 disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
                 >
                   Confirm Rejection
                 </button>
@@ -223,7 +223,7 @@ export function ConfirmationPrompt({
                 <button
                   onClick={handleReject}
                   disabled={isSubmitting}
-                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 oh-focus-outline"
                 >
                   <span className="codicon codicon-close" />
                   Reject
@@ -231,7 +231,7 @@ export function ConfirmationPrompt({
                 <button
                   onClick={handleApprove}
                   disabled={isSubmitting}
-                  className="px-4 py-2.5 rounded-lg bg-gradient-to-b from-brand-500 to-brand-600 text-white text-sm font-medium transition-all shadow-glow-sm hover:from-brand-400 hover:to-brand-500 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2.5 rounded-lg bg-gradient-to-b from-brand-500 to-brand-600 text-white text-sm font-medium transition-all shadow-glow-sm hover:from-brand-400 hover:to-brand-500 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
                 >
                   <span className="codicon codicon-check" />
                   Approve & Continue

--- a/src/webview-src/components/DropdownPopover.tsx
+++ b/src/webview-src/components/DropdownPopover.tsx
@@ -47,16 +47,8 @@ export function DropdownPopover({
 
     const next =
       preferPlacement === 'up'
-        ? canUp
-          ? 'up'
-          : canDown
-            ? 'down'
-            : 'up'
-        : canDown
-          ? 'down'
-          : canUp
-            ? 'up'
-            : 'down';
+        ? (canUp || !canDown) ? 'up' : 'down'
+        : (canDown || !canUp) ? 'down' : 'up';
 
     setPlacement((prev) => (prev === next ? prev : next));
   }, [isOpen, preferPlacement, triggerRef]);

--- a/src/webview-src/components/DropdownPopover.tsx
+++ b/src/webview-src/components/DropdownPopover.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useRef, useState, type ReactNode, type RefObject } from 'react';
+import { useCloseOnEscapeAndOutsideClick, type CloseReason } from './useCloseOnEscapeAndOutsideClick';
+
+export type DropdownPopoverPlacement = 'up' | 'down';
+
+export function DropdownPopover({
+  isOpen,
+  onClose,
+  triggerRef,
+  preferPlacement = 'up',
+  children,
+  className = '',
+}: {
+  isOpen: boolean;
+  onClose: (reason: CloseReason) => void;
+  triggerRef: RefObject<HTMLElement | null>;
+  preferPlacement?: DropdownPopoverPlacement;
+  children: ReactNode;
+  className?: string;
+}) {
+  const [placement, setPlacement] = useState<DropdownPopoverPlacement>(preferPlacement);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: popoverRef, delay: 100 });
+
+  const setPopoverNode = useCallback((node: HTMLDivElement | null) => {
+    popoverRef.current = node;
+    if (!node) {
+      setPlacement(preferPlacement);
+      return;
+    }
+    if (!isOpen) return;
+
+    const triggerEl = triggerRef.current;
+    if (!triggerEl) return;
+
+    const trigger = triggerEl.getBoundingClientRect();
+    const popover = node.getBoundingClientRect();
+    const padding = 8;
+
+    const spaceAbove = trigger.top;
+    const spaceBelow = window.innerHeight - trigger.bottom;
+    const needed = popover.height + padding;
+
+    const canUp = spaceAbove >= needed;
+    const canDown = spaceBelow >= needed;
+
+    const next =
+      preferPlacement === 'up'
+        ? canUp
+          ? 'up'
+          : canDown
+            ? 'down'
+            : 'up'
+        : canDown
+          ? 'down'
+          : canUp
+            ? 'up'
+            : 'down';
+
+    setPlacement((prev) => (prev === next ? prev : next));
+  }, [isOpen, preferPlacement, triggerRef]);
+
+  if (!isOpen) return null;
+
+  const positionClass = placement === 'up' ? 'bottom-full left-0 mb-2' : 'top-full left-0 mt-2';
+
+  return (
+    <div ref={setPopoverNode} className={`absolute ${positionClass} ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -221,7 +221,7 @@ export function HalOverlay({
                   type="button"
                   onClick={handleRejectClick}
                   disabled={!canSubmit}
-                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:text-stone-200 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:text-stone-200 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 oh-focus-outline"
                 >
                   <span className="codicon codicon-close" />
                   Reject
@@ -231,7 +231,7 @@ export function HalOverlay({
                   type="button"
                   onClick={onTeleport}
                   disabled={!canSubmit}
-                  className="px-4 py-2 rounded-lg bg-red-500/10 border border-red-400/25 text-red-200 hover:bg-red-500/20 hover:text-red-100 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-4 py-2 rounded-lg bg-red-500/10 border border-red-400/25 text-red-200 hover:bg-red-500/20 hover:text-red-100 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 oh-focus-outline"
                 >
                   <span className="codicon codicon-run-all" />
                   Teleport to Remote
@@ -241,7 +241,7 @@ export function HalOverlay({
                   type="button"
                   onClick={onApprove}
                   disabled={!canSubmit}
-                  className="px-4 py-2.5 rounded-lg bg-gradient-to-b from-brand-500 to-brand-600 text-white text-sm font-medium transition-all shadow-glow-sm hover:from-brand-400 hover:to-brand-500 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2.5 rounded-lg bg-gradient-to-b from-brand-500 to-brand-600 text-white text-sm font-medium transition-all shadow-glow-sm hover:from-brand-400 hover:to-brand-500 flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
                 >
                   <span className="codicon codicon-check" />
                   Approve Locally
@@ -260,7 +260,7 @@ export function HalOverlay({
                   onChange={(e) => setRejectReason(e.target.value)}
                   placeholder="Reason for rejection (optional)"
                   rows={3}
-                  className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 resize-none focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500/30"
+                  className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 resize-none focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]"
                   autoFocus
                 />
                 <div className="mt-3 flex items-center justify-end gap-2">
@@ -268,7 +268,7 @@ export function HalOverlay({
                     type="button"
                     onClick={handleCancelReject}
                     disabled={isSubmitting}
-                    className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-4 py-2 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:bg-white/[0.08] hover:text-stone-300 text-sm font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
                   >
                     Cancel
                   </button>
@@ -276,7 +276,7 @@ export function HalOverlay({
                     type="button"
                     onClick={handleConfirmReject}
                     disabled={isSubmitting}
-                    className="px-4 py-2 rounded-lg bg-red-500/15 hover:bg-red-500/25 text-red-300 text-sm font-medium transition-all border border-red-400/30 disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-4 py-2 rounded-lg bg-red-500/15 hover:bg-red-500/25 text-red-300 text-sm font-medium transition-all border border-red-400/30 disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
                   >
                     Confirm Rejection
                   </button>

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -91,7 +91,7 @@ function IconButton({
           text-stone-400 hover:text-stone-200
           transition-all duration-200
           hover:bg-white/[0.08] hover:border-white/[0.1]
-          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+          oh-focus-outline
           disabled:opacity-40 disabled:cursor-not-allowed
         `}
         aria-label={label}

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -110,9 +110,9 @@ function ConversationItem({
           transition-all duration-200
           border
           hover:bg-white/[0.04]
-          focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 focus:border-brand-500/25
+          oh-focus-outline
           ${isActive
-            ? 'bg-brand-500/10 border-brand-500/25 hover:bg-brand-500/15'
+            ? 'bg-brand-500/10 border-white/[0.06] oh-outline-soft hover:bg-brand-500/15 hover:border-white/[0.08]'
             : 'bg-white/[0.02] border-white/[0.04] hover:border-white/[0.08]'}
         `}
       >
@@ -295,7 +295,7 @@ export function HistoryView({
           </div>
           <button
             onClick={onClose}
-            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
+            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center oh-focus-outline"
             aria-label="Close history"
             title="Close"
           >
@@ -317,7 +317,7 @@ export function HistoryView({
                 }
               }}
               placeholder="Search history…"
-              className="w-full pl-9 pr-9 py-2 rounded-lg bg-white/[0.03] border border-white/[0.06] text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 focus:border-brand-500/25"
+              className="w-full pl-9 pr-9 py-2 rounded-lg bg-white/[0.03] border border-white/[0.06] text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]"
               aria-label="Search conversation history"
             />
             {hasAnyQuery && (

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -148,19 +148,21 @@ function ConversationItem({
         </div>
       </button>
 
-      <Tooltip content={isActive ? 'Cannot delete active conversation' : 'Delete conversation'} position="left">
-        <button
-          type="button"
-          onClick={onDelete}
-          disabled={isActive}
-          className={`absolute right-3 top-3 h-7 w-7 rounded-md text-stone-500 flex items-center justify-center transition-all ${isActive
-            ? 'opacity-40 cursor-not-allowed'
-            : 'hover:text-stone-200 hover:bg-white/[0.06]'}`}
-          aria-label="Delete conversation"
-        >
-          <span className="codicon codicon-trash text-sm" />
-        </button>
-      </Tooltip>
+      <div className="absolute right-3 top-4">
+        <Tooltip content={isActive ? 'Cannot delete active conversation' : 'Delete conversation'} position="left">
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={isActive}
+            className={`h-7 w-7 rounded-md text-stone-500 flex items-center justify-center transition-all ${isActive
+              ? 'opacity-40 cursor-not-allowed'
+              : 'hover:text-stone-200 hover:bg-white/[0.06]'}`}
+            aria-label="Delete conversation"
+          >
+            <span className="codicon codicon-trash text-sm" />
+          </button>
+        </Tooltip>
+      </div>
     </div>
   );
 }

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -172,7 +172,7 @@ export function InputArea({
             transition-all duration-200
             border
             ${isFocused
-              ? 'shadow-glow border-brand-500/30 ring-1 ring-brand-500/20'
+              ? 'shadow-glow-outline border-white/[0.08]'
               : 'shadow-event border-white/[0.06]'}
             ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
           `}
@@ -183,7 +183,7 @@ export function InputArea({
           }}
         >
           {/* Textarea */}
-            <textarea
+          <textarea
             id="openhands-chat-input"
             ref={textareaRef}
             value={value}
@@ -198,20 +198,20 @@ export function InputArea({
             disabled={disabled}
             placeholder={placeholder}
             rows={1}
-              className={`
-                w-full px-4 py-3 pr-24
-                bg-transparent
-                text-sm leading-relaxed text-stone-200
-                resize-none
-                focus:outline-none
+            className={`
+              w-full px-4 py-3 pr-24
+              bg-transparent
+              text-sm leading-relaxed text-stone-200
+              resize-none
+              focus:outline-none
               placeholder:text-stone-500
               disabled:cursor-not-allowed
             `}
             style={{
               minHeight: '44px',
-                maxHeight: '200px',
-              }}
-            />
+              maxHeight: '200px',
+            }}
+          />
 
             <div className="absolute right-2 bottom-2 flex items-center gap-2">
               {/* Attachments button (icon-only) */}
@@ -224,7 +224,7 @@ export function InputArea({
                     h-9 w-9 rounded-lg
                     flex items-center justify-center
                     transition-all duration-200
-                    focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
+                    oh-focus-outline
                     bg-white/[0.06] text-stone-300 border border-white/[0.04]
                     hover:bg-white/[0.08] hover:border-white/[0.1]
                   `}
@@ -249,7 +249,7 @@ export function InputArea({
                   h-9 w-9 rounded-lg
                   flex items-center justify-center
                   transition-all duration-200
-                  focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
+                  oh-focus-outline
                   ${canSend && !disabled
                     ? 'bg-gradient-to-b from-brand-500 to-brand-600 text-white shadow-glow-sm hover:from-brand-400 hover:to-brand-500'
                     : 'bg-white/[0.06] text-stone-500 cursor-not-allowed border border-white/[0.04]'

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -939,7 +939,16 @@ export function LlmProfilesView(props: {
                 <button
                   type="button"
                   onClick={onClose}
-                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-white/[0.04] text-stone-300 border border-white/[0.06] hover:bg-white/[0.08] hover:border-white/[0.1] transition-all"
+                  className="
+                    inline-flex items-center gap-2 px-4 py-2 rounded-lg
+                    text-sm font-medium
+                    transition-all
+                    border border-white/[0.06]
+                    bg-white/[0.04] text-stone-300
+                    hover:bg-white/[0.08] hover:border-white/[0.1]
+                    focus:outline-none focus:ring-0
+                    focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
+                  "
                 >
                   {isDirty ? 'Cancel' : 'Close'}
                 </button>
@@ -952,6 +961,8 @@ export function LlmProfilesView(props: {
                     text-sm font-medium
                     transition-all
                     border
+                    focus:outline-none focus:ring-0
+                    focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
                     ${!canSave
                       ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
                       : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -181,8 +181,10 @@ export function LlmProfilesView(props: {
     setIsAdvancedOpen(false);
   }, []);
 
+  const DRAFT_PROFILE_ID = '__draft_profile__';
+
   const startCreate = useCallback(() => {
-    activeProfileIdRef.current = null;
+    activeProfileIdRef.current = DRAFT_PROFILE_ID;
     applyEditorTransition({
       mode: 'create',
       selectedProfileId: null,
@@ -190,7 +192,7 @@ export function LlmProfilesView(props: {
       loadingProfile: false,
       useCustomBaseUrl: false,
     });
-  }, [applyEditorTransition]);
+  }, [DRAFT_PROFILE_ID, applyEditorTransition]);
 
   const startEdit = useCallback(async (profileId: string) => {
     activeProfileIdRef.current = profileId;
@@ -238,10 +240,17 @@ export function LlmProfilesView(props: {
   }, [activeProfileId, isOpen, openRequest, startCreate, startEdit]);
 
   useEffect(() => {
-    if (mode !== 'edit' || !selectedProfileId || loadingProfile) return;
+    if (!isOpen) return;
     if (!form.provider) return;
-    void refreshApiKeyStatus(selectedProfileId, { provider: form.provider });
-  }, [form.provider, loadingProfile, mode, refreshApiKeyStatus, selectedProfileId]);
+
+    if (mode === 'edit') {
+      if (!selectedProfileId || loadingProfile) return;
+      void refreshApiKeyStatus(selectedProfileId, { provider: form.provider });
+      return;
+    }
+
+    void refreshApiKeyStatus(DRAFT_PROFILE_ID, { provider: form.provider });
+  }, [DRAFT_PROFILE_ID, form.provider, isOpen, loadingProfile, mode, refreshApiKeyStatus, selectedProfileId]);
 
   const handleSave = useCallback(async () => {
     setSaveAttempted(true);
@@ -353,22 +362,29 @@ export function LlmProfilesView(props: {
   })();
 
   const showProviderKeyConfiguredIndicator = providerRequiresApiKey
-    && mode === 'edit'
+    && !overrideProfileApiKey
     && apiKeyStatus.state === 'ready'
     && apiKeyStatus.hasProviderKey
     && !apiKeyStatus.hasProfileKey;
 
   const apiKeyStatusLabel = (() => {
     if (!providerRequiresApiKey) return '—';
-    if (mode === 'create') return overrideProfileApiKey ? (apiKeyInput.trim() ? 'Draft' : 'Not set') : 'Use provider key';
-    if (apiKeyStatus.state === 'loading') return 'Checking…';
-    if (apiKeyStatus.state === 'ready') {
-      if (apiKeyStatus.hasProfileKey) return 'Override set';
-      if (apiKeyStatus.hasProviderKey) return '';
-      return 'Missing';
+
+    if (overrideProfileApiKey) {
+      if (mode === 'create') {
+        return apiKeyInput.trim() ? 'Draft' : 'Not set';
+      }
+      if (apiKeyStatus.state === 'loading') return 'Checking…';
+      if (apiKeyStatus.state === 'ready') return apiKeyStatus.hasProfileKey ? 'Override set' : 'Not set';
+      if (apiKeyStatus.state === 'error') return 'Error';
+      return '—';
     }
+
+    // Using provider key (no per-profile override).
+    if (apiKeyStatus.state === 'loading') return 'Checking…';
+    if (apiKeyStatus.state === 'ready') return apiKeyStatus.hasProviderKey ? '' : 'Missing';
     if (apiKeyStatus.state === 'error') return 'Error';
-    return '—';
+    return mode === 'create' ? 'Use provider key' : '—';
   })();
 
   const showProfileApiKeyOverrideSetIndicator = canEditApiKey
@@ -460,7 +476,7 @@ export function LlmProfilesView(props: {
     if (mode !== 'edit') return;
 
     const source = form;
-    activeProfileIdRef.current = null;
+    activeProfileIdRef.current = DRAFT_PROFILE_ID;
     const nextForm = { ...source, name: '' };
     applyEditorTransition({
       mode: 'create',
@@ -474,7 +490,7 @@ export function LlmProfilesView(props: {
     requestAnimationFrame(() => {
       nameInputRef.current?.focus();
     });
-  }, [applyEditorTransition, form, mode]);
+  }, [DRAFT_PROFILE_ID, applyEditorTransition, form, mode]);
 
   const isDirty = useMemo(() => {
     return JSON.stringify(normalizeFormStateForDirtyCheck(form)) !== JSON.stringify(normalizeFormStateForDirtyCheck(baselineForm));
@@ -664,7 +680,7 @@ export function LlmProfilesView(props: {
                             setUseCustomBaseUrl(next);
                             if (!next) update('baseUrl', '');
                           }}
-                          className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0"
+                          className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 oh-focus-outline"
                         />
                         Use custom base URL
                       </label>
@@ -836,7 +852,7 @@ export function LlmProfilesView(props: {
                                 className="
                                   w-full h-2 rounded-lg
                                   appearance-none bg-transparent
-                                  focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:ring-offset-0
+                                  oh-focus-outline
                                   disabled:opacity-50 disabled:cursor-not-allowed
                                   [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-lg [&::-webkit-slider-runnable-track]:bg-white/10
                                   [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:-mt-1
@@ -947,7 +963,7 @@ export function LlmProfilesView(props: {
                     bg-white/[0.04] text-stone-300
                     hover:bg-white/[0.08] hover:border-white/[0.1]
                     focus:outline-none focus:ring-0
-                    focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
+                    focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]
                   "
                 >
                   {isDirty ? 'Cancel' : 'Close'}
@@ -962,10 +978,10 @@ export function LlmProfilesView(props: {
                     transition-all
                     border
                     focus:outline-none focus:ring-0
-                    focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
+                    focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]
                     ${!canSave
                       ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
-                      : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
+                      : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-white/[0.06] oh-outline-soft hover:from-brand-500/35 hover:to-brand-600/30 hover:border-white/[0.1]'}
                   `}
                 >
                   <span className={`codicon codicon-${saving ? 'loading' : 'save'} ${saving ? 'animate-spin' : ''}`} />

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -618,7 +618,7 @@ export function LlmProfilesView(props: {
                         id={profileFieldId('provider')}
                         value={form.provider}
                         onChange={(v) => update('provider', v as ProfileFormState['provider'])}
-                        preferPlacement="up"
+                        preferPlacement="down"
                         ariaLabel="Provider"
                         icon="codicon-plug"
                         options={[
@@ -833,7 +833,19 @@ export function LlmProfilesView(props: {
                                 onChange={(e) => update('maxOutputTokens', e.target.value)}
                                 disabled={maxOutputTokensSlider.disabled}
                                 aria-label="Max output tokens (slider)"
-                                className="w-full accent-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                                className="
+                                  w-full h-2 rounded-lg
+                                  appearance-none bg-transparent
+                                  focus:outline-none focus:ring-2 focus:ring-brand-500/30 focus:ring-offset-0
+                                  disabled:opacity-50 disabled:cursor-not-allowed
+                                  [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-runnable-track]:rounded-lg [&::-webkit-slider-runnable-track]:bg-white/10
+                                  [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:-mt-1
+                                  [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-stone-300 [&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-white/20
+                                  [&::-moz-range-track]:h-2 [&::-moz-range-track]:rounded-lg [&::-moz-range-track]:bg-white/10
+                                  [&::-moz-range-progress]:h-2 [&::-moz-range-progress]:rounded-lg [&::-moz-range-progress]:bg-white/20
+                                  [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-stone-300
+                                  [&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-white/20
+                                "
                               />
                               <div className="flex items-center justify-between text-[11px] text-stone-500">
                                 <span>{MIN_OUTPUT_TOKENS}</span>

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -5,7 +5,7 @@ import { getVscodeApi } from '../shared/vscodeApi';
 import type { LlmProfileApiKeyStatusInfo, LlmProfileApiKeyStatusOverrides, WebviewToHostMessage } from '../../shared/webviewMessages';
 import { LlmProfileApiKeySection } from './llmProfilesView/LlmProfileApiKeySection';
 import { LlmProfilesPanelHeader } from './llmProfilesView/LlmProfilesPanelHeader';
-import { FieldError, FieldLabel, InputField, SelectField } from './llmProfilesView/fields';
+import { FieldError, FieldLabel, InputField, PopoverSelectField } from './llmProfilesView/fields';
 import {
   ADVANCED_FIELD_KEYS,
   EMPTY_FORM,
@@ -91,7 +91,6 @@ export function LlmProfilesView(props: {
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: panelRef, delay: 100 });
 
   const nameInputRef = useRef<HTMLInputElement>(null);
-  const providerSelectRef = useRef<HTMLSelectElement>(null);
   const apiKeyInputRef = useRef<HTMLInputElement>(null);
 
   const activeProfileIdRef = useRef<string | null>(null);
@@ -516,17 +515,19 @@ export function LlmProfilesView(props: {
             <div className="px-6 py-5 border-b border-white/[0.06] space-y-4">
               <div>
                 <FieldLabel label="Profile" htmlFor={profileSelectId} />
-                <SelectField
+                <PopoverSelectField
                   id={profileSelectId}
                   value={profileSelectValue}
                   onChange={handleSelectProfile}
                   disabled={loadingList}
-                >
-                  <option value={NEW_PROFILE_SELECT_VALUE}>New Profile…</option>
-                  {profileSelectOptions.map((id) => (
-                    <option key={id} value={id}>{id}</option>
-                  ))}
-                </SelectField>
+                  preferPlacement="down"
+                  ariaLabel="Profile"
+                  icon="codicon-symbol-parameter"
+                  options={[
+                    { value: NEW_PROFILE_SELECT_VALUE, label: 'New Profile…' },
+                    ...profileSelectOptions.map((id) => ({ value: id, label: id })),
+                  ]}
+                />
                 {loadingList ? (
                   <div className="text-xs text-stone-500 mt-1">Loading profiles…</div>
                 ) : profileSelectOptions.length === 0 ? (
@@ -613,19 +614,22 @@ export function LlmProfilesView(props: {
                       )}
                     </div>
                     <div className="mt-2">
-                      <SelectField
-                        ref={providerSelectRef}
+                      <PopoverSelectField
                         id={profileFieldId('provider')}
                         value={form.provider}
                         onChange={(v) => update('provider', v as ProfileFormState['provider'])}
-                      >
-                        <option value="">Select…</option>
-                        <option value="openai">openai</option>
-                        <option value="anthropic">anthropic</option>
-                        <option value="openrouter">openrouter</option>
-                        <option value="litellm_proxy">litellm_proxy</option>
-                        <option value="gemini">gemini</option>
-                      </SelectField>
+                        preferPlacement="up"
+                        ariaLabel="Provider"
+                        icon="codicon-plug"
+                        options={[
+                          { value: '', label: 'Select…' },
+                          { value: 'openai', label: 'openai' },
+                          { value: 'anthropic', label: 'anthropic' },
+                          { value: 'openrouter', label: 'openrouter' },
+                          { value: 'litellm_proxy', label: 'litellm_proxy' },
+                          { value: 'gemini', label: 'gemini' },
+                        ]}
+                      />
                       <FieldError message={errors.provider} />
                     </div>
                   </div>
@@ -685,16 +689,20 @@ export function LlmProfilesView(props: {
                   <div>
                     <FieldLabel label="OpenAI API mode" htmlFor={profileFieldId('openaiApiMode')} />
                     <div className="mt-2">
-                      <SelectField
+                      <PopoverSelectField
                         id={profileFieldId('openaiApiMode')}
                         value={form.openaiApiMode}
                         onChange={(v) => update('openaiApiMode', v as ProfileFormState['openaiApiMode'])}
                         disabled={form.provider !== 'openai'}
-                      >
-                        <option value="auto">auto</option>
-                        <option value="chat_completions">chat_completions</option>
-                        <option value="responses">responses</option>
-                      </SelectField>
+                        preferPlacement="up"
+                        ariaLabel="OpenAI API mode"
+                        icon="codicon-json"
+                        options={[
+                          { value: 'auto', label: 'auto' },
+                          { value: 'chat_completions', label: 'chat_completions' },
+                          { value: 'responses', label: 'responses' },
+                        ]}
+                      />
                       <FieldError message={errors.openaiApiMode} />
                     </div>
                   </div>
@@ -841,33 +849,41 @@ export function LlmProfilesView(props: {
                         <div>
                           <FieldLabel label="Reasoning effort" htmlFor={profileFieldId('reasoningEffort')} />
                           <div className="mt-2">
-                            <SelectField
+                            <PopoverSelectField
                               id={profileFieldId('reasoningEffort')}
                               value={form.reasoningEffort}
                               onChange={(v) => update('reasoningEffort', v as ProfileFormState['reasoningEffort'])}
-                            >
-                              <option value="">default</option>
-                              <option value="none">none</option>
-                              <option value="low">low</option>
-                              <option value="medium">medium</option>
-                              <option value="high">high</option>
-                            </SelectField>
+                              preferPlacement="up"
+                              ariaLabel="Reasoning effort"
+                              icon="codicon-lightbulb"
+                              options={[
+                                { value: '', label: 'default' },
+                                { value: 'none', label: 'none' },
+                                { value: 'low', label: 'low' },
+                                { value: 'medium', label: 'medium' },
+                                { value: 'high', label: 'high' },
+                              ]}
+                            />
                             <FieldError message={errors.reasoningEffort} />
                           </div>
                         </div>
                         <div>
                           <FieldLabel label="Reasoning summary" htmlFor={profileFieldId('reasoningSummary')} />
                           <div className="mt-2">
-                            <SelectField
+                            <PopoverSelectField
                               id={profileFieldId('reasoningSummary')}
                               value={form.reasoningSummary}
                               onChange={(v) => update('reasoningSummary', v as ProfileFormState['reasoningSummary'])}
-                            >
-                              <option value="">default</option>
-                              <option value="auto">auto</option>
-                              <option value="concise">concise</option>
-                              <option value="detailed">detailed</option>
-                            </SelectField>
+                              preferPlacement="up"
+                              ariaLabel="Reasoning summary"
+                              icon="codicon-preview"
+                              options={[
+                                { value: '', label: 'default' },
+                                { value: 'auto', label: 'auto' },
+                                { value: 'concise', label: 'concise' },
+                                { value: 'detailed', label: 'detailed' },
+                              ]}
+                            />
                             <FieldError message={errors.reasoningSummary} />
                           </div>
                         </div>

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -152,6 +152,8 @@ export function ServerSelector({
               return (
                 <div
                   key={server.url}
+                  role="option"
+                  aria-selected={selected}
                   className={`
                     flex items-center gap-2 px-3 py-2 rounded-lg
                     text-sm
@@ -166,8 +168,6 @@ export function ServerSelector({
                       onClose();
                     }}
                     className="flex-1 text-left flex items-center gap-2"
-                    role="option"
-                    aria-selected={selected}
                   >
                     <span className="codicon codicon-cloud" />
                     <div className="flex-1 min-w-0">

--- a/src/webview-src/components/ServerSelector.tsx
+++ b/src/webview-src/components/ServerSelector.tsx
@@ -210,8 +210,10 @@ export function ServerSelector({
               onKeyDown={handleKeyDown}
               placeholder="https://server-url..."
               autoFocus
-              className={`w-full px-3 py-2 text-sm bg-black/20 border rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500/50 ${
-                urlError ? 'border-red-500/50' : 'border-white/10'
+              className={`w-full px-3 py-2 text-sm bg-black/20 border rounded-lg text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-0 ${
+                urlError
+                  ? 'border-red-500/50 focus:border-red-500/50 focus:shadow-[0_0_0_1px_rgba(248,113,113,0.35)]'
+                  : 'border-white/10 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]'
               }`}
             />
             {urlError && (
@@ -223,19 +225,19 @@ export function ServerSelector({
               onChange={(e) => setNewLabel(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="Label (optional)"
-              className="w-full px-3 py-2 text-sm bg-black/20 border border-white/10 rounded-lg focus:outline-none focus:ring-2 focus:ring-brand-500/50"
+              className="w-full px-3 py-2 text-sm bg-black/20 border border-white/10 rounded-lg text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]"
             />
             <div className="flex gap-2">
               <button
                 onClick={handleAddServer}
                 disabled={!newUrl.trim()}
-                className="flex-1 px-3 py-1.5 text-sm bg-brand-500/20 text-brand-300 rounded-lg hover:bg-brand-500/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                className="flex-1 px-3 py-1.5 text-sm bg-brand-500/20 text-brand-300 rounded-lg hover:bg-brand-500/30 disabled:opacity-40 disabled:cursor-not-allowed transition-colors oh-focus-outline"
               >
                 Add
               </button>
               <button
                 onClick={handleCancelAdd}
-                className="px-3 py-1.5 text-sm bg-white/5 rounded-lg hover:bg-white/10 transition-colors"
+                className="px-3 py-1.5 text-sm bg-white/5 rounded-lg hover:bg-white/10 transition-colors oh-focus-outline"
               >
                 Cancel
               </button>
@@ -247,7 +249,7 @@ export function ServerSelector({
             onClick={() => {
               setShowAddForm(true);
             }}
-            className="w-full px-4 py-3 text-sm text-left hover:bg-white/5 transition-colors flex items-center gap-2"
+            className="w-full px-4 py-3 text-sm text-left hover:bg-white/5 transition-colors flex items-center gap-2 oh-focus-outline"
           >
             <span className="codicon codicon-add" />
             <span>Add Server</span>

--- a/src/webview-src/components/ToolbarButtons.tsx
+++ b/src/webview-src/components/ToolbarButtons.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Tooltip } from './Tooltip';
 
-const iconButtonBase = 'relative inline-flex h-8 w-8 items-center justify-center rounded-sm bg-[color-mix(in_srgb,var(--vscode-toolbar-background)_92%,transparent)] text-[var(--vscode-foreground)] hover:bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_85%,transparent)] focus:outline focus:outline-1 focus:outline-[var(--vscode-focusBorder)]';
-const accessoryButtonBase = 'relative inline-flex h-7 w-7 items-center justify-center rounded-sm bg-transparent text-[var(--vscode-foreground)] hover:bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_35%,transparent)] focus:outline focus:outline-1 focus:outline-[var(--vscode-focusBorder)]';
+const iconButtonBase = 'relative inline-flex h-8 w-8 items-center justify-center rounded-sm bg-[color-mix(in_srgb,var(--vscode-toolbar-background)_92%,transparent)] text-[var(--vscode-foreground)] hover:bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_85%,transparent)] oh-focus-outline';
+const accessoryButtonBase = 'relative inline-flex h-7 w-7 items-center justify-center rounded-sm bg-transparent text-[var(--vscode-foreground)] hover:bg-[color-mix(in_srgb,var(--vscode-toolbar-hoverBackground)_35%,transparent)] oh-focus-outline';
 
 export interface ToolbarButtonProps {
   icon: string;

--- a/src/webview-src/components/Tooltip.tsx
+++ b/src/webview-src/components/Tooltip.tsx
@@ -24,20 +24,14 @@ export function Tooltip({
   const [isVisible, setIsVisible] = useState(false);
   const [actualPosition, setActualPosition] = useState(position);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const rafRef = useRef<number | null>(null);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
 
-  const cancelScheduledRaf = useCallback(() => {
-    if (rafRef.current === null) return;
-    cancelAnimationFrame(rafRef.current);
-    rafRef.current = null;
-  }, []);
+  const setTooltipNode = useCallback((node: HTMLDivElement | null) => {
+    tooltipRef.current = node;
+    if (!node || !triggerRef.current) return;
 
-  const updatePositionIfNeeded = useCallback(() => {
-    if (!tooltipRef.current || !triggerRef.current) return;
-
-    const tooltip = tooltipRef.current.getBoundingClientRect();
+    const tooltip = node.getBoundingClientRect();
     const trigger = triggerRef.current.getBoundingClientRect();
     const padding = 8;
 
@@ -65,13 +59,8 @@ export function Tooltip({
       timeoutRef.current = null;
       setActualPosition(position);
       setIsVisible(true);
-      cancelScheduledRaf();
-      rafRef.current = requestAnimationFrame(() => {
-        rafRef.current = null;
-        updatePositionIfNeeded();
-      });
     }, delay);
-  }, [delay, position, cancelScheduledRaf, updatePositionIfNeeded]);
+  }, [delay, position]);
 
   const hideTooltip = useCallback(() => {
     if (timeoutRef.current) {
@@ -79,18 +68,14 @@ export function Tooltip({
       timeoutRef.current = null;
     }
     setIsVisible(false);
-    cancelScheduledRaf();
     setActualPosition(position);
-  }, [position, cancelScheduledRaf]);
+  }, [position]);
 
   // Cleanup timeout on unmount
   useEffect(() => {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
-      }
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
       }
     };
   }, []);
@@ -133,7 +118,7 @@ export function Tooltip({
       {trigger}
       {isVisible && content && (
         <div
-          ref={tooltipRef}
+          ref={setTooltipNode}
           role="tooltip"
           className={`
             absolute z-50 pointer-events-none

--- a/src/webview-src/components/Tooltip.tsx
+++ b/src/webview-src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, type ReactNode, useEffect, isValidElement, cloneElement, type ReactElement } from 'react';
+import { useState, useRef, useCallback, type ReactNode, useEffect } from 'react';
 
 type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
 
@@ -109,11 +109,6 @@ export function Tooltip({
     right: 'animate-tooltip-right',
   };
 
-  const title = !isMounted && typeof content === 'string' ? content : undefined;
-  const trigger = isValidElement(children)
-    ? cloneElement(children as ReactElement<{ title?: string }>, { title })
-    : children;
-
   return (
     <div
       ref={triggerRef}
@@ -123,7 +118,7 @@ export function Tooltip({
       onFocus={showTooltip}
       onBlur={hideTooltip}
     >
-      {trigger}
+      {children}
       {isMounted && content && (
         <div
           ref={setTooltipNode}

--- a/src/webview-src/components/Tooltip.tsx
+++ b/src/webview-src/components/Tooltip.tsx
@@ -21,6 +21,7 @@ export function Tooltip({
   delay = 400,
   className = '',
 }: TooltipProps) {
+  const [isMounted, setIsMounted] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
   const [actualPosition, setActualPosition] = useState(position);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -29,7 +30,11 @@ export function Tooltip({
 
   const setTooltipNode = useCallback((node: HTMLDivElement | null) => {
     tooltipRef.current = node;
-    if (!node || !triggerRef.current) return;
+    if (!node) return;
+    if (!triggerRef.current) {
+      setIsVisible(true);
+      return;
+    }
 
     const tooltip = node.getBoundingClientRect();
     const trigger = triggerRef.current.getBoundingClientRect();
@@ -48,6 +53,7 @@ export function Tooltip({
     }
 
     setActualPosition((prev) => (prev === nextPosition ? prev : nextPosition));
+    setIsVisible(true);
   }, [position]);
 
   const showTooltip = useCallback(() => {
@@ -58,7 +64,8 @@ export function Tooltip({
     timeoutRef.current = setTimeout(() => {
       timeoutRef.current = null;
       setActualPosition(position);
-      setIsVisible(true);
+      setIsMounted(true);
+      setIsVisible(false);
     }, delay);
   }, [delay, position]);
 
@@ -68,6 +75,7 @@ export function Tooltip({
       timeoutRef.current = null;
     }
     setIsVisible(false);
+    setIsMounted(false);
     setActualPosition(position);
   }, [position]);
 
@@ -101,7 +109,7 @@ export function Tooltip({
     right: 'animate-tooltip-right',
   };
 
-  const title = !isVisible && typeof content === 'string' ? content : undefined;
+  const title = !isMounted && typeof content === 'string' ? content : undefined;
   const trigger = isValidElement(children)
     ? cloneElement(children as ReactElement<{ title?: string }>, { title })
     : children;
@@ -116,14 +124,15 @@ export function Tooltip({
       onBlur={hideTooltip}
     >
       {trigger}
-      {isVisible && content && (
+      {isMounted && content && (
         <div
           ref={setTooltipNode}
           role="tooltip"
           className={`
             absolute z-50 pointer-events-none
             ${positionClasses[actualPosition]}
-            ${animationClasses[actualPosition]}
+            ${isVisible ? animationClasses[actualPosition] : ''}
+            ${isVisible ? 'opacity-100' : 'opacity-0'}
           `}
         >
           {/* Tooltip content */}

--- a/src/webview-src/components/Tooltip.tsx
+++ b/src/webview-src/components/Tooltip.tsx
@@ -32,7 +32,8 @@ export function Tooltip({
     tooltipRef.current = node;
     if (!node) return;
     if (!triggerRef.current) {
-      setIsVisible(true);
+      setIsVisible(false);
+      setIsMounted(false);
       return;
     }
 

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type { Dispatch, RefObject, SetStateAction } from 'react';
 import type { ActionEvent, Event, LLMConfiguration } from '@openhands/agent-sdk-ts';
 import { isEvent } from '@openhands/agent-sdk-ts';
@@ -162,6 +162,8 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     uiStateRef,
   } = options;
 
+  const lastModeRef = useRef<'local' | 'remote' | null>(null);
+
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       const payload = event.data as {
@@ -204,6 +206,12 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
             setStatus(payload.status);
             if (payload.mode === 'local' || payload.mode === 'remote') {
               setMode(payload.mode);
+              if (payload.mode === 'local' && lastModeRef.current !== 'local') {
+                lastModeRef.current = 'local';
+                postMessage({ type: 'requestTools' });
+              } else if (payload.mode === 'remote' && lastModeRef.current !== 'remote') {
+                lastModeRef.current = 'remote';
+              }
             }
             const nextBanner: StatusBannerState | null =
               payload.mode === 'local'

--- a/src/webview-src/components/inputArea/AccessoryButton.tsx
+++ b/src/webview-src/components/inputArea/AccessoryButton.tsx
@@ -21,7 +21,7 @@ export function AccessoryButton({ icon, label, displayLabel, onClick, badge, com
           text-xs font-medium
           transition-all duration-200
           border
-          focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
+          oh-focus-outline
           ${comingSoon
             ? 'bg-white/[0.02] text-stone-600 border-white/[0.03] cursor-not-allowed'
             : 'bg-white/[0.04] text-stone-400 border-white/[0.06] hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]'

--- a/src/webview-src/components/inputArea/ContextPicker.tsx
+++ b/src/webview-src/components/inputArea/ContextPicker.tsx
@@ -85,7 +85,7 @@ export function ContextPicker({
           placeholder="Search files..."
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
-          className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:border-brand-500/40"
+          className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)] oh-focus-outline"
           autoFocus
         />
       </div>
@@ -113,9 +113,9 @@ export function ContextPicker({
                     transition-all duration-150
                     flex items-center gap-2
                     ${isSelected
-                      ? `bg-brand-500/15 text-brand-300${isActive ? ' ring-1 ring-brand-500/40' : ''}`
+                      ? `bg-brand-500/15 text-brand-300${isActive ? ' oh-outline-soft' : ''}`
                       : isActive
-                        ? 'bg-brand-500/10 text-stone-200 ring-1 ring-brand-500/40'
+                        ? 'bg-brand-500/10 text-stone-200 oh-outline-soft'
                         : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
                     }
                   `}

--- a/src/webview-src/components/inputArea/LlmProfileSelector.tsx
+++ b/src/webview-src/components/inputArea/LlmProfileSelector.tsx
@@ -55,7 +55,7 @@ export function LlmProfileSelector({
             text-xs font-medium
             transition-all duration-200
             border
-            focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
+            oh-focus-outline
             bg-white/[0.04] text-stone-400 border-white/[0.06]
             hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]
           `}

--- a/src/webview-src/components/inputArea/LlmProfileSelector.tsx
+++ b/src/webview-src/components/inputArea/LlmProfileSelector.tsx
@@ -99,32 +99,28 @@ export function LlmProfileSelector({
                       ${selected ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
                     `}
                   >
-                    <Tooltip content={`Select profile ${id}`} position="left">
-                      <button
-                        type="button"
-                        onClick={() => handleSelect(id)}
-                        className="flex-1 flex items-center gap-2 text-left min-w-0"
-                        aria-label={`Select profile ${id}`}
-                      >
-                        <span className="codicon codicon-symbol-misc" />
-                        <span className="flex-1 font-mono truncate">{id}</span>
-                      </button>
-                    </Tooltip>
+                    <button
+                      type="button"
+                      onClick={() => handleSelect(id)}
+                      className="flex-1 flex items-center gap-2 text-left min-w-0"
+                      aria-label={`Select profile ${id}`}
+                    >
+                      <span className="codicon codicon-symbol-misc" />
+                      <span className="flex-1 font-mono truncate">{id}</span>
+                    </button>
 
                     {selected && onOpenEdit && (
-                      <Tooltip content={`Edit profile ${id}`} position="right">
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setIsOpen(false);
-                            onOpenEdit(id);
-                          }}
-                          className="h-7 w-7 rounded-md bg-white/[0.03] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:border-white/[0.1] transition-all flex items-center justify-center"
-                          aria-label={`Edit selected profile ${id}`}
-                        >
-                          <span className="codicon codicon-settings-gear text-[13px]" />
-                        </button>
-                      </Tooltip>
+                      <button
+                        type="button"
+                        onClick={() => {
+                          setIsOpen(false);
+                          onOpenEdit(id);
+                        }}
+                        className="h-7 w-7 rounded-md bg-white/[0.03] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:border-white/[0.1] transition-all flex items-center justify-center"
+                        aria-label={`Edit selected profile ${id}`}
+                      >
+                        <span className="codicon codicon-settings-gear text-[13px]" />
+                      </button>
                     )}
 
                     {selected && <span className="codicon codicon-check text-brand-400" />}
@@ -135,29 +131,27 @@ export function LlmProfileSelector({
 
             <div className="my-1 border-t border-white/10" />
 
-            <Tooltip content="Create a new LLM profile" position="left">
-              <button
-                type="button"
-                onClick={() => {
-                  if (!onOpenCreate) return;
-                  setIsOpen(false);
-                  onOpenCreate();
-                }}
-                className={`
-                  w-full text-left px-3 py-2 rounded-lg
-                  text-sm
-                  transition-colors duration-150
-                  hover:bg-white/10
-                  flex items-center gap-2
-                  ${onOpenCreate ? 'text-stone-300' : 'text-stone-500 cursor-not-allowed'}
-                `}
-                disabled={!onOpenCreate}
-                aria-label="New profile…"
-              >
-                <span className="codicon codicon-add" />
-                <span className="flex-1">New profile…</span>
-              </button>
-            </Tooltip>
+            <button
+              type="button"
+              onClick={() => {
+                if (!onOpenCreate) return;
+                setIsOpen(false);
+                onOpenCreate();
+              }}
+              className={`
+                w-full text-left px-3 py-2 rounded-lg
+                text-sm
+                transition-colors duration-150
+                hover:bg-white/10
+                flex items-center gap-2
+                ${onOpenCreate ? 'text-stone-300' : 'text-stone-500 cursor-not-allowed'}
+              `}
+              disabled={!onOpenCreate}
+              aria-label="New profile…"
+            >
+              <span className="codicon codicon-add" />
+              <span className="flex-1">New profile…</span>
+            </button>
           </div>
         </div>
       )}

--- a/src/webview-src/components/inputArea/SkillsPopover.tsx
+++ b/src/webview-src/components/inputArea/SkillsPopover.tsx
@@ -21,31 +21,33 @@ export function SkillsPopover({
 }: SkillsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
-  const [activeIndex, setActiveIndex] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(-1);
 
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: popoverRef, delay: 100 });
 
   const filteredSkills = skills.filter((skill) => skill.label.toLowerCase().includes(searchQuery.toLowerCase()));
 
   const listboxId = 'skills-picker-listbox';
-  const safeActiveIndex = filteredSkills.length > 0 ? Math.min(activeIndex, filteredSkills.length - 1) : 0;
-  const activeOptionId = filteredSkills.length > 0 ? `skills-picker-option-${safeActiveIndex}` : undefined;
+  const safeActiveIndex = filteredSkills.length > 0 ? Math.min(activeIndex, filteredSkills.length - 1) : -1;
+  const activeOptionId = safeActiveIndex >= 0 ? `skills-picker-option-${safeActiveIndex}` : undefined;
 
   const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'ArrowDown') {
       e.preventDefault();
-      setActiveIndex(() => Math.min(safeActiveIndex + 1, Math.max(filteredSkills.length - 1, 0)));
+      if (filteredSkills.length === 0) return;
+      setActiveIndex(() => (safeActiveIndex < 0 ? 0 : Math.min(safeActiveIndex + 1, filteredSkills.length - 1)));
       return;
     }
 
     if (e.key === 'ArrowUp') {
       e.preventDefault();
-      setActiveIndex(() => Math.max(safeActiveIndex - 1, 0));
+      if (filteredSkills.length === 0) return;
+      setActiveIndex(() => (safeActiveIndex < 0 ? filteredSkills.length - 1 : Math.max(safeActiveIndex - 1, 0)));
       return;
     }
 
     if (e.key === 'Enter') {
-      const skill = filteredSkills[safeActiveIndex];
+      const skill = filteredSkills[safeActiveIndex < 0 ? 0 : safeActiveIndex];
       if (!skill) return;
       e.preventDefault();
       onOpenSkill(skill.path);
@@ -79,13 +81,13 @@ export function SkillsPopover({
           value={searchQuery}
           onChange={(e) => {
             setSearchQuery(e.target.value);
-            setActiveIndex(0);
+            setActiveIndex(-1);
           }}
           onKeyDown={handleSearchKeyDown}
           placeholder="Search skills..."
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
-          className="mt-2 w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:border-brand-500/40"
+          className="mt-2 w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)] oh-focus-outline"
           autoFocus
         />
       </div>
@@ -113,7 +115,7 @@ export function SkillsPopover({
                     flex items-center gap-2
                     group
                     ${isActive
-                      ? 'bg-brand-500/10 text-stone-200 ring-1 ring-brand-500/40'
+                      ? 'bg-brand-500/10 text-stone-200 oh-outline-soft'
                       : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
                     }
                   `}
@@ -131,4 +133,3 @@ export function SkillsPopover({
     </div>
   );
 }
-

--- a/src/webview-src/components/inputArea/ToolsPopover.tsx
+++ b/src/webview-src/components/inputArea/ToolsPopover.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useCloseOnEscapeAndOutsideClick, type CloseReason } from '../useCloseOnEscapeAndOutsideClick';
 
 interface ToolDescriptor {
@@ -22,8 +22,59 @@ export function ToolsPopover({
   onToggleTool,
 }: ToolsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
+  const listboxRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
 
   useCloseOnEscapeAndOutsideClick({ isOpen, onClose, ref: popoverRef, delay: 100 });
+
+  useEffect(() => {
+    if (!isOpen) return;
+    requestAnimationFrame(() => listboxRef.current?.focus());
+  }, [isOpen]);
+
+  const safeActiveIndex = tools.length > 0 ? Math.min(activeIndex, tools.length - 1) : -1;
+  const activeOptionId = safeActiveIndex >= 0 ? `tools-picker-option-${safeActiveIndex}` : undefined;
+
+  const handleListboxKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      onClose('escape');
+      return;
+    }
+
+    if (tools.length === 0) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev < 0 ? 0 : Math.min(prev + 1, tools.length - 1)));
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex((prev) => (prev < 0 ? tools.length - 1 : Math.max(prev - 1, 0)));
+      return;
+    }
+
+    if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveIndex(0);
+      return;
+    }
+
+    if (e.key === 'End') {
+      e.preventDefault();
+      setActiveIndex(tools.length - 1);
+      return;
+    }
+
+    if (e.key === 'Enter' || e.key === ' ') {
+      const tool = tools[safeActiveIndex < 0 ? 0 : safeActiveIndex];
+      if (!tool) return;
+      e.preventDefault();
+      onToggleTool(tool.id);
+    }
+  };
 
   if (!isOpen) return null;
 
@@ -47,27 +98,37 @@ export function ToolsPopover({
         {tools.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-stone-500">No tools available</div>
         ) : (
-          <div className="p-2 space-y-0.5" role="listbox" aria-label="Tools">
-            {tools.map((tool) => {
+          <div
+            ref={listboxRef}
+            className="p-2 space-y-0.5 focus:outline-none oh-focus-outline"
+            role="listbox"
+            aria-label="Tools"
+            aria-activedescendant={activeOptionId}
+            tabIndex={0}
+            onKeyDown={handleListboxKeyDown}
+          >
+            {tools.map((tool, index) => {
               const isEnabled = enabledToolIds.includes(tool.id);
+              const isActive = index === safeActiveIndex;
               return (
                 <button
                   key={tool.id}
                   type="button"
                   onClick={() => onToggleTool(tool.id)}
                   role="option"
+                  id={`tools-picker-option-${index}`}
                   aria-label={tool.label}
                   aria-selected={isEnabled ? 'true' : 'false'}
+                  onMouseEnter={() => setActiveIndex(index)}
                   className={`
                     w-full text-left px-3 py-2 rounded-lg
                     text-sm
                     transition-all duration-150
                     flex items-center gap-2
                     group
-                    ${isEnabled
-                      ? 'bg-brand-500/10 text-stone-200'
-                      : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'
-                    }
+                    ${isEnabled ? 'bg-brand-500/10 text-stone-200 oh-outline-soft' : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'}
+                    ${isActive && !isEnabled ? 'bg-white/[0.04] text-stone-200 oh-outline-soft' : ''}
+                    ${isActive && isEnabled ? 'bg-brand-500/15' : ''}
                   `}
                 >
                   <span className="codicon codicon-symbol-method text-brand-400/70" />
@@ -82,4 +143,3 @@ export function ToolsPopover({
     </div>
   );
 }
-

--- a/src/webview-src/components/llmProfilesView/LlmProfileApiKeySection.tsx
+++ b/src/webview-src/components/llmProfilesView/LlmProfileApiKeySection.tsx
@@ -155,18 +155,21 @@ export function LlmProfileApiKeySection(props: LlmProfileApiKeySectionProps) {
               type="button"
               onClick={() => { void onSaveApiKey(); }}
               disabled={apiKeySaving}
+              aria-label="Save API key"
               className={`
-                inline-flex items-center gap-2 px-3 py-2 rounded-lg
-                text-xs font-medium
+                inline-flex items-center gap-2 px-4 py-2 rounded-lg
+                text-sm font-medium
                 transition-all
                 border
+                focus:outline-none focus:ring-0
+                focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
                 ${apiKeySaving
                   ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
                   : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
               `}
             >
               <span className={`codicon codicon-${apiKeySaving ? 'loading' : 'save'} ${apiKeySaving ? 'animate-spin' : ''}`} />
-              Save key
+              {apiKeySaving ? 'Saving…' : 'Save'}
             </button>
           </div>
         </div>

--- a/src/webview-src/components/llmProfilesView/LlmProfileApiKeySection.tsx
+++ b/src/webview-src/components/llmProfilesView/LlmProfileApiKeySection.tsx
@@ -84,13 +84,13 @@ export function LlmProfileApiKeySection(props: LlmProfileApiKeySectionProps) {
               )}
             </div>
             <label className="flex items-center gap-2 text-xs text-stone-300 select-none">
-              <input
-                type="checkbox"
-                checked={overrideProfileApiKey}
-                onChange={(e) => { onToggleOverrideProfileApiKey(e.target.checked); }}
-                disabled={apiKeySaving || (mode === 'edit' && !canEditApiKey)}
-                className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0 disabled:opacity-50"
-              />
+                <input
+                  type="checkbox"
+                  checked={overrideProfileApiKey}
+                  onChange={(e) => { onToggleOverrideProfileApiKey(e.target.checked); }}
+                  disabled={apiKeySaving || (mode === 'edit' && !canEditApiKey)}
+                  className="h-4 w-4 rounded border border-white/[0.2] bg-white/[0.02] text-brand-500 disabled:opacity-50 oh-focus-outline"
+                />
               Override for this profile
             </label>
           </div>
@@ -162,10 +162,10 @@ export function LlmProfileApiKeySection(props: LlmProfileApiKeySectionProps) {
                 transition-all
                 border
                 focus:outline-none focus:ring-0
-                focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
+                focus-visible:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]
                 ${apiKeySaving
                   ? 'bg-white/[0.03] text-stone-500 border-white/[0.06] cursor-not-allowed'
-                  : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40'}
+                  : 'bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border-white/[0.06] oh-outline-soft hover:from-brand-500/35 hover:to-brand-600/30 hover:border-white/[0.1]'}
               `}
             >
               <span className={`codicon codicon-${apiKeySaving ? 'loading' : 'save'} ${apiKeySaving ? 'animate-spin' : ''}`} />

--- a/src/webview-src/components/llmProfilesView/LlmProfilesPanelHeader.tsx
+++ b/src/webview-src/components/llmProfilesView/LlmProfilesPanelHeader.tsx
@@ -30,7 +30,7 @@ export function LlmProfilesPanelHeader(props: {
           <button
             type="button"
             onClick={onCreate}
-            className="h-9 w-9 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40 transition-all flex items-center justify-center"
+            className="h-9 w-9 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-white/[0.06] oh-outline-soft hover:from-brand-500/35 hover:to-brand-600/30 hover:border-white/[0.1] transition-all flex items-center justify-center oh-focus-outline"
             aria-label="Create profile"
           >
             <span className="codicon codicon-add" />
@@ -41,7 +41,7 @@ export function LlmProfilesPanelHeader(props: {
             type="button"
             onClick={onDuplicate}
             disabled={duplicateDisabled}
-            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
             aria-label="Duplicate profile"
           >
             <span className="codicon codicon-copy" />
@@ -52,7 +52,7 @@ export function LlmProfilesPanelHeader(props: {
             type="button"
             onClick={() => { void onDelete(); }}
             disabled={deleteDisabled}
-            className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+            className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed oh-focus-outline"
             aria-label="Delete profile"
           >
             <span className={`codicon codicon-${deleting ? 'loading' : 'trash'} ${deleting ? 'animate-spin' : ''}`} />
@@ -62,7 +62,7 @@ export function LlmProfilesPanelHeader(props: {
           <button
             type="button"
             onClick={onClose}
-            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
+            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center oh-focus-outline"
             aria-label="Close profiles view"
           >
             <span className="codicon codicon-close" />

--- a/src/webview-src/components/llmProfilesView/LlmProfilesPanelHeader.tsx
+++ b/src/webview-src/components/llmProfilesView/LlmProfilesPanelHeader.tsx
@@ -1,4 +1,5 @@
 import type { ProfileFormMode } from './formState';
+import { Tooltip } from '../Tooltip';
 
 export function LlmProfilesPanelHeader(props: {
   mode: ProfileFormMode;
@@ -25,46 +26,49 @@ export function LlmProfilesPanelHeader(props: {
         <h2 className="font-semibold text-base leading-tight text-stone-100">OpenHands - LLM Profiles</h2>
       </div>
       <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={onCreate}
-          className="h-9 w-9 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40 transition-all flex items-center justify-center"
-          aria-label="Create profile"
-          title="Create profile"
-        >
-          <span className="codicon codicon-add" />
-        </button>
-        <button
-          type="button"
-          onClick={onDuplicate}
-          disabled={duplicateDisabled}
-          className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-          aria-label="Duplicate profile"
-          title="Duplicate profile"
-        >
-          <span className="codicon codicon-copy" />
-        </button>
-        <button
-          type="button"
-          onClick={() => { void onDelete(); }}
-          disabled={deleteDisabled}
-          className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
-          aria-label="Delete profile"
-          title="Delete profile"
-        >
-          <span className={`codicon codicon-${deleting ? 'loading' : 'trash'} ${deleting ? 'animate-spin' : ''}`} />
-        </button>
-        <button
-          type="button"
-          onClick={onClose}
-          className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
-          aria-label="Close profiles view"
-          title="Close"
-        >
-          <span className="codicon codicon-close" />
-        </button>
+        <Tooltip content="Create profile" position="bottom">
+          <button
+            type="button"
+            onClick={onCreate}
+            className="h-9 w-9 rounded-lg bg-gradient-to-b from-brand-500/25 to-brand-600/20 text-brand-200 border border-brand-500/30 hover:from-brand-500/35 hover:to-brand-600/30 hover:border-brand-500/40 transition-all flex items-center justify-center"
+            aria-label="Create profile"
+          >
+            <span className="codicon codicon-add" />
+          </button>
+        </Tooltip>
+        <Tooltip content="Duplicate profile" position="bottom">
+          <button
+            type="button"
+            onClick={onDuplicate}
+            disabled={duplicateDisabled}
+            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Duplicate profile"
+          >
+            <span className="codicon codicon-copy" />
+          </button>
+        </Tooltip>
+        <Tooltip content="Delete profile" position="bottom">
+          <button
+            type="button"
+            onClick={() => { void onDelete(); }}
+            disabled={deleteDisabled}
+            className="h-9 w-9 rounded-lg bg-red-500/10 border border-red-500/20 text-red-200 hover:bg-red-500/15 hover:border-red-500/30 transition-all flex items-center justify-center disabled:opacity-50 disabled:cursor-not-allowed"
+            aria-label="Delete profile"
+          >
+            <span className={`codicon codicon-${deleting ? 'loading' : 'trash'} ${deleting ? 'animate-spin' : ''}`} />
+          </button>
+        </Tooltip>
+        <Tooltip content="Close" position="bottom">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-9 w-9 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-400 hover:text-stone-100 hover:bg-white/[0.08] transition-all flex items-center justify-center"
+            aria-label="Close profiles view"
+          >
+            <span className="codicon codicon-close" />
+          </button>
+        </Tooltip>
       </div>
     </div>
   );
 }
-

--- a/src/webview-src/components/llmProfilesView/fields.tsx
+++ b/src/webview-src/components/llmProfilesView/fields.tsx
@@ -54,7 +54,9 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
         w-full px-3 py-2 rounded-lg
         bg-white/[0.03] border border-white/[0.06]
         text-stone-200 placeholder:text-stone-600
-        focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
+        focus:outline-none focus:ring-0
+        focus:border-white/[0.08]
+        focus:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
         disabled:opacity-50 disabled:cursor-not-allowed
         ${hideNumberSpinners}
       `}

--- a/src/webview-src/components/llmProfilesView/fields.tsx
+++ b/src/webview-src/components/llmProfilesView/fields.tsx
@@ -56,7 +56,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
         text-stone-200 placeholder:text-stone-600
         focus:outline-none focus:ring-0
         focus:border-white/[0.08]
-        focus:shadow-[0_0_0_1px_rgba(232,166,66,0.16)]
+        focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)]
         disabled:opacity-50 disabled:cursor-not-allowed
         ${hideNumberSpinners}
       `}
@@ -108,7 +108,7 @@ export function PopoverSelectField(props: PopoverSelectFieldProps) {
           text-xs font-medium
           transition-all duration-200
           border
-          focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
+          oh-focus-outline
           bg-white/[0.03] text-stone-400 border-white/[0.06]
           hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]
           disabled:opacity-50 disabled:cursor-not-allowed

--- a/src/webview-src/components/llmProfilesView/fields.tsx
+++ b/src/webview-src/components/llmProfilesView/fields.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, type ReactNode } from 'react';
+import { forwardRef, useRef, useState } from 'react';
+import { DropdownPopover, type DropdownPopoverPlacement } from '../DropdownPopover';
 
 export function FieldLabel({ label, required, htmlFor }: { label: string; required?: boolean; htmlFor?: string }) {
   const requiredMarker = required ? <span className="text-red-400" aria-hidden="true"> *</span> : null;
@@ -61,31 +62,123 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
   );
 });
 
-type SelectFieldProps = {
+type PopoverSelectOption = {
+  value: string;
+  label: string;
+  disabled?: boolean;
+};
+
+type PopoverSelectFieldProps = {
   id?: string;
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
-  children: ReactNode;
+  options: PopoverSelectOption[];
+  placeholder?: string;
+  preferPlacement?: DropdownPopoverPlacement;
+  ariaLabel?: string;
+  icon?: string;
 };
 
-export const SelectField = forwardRef<HTMLSelectElement, SelectFieldProps>(function SelectField(props, ref) {
+export function PopoverSelectField(props: PopoverSelectFieldProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isDisabled = Boolean(props.disabled);
+  const selected = props.options.find((option) => option.value === props.value);
+  const shown = selected?.label ?? props.placeholder ?? 'Select…';
+
   return (
-    <select
-      ref={ref}
-      id={props.id}
-      value={props.value}
-      onChange={(e) => props.onChange(e.target.value)}
-      disabled={props.disabled}
-      className={`
-        w-full px-3 py-2 rounded-lg
-        bg-white/[0.03] border border-white/[0.06]
-        text-stone-200
-        focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:ring-offset-0
-        disabled:opacity-50 disabled:cursor-not-allowed
-      `}
-    >
-      {props.children}
-    </select>
+    <div className="relative">
+      <button
+        ref={buttonRef}
+        id={props.id}
+        type="button"
+        onClick={() => setIsOpen((prev) => (isDisabled ? false : !prev))}
+        disabled={isDisabled}
+        aria-label={props.ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        className={`
+          w-full
+          inline-flex items-center gap-2
+          px-3 py-2 rounded-lg
+          text-xs font-medium
+          transition-all duration-200
+          border
+          focus:outline-none focus:ring-1 focus:ring-brand-500/30 focus:ring-offset-0
+          bg-white/[0.03] text-stone-400 border-white/[0.06]
+          hover:bg-white/[0.08] hover:text-stone-300 hover:border-white/[0.1]
+          disabled:opacity-50 disabled:cursor-not-allowed
+          disabled:hover:bg-white/[0.03] disabled:hover:text-stone-400 disabled:hover:border-white/[0.06]
+        `}
+      >
+        {props.icon && <span className={`codicon ${props.icon} text-[13px] text-brand-400/70`} aria-hidden="true" />}
+        <span className="flex-1 font-mono text-stone-300 truncate">{shown}</span>
+        <span className={`codicon codicon-chevron-${isOpen ? 'up' : 'down'} text-[10px] opacity-70`} aria-hidden="true" />
+      </button>
+
+      <DropdownPopover
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        triggerRef={buttonRef}
+        preferPlacement={props.preferPlacement}
+        className="w-full z-50"
+      >
+        <div
+          role="listbox"
+          aria-label={props.ariaLabel ?? 'Select'}
+          className="
+            overflow-hidden rounded-xl
+            bg-[var(--surface-2)]/95
+            backdrop-blur-md
+            border border-white/[0.08]
+            shadow-lg shadow-black/30
+          "
+          style={{
+            boxShadow: `
+              inset 0 1px 0 rgba(255, 255, 255, 0.06),
+              0 12px 24px rgba(0, 0, 0, 0.55),
+              0 0 0 1px rgba(232, 166, 66, 0.10)
+            `,
+          }}
+        >
+          <div className="p-2 space-y-1">
+            {props.options.map((option) => {
+              const isSelected = option.value === props.value;
+              const isOptionDisabled = isDisabled || option.disabled === true;
+              return (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="option"
+                  aria-selected={isSelected}
+                  aria-label={option.label}
+                  disabled={isOptionDisabled}
+                  onClick={() => {
+                    if (isOptionDisabled) return;
+                    props.onChange(option.value);
+                    setIsOpen(false);
+                  }}
+                  className={`
+                    w-full text-left px-3 py-2 rounded-lg
+                    text-sm
+                    transition-colors duration-150
+                    flex items-center gap-2
+                    hover:bg-white/10
+                    ${isSelected ? 'bg-brand-500/20 text-brand-300' : 'text-stone-300'}
+                    ${isOptionDisabled ? 'opacity-50 cursor-not-allowed' : ''}
+                  `}
+                >
+                  <span className="codicon codicon-symbol-misc opacity-70" aria-hidden="true" />
+                  <span className="flex-1 font-mono truncate">{option.label}</span>
+                  {isSelected && <span className="codicon codicon-check text-brand-400" aria-hidden="true" />}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </DropdownPopover>
+    </div>
   );
-});
+}

--- a/src/webview-src/tailwind.css
+++ b/src/webview-src/tailwind.css
@@ -155,43 +155,43 @@
 @keyframes tooltipUp {
   0% {
     opacity: 0;
-    transform: translateX(-50%) translateY(4px);
+    transform: translateY(4px);
   }
   100% {
     opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    transform: translateY(0);
   }
 }
 
 @keyframes tooltipDown {
   0% {
     opacity: 0;
-    transform: translateX(-50%) translateY(-4px);
+    transform: translateY(-4px);
   }
   100% {
     opacity: 1;
-    transform: translateX(-50%) translateY(0);
+    transform: translateY(0);
   }
 }
 
 @keyframes tooltipLeft {
   0% {
     opacity: 0;
-    transform: translateY(-50%) translateX(4px);
+    transform: translateX(4px);
   }
   100% {
     opacity: 1;
-    transform: translateY(-50%) translateX(0);
+    transform: translateX(0);
   }
 }
 
 @keyframes tooltipRight {
   0% {
     opacity: 0;
-    transform: translateY(-50%) translateX(-4px);
+    transform: translateX(-4px);
   }
   100% {
     opacity: 1;
-    transform: translateY(-50%) translateX(0);
+    transform: translateX(0);
   }
 }

--- a/src/webview-src/tailwind.css
+++ b/src/webview-src/tailwind.css
@@ -99,6 +99,12 @@
     box-shadow: 0 0 16px rgba(232, 166, 66, 0.35);
   }
 
+  .shadow-glow-outline {
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.06),
+      0 0 0 1px rgba(232, 166, 66, 0.08);
+  }
+
   .shadow-glow-lg {
     box-shadow: 0 0 24px rgba(232, 166, 66, 0.45);
   }
@@ -131,6 +137,21 @@
     );
     backdrop-filter: blur(16px);
     border: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  /* Soft focus + selection outline (replace thick brand rings) */
+  .oh-outline-soft {
+    box-shadow: 0 0 0 1px rgba(232, 166, 66, 0.08);
+  }
+
+  .oh-focus-outline:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px rgba(232, 166, 66, 0.08);
+  }
+
+  .oh-focus-outline:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px rgba(232, 166, 66, 0.08);
   }
 
   /* Tooltip animations - warm technical refinement style */

--- a/src/webview-src/tailwind.css
+++ b/src/webview-src/tailwind.css
@@ -86,6 +86,19 @@
     background: rgba(232, 166, 66, 0.3);
     color: inherit;
   }
+
+  /* Global focus styling for interactive elements - same as hover */
+  button:focus-visible,
+  [role="option"]:focus-visible,
+  [role="option"]:focus-within {
+    outline: none;
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+
+  /* Don't double-apply background to buttons inside option containers */
+  [role="option"] button:focus-visible {
+    background-color: transparent;
+  }
 }
 
 /* Custom utilities for OpenHands design */

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -668,14 +668,19 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           const key = getProfileApiKeySecretKey(profileId);
           const stored = await context.secrets.get(key);
           const hasProfileKey = typeof stored === 'string' && stored.trim().length > 0;
-          const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
           const overrideProviderRaw = typeof message.provider === 'string' ? message.provider.trim() : '';
           const overrideProvider = overrideProviderRaw && isLlmProvider(overrideProviderRaw) ? overrideProviderRaw : null;
           const overrideBaseUrl = typeof message.baseUrl === 'string' ? message.baseUrl.trim() : '';
-          const provider = overrideProvider
-            ?? (overrideBaseUrl ? detectProviderFromBaseUrl(overrideBaseUrl) : null)
-            ?? profile.config.provider
-            ?? detectProviderFromBaseUrl(profile.config.baseUrl);
+
+          // Prefer explicit provider/baseUrl overrides so we can check provider keys even for
+          // draft/new profiles that do not exist yet on disk.
+          const provider = (() => {
+            if (overrideProvider) return overrideProvider;
+            if (overrideBaseUrl) return detectProviderFromBaseUrl(overrideBaseUrl);
+
+            const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
+            return profile.config.provider ?? detectProviderFromBaseUrl(profile.config.baseUrl);
+          })();
           const providerKeyName = getProviderApiKeyName(provider);
           const hasProviderKey = await hasStoredSecret(providerKeyName);
           void host.postMessage({


### PR DESCRIPTION
Bead: oh-tab-gger

- Replace native selects in `LlmProfilesView` with a shared `PopoverSelectField` so dropdown styling matches the OpenHands theme.
- Add `DropdownPopover` with automatic up/down placement (Profile opens down; other dropdowns prefer up).
- Fix tooltip anchor jump by computing final position before paint.
- Theme the max-output-tokens slider via `accent-brand-500`.

Tests:
- `npx vitest run src/webview-src/__tests__/LlmProfilesView.test.tsx`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Popover-based dropdowns/selectors across profile and settings; LLM Profiles documentation added.

* **Refactor**
  * Select controls and tooltips migrated to popover-based behavior; provider/profile API-key checks now respect override inputs and draft profiles.

* **Tests**
  * Tests standardized to use a reusable dropdown-selection helper; UI assertions updated.

* **Accessibility**
  * Improved keyboard navigation, listbox semantics, and ARIA attributes for popovers.

* **Style**
  * Unified focus/outline utilities and refreshed focus visuals and button labels (e.g., "Save API key").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->