### PR TITLE
feat: add debug JSON output channel for dev/test mode

### DIFF
--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -3,12 +3,14 @@ import * as path from 'path';
 import type { BashEvent, ConversationInstance, Event } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/llmStreaming';
 import type { HostToWebviewMessage } from '../../shared/webviewMessages';
+import type { DebugJsonOutputChannel } from '../../extension/debugJsonOutputChannel';
 
 export type AttachConversationListenersDeps = {
   context: vscode.ExtensionContext;
   conversation: ConversationInstance;
 
   getOutputChannel: () => vscode.OutputChannel | undefined;
+  getDebugJsonChannel?: () => DebugJsonOutputChannel | undefined;
   getChatView: () => vscode.WebviewView | undefined;
   isChatWebviewReady: () => boolean;
   getConversationMode: () => 'local' | 'remote';
@@ -66,6 +68,13 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
       const shouldLogToDebugConsole = deps.context.extensionMode !== vscode.ExtensionMode.Production;
       const shouldLogToOutputChannel = shouldLogToDebugConsole || deps.isVerboseEventLogging();
 
+      // Log pretty-printed JSON to the debug channel (dev/test only)
+      const debugChannel = deps.getDebugJsonChannel?.();
+      if (debugChannel?.isEnabled()) {
+        const category = key === 'llm_request_payload' ? 'LLM_REQUEST' : 'LLM_RESPONSE';
+        debugChannel.logJson(category, ev.value);
+      }
+
       if (shouldLogToOutputChannel) {
         try {
           outputChannel?.appendLine(`[llm][${key}]`);
@@ -104,6 +113,12 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
         outputChannel?.appendLine(`[event] ${deps.safeStringify(ev)}`);
       } else {
         outputChannel?.appendLine(`[event] ${ev.kind}`);
+      }
+
+      // Log events to debug JSON channel (dev/test only)
+      const debugChannel = deps.getDebugJsonChannel?.();
+      if (debugChannel?.isEnabled() && (deps.isVerboseEventLogging() || isErrorLike)) {
+        debugChannel.logJson(`EVENT_${ev.kind}`, ev);
       }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { registerDiagnosticsCommands, type RenderedEventsInfo, type UiStateSnaps
 import type { HostToWebviewMessage } from './shared/webviewMessages';
 import { resolveLocalTools } from './shared/localTools';
 import { createDevBridgeLogger, createMaskedOutputChannel } from './extension/devBridgeLogger';
+import { createDebugJsonOutputChannel, type DebugJsonOutputChannel } from './extension/debugJsonOutputChannel';
 import { createFileEditNoteTracker } from './extension/fileEditNote';
 import { getGitHeadDiffSummaryForFile, resolveGitContext } from './extension/gitDiffSummary';
 import { resolveConversationStoreRoot } from './extension/conversationStoreRoot';
@@ -53,6 +54,7 @@ let chatWebviewReady = false; // Track if chat WebviewView is ready
 let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+let debugJsonChannel: DebugJsonOutputChannel | undefined;
 let secretRegistry: SecretRegistry | undefined;
 let conversationStoreRoot: string | undefined;
 let lastKnownLlmLabel: string | null = null;
@@ -170,6 +172,12 @@ export function activate(context: vscode.ExtensionContext) {
   } catch (err) {
     console.warn('[OpenHands] Failed to create output channel:', err);
     outputChannel = undefined;
+  }
+
+  // Create debug JSON output channel (only in dev/test modes or with devBridge enabled)
+  debugJsonChannel = createDebugJsonOutputChannel({ context, secretRegistry: secrets });
+  if (debugJsonChannel.isEnabled()) {
+    outputChannel?.appendLine('[OpenHands-DEBUG] Debug JSON channel initialized');
   }
 
   pastedImagesBaseDir = getGlobalStorageBaseDir(context.globalStorageUri?.fsPath);
@@ -457,6 +465,7 @@ export function activate(context: vscode.ExtensionContext) {
         context,
         conversation,
         getOutputChannel: () => outputChannel,
+        getDebugJsonChannel: () => debugJsonChannel,
         getChatView: () => chatView,
         isChatWebviewReady: () => chatWebviewReady,
         getConversationMode: () => conversationMode,
@@ -640,11 +649,13 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
   try { conversation?.disconnect(); } catch { }
   try { terminal?.dispose(); } catch { }
+  try { debugJsonChannel?.dispose(); } catch { }
   // Reset module state to ensure clean slate for tests and re-activation
   chatView = undefined;
   conversation = undefined;
   terminal = undefined;
   terminalLogPty = undefined;
+  debugJsonChannel = undefined;
   localAgentContext = undefined;
   activeEditorFilePath = undefined;
   pendingRenderedEventsRequests.clear();

--- a/src/extension/debugJsonOutputChannel.ts
+++ b/src/extension/debugJsonOutputChannel.ts
@@ -1,0 +1,119 @@
+import * as vscode from 'vscode';
+import { maskSecretsInText } from '../shared/maskSecrets';
+import type { SecretRegistry } from '@openhands/agent-sdk-ts';
+
+export interface DebugJsonOutputChannel {
+  /** Log JSON data with a category badge and pretty formatting */
+  logJson(category: string, data: unknown): void;
+  /** Log a simple message line */
+  log(message: string): void;
+  /** Show the channel in the output panel */
+  show(): void;
+  /** Check if the channel is enabled (dev/test mode only) */
+  isEnabled(): boolean;
+  /** Dispose of the channel */
+  dispose(): void;
+}
+
+export interface CreateDebugJsonOutputChannelOptions {
+  context: vscode.ExtensionContext;
+  secretRegistry?: SecretRegistry;
+}
+
+/**
+ * Create a debug-only JSON output channel for development and testing.
+ * In production mode, returns a no-op implementation.
+ */
+export function createDebugJsonOutputChannel(
+  options: CreateDebugJsonOutputChannelOptions
+): DebugJsonOutputChannel {
+  const { context, secretRegistry } = options;
+
+  // Only enable in Development or Test modes, or if devBridge setting is enabled
+  const mode = context.extensionMode;
+  const extensionMode = vscode.ExtensionMode;
+  const isDevOrTest =
+    (extensionMode?.Development !== undefined &&
+      (mode === extensionMode.Development || mode === extensionMode.Test)) ||
+    false;
+  const enableFromSetting = !!vscode.workspace.getConfiguration().get<boolean>('openhands.devBridge.enabled');
+  const enabled = isDevOrTest || enableFromSetting;
+
+  if (!enabled) {
+    // Return no-op implementation for production
+    return {
+      logJson: () => { /* no-op in production */ },
+      log: () => { /* no-op in production */ },
+      show: () => { /* no-op in production */ },
+      isEnabled: () => false,
+      dispose: () => { /* no-op in production */ },
+    };
+  }
+
+  // Create the debug output channel
+  let channel: vscode.OutputChannel | undefined;
+  try {
+    channel = vscode.window.createOutputChannel('OpenHands-DEBUG');
+    context.subscriptions.push(channel);
+  } catch (err) {
+    console.warn('[OpenHands-DEBUG] Failed to create output channel:', err);
+    return {
+      logJson: () => { /* channel creation failed */ },
+      log: () => { /* channel creation failed */ },
+      show: () => { /* channel creation failed */ },
+      isEnabled: () => false,
+      dispose: () => { /* channel creation failed */ },
+    };
+  }
+
+  const maskSecrets = (text: string): string => {
+    return maskSecretsInText(text, secretRegistry);
+  };
+
+  const formatTimestamp = (): string => {
+    const now = new Date();
+    return now.toISOString().replace('T', ' ').replace('Z', '');
+  };
+
+  const formatJsonPretty = (data: unknown): string => {
+    try {
+      const jsonString = JSON.stringify(data, null, 2);
+      return maskSecrets(jsonString);
+    } catch (e) {
+      return `<failed to stringify: ${String(e)}>`;
+    }
+  };
+
+  return {
+    logJson(category: string, data: unknown): void {
+      if (!channel) return;
+      const timestamp = formatTimestamp();
+      const header = `[${timestamp}] [${category}]`;
+      const separator = '─'.repeat(60);
+      
+      channel.appendLine(separator);
+      channel.appendLine(header);
+      channel.appendLine(formatJsonPretty(data));
+      channel.appendLine('');
+    },
+
+    log(message: string): void {
+      if (!channel) return;
+      const timestamp = formatTimestamp();
+      channel.appendLine(`[${timestamp}] ${maskSecrets(message)}`);
+    },
+
+    show(): void {
+      channel?.show(true);
+    },
+
+    isEnabled(): boolean {
+      return enabled && !!channel;
+    },
+
+    dispose(): void {
+      channel?.dispose();
+      channel = undefined;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Add a dedicated 'OpenHands-DEBUG' VSCode output channel that displays pretty-printed JSON for LLM requests/responses and events during development/testing.

## Changes
- **New file**: `src/extension/debugJsonOutputChannel.ts`
  - Creates a dedicated output channel for JSON debugging
  - Pretty-prints JSON with 2-space indentation  
  - Adds timestamps and category badges (e.g., `[LLM_REQUEST]`, `[LLM_RESPONSE]`)
  - Masks secrets from output
  - Only enabled in dev/test modes or with `devBridge` setting
  - Returns no-op implementation for production (zero overhead)

- **Integration**: `src/extension.ts` and `src/conversation/host/attachConversationListeners.ts`
  - Logs LLM request/response payloads to debug channel
  - Logs events (verbose mode or errors) with category badges

## Example output
```
──────???───────────────────────────────────────────
[2025-12-28 10:30:15.123] [LLM_REQUEST]
{
  "model": "claude-3-5-sonnet-20241022",
  "messages": [...],
  "tools": [...]
}
```

## Testing
Run the extension in Development mode (F5) and open Output panel → select 'OpenHands-DEBUG'