### PR TITLE
Persist LLM profile selection globally (oh-tab-apqx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
           "openhands.llm.profileId": {
             "type": "string",
             "default": "",
+            "scope": "machine",
             "order": 0,
             "markdownDescription": "LLM profile identifier (filename stem). OpenHands loads provider/model/baseUrl/tuning from `~/.openhands/llm-profiles/<profileId>.json`.\n\nTo manage profiles and API keys, use the **LLM Profiles** view inside the OpenHands sidebar."
           }

--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -5,7 +5,7 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
   constructor(private context: vscode.ExtensionContext) {}
 
   private isGlobalOnlyKey(key: string): boolean {
-    return key === 'openhands.serverUrl' || key === 'openhands.servers';
+    return key === 'openhands.serverUrl' || key === 'openhands.servers' || key === 'openhands.llm.profileId';
   }
 
   private getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -96,6 +96,8 @@ export function LlmProfilesView(props: {
   const apiKeyInputRef = useRef<HTMLInputElement>(null);
 
   const activeProfileIdRef = useRef<string | null>(null);
+  const didInitializeSelectionRef = useRef(false);
+  const lastHandledOpenRequestRef = useRef<string | null>(null);
   const [profiles, setProfiles] = useState<string[]>([]);
   const [selectedProfileId, setSelectedProfileId] = useState<string | null>(null);
   const [mode, setMode] = useState<ProfileFormMode>('create');
@@ -222,15 +224,36 @@ export function LlmProfilesView(props: {
   }, [applyEditorTransition, loadProfile]);
 
   useEffect(() => {
-    if (!isOpen) return;
-    if (openRequest?.mode === 'create') {
-      startCreate();
+    if (!isOpen) {
+      didInitializeSelectionRef.current = false;
+      lastHandledOpenRequestRef.current = null;
       return;
     }
-    if (openRequest?.mode === 'edit') {
-      void startEdit(openRequest.profileId);
-      return;
+
+    const openRequestKey = (() => {
+      if (!openRequest) return null;
+      if (openRequest.mode === 'create') return 'create';
+      if (openRequest.mode === 'edit') return `edit:${openRequest.profileId}`;
+      return null;
+    })();
+
+    if (openRequest && openRequestKey && lastHandledOpenRequestRef.current !== openRequestKey) {
+      lastHandledOpenRequestRef.current = openRequestKey;
+      didInitializeSelectionRef.current = true;
+
+      if (openRequest.mode === 'create') {
+        startCreate();
+        return;
+      }
+      if (openRequest.mode === 'edit') {
+        void startEdit(openRequest.profileId);
+        return;
+      }
     }
+
+    if (didInitializeSelectionRef.current) return;
+    didInitializeSelectionRef.current = true;
+
     const normalizedActiveProfileId = typeof activeProfileId === 'string' ? activeProfileId.trim() : '';
     if (normalizedActiveProfileId) {
       void startEdit(normalizedActiveProfileId);

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -527,7 +527,14 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       }
       case 'setLlmProfileId': {
         const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        await settingsMgr.update({ llm: { profileId } });
+        try {
+          await settingsMgr.update({ llm: { profileId } }, 'global');
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          outputChannel?.appendLine(`[settings] Failed to persist LLM profile selection: ${reason}`);
+          postStatusError(`Failed to save profile selection: ${reason}`);
+          break;
+        }
 
         const updated = await settingsMgr.get();
         try {
@@ -620,7 +627,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           const before = await settingsMgr.get();
           const activeProfileId = before.llm.profileId ?? null;
           if (activeProfileId === profileId) {
-            await settingsMgr.update({ llm: { profileId: '' } });
+            await settingsMgr.update({ llm: { profileId: '' } }, 'global');
             void host.postMessage({
               type: 'statusMessage',
               level: 'error',


### PR DESCRIPTION
Fixes oh-tab-apqx.

Root cause (Output log):
- We attempted to write `openhands.llm.profileId` to Folder Settings, but the setting is not resource-scoped, so VS Code rejected the write and the profile never actually changed.

Decision:
- Persist the selected profile globally (user-wide) since profiles live in `~/.openhands/llm-profiles`.

Changes:
- `package.json`: set `openhands.llm.profileId` `scope` to `machine`.
- `src/settings/VscodeSettingsAdapter.ts`: treat `openhands.llm.profileId` as global-only.
- `src/webview/host/createWebviewMessageHandler.ts`: persist profile selection to global + show a status error if persistence fails.
- `src/webview-src/components/LlmProfilesView.tsx`: prevent selection from resetting (no jump) while the panel is open.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
