### PR TITLE
webview: show Finish tool result as inline green summary with checkmark

### DIFF
--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -27,8 +27,8 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
           <span className="font-mono text-xs text-amber-400/80 bg-amber-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
           {finishMessage && (
             <div className="ml-auto flex items-center gap-1.5">
-              <span className="codicon codicon-check text-emerald-400" />
-              <span className="text-xs font-medium text-emerald-400 whitespace-pre-wrap break-words">{finishMessage}</span>
+              <span className="codicon codicon-check text-green-700" />
+              <span className="text-xs font-medium text-green-700 whitespace-pre-wrap break-words">{finishMessage}</span>
             </div>
           )}
         </div>

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -8,6 +8,37 @@ import { Tooltip } from '../Tooltip';
  */
 export function ObservationEventBlock({ event, index }: { event: ObservationEvent; index?: number }) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const isFinishTool = event.tool_name === 'finish';
+  let finishMessage = '';
+  if (isFinishTool) {
+    const maybe = (event.observation ?? {}) as { message?: unknown };
+    if (typeof maybe.message === 'string') finishMessage = maybe.message.trim();
+  }
+
+  // Special-case: Finish tool should show a concise, green summary inline on the header row
+  if (isFinishTool) {
+    return (
+      <EventContainer accentColor={OBSERVATION_ACCENT_COLOR} bgOpacity={0.04} index={index}>
+        <div className="flex items-center gap-2.5 mb-3">
+          <div
+            className="w-7 h-7 rounded-lg flex items-center justify-center"
+            style={{ backgroundColor: withAlpha(OBSERVATION_ACCENT_COLOR, 9) }}
+          >
+            <span className="codicon codicon-eye text-sm" style={{ color: OBSERVATION_ACCENT_COLOR }} />
+          </div>
+          <div className="font-semibold text-sm text-stone-200">Tool Result</div>
+          <span className="font-mono text-xs text-amber-400/80 bg-amber-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
+          {finishMessage && (
+            <div className="ml-auto flex items-center gap-1.5">
+              <span className="codicon codicon-check text-emerald-400" />
+              <span className="text-xs font-medium text-emerald-400 whitespace-pre-wrap break-words">{finishMessage}</span>
+            </div>
+          )}
+        </div>
+      </EventContainer>
+    );
+  }
+
   const isFileEditObservation = (() => {
     if (event.tool_name !== 'file_editor') return false;
     const candidate = (event.observation as Record<string, unknown> | null) ?? null;

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -9,11 +9,8 @@ import { Tooltip } from '../Tooltip';
 export function ObservationEventBlock({ event, index }: { event: ObservationEvent; index?: number }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const isFinishTool = event.tool_name === 'finish';
-  let finishMessage = '';
-  if (isFinishTool) {
-    const maybe = (event.observation ?? {}) as { message?: unknown };
-    if (typeof maybe.message === 'string') finishMessage = maybe.message.trim();
-  }
+  const maybeMessage = isFinishTool ? event.observation['message'] : undefined;
+  const finishMessage = typeof maybeMessage === 'string' ? maybeMessage.trim() : '';
 
   // Special-case: Finish tool should show a concise, green summary inline on the header row
   if (isFinishTool) {


### PR DESCRIPTION
This PR special-cases the Finish tool observation rendering in the webview.

Changes
- Display the Finish tool message directly (no JSON) on the Tool Result header row, aligned to the right.
- Reuse our existing codicon-check icon in green and keep the standard Tool Result layout.
- Avoids raw JSON payload for the finish observation.

Implementation
- src/webview-src/components/eventBlocks/ObservationEventBlock.tsx: Add finish-specific branch that renders the message inline and suppresses the raw block.

Build/Lint
- Ran npm run compile and pre-commit lint — both passed.

Requesting review for UX copy and color choice (emerald-400).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observation events that indicate completion now show a dedicated success display with a green inline confirmation.
  * If a short completion message is provided, it appears concisely alongside the success indicator; otherwise only the header is shown.
  * All other observation event types retain their existing rendering and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->