### PR TITLE
Fix Anthropic thinking block format for tool calling

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/configGuards.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/configGuards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { LLMConfiguration } from '../types';
-import { normalizeGenerationParamsForModel } from '../configGuards';
+import { normalizeGenerationParamsForModel, isAnthropicModel, supportsThinkingBlocks } from '../configGuards';
 
 const makeConfig = (overrides: Partial<LLMConfiguration> = {}): LLMConfiguration => ({
   model: 'gpt-4o',
@@ -49,5 +49,72 @@ describe('normalizeGenerationParamsForModel', () => {
       makeConfig({ model: 'claude-opus-4-5', temperature: 0.5, reasoningEffort: 'none' })
     );
     expect(config.temperature).toBe(0.5);
+  });
+});
+
+describe('isAnthropicModel', () => {
+  it('returns true for anthropic provider', () => {
+    expect(isAnthropicModel(makeConfig({ provider: 'anthropic' }))).toBe(true);
+  });
+
+  it('returns true for claude model names', () => {
+    expect(isAnthropicModel(makeConfig({ model: 'claude-3-opus' }))).toBe(true);
+    expect(isAnthropicModel(makeConfig({ model: 'claude-opus-4-5-20251101' }))).toBe(true);
+    expect(isAnthropicModel(makeConfig({ model: 'claude-3-5-sonnet' }))).toBe(true);
+  });
+
+  it('returns true for LiteLLM anthropic routing prefix', () => {
+    expect(isAnthropicModel(makeConfig({ model: 'anthropic/claude-3-opus' }))).toBe(true);
+  });
+
+  it('returns true for anthropic.com baseUrl', () => {
+    expect(isAnthropicModel(makeConfig({ baseUrl: 'https://api.anthropic.com/v1' }))).toBe(true);
+  });
+
+  it('returns false for OpenAI models', () => {
+    expect(isAnthropicModel(makeConfig({ model: 'gpt-4o', provider: 'openai' }))).toBe(false);
+    expect(isAnthropicModel(makeConfig({ model: 'gpt-5-mini' }))).toBe(false);
+  });
+
+  it('returns false for Gemini models', () => {
+    expect(isAnthropicModel(makeConfig({ model: 'gemini-2.5-flash', provider: 'gemini' }))).toBe(false);
+  });
+
+  it('returns false for LiteLLM proxy without anthropic model', () => {
+    expect(isAnthropicModel(makeConfig({
+      model: 'gpt-4o',
+      provider: 'litellm_proxy',
+      baseUrl: 'http://localhost:4000',
+    }))).toBe(false);
+  });
+});
+
+describe('supportsThinkingBlocks', () => {
+  it('returns true for Anthropic model with extended thinking', () => {
+    expect(supportsThinkingBlocks(makeConfig({
+      model: 'claude-opus-4-5',
+      reasoningEffort: 'high',
+    }))).toBe(true);
+  });
+
+  it('returns false for Anthropic model without extended thinking', () => {
+    expect(supportsThinkingBlocks(makeConfig({
+      model: 'claude-3-opus',
+    }))).toBe(false);
+  });
+
+  it('returns false for Anthropic model with reasoningEffort=none', () => {
+    expect(supportsThinkingBlocks(makeConfig({
+      model: 'claude-opus-4-5',
+      reasoningEffort: 'none',
+    }))).toBe(false);
+  });
+
+  it('returns false for non-Anthropic model even with extended thinking', () => {
+    expect(supportsThinkingBlocks(makeConfig({
+      model: 'gpt-4o',
+      provider: 'openai',
+      reasoningEffort: 'high',
+    }))).toBe(false);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/thinkingBlocks.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/thinkingBlocks.test.ts
@@ -21,7 +21,13 @@ afterEach(() => {
 });
 
 describe('OpenAICompatibleClient thinking blocks', () => {
-  const baseConfig: LLMConfiguration = { model: 'claude-opus-4-5-20251101', provider: 'litellm_proxy', baseUrl: 'http://localhost:4000' };
+  // Config with extended thinking enabled (required for thinking blocks)
+  const baseConfig: LLMConfiguration = {
+    model: 'claude-opus-4-5-20251101',
+    provider: 'litellm_proxy',
+    baseUrl: 'http://localhost:4000',
+    reasoningEffort: 'medium',
+  };
 
   it('includes thinking blocks in assistant messages with tool calls', async () => {
     const sse = [
@@ -130,6 +136,64 @@ describe('OpenAICompatibleClient thinking blocks', () => {
     // Should have string content (no thinking block needed when no tool_calls)
     expect(typeof assistantMsg.content).toBe('string');
     expect(assistantMsg.content).toBe('Hello there!');
+  });
+
+  it('does not include thinking blocks for non-Anthropic models', async () => {
+    // Use a non-Anthropic model (GPT-4)
+    const gptConfig: LLMConfiguration = { model: 'gpt-4o', provider: 'openai' };
+
+    const sse = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Done"}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new OpenAICompatibleClient(gptConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'I will use a tool' }],
+          reasoning_content: 'This is my thinking process',
+          thinking_signature: 'sig_abc123',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'bash', arguments: '{"command":"echo hi"}' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'hi' }],
+          tool_call_id: 'call_1',
+        },
+      ],
+      tools: [{ type: 'function', function: { name: 'bash' } }],
+    };
+
+    await streamer.runChat(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+
+    // Find the assistant message
+    const assistantMsg = body?.messages?.find((m: { role: string }) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+
+    // For non-Anthropic models, should NOT include thinking blocks even with tool_calls
+    // Content should be string, tool_calls in separate field
+    expect(typeof assistantMsg.content).toBe('string');
+    expect(assistantMsg.content).toBe('I will use a tool');
+    expect(assistantMsg.tool_calls).toBeDefined();
   });
 
   it('streams thinking content and signature', async () => {

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/thinkingBlocks.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/thinkingBlocks.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { LLMStreamer } from '../../runtime';
+import { OpenAICompatibleClient, AnthropicClient } from '../index';
+import type { ChatCompletionRequest, LLMConfiguration } from '../types';
+
+const encoder = new TextEncoder();
+
+const createStreamResponse = (payload: string, status = 200): Response =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(payload));
+        controller.close();
+      },
+    }),
+    { status, headers: { 'content-type': 'text/event-stream' } },
+  );
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OpenAICompatibleClient thinking blocks', () => {
+  const baseConfig: LLMConfiguration = { model: 'claude-opus-4-5-20251101', provider: 'litellm_proxy', baseUrl: 'http://localhost:4000' };
+
+  it('includes thinking blocks in assistant messages with tool calls', async () => {
+    const sse = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Done"}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'I will use a tool' }],
+          reasoning_content: 'This is my thinking process',
+          thinking_signature: 'sig_abc123',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'bash', arguments: '{"command":"echo hi"}' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'hi' }],
+          tool_call_id: 'call_1',
+        },
+      ],
+      tools: [{ type: 'function', function: { name: 'bash' } }],
+    };
+
+    await streamer.runChat(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+
+    // Find the assistant message
+    const assistantMsg = body?.messages?.find((m: { role: string }) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+
+    // Should have content as array with thinking block first
+    expect(Array.isArray(assistantMsg.content)).toBe(true);
+
+    const thinkingBlock = assistantMsg.content.find((b: { type: string }) => b.type === 'thinking');
+    expect(thinkingBlock).toEqual({
+      type: 'thinking',
+      thinking: 'This is my thinking process',
+      signature: 'sig_abc123',
+    });
+
+    const textBlock = assistantMsg.content.find((b: { type: string }) => b.type === 'text');
+    expect(textBlock).toEqual({ type: 'text', text: 'I will use a tool' });
+
+    const toolUseBlock = assistantMsg.content.find((b: { type: string }) => b.type === 'tool_use');
+    expect(toolUseBlock).toMatchObject({
+      type: 'tool_use',
+      id: 'call_1',
+      name: 'bash',
+      input: { command: 'echo hi' },
+    });
+  });
+
+  it('does not include thinking blocks for assistant messages without tool calls', async () => {
+    const sse = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"Done"}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'Hello there!' }],
+          reasoning_content: 'This is my thinking process',
+        },
+      ],
+    };
+
+    await streamer.runChat(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+
+    // Find the assistant message
+    const assistantMsg = body?.messages?.find((m: { role: string }) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+
+    // Should have string content (no thinking block needed when no tool_calls)
+    expect(typeof assistantMsg.content).toBe('string');
+    expect(assistantMsg.content).toBe('Hello there!');
+  });
+
+  it('streams thinking content and signature', async () => {
+    const sse = [
+      'data: {"choices":[{"delta":{"reasoning_content":"Thinking..."}}]}',
+      'data: {"choices":[{"delta":{"thinking_signature":"sig_xyz"}}]}',
+      'data: {"choices":[{"delta":{"content":"Hello"}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const response = await streamer.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+    });
+
+    expect(response.message.reasoning_content).toBe('Thinking...');
+    expect(response.message.thinking_signature).toBe('sig_xyz');
+  });
+});
+
+describe('AnthropicClient thinking blocks', () => {
+  const baseConfig: LLMConfiguration = { model: 'claude-opus-4-5-20251101', provider: 'anthropic' };
+
+  it('includes thinking blocks in assistant messages with tool calls', async () => {
+    const sse = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"output_tokens":5}}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":10}}',
+      '',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new AnthropicClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'I will use a tool' }],
+          reasoning_content: 'This is my thinking process',
+          thinking_signature: 'sig_abc123',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'bash', arguments: '{"command":"echo hi"}' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'hi' }],
+          tool_call_id: 'call_1',
+        },
+      ],
+      tools: [{ type: 'function', function: { name: 'bash' } }],
+    };
+
+    await streamer.runChat(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+
+    // Find the assistant message
+    const assistantMsg = body?.messages?.find((m: { role: string }) => m.role === 'assistant');
+    expect(assistantMsg).toBeDefined();
+
+    // Should have content as array with thinking block first
+    expect(Array.isArray(assistantMsg.content)).toBe(true);
+
+    const thinkingBlock = assistantMsg.content.find((b: { type: string }) => b.type === 'thinking');
+    expect(thinkingBlock).toEqual({
+      type: 'thinking',
+      thinking: 'This is my thinking process',
+      signature: 'sig_abc123',
+    });
+
+    const textBlock = assistantMsg.content.find((b: { type: string }) => b.type === 'text');
+    expect(textBlock).toEqual({ type: 'text', text: 'I will use a tool' });
+
+    const toolUseBlock = assistantMsg.content.find((b: { type: string }) => b.type === 'tool_use');
+    expect(toolUseBlock).toMatchObject({
+      type: 'tool_use',
+      id: 'call_1',
+      name: 'bash',
+      input: { command: 'echo hi' },
+    });
+  });
+
+  it('converts tool messages to user messages with tool_result content', async () => {
+    const sse = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"output_tokens":5}}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+      '',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new AnthropicClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const request: ChatCompletionRequest = {
+      systemPrompt: 'you are a test harness',
+      messages: [
+        { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        {
+          role: 'assistant',
+          content: [],
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              function: { name: 'bash', arguments: '{"command":"echo hi"}' },
+            },
+          ],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: 'hi' }],
+          tool_call_id: 'call_1',
+        },
+      ],
+      tools: [{ type: 'function', function: { name: 'bash' } }],
+    };
+
+    await streamer.runChat(request);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+
+    // Tool result should be in a user message
+    const toolResultMsg = body?.messages?.find((m: { role: string; content: { type: string }[] }) =>
+      m.role === 'user' && m.content?.some?.((c: { type: string }) => c.type === 'tool_result'),
+    );
+    expect(toolResultMsg).toBeDefined();
+
+    const toolResultBlock = toolResultMsg.content.find((b: { type: string }) => b.type === 'tool_result');
+    expect(toolResultBlock).toEqual({
+      type: 'tool_result',
+      tool_use_id: 'call_1',
+      content: 'hi',
+    });
+  });
+
+  it('streams thinking content and signature', async () => {
+    const sse = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"output_tokens":5}}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking"}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Thinking about this..."}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"sig_xyz"}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Hello!"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+      '',
+    ].join('\n');
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new AnthropicClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const response = await streamer.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+    });
+
+    expect(response.message.reasoning_content).toBe('Thinking about this...');
+    expect(response.message.thinking_signature).toBe('sig_xyz');
+    expect(response.message.content[0]).toEqual({ type: 'text', text: 'Hello!' });
+  });
+
+  it('streams tool calls from Anthropic format', async () => {
+    const sse = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"output_tokens":5}}}',
+      '',
+      'event: content_block_start',
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_1","name":"bash"}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"command\\":"}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\"echo hi\\"}"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"}}',
+      '',
+    ].join('\n');
+
+    vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new AnthropicClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    const response = await streamer.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'run echo hi' }] }],
+      tools: [{ type: 'function', function: { name: 'bash' } }],
+    });
+
+    expect(response.message.tool_calls).toHaveLength(1);
+    expect(response.message.tool_calls?.[0]).toMatchObject({
+      id: 'toolu_1',
+      type: 'function',
+      function: {
+        name: 'bash',
+        arguments: '{"command":"echo hi"}',
+      },
+    });
+  });
+
+  it('includes tools in request body', async () => {
+    const sse = [
+      'event: message_start',
+      'data: {"type":"message_start","message":{"id":"msg_1","usage":{"input_tokens":10,"output_tokens":5}}}',
+      '',
+      'event: content_block_delta',
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Done"}}',
+      '',
+      'event: message_delta',
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"}}',
+      '',
+    ].join('\n');
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(createStreamResponse(sse));
+
+    const client = new AnthropicClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    await streamer.runChat({
+      systemPrompt: 'you are a test harness',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+      tools: [
+        {
+          type: 'function',
+          function: {
+            name: 'bash',
+            description: 'Run a bash command',
+            parameters: {
+              type: 'object',
+              properties: { command: { type: 'string' } },
+              required: ['command'],
+            },
+          },
+        },
+      ],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+
+    expect(body?.tools).toEqual([
+      {
+        name: 'bash',
+        description: 'Run a bash command',
+        input_schema: {
+          type: 'object',
+          properties: { command: { type: 'string' } },
+          required: ['command'],
+        },
+      },
+    ]);
+    expect(body?.tool_choice).toEqual({ type: 'auto' });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -1,15 +1,41 @@
 import { setTimeout as delay } from 'node:timers/promises';
-import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions } from './types';
+import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions, type ToolCallAccumulator } from './types';
 
 const decoder = new TextDecoder();
 
+// Anthropic content block types
+type AnthropicThinkingBlock = {
+  type: 'thinking';
+  thinking: string;
+  signature?: string;
+};
+
+type AnthropicTextBlock = {
+  type: 'text';
+  text: string;
+};
+
+type AnthropicToolUseBlock = {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+};
+
+type AnthropicToolResultBlock = {
+  type: 'tool_result';
+  tool_use_id: string;
+  content: string;
+};
+
+type AnthropicContentBlock = AnthropicThinkingBlock | AnthropicTextBlock | AnthropicToolUseBlock | AnthropicToolResultBlock;
+
 interface AnthropicMessage {
   role: 'user' | 'assistant';
-  content: Array<{ type: 'text'; text: string }>;
-  name?: string;
+  content: AnthropicContentBlock[];
 }
 
-type AnthropicEventName = 'message_start' | 'content_block_delta' | 'message_delta' | (string & {});
+type AnthropicEventName = 'message_start' | 'content_block_start' | 'content_block_delta' | 'message_delta' | (string & {});
 
 interface AnthropicMessageStartEvent {
   message?: {
@@ -22,16 +48,37 @@ interface AnthropicMessageStartEvent {
   };
 }
 
+interface AnthropicContentBlockStartEvent {
+  index: number;
+  content_block?: {
+    type: 'text' | 'tool_use' | 'thinking';
+    id?: string;
+    name?: string;
+    signature?: string;
+  };
+}
+
 interface AnthropicContentDeltaEvent {
-  delta?: { type?: string; text?: string };
+  index?: number;
+  delta?: {
+    type?: string;
+    text?: string;
+    thinking?: string;
+    partial_json?: string;
+    signature?: string;
+  };
 }
 
 interface AnthropicMessageDeltaEvent {
   delta?: { stop_reason?: string };
+  usage?: { output_tokens?: number };
 }
 
 const isMessageStartEvent = (data: unknown): data is AnthropicMessageStartEvent =>
   typeof data === 'object' && data !== null && 'message' in data;
+
+const isContentBlockStartEvent = (data: unknown): data is AnthropicContentBlockStartEvent =>
+  typeof data === 'object' && data !== null && 'index' in data && 'content_block' in data;
 
 const isContentDeltaEvent = (data: unknown): data is AnthropicContentDeltaEvent =>
   typeof data === 'object' && data !== null && 'delta' in data;
@@ -39,14 +86,129 @@ const isContentDeltaEvent = (data: unknown): data is AnthropicContentDeltaEvent 
 const isMessageDeltaEvent = (data: unknown): data is AnthropicMessageDeltaEvent =>
   typeof data === 'object' && data !== null && 'delta' in data;
 
-const toAnthropicMessages = (request: ChatCompletionRequest): AnthropicMessage[] =>
-  request.messages
-    .filter((message) => message.role === 'user' || message.role === 'assistant')
-    .map((message) => ({
-      role: message.role as AnthropicMessage['role'],
-      content: [{ type: 'text', text: reduceTextContent(message) }],
-      name: message.name,
+// Tool call accumulator for Anthropic streaming
+class AnthropicToolCallAccumulator implements ToolCallAccumulator {
+  complete = [] as ToolCallAccumulator['complete'];
+  private readonly partial = new Map<number, { id: string; name: string; arguments: string }>();
+
+  applyDelta(delta: { index: number; id?: string; name?: string; arguments?: string }): { accumulated: ToolCallAccumulator['complete']; current: { id: string; name: string; argumentsDelta: string } } {
+    const existing = this.partial.get(delta.index);
+    const id = delta.id ?? existing?.id ?? `tool_call_${delta.index}`;
+    const name = delta.name ?? existing?.name ?? '';
+    const updated = {
+      id,
+      name,
+      arguments: `${existing?.arguments ?? ''}${delta.arguments ?? ''}`,
+    };
+    this.partial.set(delta.index, updated);
+
+    this.complete = Array.from(this.partial.values()).map((value) => ({
+      id: value.id,
+      type: 'function',
+      function: { name: value.name, arguments: value.arguments },
     }));
+
+    return {
+      accumulated: this.complete,
+      current: {
+        id,
+        name,
+        argumentsDelta: delta.arguments ?? '',
+      },
+    };
+  }
+}
+
+const toAnthropicMessages = (request: ChatCompletionRequest): AnthropicMessage[] => {
+  const result: AnthropicMessage[] = [];
+
+  for (const message of request.messages) {
+    if (message.role === 'user') {
+      // User messages: simple text content
+      result.push({
+        role: 'user',
+        content: [{ type: 'text', text: reduceTextContent(message) }],
+      });
+    } else if (message.role === 'assistant') {
+      // Assistant messages: may have thinking + tool_use
+      const contentBlocks: AnthropicContentBlock[] = [];
+
+      // Thinking block must come first if present
+      if (message.reasoning_content) {
+        contentBlocks.push({
+          type: 'thinking',
+          thinking: message.reasoning_content,
+          ...(message.thinking_signature ? { signature: message.thinking_signature } : {}),
+        });
+      }
+
+      // Text content
+      const textContent = reduceTextContent(message);
+      if (textContent) {
+        contentBlocks.push({ type: 'text', text: textContent });
+      }
+
+      // Tool use blocks
+      if (message.tool_calls?.length) {
+        for (const toolCall of message.tool_calls) {
+          let input: unknown;
+          try {
+            input = JSON.parse(toolCall.function.arguments);
+          } catch {
+            input = toolCall.function.arguments;
+          }
+          contentBlocks.push({
+            type: 'tool_use',
+            id: toolCall.id,
+            name: toolCall.function.name,
+            input,
+          });
+        }
+      }
+
+      // Only add message if there's content
+      if (contentBlocks.length > 0) {
+        result.push({
+          role: 'assistant',
+          content: contentBlocks,
+        });
+      }
+    } else if (message.role === 'tool') {
+      // Tool results must be sent as user messages with tool_result content
+      // Find the last user message or create a new one
+      const lastMessage = result[result.length - 1];
+      const toolResultBlock: AnthropicToolResultBlock = {
+        type: 'tool_result',
+        tool_use_id: message.tool_call_id ?? '',
+        content: reduceTextContent(message),
+      };
+
+      if (lastMessage?.role === 'user') {
+        // Append to existing user message
+        lastMessage.content.push(toolResultBlock);
+      } else {
+        // Create new user message
+        result.push({
+          role: 'user',
+          content: [toolResultBlock],
+        });
+      }
+    }
+    // Skip 'system' role - handled separately
+  }
+
+  return result;
+};
+
+// Convert OpenAI tool definitions to Anthropic format
+const toAnthropicTools = (tools?: LLMToolDefinition[]): Array<{ name: string; description?: string; input_schema: unknown }> | undefined => {
+  if (!tools?.length) return undefined;
+  return tools.map((tool) => ({
+    name: tool.function.name,
+    description: tool.function.description,
+    input_schema: tool.function.parameters ?? { type: 'object', properties: {} },
+  }));
+};
 
 const parseAnthropicStream = async function* (response: Response): AsyncGenerator<{ event?: AnthropicEventName; data?: unknown }> {
   const reader = response.body?.getReader();
@@ -93,6 +255,10 @@ export class AnthropicClient implements LLMClient {
 
   async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
     const response = await this.fetchWithRetry(request);
+    const accumulator = new AnthropicToolCallAccumulator();
+    // Track which content block indices are tool_use blocks
+    const toolBlockIndices = new Map<number, { id: string; name: string }>();
+
     for await (const { event, data } of parseAnthropicStream(response)) {
       if (!data) continue;
       switch (event) {
@@ -107,14 +273,64 @@ export class AnthropicClient implements LLMClient {
             };
           }
           break;
+        case 'content_block_start':
+          if (isContentBlockStartEvent(data)) {
+            const block = data.content_block;
+            if (block?.type === 'tool_use' && block.id && block.name) {
+              // Register this index as a tool_use block
+              toolBlockIndices.set(data.index, { id: block.id, name: block.name });
+              // Emit initial tool call delta with id and name
+              accumulator.applyDelta({ index: data.index, id: block.id, name: block.name });
+              yield {
+                type: 'tool_call_delta',
+                id: block.id,
+                name: block.name,
+                arguments: '',
+              };
+            }
+          }
+          break;
         case 'content_block_delta':
-          if (isContentDeltaEvent(data) && data.delta?.type === 'text_delta' && data.delta.text) {
-            yield { type: 'text', text: data.delta.text };
+          if (isContentDeltaEvent(data)) {
+            const delta = data.delta;
+            const index = data.index ?? 0;
+
+            if (delta?.type === 'text_delta' && delta.text) {
+              yield { type: 'text', text: delta.text };
+            } else if (delta?.type === 'thinking_delta' && delta.thinking) {
+              yield { type: 'reasoning', reasoning: delta.thinking };
+            } else if (delta?.type === 'signature_delta' && delta.signature) {
+              yield { type: 'thinking_signature', signature: delta.signature };
+            } else if (delta?.type === 'input_json_delta' && delta.partial_json) {
+              // Tool call argument delta
+              const toolInfo = toolBlockIndices.get(index);
+              if (toolInfo) {
+                const result = accumulator.applyDelta({
+                  index,
+                  arguments: delta.partial_json,
+                });
+                yield {
+                  type: 'tool_call_delta',
+                  id: result.current.id,
+                  name: result.current.name,
+                  arguments: result.current.argumentsDelta,
+                };
+              }
+            }
           }
           break;
         case 'message_delta':
-          if (isMessageDeltaEvent(data) && data.delta?.stop_reason) {
-            yield { type: 'finish', finishReason: data.delta.stop_reason };
+          if (isMessageDeltaEvent(data)) {
+            // Anthropic sends output_tokens in message_delta
+            if (data.usage?.output_tokens) {
+              yield {
+                type: 'usage',
+                outputTokens: data.usage.output_tokens,
+              };
+            }
+            if (data.delta?.stop_reason) {
+              yield { type: 'finish', finishReason: data.delta.stop_reason };
+            }
           }
           break;
         default:
@@ -184,6 +400,7 @@ export class AnthropicClient implements LLMClient {
   }
 
   private requestBody(request: ChatCompletionRequest): Record<string, unknown> {
+    const anthropicTools = toAnthropicTools(request.tools);
     return {
       model: this.config.model,
       max_tokens: this.config.maxOutputTokens ?? 1024,
@@ -191,6 +408,7 @@ export class AnthropicClient implements LLMClient {
       system: [{ type: 'text', text: request.systemPrompt }],
       messages: toAnthropicMessages(request),
       stream: true,
+      ...(anthropicTools ? { tools: anthropicTools, tool_choice: { type: 'auto' } } : {}),
       thinking: this.config.reasoningEffort && this.config.reasoningEffort !== 'none'
         ? { type: 'enabled', budget_tokens: this.config.maxOutputTokens ?? undefined }
         : undefined,

--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -59,7 +59,7 @@ interface AnthropicContentBlockStartEvent {
 }
 
 interface AnthropicContentDeltaEvent {
-  index?: number;
+  index: number;
   delta?: {
     type?: string;
     text?: string;
@@ -81,7 +81,7 @@ const isContentBlockStartEvent = (data: unknown): data is AnthropicContentBlockS
   typeof data === 'object' && data !== null && 'index' in data && 'content_block' in data;
 
 const isContentDeltaEvent = (data: unknown): data is AnthropicContentDeltaEvent =>
-  typeof data === 'object' && data !== null && 'delta' in data;
+  typeof data === 'object' && data !== null && 'delta' in data && 'index' in data && typeof (data as { index: unknown }).index === 'number';
 
 const isMessageDeltaEvent = (data: unknown): data is AnthropicMessageDeltaEvent =>
   typeof data === 'object' && data !== null && 'delta' in data;
@@ -293,7 +293,7 @@ export class AnthropicClient implements LLMClient {
         case 'content_block_delta':
           if (isContentDeltaEvent(data)) {
             const delta = data.delta;
-            const index = data.index ?? 0;
+            const index = data.index;
 
             if (delta?.type === 'text_delta' && delta.text) {
               yield { type: 'text', text: delta.text };

--- a/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/configGuards.ts
@@ -17,6 +17,38 @@ const hasExtendedThinking = (config: LLMConfiguration): boolean => {
   return config.reasoningEffort !== null && config.reasoningEffort !== undefined && config.reasoningEffort !== 'none';
 };
 
+/**
+ * Detect if a model is an Anthropic Claude model.
+ * This includes direct API access and LiteLLM proxy routing (anthropic/model-name).
+ */
+export const isAnthropicModel = (config: LLMConfiguration): boolean => {
+  // Check provider first
+  if (config.provider === 'anthropic') return true;
+
+  // Check model name patterns
+  const model = config.model?.trim().toLowerCase() ?? '';
+
+  // LiteLLM routing prefix (e.g., anthropic/claude-3-opus)
+  if (model.startsWith('anthropic/')) return true;
+
+  // Claude model names (claude-3, claude-opus, claude-sonnet, etc.)
+  if (model.includes('claude')) return true;
+
+  // Check baseUrl for Anthropic endpoints
+  const baseUrl = config.baseUrl?.toLowerCase() ?? '';
+  if (baseUrl.includes('anthropic.com')) return true;
+
+  return false;
+};
+
+/**
+ * Check if the model supports extended thinking with thinking blocks.
+ * Currently only Anthropic Claude models support this format.
+ */
+export const supportsThinkingBlocks = (config: LLMConfiguration): boolean => {
+  return isAnthropicModel(config) && hasExtendedThinking(config);
+};
+
 export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {
   // GPT-5 models: strip temperature entirely
   if (isGpt5Model(config.model)) {

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -12,3 +12,4 @@ export * from './profiles';
 export * from './contextLimit';
 export * from './condensationLlmConfig';
 export * from './debug';
+export * from './configGuards';

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -9,9 +9,29 @@ const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, 
   ...(overrides ?? {}),
 });
 
+type OpenAIThinkingContentBlock = {
+  type: 'thinking';
+  thinking: string;
+  signature?: string;
+};
+
+type OpenAITextContentBlock = {
+  type: 'text';
+  text: string;
+};
+
+type OpenAIToolUseContentBlock = {
+  type: 'tool_use';
+  id: string;
+  name: string;
+  input: unknown;
+};
+
+type OpenAIContentBlock = OpenAIThinkingContentBlock | OpenAITextContentBlock | OpenAIToolUseContentBlock;
+
 type OpenAIChatMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
-  content: string;
+  content: string | OpenAIContentBlock[];
   name?: string;
   tool_call_id?: string;
   tool_calls?: ChatCompletionRequest['messages'][number]['tool_calls'];
@@ -29,6 +49,8 @@ type OpenAIChoiceDelta = {
   content?: string | OpenAIContentPart[];
   tool_calls?: OpenAIToolCallDelta[];
   reasoning_content?: string | { text?: string }[];
+  /** Anthropic thinking signature (via LiteLLM) */
+  thinking_signature?: string;
 };
 
 type OpenAIChoice = {
@@ -50,6 +72,48 @@ const isOpenAIStreamChunk = (value: unknown): value is OpenAIStreamChunk =>
 
 const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number]): OpenAIChatMessage => {
   const contentText = reduceTextContent(message);
+
+  // For assistant messages with thinking content and tool calls, we need to include
+  // thinking blocks in the content array (required by Anthropic via LiteLLM)
+  if (message.role === 'assistant' && message.reasoning_content && message.tool_calls?.length) {
+    const contentBlocks: OpenAIContentBlock[] = [];
+
+    // Thinking block must come first
+    contentBlocks.push({
+      type: 'thinking',
+      thinking: message.reasoning_content,
+      ...(message.thinking_signature ? { signature: message.thinking_signature } : {}),
+    });
+
+    // Then text content (if any)
+    if (contentText) {
+      contentBlocks.push({ type: 'text', text: contentText });
+    }
+
+    // Then tool_use blocks
+    for (const toolCall of message.tool_calls) {
+      let input: unknown;
+      try {
+        input = JSON.parse(toolCall.function.arguments);
+      } catch {
+        input = toolCall.function.arguments;
+      }
+      contentBlocks.push({
+        type: 'tool_use',
+        id: toolCall.id,
+        name: toolCall.function.name,
+        input,
+      });
+    }
+
+    return {
+      role: 'assistant',
+      content: contentBlocks,
+      ...(message.name ? { name: message.name } : {}),
+    };
+  }
+
+  // Standard case: plain text content
   const base: OpenAIChatMessage = {
     role: message.role,
     content: contentText,
@@ -191,6 +255,10 @@ const mapChunkToStream = (chunk: OpenAIStreamChunk, accumulator: OpenAIToolCallA
       ? delta.reasoning_content.map((entry) => entry?.text ?? '').join('')
       : String(delta.reasoning_content ?? '');
     if (reasoning) deltas.push({ type: 'reasoning', reasoning });
+  }
+
+  if (delta.thinking_signature) {
+    deltas.push({ type: 'thinking_signature', signature: delta.thinking_signature });
   }
 
   if (chunk.usage) {

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -1,6 +1,7 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions, type ToolCallAccumulator } from './types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
+import { supportsThinkingBlocks } from './configGuards';
 
 const decoder = new TextDecoder();
 
@@ -70,12 +71,18 @@ type OpenAIStreamChunk = {
 const isOpenAIStreamChunk = (value: unknown): value is OpenAIStreamChunk =>
   typeof value === 'object' && value !== null && ('choices' in value || 'usage' in value);
 
-const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number]): OpenAIChatMessage => {
+/**
+ * Convert internal message format to OpenAI-compatible format.
+ * When targeting Anthropic models (via LiteLLM), includes thinking blocks.
+ */
+const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number], config: LLMConfiguration): OpenAIChatMessage => {
   const contentText = reduceTextContent(message);
 
-  // For assistant messages with thinking content and tool calls, we need to include
-  // thinking blocks in the content array (required by Anthropic via LiteLLM)
-  if (message.role === 'assistant' && message.reasoning_content && message.tool_calls?.length) {
+  // For Anthropic models with thinking enabled: include thinking blocks in content array
+  // This is required when assistant messages have both thinking content and tool calls
+  const includeThinkingBlocks = supportsThinkingBlocks(config);
+
+  if (includeThinkingBlocks && message.role === 'assistant' && message.reasoning_content && message.tool_calls?.length) {
     const contentBlocks: OpenAIContentBlock[] = [];
 
     // Thinking block must come first
@@ -113,7 +120,7 @@ const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number]): Op
     };
   }
 
-  // Standard case: plain text content
+  // Standard case: plain text content (for non-Anthropic models or messages without thinking+tools)
   const base: OpenAIChatMessage = {
     role: message.role,
     content: contentText,
@@ -131,7 +138,7 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
       role: 'system',
       content: request.systemPrompt,
     },
-    ...request.messages.map(toOpenAIMessage),
+    ...request.messages.map((msg) => toOpenAIMessage(msg, config)),
   ],
   stream: true,
   stream_options: { include_usage: true },

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -52,6 +52,7 @@ export interface ChatCompletionRequest {
 export type LLMStreamChunk =
   | { type: 'text'; text: string }
   | { type: 'reasoning'; reasoning: string }
+  | { type: 'thinking_signature'; signature: string }
   | { type: 'responses_reasoning_item'; item: ResponsesReasoningItem }
   | { type: 'tool_call_delta'; id: string; name?: string; arguments?: string }
   | { type: 'usage'; inputTokens?: number; outputTokens?: number; cacheReadTokens?: number; cacheWriteTokens?: number }

--- a/packages/agent-sdk-ts/src/sdk/runtime/LLMStreamer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/LLMStreamer.ts
@@ -39,6 +39,9 @@ export class LLMStreamer {
         case 'reasoning':
           message.reasoning_content = (message.reasoning_content ?? '') + chunk.reasoning;
           break;
+        case 'thinking_signature':
+          message.thinking_signature = chunk.signature;
+          break;
         case 'responses_reasoning_item':
           message.responses_reasoning_item = chunk.item;
           break;

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -35,6 +35,8 @@ export interface Message {
   tool_call_id?: string;
   name?: string;
   reasoning_content?: string;
+  /** Signature for the thinking block (required when passing thinking back to Anthropic) */
+  thinking_signature?: string;
   responses_reasoning_item?: ResponsesReasoningItem | null;
 }
 


### PR DESCRIPTION
## Summary

- Include thinking blocks in assistant message content arrays when tool calls follow (required by Anthropic)
- Add full tool calling support to AnthropicClient
- Add thinking signature capture and preservation
- Add comprehensive test coverage

### Commits

1. **OpenAICompatibleClient**: Include thinking blocks in assistant messages for Anthropic via LiteLLM
   - Add content block types (thinking, text, tool_use)
   - Update `toOpenAIMessage()` to include thinking blocks first when tool_calls present
   - Parse `thinking_signature` from stream
   - Add `thinking_signature` field to Message type

2. **AnthropicClient**: Add tool calling and thinking block support
   - Add content block types for thinking, text, tool_use, tool_result
   - Update `toAnthropicMessages()` to handle thinking blocks, tool use, and tool results
   - Convert OpenAI tool definitions to Anthropic format
   - Add tool call accumulator for streaming
   - Parse `thinking_delta`, `signature_delta`, and `input_json_delta` from stream

3. **Tests**: Test coverage for thinking block preservation
   - OpenAICompatibleClient thinking block tests
   - AnthropicClient thinking block and tool calling tests

## Test plan
- [x] Run `npm test` - all 292 tests pass
- [x] Run `npm run typecheck` - no errors
- [x] Run `npm run lint` - no errors
- [ ] Test with Opus 4.5 via LiteLLM proxy
- [ ] Test with direct Anthropic API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added thinking block support, enabling access to AI model reasoning and internal thought processes.
  * Enhanced tool call integration across both OpenAI-compatible and Anthropic providers with improved structured message formatting.
  * Improved streaming support for thinking content, reasoning, and tool usage with signature tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->