### PR TITLE
fix: set thinking budget_tokens < max_tokens for Anthropic

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/providerQuirks.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/providerQuirks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { LLMConfiguration } from '../types';
-import { normalizeGenerationParamsForModel, isAnthropicModel, supportsThinkingBlocks } from '../providerQuirks';
+import { normalizeGenerationParamsForModel, isAnthropicModel, supportsThinkingBlocks, getAnthropicThinkingBudget } from '../providerQuirks';
 
 const makeConfig = (overrides: Partial<LLMConfiguration> = {}): LLMConfiguration => ({
   model: 'gpt-4o',
@@ -132,5 +132,62 @@ describe('supportsThinkingBlocks', () => {
       provider: 'openai',
       reasoningEffort: 'high',
     }))).toBe(false);
+  });
+});
+
+describe('getAnthropicThinkingBudget', () => {
+  it('returns undefined for non-Anthropic models', () => {
+    expect(getAnthropicThinkingBudget(makeConfig({
+      model: 'gpt-4o',
+      reasoningEffort: 'high',
+    }))).toBeUndefined();
+  });
+
+  it('returns undefined when thinking is not enabled', () => {
+    expect(getAnthropicThinkingBudget(makeConfig({
+      model: 'claude-3-opus',
+    }))).toBeUndefined();
+  });
+
+  it('returns undefined when reasoningEffort is none', () => {
+    expect(getAnthropicThinkingBudget(makeConfig({
+      model: 'claude-3-opus',
+      reasoningEffort: 'none',
+    }))).toBeUndefined();
+  });
+
+  it('returns 80% of maxOutputTokens for Anthropic with thinking', () => {
+    const budget = getAnthropicThinkingBudget(makeConfig({
+      model: 'claude-3-opus',
+      reasoningEffort: 'high',
+      maxOutputTokens: 10000,
+    }));
+    expect(budget).toBe(8000); // 80% of 10000
+  });
+
+  it('enforces minimum budget of 1024', () => {
+    const budget = getAnthropicThinkingBudget(makeConfig({
+      model: 'claude-3-opus',
+      reasoningEffort: 'high',
+      maxOutputTokens: 500, // 80% = 400, below minimum
+    }));
+    expect(budget).toBe(1024);
+  });
+
+  it('enforces maximum budget of 128000', () => {
+    const budget = getAnthropicThinkingBudget(makeConfig({
+      model: 'claude-3-opus',
+      reasoningEffort: 'high',
+      maxOutputTokens: 200000, // 80% = 160000, above maximum
+    }));
+    expect(budget).toBe(128000);
+  });
+
+  it('uses default maxOutputTokens of 16000 when not specified', () => {
+    const budget = getAnthropicThinkingBudget(makeConfig({
+      model: 'claude-3-opus',
+      reasoningEffort: 'high',
+    }));
+    expect(budget).toBe(12800); // 80% of 16000
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -1,5 +1,6 @@
 import { setTimeout as delay } from 'node:timers/promises';
 import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions, type ToolCallAccumulator } from './types';
+import { getAnthropicThinkingBudget } from './providerQuirks';
 
 const decoder = new TextDecoder();
 
@@ -404,10 +405,11 @@ export class AnthropicClient implements LLMClient {
 
   private requestBody(request: ChatCompletionRequest): Record<string, unknown> {
     const anthropicTools = toAnthropicTools(request.tools);
-    const thinkingEnabled = this.config.reasoningEffort && this.config.reasoningEffort !== 'none';
+    const thinkingBudget = getAnthropicThinkingBudget(this.config);
+
     return {
       model: this.config.model,
-      max_tokens: this.config.maxOutputTokens ?? 1024,
+      max_tokens: this.config.maxOutputTokens ?? 16000,
       // Note: temperature is normalized by providerQuirks.normalizeGenerationParamsForModel()
       // which sets temperature=1 when thinking is enabled (Anthropic requirement)
       temperature: this.config.temperature ?? 0,
@@ -415,8 +417,8 @@ export class AnthropicClient implements LLMClient {
       messages: toAnthropicMessages(request),
       stream: true,
       ...(anthropicTools ? { tools: anthropicTools, tool_choice: { type: 'auto' } } : {}),
-      thinking: thinkingEnabled
-        ? { type: 'enabled', budget_tokens: this.config.maxOutputTokens ?? undefined }
+      thinking: thinkingBudget !== undefined
+        ? { type: 'enabled', budget_tokens: thinkingBudget }
         : undefined,
     };
   }

--- a/packages/agent-sdk-ts/src/sdk/llm/providerQuirks.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/providerQuirks.ts
@@ -1,5 +1,40 @@
 import type { LLMConfiguration } from './types';
 
+/**
+ * Provider Quirks
+ * 
+ * This module centralizes provider-specific API requirements and constraints.
+ * Each provider has its own quirks that must be handled to avoid API errors.
+ * 
+ * References:
+ * - Anthropic Messages API: https://platform.claude.com/docs/en/api/messages.md
+ * - Anthropic Extended Thinking: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+ */
+
+// =============================================================================
+// Anthropic Extended Thinking Constraints
+// =============================================================================
+// 
+// When extended thinking is enabled, Anthropic has several requirements:
+// 
+// 1. Temperature MUST be exactly 1
+//    - Any other value returns 400 error
+//    - See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations
+// 
+// 2. budget_tokens constraints:
+//    - Minimum: 1024 tokens
+//    - Maximum: 128000 tokens (model dependent, but 128k is safe upper bound)
+//    - Must be LESS than max_tokens (max_tokens > budget_tokens)
+//    - See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#max-tokens-and-context-window-size
+// 
+// 3. Thinking signature is required when sending thinking blocks back
+//    - The signature field from the response must be included
+//    - See: toAnthropicMessages() in anthropic.ts
+// =============================================================================
+
+const ANTHROPIC_THINKING_MIN_BUDGET = 1024;
+const ANTHROPIC_THINKING_MAX_BUDGET = 128000;
+
 const isGpt5Model = (model: string | undefined): boolean => {
   if (typeof model !== 'string') return false;
   const normalized = model.trim().toLowerCase();
@@ -43,12 +78,31 @@ export const supportsThinkingBlocks = (config: LLMConfiguration): boolean => {
 };
 
 /**
+ * Get the thinking budget tokens for Anthropic extended thinking.
+ * 
+ * Returns undefined if thinking is not enabled.
+ * Otherwise returns a value that satisfies Anthropic's constraints:
+ * - At least 1024 tokens (minimum)
+ * - At most 128000 tokens (maximum)
+ * - 80% of maxOutputTokens (leaving 20% for actual output)
+ */
+export const getAnthropicThinkingBudget = (config: LLMConfiguration): number | undefined => {
+  if (!isAnthropicModel(config) || !hasExtendedThinking(config)) {
+    return undefined;
+  }
+
+  const maxTokens = config.maxOutputTokens ?? 16000;
+  const budget = Math.floor(maxTokens * 0.8);
+
+  return Math.min(ANTHROPIC_THINKING_MAX_BUDGET, Math.max(ANTHROPIC_THINKING_MIN_BUDGET, budget));
+};
+
+/**
  * Normalize generation parameters based on provider-specific requirements.
  * 
  * Provider quirks handled:
  * - GPT-5 models: temperature must be stripped entirely
  * - Anthropic with extended thinking: temperature must be exactly 1
- *   See: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#important-considerations
  */
 export const normalizeGenerationParamsForModel = (config: LLMConfiguration): LLMConfiguration => {
   // GPT-5 models: strip temperature entirely


### PR DESCRIPTION
## Problem

Anthropic requires `max_tokens > thinking.budget_tokens`. We were setting them equal, causing:
```
`max_tokens` must be greater than `thinking.budget_tokens`
```

## Solution

Use 80% of `max_tokens` for thinking budget, leaving 20% for actual output.

## Reference

https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#max-tokens-and-context-window-size

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/342fd930e5074487a9bb6361aa5e80de)