### PR TITLE
fix multiple bugs with persistence and clean up code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/conversation-stats.test.ts
@@ -29,14 +29,13 @@ function makePricedMetrics(params: {
 describe('ConversationStats', () => {
   it('registers llm metrics and combines', () => {
     const stats = new ConversationStats();
-    const llmA = { llm: { usageId: 'a', metrics: makeMetrics(1), label: 'profile-a' } };
-    const llmB = { llm: { usageId: 'b', metrics: makeMetrics(2), label: 'profile-b' } };
+    const llmA = { llm: { usageId: 'a', metrics: makeMetrics(1) } };
+    const llmB = { llm: { usageId: 'b', metrics: makeMetrics(2) } };
 
     stats.registerLlm(llmA);
     stats.registerLlm(llmB);
 
     expect(Object.keys(stats.usageToMetrics)).toEqual(['a', 'b']);
-    expect(stats.usageToLabels).toEqual({ a: 'profile-a', b: 'profile-b' });
 
     const combined = stats.getCombinedMetrics().getSnapshot();
     expect(combined.accumulatedTokenUsage?.promptTokens).toBe(3);
@@ -44,14 +43,13 @@ describe('ConversationStats', () => {
 
   it('serializes and restores from JSON', () => {
     const stats = new ConversationStats();
-    stats.registerLlm({ llm: { usageId: 'a', metrics: makeMetrics(3), label: 'profile-a' } });
+    stats.registerLlm({ llm: { usageId: 'a', metrics: makeMetrics(3) } });
 
     const json = stats.toJSON();
     const restored = ConversationStats.fromJSON(json);
 
     const m = restored.getMetricsForUsage('a');
     expect(m.getSnapshot().accumulatedTokenUsage?.promptTokens).toBe(3);
-    expect(restored.usageToLabels).toEqual({ a: 'profile-a' });
   });
 
   it('restores and merges metrics correctly on re-registration', () => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
@@ -35,8 +35,6 @@ describe('LLMFactory profile selection', () => {
 
       const tracked = client as TrackedLLMClient;
       expect(tracked.modelName).toBe('gpt-5');
-      expect(tracked.label).toBe('p1');
-      expect(stats.usageToLabels.default).toBe('p1');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -61,8 +59,6 @@ describe('LLMFactory profile selection', () => {
     expect(client).toBeInstanceOf(TrackedLLMClient);
     const tracked = client as TrackedLLMClient;
     expect(tracked.modelName).toBe('gpt-5-mini');
-    expect(tracked.label).toBe('gpt-5-mini');
-    expect(stats.usageToLabels.default).toBe('gpt-5-mini');
   });
 
   it('falls back to provider env key when profileId key is missing', async () => {
@@ -133,7 +129,6 @@ describe('LLMFactory profile selection', () => {
       (second as TrackedLLMClient).metrics.addTokenUsage({ promptTokens: 5, completionTokens: 2, responseId: 'r2' });
 
       expect(Object.keys(stats.usageToMetrics)).toEqual(['agent']);
-      expect(stats.usageToLabels.agent).toBe('sonnet-45');
       expect(stats.usageToMetrics.agent.accumulatedTokenUsage).toMatchObject({
         promptTokens: 15,
         completionTokens: 3,

--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -85,6 +85,33 @@ describe('FileStore', () => {
   });
 });
 
+
+describe('EventLog filtering', () => {
+  it('does not persist transient LLM streaming updates (llm_stream, llm_tool_call)', () => {
+    const dir = makeTempDir('conversation-stream-filter-');
+    const persistence = new FileStore({ rootDir: dir, conversationId: 'conv-stream' });
+    const log = new EventLog({ persistence });
+
+    // Push transient streaming updates
+    log.push({ kind: 'ConversationStateUpdateEvent', key: 'llm_stream', value: 'partial', source: 'agent' } as unknown as Event);
+    log.push({ kind: 'ConversationStateUpdateEvent', key: 'llm_tool_call', value: 'call_123', source: 'agent' } as unknown as Event);
+
+    // Push a durable final assistant message
+    log.push({
+      kind: 'MessageEvent',
+      source: 'agent',
+      llm_message: { role: 'assistant', content: [{ type: 'text', text: 'final answer' }] },
+    } as Event);
+
+    const events = persistence.readEvents();
+    expect(events).toHaveLength(1);
+    const only = events[0] as MessageEvent;
+    expect(only.kind).toBe('MessageEvent');
+    expect((only.llm_message.content[0] as TextContent).text).toBe('final answer');
+  });
+});
+
+
 describe('LocalConversation persistence', () => {
   it('replays persisted history when restored', async () => {
     const dir = makeTempDir('local-conversation-');

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -115,6 +115,12 @@ export class LocalConversation extends EventEmitter {
     // Reset persistence so a new store is created for the new id (if configured)
     this.persistence = undefined;
 
+    // Clear the LLM registry so cached clients with stale metrics don't carry over
+    this.llmRegistry.clear();
+
+    // Reset stats so accumulated metrics from previous conversations don't carry over
+    this.stats.usageToMetrics = {};
+
     // Recreate logs/state
     this.events = new EventLog();
     this.state = new ConversationState({ eventLog: this.events });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -119,7 +119,7 @@ export class LocalConversation extends EventEmitter {
     this.llmRegistry.clear();
 
     // Reset stats so accumulated metrics from previous conversations don't carry over
-    this.stats.usageToMetrics = {};
+    this.stats.clear();
 
     // Recreate logs/state
     this.events = new EventLog();

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -69,7 +69,6 @@ export class LLMFactory {
     config = normalizeGenerationParamsForModel(config);
 
     const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
-    const label = normalizeOptionalString(config.profileId) ?? config.model;
 
     const inlineApiKey =
       typeof config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(config.apiKey)
@@ -151,7 +150,6 @@ export class LLMFactory {
       try {
         const cached = this.registry.get(derivedUsageId);
         cached.setOnMetricsUpdate(this.onMetricsUpdate);
-        cached.setLabel(label);
         // Re-announce selection so stats/UI have a consistent "current llm" signal.
         this.registry.switchLlm(cached, registryKey);
         return cached;
@@ -179,7 +177,6 @@ export class LLMFactory {
         inner: base,
         usageId: derivedUsageId,
         modelName: config.model,
-        label,
         metrics,
         onMetricsUpdate: this.onMetricsUpdate,
       });

--- a/packages/agent-sdk-ts/src/sdk/llm/registry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/registry.ts
@@ -98,13 +98,17 @@ export class LLMRegistry {
   }
 
   listUsageIds(): string[] { return Array.from(this.usageToLLM.keys()); }
+
+  clear(): void {
+    this.usageToLLM.clear();
+    this.keyToLLM.clear();
+  }
 }
 
 export class TrackedLLMClient implements LLMClient {
   readonly inner: LLMClient;
   readonly usageId: string;
   readonly modelName: string;
-  label: string;
   readonly metrics: Metrics;
   private onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
 
@@ -112,24 +116,18 @@ export class TrackedLLMClient implements LLMClient {
     inner: LLMClient;
     usageId: string;
     modelName: string;
-    label?: string;
     metrics: Metrics;
     onMetricsUpdate?: (usageId: string, metrics: Metrics) => void;
   }) {
     this.inner = params.inner;
     this.usageId = params.usageId;
     this.modelName = params.modelName;
-    this.label = params.label ?? params.modelName;
     this.metrics = params.metrics;
     this.onMetricsUpdate = params.onMetricsUpdate;
   }
 
   setOnMetricsUpdate(cb?: (usageId: string, metrics: Metrics) => void): void {
     this.onMetricsUpdate = cb;
-  }
-
-  setLabel(label: string): void {
-    this.label = label;
   }
 
   async *streamChat(request: import('./types').ChatCompletionRequest): AsyncGenerator<import('./types').LLMStreamChunk> {

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -32,6 +32,11 @@ export class ConversationStats {
     this.restoredUsageIds = new Set(other.restoredUsageIds);
   }
 
+  clear(): void {
+    this.usageToMetrics = {};
+    this.restoredUsageIds.clear();
+  }
+
   getCombinedMetrics(): Metrics {
     const total = new Metrics('combined');
     for (const m of Object.values(this.usageToMetrics)) total.merge(m);

--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationStats.ts
@@ -2,7 +2,6 @@ import { Metrics } from '../llm/metrics';
 
 export class ConversationStats {
   usageToMetrics: Record<string, Metrics> = {};
-  usageToLabels: Record<string, string> = {};
   private restoredUsageIds = new Set<string>();
 
   static fromJSON(json: unknown): ConversationStats {
@@ -16,14 +15,6 @@ export class ConversationStats {
         stats.usageToMetrics[key] = Metrics.fromJSON(value);
       }
     }
-    const labels = obj['usage_to_labels'];
-    if (labels && typeof labels === 'object') {
-      for (const [usageId, label] of Object.entries(labels as Record<string, unknown>)) {
-        if (typeof label === 'string' && label.trim()) {
-          stats.usageToLabels[usageId] = label;
-        }
-      }
-    }
     const restored = obj['_restored_usage_ids'];
     if (Array.isArray(restored)) restored.forEach((id) => stats.restoredUsageIds.add(String(id)));
     return stats;
@@ -32,14 +23,12 @@ export class ConversationStats {
   toJSON(): Record<string, unknown> {
     return {
       usage_to_metrics: Object.fromEntries(Object.entries(this.usageToMetrics).map(([k, v]) => [k, v.toJSON()])),
-      usage_to_labels: { ...this.usageToLabels },
       _restored_usage_ids: Array.from(this.restoredUsageIds),
     };
   }
 
   restore(other: ConversationStats): void {
     this.usageToMetrics = other.usageToMetrics;
-    this.usageToLabels = other.usageToLabels;
     this.restoredUsageIds = new Set(other.restoredUsageIds);
   }
 
@@ -55,7 +44,7 @@ export class ConversationStats {
     return metrics;
   }
 
-  registerLlm(event: { llm: { usageId: string; metrics: Metrics; label?: string } }): void {
+  registerLlm(event: { llm: { usageId: string; metrics: Metrics } }): void {
     const llm = event.llm;
     const usageId = llm.usageId;
     const existing = this.usageToMetrics[usageId];
@@ -66,8 +55,5 @@ export class ConversationStats {
     }
     // Ensure we track the live metrics object.
     this.usageToMetrics[usageId] = llm.metrics;
-    if (llm.label) {
-      this.usageToLabels[usageId] = llm.label;
-    }
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/runtime/EventLog.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/EventLog.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { isEvent, type Event } from '../types';
+import { isEvent, isConversationStateUpdateEvent, type Event } from '../types';
 import type { ConversationPersistence } from './persistence';
 
 export type EventListener = (event: Event) => void;
@@ -56,8 +56,17 @@ export class EventLog {
 
     this.events.push(normalized);
 
+    // Persist only durable events. Drop transient LLM streaming state updates to avoid
+    // bloating events.jsonl with in-stream fragments.
     if (options.persist && this.persistence) {
-      this.persistence.appendEvent(normalized);
+      let shouldPersist = true;
+      if (isConversationStateUpdateEvent(normalized)) {
+        const key = normalized.key;
+        if (key === 'llm_stream' || key === 'llm_tool_call') {
+          shouldPersist = false;
+        }
+      }
+      if (shouldPersist) this.persistence.appendEvent(normalized);
     }
 
     if (options.emit) {


### PR DESCRIPTION
Fix multiple bugs with persistence, new conversations, and clean up dead code about labels thingie.

(it's okay, OpenHands-Agent, I got them!)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Transient streaming updates are no longer persisted; only durable final events are saved.
  * Prevented stale LLM metrics from carrying over between conversations by clearing per-conversation state.

* **Changes**
  * Removed LLM label tracking from metrics and telemetry to simplify usage data.

* **New Features**
  * Added explicit clear/reset methods to ensure fresh per-conversation state.

* **Tests**
  * Updated tests to reflect removed label expectations and persisted-event filtering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->