### PR TITLE
Show all available tools and allow user selection

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -125,7 +125,10 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     TerminalTool: vi.fn(() => new StubTool('terminal')),
     FileEditorTool: vi.fn(() => new StubTool('file_editor')),
     TaskTrackerTool: vi.fn(() => new StubTool('task_tracker')),
+    GlobTool: vi.fn(() => new StubTool('glob')),
+    GrepTool: vi.fn(() => new StubTool('grep')),
     BrowserTool: vi.fn(() => new StubTool('browser')),
+    FinishTool: vi.fn(() => new StubTool('finish')),
   };
 });
 

--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -44,9 +44,13 @@ describe('Tools picker host messages', () => {
 
     const payload = postMessage.mock.calls[0][0] as any;
     expect(payload.tools).toEqual([
-      { id: 'terminal', label: 'Terminal' },
-      { id: 'file_editor', label: 'File Editor' },
-      { id: 'task_tracker', label: 'Task Tracker' },
+      { id: 'terminal', label: 'Terminal', description: 'Execute shell commands in a controlled environment', isDefault: true },
+      { id: 'file_editor', label: 'File Editor', description: 'Read, create, and modify files in the workspace', isDefault: true },
+      { id: 'task_tracker', label: 'Task Tracker', description: 'Track tasks and progress during the conversation', isDefault: true },
+      { id: 'glob', label: 'File Search (Glob)', description: 'Find files by name patterns (e.g., **/*.ts)', isDefault: false },
+      { id: 'grep', label: 'Content Search (Grep)', description: 'Search file contents using regex patterns', isDefault: false },
+      { id: 'browser', label: 'Web Fetch', description: 'Make HTTP GET/POST requests to fetch web content', isDefault: false },
+      { id: 'finish', label: 'Finish', description: 'Signal that the agent has completed its task', isDefault: false },
     ]);
   });
 

--- a/src/shared/localTools.ts
+++ b/src/shared/localTools.ts
@@ -1,17 +1,73 @@
 import type { ToolDefinition } from '@openhands/agent-sdk-ts';
-import { FileEditorTool, TaskTrackerTool, TerminalTool } from '@openhands/agent-sdk-ts';
+import {
+  BrowserTool,
+  FileEditorTool,
+  FinishTool,
+  GlobTool,
+  GrepTool,
+  TaskTrackerTool,
+  TerminalTool,
+} from '@openhands/agent-sdk-ts';
 
-export type LocalToolId = 'terminal' | 'file_editor' | 'task_tracker';
+export type LocalToolId =
+  | 'terminal'
+  | 'file_editor'
+  | 'task_tracker'
+  | 'glob'
+  | 'grep'
+  | 'browser'
+  | 'finish';
 
 export type LocalToolDescriptor = {
   id: LocalToolId;
   label: string;
+  description: string;
+  isDefault: boolean;
 };
 
 const LOCAL_TOOLS: LocalToolDescriptor[] = [
-  { id: 'terminal', label: 'Terminal' },
-  { id: 'file_editor', label: 'File Editor' },
-  { id: 'task_tracker', label: 'Task Tracker' },
+  {
+    id: 'terminal',
+    label: 'Terminal',
+    description: 'Execute shell commands in a controlled environment',
+    isDefault: true,
+  },
+  {
+    id: 'file_editor',
+    label: 'File Editor',
+    description: 'Read, create, and modify files in the workspace',
+    isDefault: true,
+  },
+  {
+    id: 'task_tracker',
+    label: 'Task Tracker',
+    description: 'Track tasks and progress during the conversation',
+    isDefault: true,
+  },
+  {
+    id: 'glob',
+    label: 'File Search (Glob)',
+    description: 'Find files by name patterns (e.g., **/*.ts)',
+    isDefault: false,
+  },
+  {
+    id: 'grep',
+    label: 'Content Search (Grep)',
+    description: 'Search file contents using regex patterns',
+    isDefault: false,
+  },
+  {
+    id: 'browser',
+    label: 'Web Fetch',
+    description: 'Make HTTP GET/POST requests to fetch web content',
+    isDefault: false,
+  },
+  {
+    id: 'finish',
+    label: 'Finish',
+    description: 'Signal that the agent has completed its task',
+    isDefault: false,
+  },
 ];
 
 type LocalToolInstances = Record<LocalToolId, ToolDefinition<unknown, unknown>>;
