### PR TITLE
Fix Opus 4.5 temperature when extended thinking is enabled

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/configGuards.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/configGuards.test.ts
@@ -22,4 +22,32 @@ describe('normalizeGenerationParamsForModel', () => {
     const config = normalizeGenerationParamsForModel(makeConfig({ model: 'openai/gpt-5-codex', temperature: 0.7 }));
     expect(config.temperature).toBeNull();
   });
+
+  it('forces temperature to 1 for opus-4.5 with extended thinking', () => {
+    const config = normalizeGenerationParamsForModel(
+      makeConfig({ model: 'claude-opus-4-5', temperature: 0, reasoningEffort: 'high' })
+    );
+    expect(config.temperature).toBe(1);
+  });
+
+  it('forces temperature to 1 for opus-4.5 variant with extended thinking', () => {
+    const config = normalizeGenerationParamsForModel(
+      makeConfig({ model: 'anthropic/opus-4.5', temperature: 0.5, reasoningEffort: 'medium' })
+    );
+    expect(config.temperature).toBe(1);
+  });
+
+  it('preserves temperature for opus-4.5 without extended thinking', () => {
+    const config = normalizeGenerationParamsForModel(
+      makeConfig({ model: 'claude-opus-4-5', temperature: 0.7 })
+    );
+    expect(config.temperature).toBe(0.7);
+  });
+
+  it('preserves temperature for opus-4.5 with reasoningEffort=none', () => {
+    const config = normalizeGenerationParamsForModel(
+      makeConfig({ model: 'claude-opus-4-5', temperature: 0.5, reasoningEffort: 'none' })
+    );
+    expect(config.temperature).toBe(0.5);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
@@ -14,7 +14,7 @@ const isOpus45Model = (model: string | undefined): boolean => {
 };
 
 const hasExtendedThinking = (config: LLMConfiguration): boolean => {
-  return config.reasoningEffort != null && config.reasoningEffort !== 'none';
+  return config.reasoningEffort !== null && config.reasoningEffort !== undefined && config.reasoningEffort !== 'none';
 };
 
 export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {

--- a/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
@@ -14,7 +14,7 @@ const isOpus45Model = (model: string | undefined): boolean => {
 };
 
 const hasExtendedThinking = (config: LLMConfiguration): boolean => {
-  return config.reasoningEffort !== null && config.reasoningEffort !== undefined && config.reasoningEffort !== 'none';
+  return config.reasoningEffort != null && config.reasoningEffort !== 'none';
 };
 
 export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {

--- a/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
@@ -6,8 +6,27 @@ const isGpt5Model = (model: string | undefined): boolean => {
   return normalized.includes('gpt-5');
 };
 
-export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {
-  if (!isGpt5Model(config.model)) return config;
+const isOpus45Model = (model: string | undefined): boolean => {
+  if (typeof model !== 'string') return false;
+  const normalized = model.trim().toLowerCase();
+  // Match opus-4-5, opus-4.5, claude-opus-4-5, claude-opus-4.5, etc.
+  return normalized.includes('opus-4-5') || normalized.includes('opus-4.5');
+};
 
-  return { ...config, temperature: null };
+const hasExtendedThinking = (config: LLMConfiguration): boolean => {
+  return config.reasoningEffort !== null && config.reasoningEffort !== undefined && config.reasoningEffort !== 'none';
+};
+
+export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {
+  // GPT-5 models: strip temperature entirely
+  if (isGpt5Model(config.model)) {
+    return { ...config, temperature: null };
+  }
+
+  // Opus 4.5 with extended thinking: temperature must be exactly 1
+  if (isOpus45Model(config.model) && hasExtendedThinking(config)) {
+    return { ...config, temperature: 1 };
+  }
+
+  return config;
 };


### PR DESCRIPTION
## Summary
- Adds temperature normalization for Claude Opus 4.5 models when extended thinking (`reasoningEffort`) is enabled
- Claude requires `temperature=1` when thinking mode is active; this was causing 400 errors with `temperature=0`
- Follows the same pattern as GPT-5 temperature handling from #576

## Test plan
- [x] Added 4 new test cases for Opus 4.5 temperature normalization
- [x] All 682 tests pass (`npm test`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)