### PR TITLE
fix: do not send Gemini tool summaries to the LLM

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -506,7 +506,6 @@ export class Agent extends EventEmitter {
       }
 
       if (!response) break;
-      this.toolSummarizer.resetPendingSummaries();
 
       const assistantEvent: MessageEvent = {
         kind: 'MessageEvent',
@@ -642,11 +641,7 @@ export class Agent extends EventEmitter {
         }
         return event.llm_message;
       });
-    const messages = (() => {
-      const sanitized = sanitizeChatMessages(rawMessages);
-      const summaryMessage = this.toolSummarizer.buildToolSummaryMessage();
-      return summaryMessage ? [...sanitized, summaryMessage] : sanitized;
-    })();
+    const messages = sanitizeChatMessages(rawMessages);
     const tools = this.getToolDefinitions();
     return { systemPrompt, messages, tools };
   }
@@ -1074,8 +1069,10 @@ export class Agent extends EventEmitter {
     try {
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
       const result = await tool.execute(validated, context);
+      // Attach specialized summaries first (file diff, terminal), then general tool call summary as fallback
       let enrichedResult = await this.toolSummarizer.maybeAttachFileDiffSummary(toolCall, result);
       enrichedResult = await this.toolSummarizer.maybeAttachTerminalObservationSummary(toolCall, enrichedResult);
+      enrichedResult = await this.toolSummarizer.maybeAttachToolCallSummary(toolCall, enrichedResult);
 
       if (toolCall.function.name === 'terminal') {
         this.emitTerminalEvents(toolCall, enrichedResult);
@@ -1091,7 +1088,18 @@ export class Agent extends EventEmitter {
       } as Event;
       this.events.push(observation);
 
-      const formatted = formatToolMessageText(toolCall, enrichedResult);
+      // Remove summary from result before formatting for LLM - summaries are for UI display only
+      const resultForLlm = (() => {
+        if (enrichedResult && typeof enrichedResult === 'object' && !Array.isArray(enrichedResult) && 'summary' in enrichedResult) {
+          const record = enrichedResult as Record<string, unknown>;
+          const rest = { ...record };
+          delete rest.summary;
+          return rest;
+        }
+        return enrichedResult;
+      })();
+
+      const formatted = formatToolMessageText(toolCall, resultForLlm);
       const masked = this.secretMasker.maskText(formatted);
       const clipped = truncateToolMessage(masked);
 
@@ -1106,8 +1114,6 @@ export class Agent extends EventEmitter {
         },
       };
       this.events.push(toolMessage);
-
-      await this.toolSummarizer.maybeSummarizeToolCall(toolCall, enrichedResult);
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_execute', toolName: tool.name });
       if (classified.classification === 'agent') {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts
@@ -6,6 +6,7 @@ import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm
 import { Agent, EventLog } from '..';
 import type { OpenHandsSettings } from '../../types/settings';
 import type { ToolDefinition } from '../../types/tools';
+import type { Event, ObservationEvent } from '../../types';
 
 class RecordingLLM implements LLMClient {
   readonly requests: ChatCompletionRequest[] = [];
@@ -51,8 +52,10 @@ afterEach(() => {
   }
 });
 
-describe('Agent tool-call summaries (optional)', () => {
-  it('injects a summary into the next LLM request when enabled', async () => {
+describe('Agent tool-call summaries', () => {
+  it('attaches summary to observation event for UI display but does NOT send to LLM', async () => {
+    // Gemini summaries should be saved in events for UI display, but NOT sent to the LLM.
+    // Messages with role="assistant" must only come from the LLM, not be invented.
     const settings: OpenHandsSettings = {
       llm: { model: 'test-model' },
       agent: { summarizeToolCalls: true },
@@ -62,7 +65,7 @@ describe('Agent tool-call summaries (optional)', () => {
     };
     const log = new EventLog();
     const llm = new RecordingLLM();
-    const summarizer = new SummaryLLM('Ran example tool successfully.');
+    const summarizer = new SummaryLLM('Tool executed successfully with value 1.');
 
     const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
       name: 'example',
@@ -81,18 +84,39 @@ describe('Agent tool-call summaries (optional)', () => {
 
     await agent.run('hi');
 
-    expect(summarizer.requests).toHaveLength(1);
-    expect(llm.requests).toHaveLength(2);
+    // Verify summary is attached to observation event for UI display
+    const events = log.list();
+    const observationEvent = events.find((e: Event) => e.kind === 'ObservationEvent') as ObservationEvent | undefined;
+    expect(observationEvent).toBeDefined();
+    expect(observationEvent!.observation.summary).toBe('Tool executed successfully with value 1.');
 
+    // Verify that NO synthetic assistant messages with tool summaries are injected into LLM requests
+    expect(llm.requests).toHaveLength(2);
+    for (const request of llm.requests) {
+      for (const message of request.messages) {
+        if (message.role === 'assistant') {
+          const text = message.content
+            .filter((part) => part.type === 'text')
+            .map((part) => part.text)
+            .join('\n');
+          // Synthetic tool summary messages should NOT be present
+          expect(text).not.toContain('Tool summary');
+          expect(text).not.toContain('Tool executed successfully');
+        }
+      }
+    }
+
+    // The last message in the second request should be a tool message, not an assistant message
     const secondRequest = llm.requests[1];
     const lastMessage = secondRequest.messages[secondRequest.messages.length - 1];
-    expect(lastMessage.role).toBe('assistant');
+    expect(lastMessage.role).toBe('tool');
 
-    const lastText = lastMessage.content
+    // Verify the tool message content does NOT contain the summary
+    const toolMessageText = lastMessage.content
       .filter((part) => part.type === 'text')
       .map((part) => part.text)
-      .join('\n');
-    expect(lastText).toContain('Ran example tool successfully.');
+      .join('');
+    expect(toolMessageText).not.toContain('Tool executed successfully with value 1.');
   });
 
   it('does not summarize tools when disabled', async () => {
@@ -124,15 +148,20 @@ describe('Agent tool-call summaries (optional)', () => {
 
     await agent.run('hi');
 
+    // Verify no summary is attached when disabled
+    const events = log.list();
+    const observationEvent = events.find((e: Event) => e.kind === 'ObservationEvent') as ObservationEvent | undefined;
+    expect(observationEvent).toBeDefined();
+    expect(observationEvent!.observation.summary).toBeUndefined();
+
+    // Verify summarizer was not called
     expect(summarizer.requests).toHaveLength(0);
+
     expect(llm.requests).toHaveLength(2);
     const secondRequest = llm.requests[1];
     const lastMessage = secondRequest.messages[secondRequest.messages.length - 1];
-    const lastText = lastMessage.content
-      .filter((part) => part.type === 'text')
-      .map((part) => part.text)
-      .join('\n');
-    expect(lastText).not.toContain('should not be used');
+    // Last message should be a tool message, not an assistant message with summaries
+    expect(lastMessage.role).toBe('tool');
   });
 });
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
@@ -1,5 +1,5 @@
 import type { ChatCompletionRequest, LLMClient } from '../llm';
-import type { Message, ToolCall } from '../types';
+import type { ToolCall } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import { summarizeFileChangesWithGeminiFlash } from './fileDiffSummarizer';
 import { getGeminiClient } from './geminiClient';
@@ -19,7 +19,6 @@ export class ToolSummarizer {
   private enabled = false;
   private failed = false;
   private debug = false;
-  private pendingToolSummaries: Array<{ toolName: string; summary: string }> = [];
   private client?: LLMClient;
   private clientInitPromise?: Promise<LLMClient>;
 
@@ -34,9 +33,6 @@ export class ToolSummarizer {
   updateSettings(settings: OpenHandsSettings, options: { debug: boolean }): void {
     this.debug = options.debug;
     this.enabled = settings?.agent?.summarizeToolCalls ?? false;
-    if (!this.enabled) {
-      this.pendingToolSummaries = [];
-    }
 
     // If the user updates settings/secrets, allow retrying tool summarization.
     this.failed = false;
@@ -47,39 +43,22 @@ export class ToolSummarizer {
     }
   }
 
-  resetPendingSummaries(): void {
-    this.pendingToolSummaries = [];
-  }
+  async maybeAttachToolCallSummary(toolCall: ToolCall, result: unknown): Promise<unknown> {
+    if (!this.enabled) return result;
+    if (this.failed) return result;
+    if (!result || typeof result !== 'object' || Array.isArray(result)) return result;
 
-  buildToolSummaryMessage(): Message | undefined {
-    if (!this.enabled) return undefined;
-    if (!this.pendingToolSummaries.length) return undefined;
-
-    if (this.pendingToolSummaries.length === 1) {
-      const only = this.pendingToolSummaries[0];
-      return {
-        role: 'assistant',
-        content: [{ type: 'text', text: `Tool summary (${only.toolName}): ${only.summary}` }],
-      };
-    }
-
-    const lines = [
-      'Tool summaries:',
-      ...this.pendingToolSummaries.map((entry) => `- ${entry.toolName}: ${entry.summary}`),
-    ];
-    return { role: 'assistant', content: [{ type: 'text', text: lines.join('\n') }] };
-  }
-
-  async maybeSummarizeToolCall(toolCall: ToolCall, result: unknown): Promise<void> {
-    if (!this.enabled) return;
-    if (this.failed) return;
+    const record = result as Record<string, unknown>;
+    // Skip if already has a summary (from specialized summarizers like file diff or terminal)
+    if (typeof record.summary === 'string' && record.summary.trim()) return result;
 
     try {
       const summary = await this.summarizeToolCall(toolCall, result);
-      if (!summary) return;
-      this.pendingToolSummaries.push({ toolName: toolCall.function.name, summary });
+      if (!summary) return result;
+      return { ...record, summary };
     } catch (error) {
       this.markFailed('[Agent] Tool call summarization failed; disabling for this session:', error);
+      return result;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #585

Gemini tool summaries were being injected as synthetic `role="assistant"` messages into LLM requests. This was incorrect because:

1. **Gemini summaries should only be used for UI display, not sent to the LLM** - The summaries are generated by Gemini Flash for display purposes only
2. **Messages with `role="assistant"` must only come from the LLM, not be invented** - Creating synthetic assistant messages violates the expected message flow

## What's preserved

These summaries are stored in the `summary` field of observation events and are used for UI display purposes only. (and logging)

## Testing

- All 411 existing tests pass
- Updated test explicitly verifies that no synthetic assistant messages with tool summaries are injected into LLM requests
- TypeScript compilation passes with no errors

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2538557bd00a46568ff308da3eb815bc)