@@ -23,7 +79,13 @@ export function listLocalToolDescriptors(): LocalToolDescriptor[] {
 }
 
 export function getDefaultLocalToolIds(): LocalToolId[] {
-  return LOCAL_TOOLS.map((tool) => tool.id);
+  return LOCAL_TOOLS.filter((tool) => tool.isDefault).map((tool) => tool.id);
+}
+
+const VALID_TOOL_IDS = new Set<LocalToolId>(LOCAL_TOOLS.map((tool) => tool.id));
+
+export function isValidLocalToolId(id: string): id is LocalToolId {
+  return VALID_TOOL_IDS.has(id as LocalToolId);
 }
 
 export function normalizeLocalToolIds(value: unknown): LocalToolId[] | null {
@@ -34,8 +96,8 @@ export function normalizeLocalToolIds(value: unknown): LocalToolId[] | null {
   const seen = new Set<LocalToolId>();
   for (const item of value) {
     if (typeof item !== 'string') continue;
-    const id = item.trim() as LocalToolId;
-    if (id !== 'terminal' && id !== 'file_editor' && id !== 'task_tracker') continue;
+    const id = item.trim();
+    if (!isValidLocalToolId(id)) continue;
     if (seen.has(id)) continue;
     seen.add(id);
     out.push(id);
@@ -49,6 +111,10 @@ function getOrCreateLocalToolInstances(): LocalToolInstances {
     terminal: new TerminalTool(),
     file_editor: new FileEditorTool(),
     task_tracker: new TaskTrackerTool(),
+    glob: new GlobTool(),
+    grep: new GrepTool(),
+    browser: new BrowserTool(),
+    finish: new FinishTool(),
   };
   return instances;
 }
@@ -59,7 +125,7 @@ export function resolveLocalTools(toolIds?: LocalToolId[] | null): ToolDefinitio
   const ids = toolIds === undefined || toolIds === null ? getDefaultLocalToolIds() : toolIds;
 
   for (const id of ids) {
-    if (id === 'terminal' || id === 'file_editor' || id === 'task_tracker') {
+    if (isValidLocalToolId(id)) {
       resolved.push(byId[id]);
     }
   }

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -53,7 +53,7 @@ export type HostToWebviewMessage =
   }
   | { type: 'workspaceFiles'; files: string[] }
   | { type: 'skillsList'; skills: Array<{ label: string; path: string }> }
-  | { type: 'toolsList'; tools: Array<{ id: string; label: string }>; enabledToolIds: string[] }
+  | { type: 'toolsList'; tools: Array<{ id: string; label: string; description?: string; isDefault?: boolean }>; enabledToolIds: string[] }
   | { type: 'attachmentsSelected'; attachments: Array<{ uri: string; label: string; sizeBytes?: number }> }
   | { type: 'config'; serverUrl: string | null; mode: 'local' | 'remote' }
   | { type: 'conversationStarted'; conversationId: string }

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -480,4 +480,143 @@ describe('Agent-SDK event rendering', () => {
     });
   });
 
