### PR TITLE
feat(webview): add Stop button to halt agent during RUNNING state

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -275,6 +275,61 @@ describe('App - Advanced Test Coverage', () => {
         expect(mockApi.postMessage).toHaveBeenCalled();
       });
     });
+
+    it('shows stop button when agent is RUNNING and sends pause command on click', async () => {
+      render(<App />);
+
+      // Initially no stop button
+      expect(screen.queryByTestId('stop-agent-button')).not.toBeInTheDocument();
+
+      // Transition to RUNNING
+      const stateRunning: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        agent_status: 'RUNNING'
+      };
+      postToWindow({ type: 'event', event: stateRunning });
+
+      // Stop button should appear
+      await waitFor(() => {
+        expect(screen.getByTestId('stop-agent-button')).toBeInTheDocument();
+      });
+
+      // Clear previous calls to isolate the pause command
+      mockApi.postMessage.mockClear();
+
+      // Click the stop button
+      await userEvent.click(screen.getByTestId('stop-agent-button'));
+
+      // Should send pause command
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'pause' });
+    });
+
+    it('hides stop button when agent transitions from RUNNING to IDLE', async () => {
+      render(<App />);
+
+      // Transition to RUNNING
+      const stateRunning: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        agent_status: 'RUNNING'
+      };
+      postToWindow({ type: 'event', event: stateRunning });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('stop-agent-button')).toBeInTheDocument();
+      });
+
+      // Transition to IDLE
+      const stateIdle: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        agent_status: 'IDLE'
+      };
+      postToWindow({ type: 'event', event: stateIdle });
+
+      // Stop button should disappear
+      await waitFor(() => {
+        expect(screen.queryByTestId('stop-agent-button')).not.toBeInTheDocument();
+      });
+    });
   });
 
   describe('Status banner updates', () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -175,6 +175,11 @@ export function App() {
     showStatusMessage('info', 'Rejection submitted');
   }, [isSubmitting, postMessage, showStatusMessage]);
 
+  const handleStopAgent = useCallback(() => {
+    postMessage({ type: 'command', command: 'pause' });
+    showStatusMessage('info', 'Stopping agent...');
+  }, [postMessage, showStatusMessage]);
+
   const {
     halSettings,
     applyHalSettings,
@@ -758,6 +763,8 @@ export function App() {
         }}
         statusBanner={statusBanner}
         onDismissStatusBanner={() => setStatusBanner(null)}
+        agentStatus={agentStatus}
+        onStopAgent={handleStopAgent}
       />
 
       {/* LLM Profiles view (slide-over panel) */}

--- a/src/webview-src/components/app/ConversationInputDock.tsx
+++ b/src/webview-src/components/app/ConversationInputDock.tsx
@@ -7,11 +7,38 @@ export function ConversationInputDock(props: {
   inputAreaProps: ComponentProps<typeof InputArea>;
   statusBanner: StatusBannerState | null;
   onDismissStatusBanner: () => void;
+  agentStatus?: string;
+  onStopAgent?: () => void;
 }) {
-  const { inputAreaProps, statusBanner, onDismissStatusBanner } = props;
+  const { inputAreaProps, statusBanner, onDismissStatusBanner, agentStatus, onStopAgent } = props;
+
+  const isRunning = agentStatus === 'RUNNING';
 
   return (
     <div className="relative">
+      {/* Stop button - shown when agent is running */}
+      {isRunning && onStopAgent && (
+        <button
+          type="button"
+          onClick={onStopAgent}
+          className="
+            w-full px-4 py-3
+            flex items-center justify-center gap-2
+            bg-gradient-to-r from-red-500/15 to-red-600/10
+            border-t border-b border-red-500/20
+            text-red-300 hover:text-red-200
+            hover:from-red-500/20 hover:to-red-600/15
+            transition-all duration-200
+            text-sm font-medium
+          "
+          aria-label="Stop the agent"
+          data-testid="stop-agent-button"
+        >
+          <span className="codicon codicon-debug-stop" />
+          <span>Stop the agent</span>
+        </button>
+      )}
+
       <InputArea {...inputAreaProps} />
 
       {/* Bottom status bar (below prompt + controls) */}


### PR DESCRIPTION
## Summary
- Add Stop button UI above input area, visible only when agent status is RUNNING
- Button sends `pause` command to extension host (handler already existed at line 1114)
- Shows "Stopping agent..." status message on click
- Full-width red-themed button with stop icon matching codebase conventions

## Test plan
- [x] Unit tests added for stop button visibility and command sending
- [x] `npm test` passes (294 tests)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [ ] Manual test: start a long-running agent task, click Stop, verify agent halts

Closes oh-tab-4zwl

🤖 Generated with [Claude Code](https://claude.com/claude-code)