### PR TITLE
Display GPT-5 reasoning summaries in Extended Thinking block

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1032,11 +1032,17 @@ export class Agent extends EventEmitter {
     securityRisk?: SecurityRisk,
   ): ActionEvent {
     const thought = message.content.filter(isTextContent);
+    // Use reasoning_content if available (Anthropic/OpenAI Chat Completions),
+    // otherwise fall back to responses_reasoning_item.summary (OpenAI Responses API / GPT-5)
+    const reasoningContent = message.reasoning_content
+      ?? (message.responses_reasoning_item?.summary?.length
+        ? message.responses_reasoning_item.summary.join('\n\n')
+        : undefined);
     return {
       kind: 'ActionEvent',
       source: 'agent',
       thought,
-      reasoning_content: message.reasoning_content,
+      reasoning_content: reasoningContent,
       action: args,
       tool_name: toolCall.function.name,
       tool_call_id: toolCall.id,

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -199,16 +199,24 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
             </div>
           )}
 
-          {message.reasoning_content && (
-            <details className="mt-3 text-xs">
-              <summary className="cursor-pointer text-stone-400 hover:text-stone-300 font-medium mb-2 transition-colors">
-                Extended Thinking
-              </summary>
-              <div className="font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 mt-2 leading-relaxed text-stone-400">
-                {message.reasoning_content}
-              </div>
-            </details>
-          )}
+          {(() => {
+            // Use reasoning_content if available (Anthropic/OpenAI Chat Completions),
+            // otherwise fall back to responses_reasoning_item.summary (OpenAI Responses API / GPT-5)
+            const reasoningContent = message.reasoning_content
+              ?? (message.responses_reasoning_item?.summary?.length
+                ? message.responses_reasoning_item.summary.join('\n\n')
+                : undefined);
+            return reasoningContent ? (
+              <details className="mt-3 text-xs">
+                <summary className="cursor-pointer text-stone-400 hover:text-stone-300 font-medium mb-2 transition-colors">
+                  Extended Thinking
+                </summary>
+                <div className="font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 mt-2 leading-relaxed text-stone-400">
+                  {reasoningContent}
+                </div>
+              </details>
+            ) : null;
+          })()}
 
           {event.activated_skills && event.activated_skills.length > 0 && (
             <div className="mt-3 pt-3 border-t border-white/[0.06] flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- Fixes GPT-5 reasoning summaries not showing in the Extended Thinking UI block
- For GPT-5 via the Responses API, reasoning summaries are in `responses_reasoning_item.summary` (array), not `reasoning_content` (string)
- Adds fallback logic in both `Agent.createActionEvent()` and `MessageEventBlock` to check `responses_reasoning_item.summary` when `reasoning_content` is unavailable

## Test plan
- [x] All 682 tests pass (`npm test`)
- [x] Typecheck passes (`npm run typecheck`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual test: Enable reasoning summary (e.g., "detailed") on a GPT-5 profile and verify Extended Thinking block appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of reasoning content display across the SDK and user interface to ensure extended thinking blocks appear consistently, with enhanced fallback mechanisms to properly handle reasoning information from multiple sources.
  * Refined content detection logic to ensure seamless display of extended thinking information regardless of its source or origin.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->