### PR TITLE
fix(agent): properly handle pause during streaming and resume on new message

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -278,6 +278,7 @@ export class Agent extends EventEmitter {
   async run(input: AgentRunInput): Promise<Message | undefined> {
     this.cancelled = false;
     this.finished = false;
+    this.paused = false;
     return this.lock.acquire(async () => {
       this.ensureSystemPrompt();
       this.pushUserMessage(input);
@@ -518,6 +519,11 @@ export class Agent extends EventEmitter {
       }
       this.state.incrementIteration();
       lastAssistantMessage = response.message;
+
+      // Check if paused during streaming - don't execute tool calls
+      if (this.paused || this.cancelled) {
+        break;
+      }
 
       const toolCalls = response.message.tool_calls ?? [];
       if (!toolCalls.length) {


### PR DESCRIPTION
## Summary
Fixes the Stop button behavior in the agent runtime:

- **Skip tool execution when paused**: After LLM streaming completes, check if `paused` or `cancelled` flag was set during streaming and break out of the loop before executing tool calls
- **Resume on new message**: Reset `paused` flag in `run()` so sending a new message properly resumes from paused state

## Test plan
- [x] `npm test` passes (294 tests)
- [ ] Manual test: Start conversation → Click Stop during streaming → Tool calls should NOT execute
- [ ] Manual test: After stopping → Send new message → Agent should resume and run

Follow-up to #589

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced pause and cancellation handling to prevent tool calls from executing when an agent execution is paused or cancelled.
- Improved state management during agent execution to reliably respect pause and cancellation requests throughout streaming operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->