+  it('renders friendly summaries for glob tool events', async () => {
+    render(<App />);
+    const actionEvent = {
+      kind: 'ActionEvent',
+      source: 'agent' as const,
+      thought: [{ type: 'text' as const, text: 'Finding TypeScript files' }],
+      action: { pattern: '**/*.ts', path: '/workspace' },
+      tool_name: 'glob',
+      tool_call_id: 'call_glob_1',
+      tool_call: { id: 'call_glob_1', type: 'function' as const, function: { name: 'glob', arguments: '{}' } },
+      llm_response_id: 'resp_glob_1',
+    } as any;
+    postToWindow({ type: 'event', event: actionEvent });
+    expect(await screen.findByText(/The agent wants to search for files matching a pattern/)).toBeInTheDocument();
+    expect(await screen.findByText('**/*.ts')).toBeInTheDocument();
+
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        files: ['/workspace/src/index.ts', '/workspace/src/utils.ts', '/workspace/test/test.ts'],
+        pattern: '**/*.ts',
+        searchPath: '/workspace',
+        truncated: false,
+      },
+      tool_name: 'glob',
+      tool_call_id: 'call_glob_1',
+      action_id: 'action_glob_1',
+    } as any;
+    postToWindow({ type: 'event', event: observationEvent });
+    const foundTexts = await screen.findAllByText(/Found/);
+    expect(foundTexts.length).toBeGreaterThan(0);
+    expect(await screen.findByText('3')).toBeInTheDocument();
+    // Check file count is displayed
+    const fileTexts = await screen.findAllByText(/file/i);
+    expect(fileTexts.length).toBeGreaterThan(0);
+  });
+
+  it('renders friendly summaries for grep tool events', async () => {
+    render(<App />);
+    const actionEvent = {
+      kind: 'ActionEvent',
+      source: 'agent' as const,
+      thought: [{ type: 'text' as const, text: 'Searching for TODO comments' }],
+      action: { pattern: 'TODO:', include: '*.ts' },
+      tool_name: 'grep',
+      tool_call_id: 'call_grep_1',
+      tool_call: { id: 'call_grep_1', type: 'function' as const, function: { name: 'grep', arguments: '{}' } },
+      llm_response_id: 'resp_grep_1',
+    } as any;
+    postToWindow({ type: 'event', event: actionEvent });
+    expect(await screen.findByText(/The agent wants to search file contents for a pattern/)).toBeInTheDocument();
+    expect(await screen.findByText('TODO:')).toBeInTheDocument();
+
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        matches: ['/workspace/src/index.ts', '/workspace/src/utils.ts'],
+        pattern: 'TODO:',
+        searchPath: '/workspace',
+        includePattern: '*.ts',
+        truncated: false,
+      },
+      tool_name: 'grep',
+      tool_call_id: 'call_grep_1',
+      action_id: 'action_grep_1',
+    } as any;
+    postToWindow({ type: 'event', event: observationEvent });
+    expect(await screen.findByText(/Found/)).toBeInTheDocument();
+    expect(await screen.findByText('2')).toBeInTheDocument();
+    expect(await screen.findByText(/matching file/)).toBeInTheDocument();
+  });
+
+  it('renders friendly summaries for browser tool events', async () => {
+    render(<App />);
+    const actionEvent = {
+      kind: 'ActionEvent',
+      source: 'agent' as const,
+      thought: [{ type: 'text' as const, text: 'Fetching API data' }],
+      action: { url: 'https://api.example.com/data', method: 'GET' },
+      tool_name: 'browser',
+      tool_call_id: 'call_browser_1',
+      tool_call: { id: 'call_browser_1', type: 'function' as const, function: { name: 'browser', arguments: '{}' } },
+      llm_response_id: 'resp_browser_1',
+    } as any;
+    postToWindow({ type: 'event', event: actionEvent });
+    expect(await screen.findByText(/The agent wants to fetch a web resource/)).toBeInTheDocument();
+    expect(await screen.findByText('GET')).toBeInTheDocument();
+    expect(await screen.findByText('https://api.example.com/data')).toBeInTheDocument();
+
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        url: 'https://api.example.com/data',
+        status: 200,
+        content: '{"result": "success"}',
+      },
+      tool_name: 'browser',
+      tool_call_id: 'call_browser_1',
+      action_id: 'action_browser_1',
+    } as any;
+    postToWindow({ type: 'event', event: observationEvent });
+    expect(await screen.findByText('200')).toBeInTheDocument();
+    expect(await screen.findByText(/Received 21 characters/)).toBeInTheDocument();
+  });
+
+  it('renders friendly summaries for finish tool events', async () => {
+    render(<App />);
+    const actionEvent = {
+      kind: 'ActionEvent',
+      source: 'agent' as const,
+      thought: [{ type: 'text' as const, text: 'Task completed successfully' }],
+      action: { message: 'All tests pass and the code is ready for review.' },
+      tool_name: 'finish',
+      tool_call_id: 'call_finish_1',
+      tool_call: { id: 'call_finish_1', type: 'function' as const, function: { name: 'finish', arguments: '{}' } },
+      llm_response_id: 'resp_finish_1',
+    } as any;
+    postToWindow({ type: 'event', event: actionEvent });
+    expect(await screen.findByText(/The agent wants to finish the current task/)).toBeInTheDocument();
+    expect(await screen.findByText(/All tests pass and the code is ready for review/)).toBeInTheDocument();
+
+    const observationEvent = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        message: 'All tests pass and the code is ready for review.',
+      },
+      tool_name: 'finish',
+      tool_call_id: 'call_finish_1',
+      action_id: 'action_finish_1',
+    } as any;
+    postToWindow({ type: 'event', event: observationEvent });
+    const completedTexts = await screen.findAllByText(/Task completed/);
+    expect(completedTexts.length).toBeGreaterThan(0);
+  });
+
 });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -78,7 +78,7 @@ export function App() {
 
   // Tools state (local mode only)
   const [showToolsPopover, setShowToolsPopover] = useState(false);
-  const [tools, setTools] = useState<{ id: string; label: string }[]>([]);
+  const [tools, setTools] = useState<{ id: string; label: string; description?: string; isDefault?: boolean }[]>([]);
   const [enabledToolIds, setEnabledToolIds] = useState<string[]>([]);
 
   // History state

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -89,7 +89,7 @@ export type HostMessageHandlerOptions = {
   setStatus: Dispatch<SetStateAction<'online' | 'offline' | 'connecting'>>;
   setStatusBanner: Dispatch<SetStateAction<StatusBannerState | null>>;
   setStreamingContent: Dispatch<SetStateAction<string | null>>;
-  setTools: Dispatch<SetStateAction<{ id: string; label: string }[]>>;
+  setTools: Dispatch<SetStateAction<{ id: string; label: string; description?: string; isDefault?: boolean }[]>>;
   setWorkspaceFiles: Dispatch<SetStateAction<string[]>>;
   showStatusMessage: ShowStatusMessage;
   currentServerUrlRef: RefObject<string | undefined>;

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -509,12 +509,19 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
         case 'toolsList': {
           if (!Array.isArray(payload.tools) || !Array.isArray(payload.enabledToolIds)) break;
           setTools(
-            payload.tools.filter((tool): tool is { id: string; label: string } => (
-              typeof tool === 'object'
-              && tool !== null
-              && typeof (tool as { id?: unknown }).id === 'string'
-              && typeof (tool as { label?: unknown }).label === 'string'
-            ))
+            payload.tools
+              .filter((tool): tool is { id: string; label: string; description?: string; isDefault?: boolean } => (
+                typeof tool === 'object'
+                && tool !== null
+                && typeof (tool as { id?: unknown }).id === 'string'
+                && typeof (tool as { label?: unknown }).label === 'string'
+              ))
+              .map((tool) => ({
+                id: tool.id,
+                label: tool.label,
+                description: typeof tool.description === 'string' ? tool.description : undefined,
+                isDefault: typeof tool.isDefault === 'boolean' ? tool.isDefault : undefined,
+              }))
           );
           setEnabledToolIds(payload.enabledToolIds.filter((id): id is string => typeof id === 'string'));
           break;

--- a/src/webview-src/components/eventBlocks/ActionEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ActionEventBlock.tsx
@@ -1,7 +1,17 @@
 import { useState } from 'react';
 import type { ActionEvent } from '@openhands/agent-sdk-ts';
 import { SecurityRiskBadge } from '../SecurityRiskBadge';
-import { ACTION_ACCENT_COLOR, EventContainer, FileEditorActionSummary, TerminalActionSummary, withAlpha } from './shared';
+import {
+  ACTION_ACCENT_COLOR,
+  BrowserActionSummary,
+  EventContainer,
+  FileEditorActionSummary,
+  FinishActionSummary,
+  GlobActionSummary,
+  GrepActionSummary,
+  TerminalActionSummary,
+  withAlpha,
+} from './shared';
 
 /**
  * Renders agent action - shows thought process, tool invocation, and security risk.
@@ -10,13 +20,25 @@ export function ActionEventBlock({ event, index }: { event: ActionEvent; index?:
   const thought = event.thought.map((t) => t.text).join('\n');
   const isExecuted = event.action !== null;
   const [isExpanded, setIsExpanded] = useState(false);
-  const actionSummary = isExecuted
-    ? event.tool_name === 'file_editor'
-      ? <FileEditorActionSummary action={event.action} />
-      : event.tool_name === 'terminal'
-        ? <TerminalActionSummary action={event.action} />
-        : null
-    : null;
+  const actionSummary = (() => {
+    if (!isExecuted) return null;
+    switch (event.tool_name) {
+      case 'file_editor':
+        return <FileEditorActionSummary action={event.action} />;
+      case 'terminal':
+        return <TerminalActionSummary action={event.action} />;
+      case 'glob':
+        return <GlobActionSummary action={event.action} />;
+      case 'grep':
+        return <GrepActionSummary action={event.action} />;
+      case 'browser':
+        return <BrowserActionSummary action={event.action} />;
+      case 'finish':
+        return <FinishActionSummary action={event.action} />;
+      default:
+        return null;
+    }
+  })();
 
   return (
     <EventContainer accentColor={ACTION_ACCENT_COLOR} bgOpacity={0.05} index={index}>

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -1,6 +1,16 @@
 import { useState } from 'react';
 import type { ObservationEvent } from '@openhands/agent-sdk-ts';
-import { EventContainer, FileEditorObservationSummary, OBSERVATION_ACCENT_COLOR, TerminalObservationSummary, withAlpha, MarkdownMessage } from './shared';
+import {
+  BrowserObservationSummary,
+  EventContainer,
+  FileEditorObservationSummary,
+  GlobObservationSummary,
+  GrepObservationSummary,
+  MarkdownMessage,
+  OBSERVATION_ACCENT_COLOR,
+  TerminalObservationSummary,
+  withAlpha,
+} from './shared';
 import { Tooltip } from '../Tooltip';
 
 /**
@@ -48,11 +58,22 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
     const command = typeof candidate.command === 'string' ? candidate.command : '';
     return command === 'insert' || command === 'str_replace';
   })();
-  const observationSummary = event.tool_name === 'file_editor'
-    ? <FileEditorObservationSummary observation={event.observation} />
-    : event.tool_name === 'terminal'
-      ? <TerminalObservationSummary observation={event.observation} isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />
-      : null;
+  const observationSummary = (() => {
+    switch (event.tool_name) {
+      case 'file_editor':
+        return <FileEditorObservationSummary observation={event.observation} />;
+      case 'terminal':
+        return <TerminalObservationSummary observation={event.observation} isExpanded={isExpanded} onToggle={() => setIsExpanded(!isExpanded)} />;
+      case 'glob':
+        return <GlobObservationSummary observation={event.observation} />;
+      case 'grep':
+        return <GrepObservationSummary observation={event.observation} />;
+      case 'browser':
+        return <BrowserObservationSummary observation={event.observation} />;
+      default:
+        return null;
+    }
+  })();
   const hasSummary = observationSummary !== null;
   const shouldShowRaw = isFileEditObservation ? false : !hasSummary || isExpanded;
   const observationString = shouldShowRaw ? JSON.stringify(event.observation, null, 2) : '';

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -441,6 +441,224 @@ export function TerminalObservationSummary({
   );
 }
 
+/** Renders human-readable summary for glob action */
+export function GlobActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+  if (!action) return null;
+  const pattern = getString(action.pattern);
+  const searchPath = getString(action.path);
+  return (
+    <div className="text-sm leading-relaxed space-y-1">
+      <p>The agent wants to search for files matching a pattern.</p>
+      {pattern && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-stone-500">Pattern:</span>
+          <code className="px-2 py-0.5 rounded bg-black/30 border border-white/[0.06] font-mono text-xs text-stone-300">{pattern}</code>
+        </div>
+      )}
+      {searchPath && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-stone-500">In:</span>
+          <code className="px-2 py-0.5 rounded bg-black/30 border border-white/[0.06] font-mono text-xs text-stone-300">{searchPath}</code>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders human-readable summary for glob observation */
+export function GlobObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+  const files = Array.isArray(observation.files) ? observation.files.filter((f): f is string => typeof f === 'string') : [];
+  const pattern = getString(observation.pattern);
+  const searchPath = getString(observation.searchPath);
+  const truncated = observation.truncated === true;
+  const count = files.length;
+
+  return (
+    <div className="text-sm leading-relaxed space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-stone-300">
+          Found <span className="font-semibold text-brand-300">{count}</span> file{count === 1 ? '' : 's'}
+          {truncated && <span className="text-stone-500"> (results truncated)</span>}
+        </span>
+      </div>
+      {pattern && (
+        <div className="flex items-center gap-2 text-xs text-stone-400">
+          <span className="codicon codicon-search text-brand-400/60" />
+          <code className="font-mono">{pattern}</code>
+          {searchPath && <span className="text-stone-500">in {searchPath}</span>}
+        </div>
+      )}
+      {count > 0 && count <= 10 && (
+        <div className="space-y-0.5">
+          {files.slice(0, 10).map((file, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <InlineFileReference path={file} />
+            </div>
+          ))}
+        </div>
+      )}
+      {count > 10 && (
+        <div className="text-xs text-stone-500">
+          Showing first 10 results. Use the expand button to see all files.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders human-readable summary for grep action */
+export function GrepActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+  if (!action) return null;
+  const pattern = getString(action.pattern);
+  const searchPath = getString(action.path);
+  const include = getString(action.include);
+  return (
+    <div className="text-sm leading-relaxed space-y-1">
+      <p>The agent wants to search file contents for a pattern.</p>
+      {pattern && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-stone-500">Regex:</span>
+          <code className="px-2 py-0.5 rounded bg-black/30 border border-white/[0.06] font-mono text-xs text-stone-300">{pattern}</code>
+        </div>
+      )}
+      {include && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-stone-500">Files:</span>
+          <code className="px-2 py-0.5 rounded bg-black/30 border border-white/[0.06] font-mono text-xs text-stone-300">{include}</code>
+        </div>
+      )}
+      {searchPath && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-stone-500">In:</span>
+          <code className="px-2 py-0.5 rounded bg-black/30 border border-white/[0.06] font-mono text-xs text-stone-300">{searchPath}</code>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders human-readable summary for grep observation */
+export function GrepObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+  const matches = Array.isArray(observation.matches) ? observation.matches.filter((f): f is string => typeof f === 'string') : [];
+  const pattern = getString(observation.pattern);
+  const searchPath = getString(observation.searchPath);
+  const includePattern = getString(observation.includePattern);
+  const truncated = observation.truncated === true;
+  const count = matches.length;
+
+  return (
+    <div className="text-sm leading-relaxed space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        <span className="text-stone-300">
+          Found <span className="font-semibold text-brand-300">{count}</span> matching file{count === 1 ? '' : 's'}
+          {truncated && <span className="text-stone-500"> (results truncated)</span>}
+        </span>
+      </div>
+      {pattern && (
+        <div className="flex items-center gap-2 text-xs text-stone-400">
+          <span className="codicon codicon-regex text-brand-400/60" />
+          <code className="font-mono">{pattern}</code>
+          {includePattern && <span className="text-stone-500">in {includePattern} files</span>}
+          {searchPath && <span className="text-stone-500">under {searchPath}</span>}
+        </div>
+      )}
+      {count > 0 && count <= 10 && (
+        <div className="space-y-0.5">
+          {matches.slice(0, 10).map((file, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <InlineFileReference path={file} />
+            </div>
+          ))}
+        </div>
+      )}
+      {count > 10 && (
+        <div className="text-xs text-stone-500">
+          Showing first 10 results. Use the expand button to see all files.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders human-readable summary for browser (web fetch) action */
+export function BrowserActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+  if (!action) return null;
+  const url = getString(action.url);
+  const method = getString(action.method) ?? 'GET';
+  return (
+    <div className="text-sm leading-relaxed space-y-1">
+      <p>The agent wants to fetch a web resource.</p>
+      <div className="flex items-center gap-2">
+        <span className="px-1.5 py-0.5 rounded bg-blue-500/20 border border-blue-400/20 text-xs font-mono text-blue-300">{method}</span>
+        {url && (
+          <code className="px-2 py-0.5 rounded bg-black/30 border border-white/[0.06] font-mono text-xs text-stone-300 truncate max-w-md">{url}</code>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Renders human-readable summary for browser (web fetch) observation */
+export function BrowserObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+  const url = getString(observation.url);
+  const status = getNumber(observation.status);
+  const content = getString(observation.content);
+  const contentLength = content?.length ?? 0;
+
+  const isSuccess = status !== undefined && status >= 200 && status < 300;
+  const statusColor = isSuccess ? 'text-green-400' : status !== undefined && status >= 400 ? 'text-red-400' : 'text-stone-400';
+
+  return (
+    <div className="text-sm leading-relaxed space-y-2">
+      <div className="flex items-center gap-2 flex-wrap">
+        {status !== undefined && (
+          <span className={`px-1.5 py-0.5 rounded bg-black/30 border border-white/[0.06] text-xs font-mono ${statusColor}`}>
+            {status}
+          </span>
+        )}
+        {url && (
+          <code className="font-mono text-xs text-stone-400 truncate max-w-md">{url}</code>
+        )}
+      </div>
+      {contentLength > 0 && (
+        <div className="text-xs text-stone-500">
+          Received {contentLength.toLocaleString()} characters
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Renders human-readable summary for finish action */
+export function FinishActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+  if (!action) return null;
+  const message = getString(action.message);
+  return (
+    <div className="text-sm leading-relaxed space-y-1">
+      <p className="text-stone-300">The agent wants to finish the current task.</p>
+      {message && (
+        <div className="italic text-stone-400">{message}</div>
+      )}
+    </div>
+  );
+}
+
+/** Renders human-readable summary for finish observation */
+export function FinishObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+  const message = getString(observation.message);
+  return (
+    <div className="text-sm leading-relaxed">
+      <div className="flex items-center gap-2">
+        <span className="codicon codicon-check-all text-green-400" />
+        <span className="text-stone-300">Task completed</span>
+      </div>
+      {message && (
+        <div className="mt-1 italic text-stone-400">{message}</div>
+      )}
+    </div>
+  );
+}
+
 /**
  * Event color tokens - CSS custom properties defined in tailwind.css
  * Design Philosophy: "Simplified Warm Palette"

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -499,7 +499,7 @@ export function GlobObservationSummary({ observation }: { observation: JsonRecor
       )}
       {count > 10 && (
         <div className="text-xs text-stone-500">
-          Showing first 10 results. Use the expand button to see all files.
+          Showing first 10 results. Expand to see the full raw data.
         </div>
       )}
     </div>
@@ -573,7 +573,7 @@ export function GrepObservationSummary({ observation }: { observation: JsonRecor
       )}
       {count > 10 && (
         <div className="text-xs text-stone-500">
-          Showing first 10 results. Use the expand button to see all files.
+          Showing first 10 results. Expand to see the full raw data.
         </div>
       )}
     </div>

--- a/src/webview-src/components/inputArea/ToolsPopover.tsx
+++ b/src/webview-src/components/inputArea/ToolsPopover.tsx
@@ -4,6 +4,8 @@ import { useCloseOnEscapeAndOutsideClick, type CloseReason } from '../useCloseOn
 interface ToolDescriptor {
   id: string;
   label: string;
+  description?: string;
+  isDefault?: boolean;
 }
 
 interface ToolsPopoverProps {
@@ -12,6 +14,57 @@ interface ToolsPopoverProps {
   tools: ToolDescriptor[];
   enabledToolIds: string[];
   onToggleTool: (toolId: string) => void;
+}
+
+function ToolButton({
+  tool,
+  isEnabled,
+  isActive,
+  onToggle,
+  onMouseEnter,
+  id,
+}: {
+  tool: ToolDescriptor;
+  isEnabled: boolean;
+  isActive: boolean;
+  onToggle: () => void;
+  onMouseEnter: () => void;
+  id: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      onMouseEnter={onMouseEnter}
+      role="option"
+      id={id}
+      aria-label={tool.label}
+      aria-selected={isEnabled ? 'true' : 'false'}
+      className={`
+        w-full text-left px-3 py-2.5 rounded-lg
+        text-sm
+        transition-all duration-150
+        flex items-start gap-2.5
+        group
+        ${isEnabled ? 'bg-brand-500/10 text-stone-200 oh-outline-soft' : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'}
+        ${isActive && !isEnabled ? 'bg-white/[0.04] text-stone-200 oh-outline-soft' : ''}
+        ${isActive && isEnabled ? 'bg-brand-500/15' : ''}
+      `}
+    >
+      <span className="codicon codicon-symbol-method text-brand-400/70 mt-0.5 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{tool.label}</span>
+          {isEnabled && <span className="codicon codicon-check text-brand-400 text-xs" />}
+        </div>
+        {tool.description && (
+          <div className="text-xs text-stone-500 mt-0.5 leading-snug">
+            {tool.description}
+          </div>
+        )}
+      </div>
+    </button>
+  );
 }
 
 export function ToolsPopover({
@@ -78,10 +131,17 @@ export function ToolsPopover({
 
   if (!isOpen) return null;
 
+  // Separate tools into core (default) and additional
+  const coreTools = tools.filter((t) => t.isDefault);
+  const additionalTools = tools.filter((t) => !t.isDefault);
+
+  // Build a flat list for keyboard navigation indexing
+  const allToolsFlat = [...coreTools, ...additionalTools];
+
   return (
     <div
       ref={popoverRef}
-      className="absolute bottom-full left-0 mb-1 w-64 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
+      className="absolute bottom-full left-0 mb-1 w-72 max-h-96 bg-[var(--vscode-editor-background)] border border-white/[0.08] rounded-xl shadow-2xl overflow-hidden animate-slide-up z-50"
       style={{
         background: 'linear-gradient(135deg, rgba(28, 25, 23, 0.98) 0%, rgba(12, 10, 9, 0.98) 100%)',
       }}
@@ -94,50 +154,73 @@ export function ToolsPopover({
         <div className="mt-1 text-xs text-stone-500">Select which tools the agent can use</div>
       </div>
 
-      <div className="overflow-y-auto max-h-64">
+      <div
+        ref={listboxRef}
+        className="overflow-y-auto max-h-80 focus:outline-none oh-focus-outline"
+        role="listbox"
+        aria-label="Tools"
+        aria-activedescendant={activeOptionId}
+        tabIndex={0}
+        onKeyDown={handleListboxKeyDown}
+      >
         {tools.length === 0 ? (
           <div className="px-4 py-8 text-center text-sm text-stone-500">No tools available</div>
         ) : (
-          <div
-            ref={listboxRef}
-            className="p-2 space-y-0.5 focus:outline-none oh-focus-outline"
-            role="listbox"
-            aria-label="Tools"
-            aria-activedescendant={activeOptionId}
-            tabIndex={0}
-            onKeyDown={handleListboxKeyDown}
-          >
-            {tools.map((tool, index) => {
-              const isEnabled = enabledToolIds.includes(tool.id);
-              const isActive = index === safeActiveIndex;
-              return (
-                <button
-                  key={tool.id}
-                  type="button"
-                  onClick={() => onToggleTool(tool.id)}
-                  role="option"
-                  id={`tools-picker-option-${index}`}
-                  aria-label={tool.label}
-                  aria-selected={isEnabled ? 'true' : 'false'}
-                  onMouseEnter={() => setActiveIndex(index)}
-                  className={`
-                    w-full text-left px-3 py-2 rounded-lg
-                    text-sm
-                    transition-all duration-150
-                    flex items-center gap-2
-                    group
-                    ${isEnabled ? 'bg-brand-500/10 text-stone-200 oh-outline-soft' : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'}
-                    ${isActive && !isEnabled ? 'bg-white/[0.04] text-stone-200 oh-outline-soft' : ''}
-                    ${isActive && isEnabled ? 'bg-brand-500/15' : ''}
-                  `}
-                >
-                  <span className="codicon codicon-symbol-method text-brand-400/70" />
-                  <span className="flex-1 truncate">{tool.label}</span>
-                  {isEnabled && <span className="codicon codicon-check text-brand-400" />}
-                </button>
-              );
-            })}
-          </div>
+          <>
+            {/* Core Tools */}
+            {coreTools.length > 0 && (
+              <div className="p-2" role="group" aria-label="Core Tools">
+                <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-stone-500">
+                  Core Tools
+                </div>
+                <div className="space-y-0.5">
+                  {coreTools.map((tool) => {
+                    const globalIndex = allToolsFlat.findIndex((t) => t.id === tool.id);
+                    const isEnabled = enabledToolIds.includes(tool.id);
+                    const isActive = globalIndex === safeActiveIndex;
+                    return (
+                      <ToolButton
+                        key={tool.id}
+                        tool={tool}
+                        isEnabled={isEnabled}
+                        isActive={isActive}
+                        onToggle={() => onToggleTool(tool.id)}
+                        onMouseEnter={() => setActiveIndex(globalIndex)}
+                        id={`tools-picker-option-${globalIndex}`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {/* Additional Tools */}
+            {additionalTools.length > 0 && (
+              <div className="p-2 border-t border-white/[0.04]" role="group" aria-label="Additional Tools">
+                <div className="px-2 py-1 text-[10px] font-medium uppercase tracking-wider text-stone-500">
+                  Additional Tools
+                </div>
+                <div className="space-y-0.5">
+                  {additionalTools.map((tool) => {
+                    const globalIndex = allToolsFlat.findIndex((t) => t.id === tool.id);
+                    const isEnabled = enabledToolIds.includes(tool.id);
+                    const isActive = globalIndex === safeActiveIndex;
+                    return (
+                      <ToolButton
+                        key={tool.id}
+                        tool={tool}
+                        isEnabled={isEnabled}
+                        isActive={isActive}
+                        onToggle={() => onToggleTool(tool.id)}
+                        onMouseEnter={() => setActiveIndex(globalIndex)}
+                        id={`tools-picker-option-${globalIndex}`}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </>
         )}
       </div>
     </div>


### PR DESCRIPTION
- Extend localTools.ts to include all SDK tools (glob, grep, browser, finish)
- Add descriptions and isDefault flags to tool definitions
- Update ToolsPopover to categorize tools into Core and Additional sections
- Add human-friendly rendering for glob, grep, browser, and finish tools
- Show tool descriptions in the tools selection popover
- Allow users to enable/disable tools before conversation starts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four new tools added: Glob (file pattern matching), Grep (content search), Browser (web fetch), Finish (task completion).
  * Tool descriptions shown and tools grouped into "Core Tools" and "Additional Tools" in the picker.
  * Enhanced human-friendly summaries for actions and observations (glob, grep, browser, finish).

* **Tests**
  * Added tests validating friendly summaries and observation rendering for the new tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->