### PR TITLE
Improve LLM error UX and request logging

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/configGuards.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/configGuards.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import type { LLMConfiguration } from '../types';
+import { normalizeGenerationParamsForModel } from '../configGuards';
+
+const makeConfig = (overrides: Partial<LLMConfiguration> = {}): LLMConfiguration => ({
+  model: 'gpt-4o',
+  ...overrides,
+});
+
+describe('normalizeGenerationParamsForModel', () => {
+  it('preserves generation parameters for non-gpt-5 models', () => {
+    const config = normalizeGenerationParamsForModel(makeConfig({ temperature: 0.5 }));
+    expect(config.temperature).toBe(0.5);
+  });
+
+  it('drops temperature for gpt-5 models', () => {
+    const config = normalizeGenerationParamsForModel(makeConfig({ model: 'gpt-5.1', temperature: 0.2 }));
+    expect(config.temperature).toBeNull();
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
@@ -1,0 +1,13 @@
+import type { LLMConfiguration } from './types';
+
+const isGpt5Model = (model: string | undefined): boolean => {
+  if (typeof model !== 'string') return false;
+  const normalized = model.trim().toLowerCase();
+  return normalized.startsWith('gpt-5');
+};
+
+export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {
+  if (!isGpt5Model(config.model)) return config;
+
+  return { ...config, temperature: null };
+};

--- a/packages/agent-sdk-ts/src/sdk/llm/debug.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/debug.ts
@@ -1,0 +1,62 @@
+import type { OpenHandsSettings } from '../types/settings';
+import { assertValidProfileId, loadProfile } from './profiles';
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+};
+
+const pickFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return undefined;
+  return value;
+};
+
+const pickReasoningEffort = (value: unknown): 'low' | 'medium' | 'high' | 'none' | undefined => {
+  return value === 'low' || value === 'medium' || value === 'high' || value === 'none' ? value : undefined;
+};
+
+const pickReasoningSummary = (value: unknown): 'auto' | 'concise' | 'detailed' | undefined => {
+  return value === 'auto' || value === 'concise' || value === 'detailed' ? value : undefined;
+};
+
+const mergeGenerationParams = (
+  source: { temperature?: unknown; maxOutputTokens?: unknown; reasoningEffort?: unknown; reasoningSummary?: unknown } | undefined,
+  target: Record<string, unknown>,
+) => {
+  const temperature = pickFiniteNumber(source?.temperature);
+  if (temperature !== undefined) target.temperature = temperature;
+
+  const maxOutputTokens = pickFiniteNumber(source?.maxOutputTokens);
+  if (maxOutputTokens !== undefined) target.maxOutputTokens = maxOutputTokens;
+
+  const reasoningEffort = pickReasoningEffort(source?.reasoningEffort);
+  if (reasoningEffort) target.reasoningEffort = reasoningEffort;
+
+  const reasoningSummary = pickReasoningSummary(source?.reasoningSummary);
+  if (reasoningSummary) target.reasoningSummary = reasoningSummary;
+};
+
+export const buildLlmRequestParametersForDebug = (params: {
+  llmSettings?: OpenHandsSettings['llm'];
+  model: string;
+}): Record<string, unknown> | undefined => {
+  const settings = params.llmSettings;
+  const parameters: Record<string, unknown> = {};
+
+  mergeGenerationParams(settings, parameters);
+
+  const profileId = toOptionalNonEmptyString(settings?.profileId);
+  if (profileId) {
+    assertValidProfileId(profileId);
+    const profile = loadProfile(profileId);
+    mergeGenerationParams(profile.config, parameters);
+  }
+
+  const normalizedModel = params.model.trim().toLowerCase();
+  if (normalizedModel.startsWith('gpt-5')) {
+    delete parameters.temperature;
+  }
+
+  return Object.keys(parameters).length ? parameters : undefined;
+};

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -7,6 +7,7 @@ import { GeminiClient } from './gemini';
 import type { ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
 import type { LLMProfileStoreOptions } from './profiles';
 import { loadProfile } from './profiles';
+import { normalizeGenerationParamsForModel } from './configGuards';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMRegistry, TrackedLLMClient, llmRegistryKeyToString, toLLMRegistryKey } from './registry';
 import { Metrics } from './metrics';
@@ -48,7 +49,7 @@ export class LLMFactory {
     };
 
     const profileId = normalizeOptionalString(this.config.profileId);
-    const config: LLMConfiguration = (() => {
+    let config: LLMConfiguration = (() => {
       if (!profileId) return this.config;
       const profile = loadProfile(profileId, this.profileStoreOptions);
       const merged: LLMConfiguration = {
@@ -65,6 +66,7 @@ export class LLMFactory {
       if (requestedApiKey) merged.apiKey = requestedApiKey;
       return merged;
     })();
+    config = normalizeGenerationParamsForModel(config);
 
     const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
     const label = normalizeOptionalString(config.profileId) ?? config.model;

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -11,3 +11,4 @@ export * from './registry';
 export * from './profiles';
 export * from './contextLimit';
 export * from './condensationLlmConfig';
+export * from './debug';

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -49,6 +49,7 @@ import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } 
 import { deepTruncate, truncateToolMessage } from './toolResultTruncation';
 import { SecretMasker } from './secretMasker';
 import { ToolSummarizer } from './toolSummarizer';
+import { buildLlmRequestParametersForDebug } from '../llm/debug';
 
 export type AgentRunInput = string | Message;
 
@@ -427,6 +428,10 @@ export class Agent extends EventEmitter {
           try {
             const provider = llmConfig.provider ?? detectProviderFromBaseUrl(llmConfig.baseUrl);
             const baseUrl = llmConfig.baseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider];
+            const debugParameters = buildLlmRequestParametersForDebug({
+              llmSettings: this.options.settings.llm,
+              model: llmConfig.model,
+            });
             this.events.push({
               kind: 'ConversationStateUpdateEvent',
               source: 'agent',
@@ -438,7 +443,7 @@ export class Agent extends EventEmitter {
                   baseUrl,
                   ...(typeof llmConfig.openaiApiMode === 'string' ? { openaiApiMode: llmConfig.openaiApiMode } : {}),
                 },
-                request: sanitizeChatRequestForDebug(request),
+                request: sanitizeChatRequestForDebug(request, { parameters: debugParameters }),
               },
             } as Event);
           } catch (error) {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts
@@ -20,7 +20,7 @@ class MultiCallMockLLM implements LLMClient {
 }
 
 const baseSettings: OpenHandsSettings = {
-  llm: { model: 'test-model', provider: 'openai' },
+  llm: { model: 'test-model', provider: 'openai', temperature: 0.25, maxOutputTokens: 64 },
   agent: { debug: true },
   conversation: { maxIterations: 2 },
   confirmation: {},
@@ -68,6 +68,7 @@ describe('Agent debug LLM payload events', () => {
     expect(Array.isArray(firstRequest.request.tools)).toBe(true);
     expect(firstRequest.request.tools).toContain('noop');
     expect(typeof firstRequest.request.tools[0]).toBe('string');
+    expect(firstRequest.request.parameters).toEqual({ temperature: 0.25, maxOutputTokens: 64 });
 
     const secondRequest = requestPayloads[1];
     const toolMessage = (secondRequest.request.messages as any[]).find((m) => m?.role === 'tool');
@@ -97,4 +98,3 @@ describe('Agent debug LLM payload events', () => {
     expect(argStr.length).toBeLessThanOrEqual(2015);
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -69,7 +69,7 @@ describe('textSanitizers', () => {
     expect(text.length).toBeLessThan(250);
   });
 
-  it('sanitizeChatRequestForDebug strips system prompt and lists tool names', () => {
+  it('sanitizeChatRequestForDebug strips system prompt, lists tool names, and includes parameters when provided', () => {
     const request: ChatCompletionRequest = {
       systemPrompt: 'REAL_SYSTEM',
       messages: [
@@ -79,11 +79,12 @@ describe('textSanitizers', () => {
       tools: [{ type: 'function', function: { name: 'terminal', description: '', parameters: {} } }],
     };
 
-    const sanitized = sanitizeChatRequestForDebug(request);
+    const sanitized = sanitizeChatRequestForDebug(request, { parameters: { temperature: 0.4, maxOutputTokens: undefined } });
     expect(sanitized.systemPrompt).toBe('SYSTEM_PROMPT');
     expect(sanitized.tools).toEqual(['terminal']);
     expect(sanitized.messages).toHaveLength(2);
     const toolText = sanitized.messages[1].content[0].type === 'text' ? sanitized.messages[1].content[0].text : '';
     expect(toolText).toContain('…');
+    expect(sanitized.parameters).toEqual({ temperature: 0.4 });
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -129,13 +129,23 @@ export const sanitizeMessageForDebug = (message: Message): Message => {
   return out;
 };
 
-export function sanitizeChatRequestForDebug(request: ChatCompletionRequest): { systemPrompt: string; messages: Message[]; tools: string[] } {
+export function sanitizeChatRequestForDebug(
+  request: ChatCompletionRequest,
+  options?: { parameters?: Record<string, unknown> },
+): { systemPrompt: string; messages: Message[]; tools: string[]; parameters?: Record<string, unknown> } {
   const toolNames = (request.tools ?? [])
     .map((t) => t.function?.name)
     .filter((n): n is string => typeof n === 'string' && n.trim().length > 0);
+  const parameters = Object.entries(options?.parameters ?? {})
+    .filter(([, value]) => value !== undefined)
+    .reduce<Record<string, unknown>>((acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    }, {});
   return {
     systemPrompt: 'SYSTEM_PROMPT',
     messages: request.messages.map(sanitizeMessageForDebug),
     tools: toolNames,
+    ...(Object.keys(parameters).length ? { parameters } : {}),
   };
 }

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -170,7 +170,7 @@ describe('TerminalTool session behavior', () => {
     const started = await tool.execute(tool.validate({ command: 'sleep 0.15; echo first', timeout: 0.05 }), { workspace });
     expect(started.exit_code).toBe(-1);
 
-    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    await new Promise<void>((resolve) => setTimeout(resolve, 400));
 
     const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
     expect(next.exit_code).toBe(0);
@@ -191,7 +191,7 @@ describe('TerminalTool session behavior', () => {
     );
     expect(started.exit_code).toBe(-1);
 
-    await new Promise<void>((resolve) => setTimeout(resolve, 250));
+    await new Promise<void>((resolve) => setTimeout(resolve, 400));
 
     const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
     expect(next.exit_code).toBe(0);

--- a/src/__tests__/transformEventForWebview.test.ts
+++ b/src/__tests__/transformEventForWebview.test.ts
@@ -27,5 +27,19 @@ describe('transformEventForWebview', () => {
     expect(text).toContain('/tmp/oh-tab-test/pasted-images/0123456789abcdef.png');
     expect(text).not.toContain(OPENHANDS_IMAGE_URL_PREFIX);
   });
-});
 
+  it('summarizes error events for webview display', () => {
+    const event: any = {
+      kind: 'ConversationErrorEvent',
+      source: 'agent',
+      detail:
+        "LLM request failed (400): {\"error\":{\"message\":\"Unsupported parameter: 'temperature' is not supported with this model.\"}} (mode=local, llm.model=gpt-5)",
+    };
+
+    const transformed: any = transformEventForWebview(event, { webview: {} as any, pastedImagesBaseDir: '/tmp' });
+    expect(transformed.detail).toBe(
+      "LLM request failed (400): Unsupported parameter: 'temperature' is not supported with this model.",
+    );
+    expect(transformed.hint).toContain('temperature');
+  });
+});

--- a/src/conversation/host/transformEventForWebview.ts
+++ b/src/conversation/host/transformEventForWebview.ts
@@ -2,11 +2,14 @@ import * as vscode from 'vscode';
 import type { Event, MessageEvent } from '@openhands/agent-sdk-ts';
 import { isTextContent } from '@openhands/agent-sdk-ts';
 import { getPastedImagePath, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
+import { summarizeAgentErrorEvent, summarizeConversationErrorEvent } from '../../shared/errorSummaries';
 
 export function transformEventForWebview(
   event: Event,
   params: { webview: vscode.Webview; pastedImagesBaseDir: string }
 ): Event {
+  if (event.kind === 'AgentErrorEvent') return summarizeAgentErrorEvent(event);
+  if (event.kind === 'ConversationErrorEvent') return summarizeConversationErrorEvent(event);
   if (event.kind !== 'MessageEvent') return event;
   const msgEvent: MessageEvent = event;
   const msg = msgEvent.llm_message;

--- a/src/shared/errorSummaries.ts
+++ b/src/shared/errorSummaries.ts
@@ -1,0 +1,94 @@
+import type { AgentErrorEvent, ConversationErrorEvent } from '@openhands/agent-sdk-ts';
+
+type ErrorSummary = { message: string; hint?: string };
+
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+};
+
+const stripDiagnosticContext = (input: string): { text: string; modelHint?: string } => {
+  const modelMatch = input.match(/llm\.(effectiveModel|model)=([^) ,]+)/i);
+  const modelHint = modelMatch?.[2];
+
+  const markers = ['(mode=', '(llm.', '(serverUrl='];
+  let cutoff = input.length;
+  for (const marker of markers) {
+    const index = input.indexOf(marker);
+    if (index !== -1 && index < cutoff) cutoff = index;
+  }
+
+  return { text: input.slice(0, cutoff).trim(), modelHint };
+};
+
+const extractJsonMessage = (input: string): string | undefined => {
+  const start = input.indexOf('{');
+  const end = input.lastIndexOf('}');
+  if (start === -1 || end === -1 || end <= start) return undefined;
+  try {
+    const parsed = JSON.parse(input.slice(start, end + 1)) as unknown;
+    if (!isRecord(parsed)) return undefined;
+    const parsedError = isRecord(parsed.error) ? parsed.error : undefined;
+    if (typeof parsedError?.message === 'string') return parsedError.message;
+    if (typeof parsed.message === 'string') return parsed.message;
+  } catch {
+    return undefined;
+  }
+  return undefined;
+};
+
+const extractInlineMessage = (input: string): string | undefined => {
+  const messageField = input.match(/"message"\s*:\s*"([^"]+)"/i);
+  if (messageField?.[1]) return messageField[1];
+  const firstColon = input.indexOf(':');
+  if (firstColon === -1) return undefined;
+  const tail = input.slice(firstColon + 1).trim();
+  return tail || undefined;
+};
+
+const deriveHint = (raw: string, providerMessage: string | undefined, modelHint?: string): string | undefined => {
+  const needle = (providerMessage ?? raw).toLowerCase();
+  const mentionsTemperature = needle.includes('temperature');
+  const mentionsGpt5 = (modelHint ?? raw).toLowerCase().includes('gpt-5');
+  if (mentionsTemperature && mentionsGpt5) {
+    return 'GPT-5 models do not support temperature. Remove temperature from this profile.';
+  }
+  return undefined;
+};
+
+const toUserFacingError = (raw: string): ErrorSummary => {
+  const normalized = raw.replace(/\s+/g, ' ').trim();
+  if (!normalized) return { message: 'An unexpected error occurred.' };
+
+  const { text, modelHint } = stripDiagnosticContext(normalized);
+  const statusMatch = text.match(/LLM request failed\s*\(?(?:HTTP\s*)?(\d{3})\)?/i);
+  const status = statusMatch?.[1];
+  const providerMessage = extractJsonMessage(text) ?? extractInlineMessage(text);
+
+  const fallback = text.length > 500 ? `${text.slice(0, 500)}…` : text;
+  const message = status
+    ? `LLM request failed (${status}): ${providerMessage ?? 'See Output for details.'}`
+    : providerMessage ?? fallback;
+  const hint = deriveHint(normalized, providerMessage, modelHint);
+  return hint ? { message, hint } : { message };
+};
+
+export const summarizeAgentErrorEvent = (event: AgentErrorEvent): AgentErrorEvent & { hint?: string } => {
+  const summary = toUserFacingError(event.error);
+  return {
+    ...event,
+    error: summary.message,
+    ...(summary.hint ? { hint: summary.hint } : {}),
+  };
+};
+
+export const summarizeConversationErrorEvent = (
+  event: ConversationErrorEvent,
+): ConversationErrorEvent & { hint?: string } => {
+  const source = event.detail ?? event.code ?? 'Conversation error';
+  const summary = toUserFacingError(source);
+  return {
+    ...event,
+    detail: summary.message,
+    ...(summary.hint ? { hint: summary.hint } : {}),
+  };
+};

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -150,8 +150,6 @@ describe('Agent-SDK event rendering', () => {
     postToWindow({ type: 'event', event: ev });
     expect(await screen.findByText(/Conversation Error/)).toBeInTheDocument();
     expect(await screen.findByText(/LLMBadRequestError/)).toBeInTheDocument();
-    const details = await screen.findByText(/Details/);
-    fireEvent.click(details);
     expect(await screen.findByText(/Unsupported value/)).toBeInTheDocument();
   });
 

--- a/src/webview-src/components/eventBlocks/ErrorBlocks.tsx
+++ b/src/webview-src/components/eventBlocks/ErrorBlocks.tsx
@@ -3,6 +3,7 @@ import { ERROR_ACCENT_COLOR, EventContainer, withAlpha } from './shared';
 
 /** Renders agent error events with tool context. */
 export function AgentErrorBlock({ event, index }: { event: AgentErrorEvent; index?: number }) {
+  const hint = (event as AgentErrorEvent & { hint?: string }).hint;
   return (
     <EventContainer accentColor={ERROR_ACCENT_COLOR} bgOpacity={0.06} index={index}>
       <div className="flex items-center gap-2.5 mb-3">
@@ -20,12 +21,19 @@ export function AgentErrorBlock({ event, index }: { event: AgentErrorEvent; inde
       <div className="text-sm font-mono bg-red-500/5 border border-red-500/10 rounded-lg p-3 leading-relaxed text-red-200">
         {event.error}
       </div>
+      {hint && (
+        <div className="text-xs text-stone-400 mt-2">
+          Hint: {hint}
+        </div>
+      )}
     </EventContainer>
   );
 }
 
 /** Renders conversation-level errors (connection, auth, etc). */
 export function ConversationErrorBlock({ event, index }: { event: ConversationErrorEvent; index?: number }) {
+  const hint = (event as ConversationErrorEvent & { hint?: string }).hint;
+  const detail = event.detail ?? 'Conversation error';
   return (
     <EventContainer accentColor={ERROR_ACCENT_COLOR} bgOpacity={0.06} index={index}>
       <div className="flex items-center gap-2.5 mb-3">
@@ -37,20 +45,15 @@ export function ConversationErrorBlock({ event, index }: { event: ConversationEr
         </div>
         <div className="font-semibold text-sm text-stone-200">Conversation Error</div>
       </div>
-      {event.code && (
-        <div className="text-xs font-mono mb-2 text-stone-500">Code: {event.code}</div>
-      )}
-      {event.detail && (
-        <details className="text-xs">
-          <summary className="cursor-pointer text-stone-400 hover:text-stone-300 font-medium transition-colors">
-            Details
-          </summary>
-          <div className="mt-2 text-sm bg-red-500/5 border border-red-500/10 rounded-lg p-3 font-mono whitespace-pre-wrap break-words text-red-200">
-            {event.detail}
-          </div>
-        </details>
+      {event.code && <div className="text-xs font-mono mb-2 text-stone-500">Code: {event.code}</div>}
+      <div className="text-sm bg-red-500/5 border border-red-500/10 rounded-lg p-3 font-mono whitespace-pre-wrap break-words text-red-200">
+        {detail}
+      </div>
+      {hint && (
+        <div className="text-xs text-stone-400 mt-2">
+          Hint: {hint}
+        </div>
       )}
     </EventContainer>
   );
 }
-


### PR DESCRIPTION
## Summary
- add model guard to strip temperature from GPT-5 requests and cover it with unit tests
- include LLM request parameters in debug payload events for clearer Output logging
- summarize LLM-related errors before sending them to the webview and surface concise hints in the UI
- move LLM debug parameter building into the llm module and enforce profile validation instead of silently falling back

## Testing
- npm run lint
- npm test
- npm run typecheck
- npx vitest run src/tools/__tests__/TerminalTool.session.test.ts --reporter=basic *(pre-change failure; now covered by full test run)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950200104c883209c3f7ba20500736d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error reporting with contextual hints for parameter incompatibilities.
  * Improved LLM request debugging with parameter visibility in logs.

* **Bug Fixes**
  * Fixed temperature parameter handling for GPT-5 models to prevent configuration errors.

* **Tests**
  * Added comprehensive test coverage for model-specific parameter normalization and error summarization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->