### PR TITLE
feat: add Gemini 3 Flash thinking test script

### DIFF
--- a/.github/workflows/llm-gemini-test.yml
+++ b/.github/workflows/llm-gemini-test.yml
@@ -1,0 +1,122 @@
+name: LLM Quirks - Gemini
+
+on:
+  # Manual trigger only
+  workflow_dispatch:
+    inputs:
+      test_mode:
+        description: 'Test mode to run'
+        required: true
+        default: 'direct'
+        type: choice
+        options:
+          - direct
+          - litellm
+          - all
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: llm-gemini-test-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  test-gemini-thinking:
+    runs-on: ubuntu-latest
+    environment: LLM
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          check-latest: true
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Build SDK
+        run: npm run build -w @openhands/agent-sdk-ts
+
+      - name: Determine test mode
+        id: mode
+        run: |
+          echo "mode=${{ github.event.inputs.test_mode }}" >> $GITHUB_OUTPUT
+
+      - name: Run Gemini Integration Test
+        id: test
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+        run: |
+          MODE="${{ steps.mode.outputs.mode }}"
+          echo "Running Gemini test in mode: $MODE"
+          
+          # Run test and capture output
+          set +e
+          case "$MODE" in
+            direct)
+              cd packages/agent-sdk-ts
+              node ../../.github/workflows/scripts/test-gemini-thinking.mjs 2>&1 | tee ../../test-output.log
+              cd ../..
+              ;;
+            litellm)
+              echo "LiteLLM mode not yet implemented for Gemini"
+              echo "❌ FAIL - LiteLLM mode not implemented" > test-output.log
+              exit 1
+              ;;
+            all)
+              cd packages/agent-sdk-ts
+              node ../../.github/workflows/scripts/test-gemini-thinking.mjs 2>&1 | tee ../../test-output.log
+              cd ../..
+              ;;
+          esac
+          TEST_EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+          
+          # Parse results from log
+          if grep -q "🎉 All tests passed!" test-output.log; then
+            echo "result=PASS" >> $GITHUB_OUTPUT
+            echo "status=✅ PASS" >> $GITHUB_OUTPUT
+          else
+            echo "result=FAIL" >> $GITHUB_OUTPUT
+            echo "status=❌ FAIL" >> $GITHUB_OUTPUT
+          fi
+          
+          # Extract test summary lines
+          SUMMARY=$(grep -E "^(✅|❌|⚠️) (PASS|FAIL)" test-output.log || echo "No summary found")
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          echo "$SUMMARY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          
+          exit $TEST_EXIT_CODE
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gemini-test-logs-${{ github.run_number }}
+          path: test-output.log
+          retention-days: 30
+
+      - name: Create GitHub Step Summary
+        if: always()
+        run: |
+          echo "## Gemini Integration Test Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **Status:** ${{ steps.test.outputs.status }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Branch:** ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Commit:** \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Test Mode:** ${{ steps.mode.outputs.mode }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Run:** [#${{ github.run_number }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Summary" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.test.outputs.summary }}" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/scripts/test-gemini-thinking.mjs
+++ b/.github/workflows/scripts/test-gemini-thinking.mjs
@@ -56,7 +56,7 @@ const fileEditorTool = {
       properties: {
         command: {
           type: 'string',
-          enum: ['view', 'create', 'str_replace'],
+          enum: ['view', 'create'],
           description: 'The command to run'
         },
         path: {
@@ -111,14 +111,18 @@ async function streamResponse(client, request) {
 }
 
 function buildAssistantMessage(result) {
+  const toolCallsArray = Object.values(result.toolCalls);
   return {
     role: 'assistant',
     content: result.textContent ? [{ type: 'text', text: result.textContent }] : [],
-    tool_calls: Object.values(result.toolCalls).map(tc => ({
-      id: tc.id,
-      type: 'function',
-      function: { name: tc.name, arguments: tc.arguments }
-    })),
+    // Only include tool_calls if there are any (some APIs reject empty arrays)
+    ...(toolCallsArray.length > 0 && {
+      tool_calls: toolCallsArray.map(tc => ({
+        id: tc.id,
+        type: 'function',
+        function: { name: tc.name, arguments: tc.arguments }
+      }))
+    }),
     reasoning_content: result.reasoningContent || undefined,
     thinking_signature: result.thinkingSignature || undefined,
   };
@@ -299,9 +303,10 @@ async function runTest() {
   if (issues.length > 0) {
     console.log('\n⚠️  Warnings:');
     issues.forEach(issue => console.log(`  - ${issue}`));
+    console.log(`\n⚠️ Test "Gemini 3 Flash Thinking" completed with warnings in ${turn} turns`);
+  } else {
+    console.log(`\n✅ Test "Gemini 3 Flash Thinking" completed successfully in ${turn} turns`);
   }
-
-  console.log(`\n✅ Test "Gemini 3 Flash Thinking" completed successfully in ${turn} turns`);
   return { success: true, turns: turn, hadThinking, hadSignature, hadToolCalls };
 }
 

--- a/.github/workflows/scripts/test-gemini-thinking.mjs
+++ b/.github/workflows/scripts/test-gemini-thinking.mjs
@@ -1,0 +1,335 @@
+#!/usr/bin/env node
+/**
+ * Test script for Gemini 3 Flash with thinking (thought signatures).
+ * 
+ * This script tests the Gemini API with extended thinking, which requires:
+ * 1. Passing thinkingConfig with thinkingLevel
+ * 2. Preserving thoughtSignature in function call responses
+ * 3. Handling multi-turn conversations with signatures
+ * 
+ * The test ACTUALLY executes file operations to verify end-to-end behavior.
+ * 
+ * API Documentation:
+ * - Gemini Thought Signatures: https://ai.google.dev/gemini-api/docs/thought-signatures
+ * - Gemini 3 Models: https://ai.google.dev/gemini-api/docs/gemini-3
+ * 
+ * Key Gemini 3 Thinking Quirks:
+ * - thoughtSignature MUST be passed back during function calling (400 error otherwise)
+ * - For parallel function calls, only the FIRST function call has the signature
+ * - For sequential function calls, ALL signatures must be preserved
+ * - Non-function-call responses may have optional signatures (recommended to preserve)
+ * 
+ * Usage:
+ *   GEMINI_API_KEY=... node test-gemini-thinking.mjs
+ * 
+ * Exit codes:
+ *   0 - Test passed
+ *   1 - Test failed
+ *   2 - Missing required environment variables
+ */
+
+import { LLMFactory } from '../../../packages/agent-sdk-ts/dist/index.mjs';
+import { readFile, writeFile, unlink } from 'fs/promises';
+import { existsSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// Repo root is three levels up from .github/workflows/scripts/
+const REPO_ROOT = join(__dirname, '..', '..', '..');
+const README_PATH = join(REPO_ROOT, 'README.md');
+
+const GEMINI_MODEL = 'gemini-3-flash-preview';
+
+// Files created during test - will be cleaned up
+const TEST_OUTPUT_FILE = 'summary.md';
+
+const fileEditorTool = {
+  type: 'function',
+  function: {
+    name: 'file_editor',
+    description: 'Create, view, or edit files',
+    parameters: {
+      type: 'object',
+      properties: {
+        command: {
+          type: 'string',
+          enum: ['view', 'create', 'str_replace'],
+          description: 'The command to run'
+        },
+        path: {
+          type: 'string',
+          description: 'Path to the file'
+        },
+        file_text: {
+          type: 'string',
+          description: 'Content for create command'
+        }
+      },
+      required: ['command', 'path']
+    }
+  }
+};
+
+async function streamResponse(client, request) {
+  let textContent = '';
+  let reasoningContent = '';
+  let thinkingSignature = '';
+  const toolCalls = {};
+  let usage = null;
+
+  for await (const chunk of client.streamChat(request)) {
+    switch (chunk.type) {
+      case 'text':
+        textContent += chunk.text;
+        process.stdout.write(chunk.text);
+        break;
+      case 'reasoning':
+        reasoningContent += chunk.reasoning;
+        break;
+      case 'thinking_signature':
+        thinkingSignature = chunk.signature;
+        break;
+      case 'tool_call_delta':
+        if (!toolCalls[chunk.id]) {
+          toolCalls[chunk.id] = { id: chunk.id, name: chunk.name || '', arguments: '' };
+        }
+        if (chunk.name) toolCalls[chunk.id].name = chunk.name;
+        if (chunk.arguments) toolCalls[chunk.id].arguments += chunk.arguments;
+        break;
+      case 'usage':
+        usage = { input: chunk.inputTokens, output: chunk.outputTokens };
+        break;
+      case 'finish':
+        break;
+    }
+  }
+
+  return { textContent, reasoningContent, thinkingSignature, toolCalls, usage };
+}
+
+function buildAssistantMessage(result) {
+  return {
+    role: 'assistant',
+    content: result.textContent ? [{ type: 'text', text: result.textContent }] : [],
+    tool_calls: Object.values(result.toolCalls).map(tc => ({
+      id: tc.id,
+      type: 'function',
+      function: { name: tc.name, arguments: tc.arguments }
+    })),
+    reasoning_content: result.reasoningContent || undefined,
+    thinking_signature: result.thinkingSignature || undefined,
+  };
+}
+
+function buildToolMessages(toolCalls, results) {
+  return Object.values(toolCalls).map(tc => ({
+    role: 'tool',
+    tool_call_id: tc.id,
+    name: tc.name,
+    content: [{ type: 'text', text: results[tc.id] || 'Tool executed successfully' }]
+  }));
+}
+
+/**
+ * Run the Gemini thinking test
+ */
+async function runTest() {
+  console.log('='.repeat(60));
+  console.log('Testing: Gemini 3 Flash with Thinking');
+  console.log(`Provider: gemini`);
+  console.log(`Model: ${GEMINI_MODEL}`);
+  console.log('='.repeat(60));
+
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    console.error('Missing GEMINI_API_KEY environment variable');
+    return { success: false, turns: 0, error: 'Missing GEMINI_API_KEY' };
+  }
+
+  const config = {
+    provider: 'gemini',
+    model: GEMINI_MODEL,
+    apiKey: apiKey,
+    reasoningEffort: 'high',  // Enable thinking
+    maxOutputTokens: 8000,
+  };
+
+  console.log('\nCreating LLM client...');
+  let client;
+  try {
+    const factory = new LLMFactory(config);
+    client = await factory.createClient();
+  } catch (error) {
+    console.error(`Failed to create client: ${error.message}`);
+    return { success: false, turns: 0, error: `Client creation failed: ${error.message}` };
+  }
+
+  const systemPrompt = 'You are a helpful assistant. Use the file_editor tool to read and create files.';
+  const userMessage = {
+    role: 'user',
+    content: [{ type: 'text', text: 'Read the README.md file and find 3 facts to save in summary.md' }]
+  };
+
+  let messages = [userMessage];
+  let turn = 0;
+  const maxTurns = 5;
+  let hadThinking = false;
+  let hadSignature = false;
+  let hadToolCalls = false;
+
+  while (turn < maxTurns) {
+    turn++;
+    console.log(`\n--- Turn ${turn} ---`);
+
+    const request = {
+      systemPrompt,
+      messages,
+      tools: [fileEditorTool]
+    };
+
+    let result;
+    try {
+      result = await streamResponse(client, request);
+    } catch (error) {
+      console.error(`\nError during turn ${turn}: ${error.message}`);
+      return { success: false, turns: turn, error: error.message };
+    }
+
+    console.log('');
+    console.log(`  Text: ${result.textContent.length} chars`);
+    console.log(`  Reasoning: ${result.reasoningContent.length} chars`);
+    console.log(`  Signature: ${result.thinkingSignature ? 'present' : 'missing'}`);
+    console.log(`  Tool calls: ${Object.keys(result.toolCalls).length}`);
+    if (result.usage) {
+      console.log(`  Usage: input=${result.usage.input}, output=${result.usage.output}`);
+    }
+
+    // Track what we've seen
+    if (result.reasoningContent.length > 0) hadThinking = true;
+    if (result.thinkingSignature) hadSignature = true;
+    if (Object.keys(result.toolCalls).length > 0) hadToolCalls = true;
+
+    // If no tool calls, we're done
+    if (Object.keys(result.toolCalls).length === 0) {
+      console.log('\n=== Agent completed (no more tool calls) ===');
+      console.log('\nFinal response:');
+      console.log(result.textContent);
+      break;
+    }
+
+    // Process tool calls - ACTUALLY execute them
+    const toolResults = {};
+    for (const [id, tc] of Object.entries(result.toolCalls)) {
+      let args;
+      try {
+        args = JSON.parse(tc.arguments);
+      } catch {
+        args = {};
+      }
+
+      console.log(`  Executing: ${tc.name}(${JSON.stringify(args).slice(0, 100)}...)`);
+
+      if (tc.name === 'file_editor') {
+        try {
+          if (args.command === 'view') {
+            // Map README.md to the actual repo README
+            const filePath = args.path === 'README.md' ? README_PATH : args.path;
+            const content = await readFile(filePath, 'utf-8');
+            toolResults[id] = `File content:\n${content}`;
+            console.log(`  Read file: ${args.path} -> ${filePath} (${content.length} chars)`);
+          } else if (args.command === 'create') {
+            // Actually create the file in cwd
+            await writeFile(args.path, args.file_text || '');
+            toolResults[id] = `File created successfully at ${args.path}`;
+            console.log(`  Created file: ${args.path}`);
+            if (args.file_text) {
+              console.log(`  Content preview: ${args.file_text.slice(0, 200)}...`);
+            }
+          } else {
+            toolResults[id] = `Command ${args.command} not implemented in test`;
+          }
+        } catch (err) {
+          toolResults[id] = `Error: ${err.message}`;
+          console.log(`  Error: ${err.message}`);
+        }
+      } else {
+        toolResults[id] = 'Tool not implemented in test';
+      }
+    }
+
+    // Build next messages
+    const assistantMessage = buildAssistantMessage(result);
+    const toolMessages = buildToolMessages(result.toolCalls, toolResults);
+    messages = [...messages, assistantMessage, ...toolMessages];
+  }
+
+  if (turn >= maxTurns) {
+    console.log('\n=== Max turns reached ===');
+    return { success: false, turns: turn, error: 'Max turns reached without completion' };
+  }
+
+  // Validate results
+  const issues = [];
+  if (!hadThinking) issues.push('No thinking/reasoning content received');
+  if (!hadSignature) issues.push('No thinking signature received');
+  if (!hadToolCalls) issues.push('No tool calls made');
+
+  // Verify the output file was actually created
+  const outputPath = join(process.cwd(), TEST_OUTPUT_FILE);
+  console.log(`\n🔍 Checking for output file at: ${outputPath}`);
+
+  if (existsSync(outputPath)) {
+    const content = await readFile(outputPath, 'utf-8');
+    console.log(`📄 Verified ${TEST_OUTPUT_FILE} was created (${content.length} chars)`);
+    console.log('--- File content ---');
+    console.log(content);
+    console.log('--- End of file ---');
+
+    // Clean up
+    await unlink(outputPath);
+    console.log(`🧹 Cleaned up ${TEST_OUTPUT_FILE}`);
+  } else {
+    console.log(`❌ File NOT found at ${outputPath}`);
+    issues.push(`Output file ${TEST_OUTPUT_FILE} was not created`);
+  }
+
+  if (issues.length > 0) {
+    console.log('\n⚠️  Warnings:');
+    issues.forEach(issue => console.log(`  - ${issue}`));
+  }
+
+  console.log(`\n✅ Test "Gemini 3 Flash Thinking" completed successfully in ${turn} turns`);
+  return { success: true, turns: turn, hadThinking, hadSignature, hadToolCalls };
+}
+
+async function main() {
+  console.log('');
+  const result = await runTest();
+
+  console.log('\n' + '='.repeat(60));
+  console.log('TEST SUMMARY');
+  console.log('='.repeat(60));
+
+  const status = result.success ? '✅ PASS' : '❌ FAIL';
+  console.log(`${status} - Gemini 3 Flash Thinking (${result.turns} turns)`);
+  if (result.error) {
+    console.log(`       Error: ${result.error}`);
+  }
+
+  console.log('');
+  if (result.success) {
+    console.log('🎉 All tests passed!');
+    process.exit(0);
+  } else {
+    console.log('💥 Test failed.');
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/.github/workflows/scripts/test-gemini-thinking.mjs
+++ b/.github/workflows/scripts/test-gemini-thinking.mjs
@@ -146,7 +146,7 @@ async function runTest() {
   const apiKey = process.env.GEMINI_API_KEY;
   if (!apiKey) {
     console.error('Missing GEMINI_API_KEY environment variable');
-    return { success: false, turns: 0, error: 'Missing GEMINI_API_KEY' };
+    process.exit(2);
   }
 
   const config = {

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -56,12 +56,15 @@ type GeminiGenerateContentRequest = {
     maxOutputTokens?: number;
     thinkingConfig?: {
       thinkingLevel: GeminiThinkingLevel;
+      // Enable thought summaries in response
+      // See: https://ai.google.dev/gemini-api/docs/thinking#thought_summaries
+      includeThoughts?: boolean;
     };
   };
 };
 
 type GeminiStreamCandidatePart =
-  | { text?: string; thoughtSignature?: string }
+  | { text?: string; thought?: boolean; thoughtSignature?: string }
   | { functionCall?: { name?: string; args?: unknown }; thoughtSignature?: string };
 
 type GeminiStreamResponse = {
@@ -200,7 +203,8 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
     topK: typeof config.topK === 'number' ? config.topK : undefined,
     maxOutputTokens: typeof config.maxOutputTokens === 'number' ? config.maxOutputTokens : undefined,
     // Enable thinking for Gemini 3 models when reasoningEffort is set
-    ...(thinkingLevel ? { thinkingConfig: { thinkingLevel } } : {}),
+    // includeThoughts enables thought summaries in the response
+    ...(thinkingLevel ? { thinkingConfig: { thinkingLevel, includeThoughts: true } } : {}),
   };
 
   const body: GeminiGenerateContentRequest = {
@@ -280,17 +284,6 @@ export class GeminiClient implements LLMClient {
       }
 
       const parts = parsed.candidates?.[0]?.content?.parts ?? [];
-      const chunkText = parts
-        .flatMap((part) => ('text' in part && typeof part.text === 'string' ? [part.text] : []))
-        .join('');
-
-      if (chunkText) {
-        const delta = chunkText.startsWith(emittedText) ? chunkText.slice(emittedText.length) : chunkText;
-        if (delta) {
-          emittedText = chunkText.startsWith(emittedText) ? chunkText : `${emittedText}${delta}`;
-          yield { type: 'text', text: delta };
-        }
-      }
 
       for (const part of parts) {
         // Extract thoughtSignature from any part (text or functionCall)
@@ -300,6 +293,23 @@ export class GeminiClient implements LLMClient {
           yield { type: 'thinking_signature', signature };
         }
 
+        // Handle text parts - check if it's a thought summary or regular text
+        if ('text' in part && typeof part.text === 'string' && part.text) {
+          const isThought = 'thought' in part && part.thought === true;
+          if (isThought) {
+            // Thought summary - emit as reasoning
+            yield { type: 'reasoning', reasoning: part.text };
+          } else {
+            // Regular text - emit as text with delta tracking
+            const delta = part.text.startsWith(emittedText) ? part.text.slice(emittedText.length) : part.text;
+            if (delta) {
+              emittedText = part.text.startsWith(emittedText) ? part.text : `${emittedText}${delta}`;
+              yield { type: 'text', text: delta };
+            }
+          }
+        }
+
+        // Handle function calls
         const call = 'functionCall' in part ? (part.functionCall ?? undefined) : undefined;
         if (!call || typeof call !== 'object') continue;
         const toolCall = normalizeToolCall(call, toolCallIndex);

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -2,6 +2,23 @@ import { DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, 
 import type { Content, Message, ToolCall } from '../types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 
+/**
+ * Gemini Client
+ * 
+ * Supports Gemini 3 models with extended thinking (thought signatures).
+ * 
+ * API Documentation:
+ * - Gemini Thought Signatures: https://ai.google.dev/gemini-api/docs/thought-signatures
+ * - Gemini 3 Models: https://ai.google.dev/gemini-api/docs/gemini-3
+ * 
+ * Key Gemini 3 Thinking Quirks:
+ * - thoughtSignature MUST be passed back during function calling (400 error otherwise)
+ * - For parallel function calls, only the FIRST function call has the signature
+ * - For sequential function calls, ALL signatures must be preserved
+ * - Non-function-call responses may have optional signatures (recommended to preserve)
+ * - thinkingLevel can be: 'NONE', 'LOW', 'MEDIUM', 'HIGH'
+ */
+
 const decoder = new TextDecoder();
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -9,8 +26,8 @@ const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 type GeminiRole = 'user' | 'model';
 
 type GeminiPart =
-  | { text: string }
-  | { functionCall: { name: string; args?: unknown } }
+  | { text: string; thoughtSignature?: string }
+  | { functionCall: { name: string; args?: unknown }; thoughtSignature?: string }
   | { functionResponse: { name: string; response?: unknown } };
 
 type GeminiContent = {
@@ -24,6 +41,9 @@ type GeminiFunctionDeclaration = {
   parameters?: unknown;
 };
 
+// Gemini thinking levels map to reasoningEffort
+type GeminiThinkingLevel = 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH';
+
 type GeminiGenerateContentRequest = {
   systemInstruction?: { parts: Array<{ text: string }> };
   contents: GeminiContent[];
@@ -34,12 +54,15 @@ type GeminiGenerateContentRequest = {
     topP?: number;
     topK?: number;
     maxOutputTokens?: number;
+    thinkingConfig?: {
+      thinkingLevel: GeminiThinkingLevel;
+    };
   };
 };
 
 type GeminiStreamCandidatePart =
-  | { text?: string }
-  | { functionCall?: { name?: string; args?: unknown } };
+  | { text?: string; thoughtSignature?: string }
+  | { functionCall?: { name?: string; args?: unknown }; thoughtSignature?: string };
 
 type GeminiStreamResponse = {
   candidates?: Array<{
@@ -86,14 +109,24 @@ const toGeminiPartsForMessage = (message: Message): GeminiPart[] => {
 
   const parts: GeminiPart[] = [];
 
+  // Add text content with optional thought signature
+  // Gemini 3 requires thoughtSignature to be preserved on text parts
   for (const item of message.content) {
     if (item.type === 'text') {
-      parts.push({ text: item.text });
+      const part: GeminiPart = { text: item.text };
+      // Preserve thinking_signature if present (from previous assistant response)
+      if (message.thinking_signature) {
+        part.thoughtSignature = message.thinking_signature;
+      }
+      parts.push(part);
     }
   }
 
+  // Add function calls with thought signatures
+  // Gemini 3 requires thoughtSignature on the FIRST function call in each step
   if (Array.isArray(message.tool_calls)) {
-    for (const call of message.tool_calls) {
+    for (let i = 0; i < message.tool_calls.length; i++) {
+      const call = message.tool_calls[i];
       const args = (() => {
         const raw = typeof call.function.arguments === 'string' ? call.function.arguments : '';
         if (!raw.trim()) return {};
@@ -103,7 +136,12 @@ const toGeminiPartsForMessage = (message: Message): GeminiPart[] => {
           return { __raw: raw };
         }
       })();
-      parts.push({ functionCall: { name: call.function.name, args } });
+      const part: GeminiPart = { functionCall: { name: call.function.name, args } };
+      // Preserve thinking_signature on the first function call (Gemini requirement)
+      if (i === 0 && message.thinking_signature) {
+        part.thoughtSignature = message.thinking_signature;
+      }
+      parts.push(part);
     }
   }
 
@@ -137,14 +175,32 @@ const toGeminiTools = (tools: ChatCompletionRequest['tools']): GeminiGenerateCon
   return [{ functionDeclarations }];
 };
 
+/**
+ * Map reasoningEffort to Gemini thinkingLevel
+ * See: https://ai.google.dev/gemini-api/docs/thought-signatures
+ */
+const toGeminiThinkingLevel = (reasoningEffort: LLMConfiguration['reasoningEffort']): GeminiThinkingLevel | undefined => {
+  if (!reasoningEffort || reasoningEffort === 'none') return undefined;
+  switch (reasoningEffort) {
+    case 'low': return 'LOW';
+    case 'medium': return 'MEDIUM';
+    case 'high': return 'HIGH';
+    default: return undefined;
+  }
+};
+
 const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest): GeminiGenerateContentRequest => {
   const systemPrompt = typeof request.systemPrompt === 'string' ? request.systemPrompt.trim() : '';
   const tools = toGeminiTools(request.tools);
+  const thinkingLevel = toGeminiThinkingLevel(config.reasoningEffort);
+  
   const generationConfig: GeminiGenerateContentRequest['generationConfig'] = {
     temperature: typeof config.temperature === 'number' ? config.temperature : undefined,
     topP: typeof config.topP === 'number' ? config.topP : undefined,
     topK: typeof config.topK === 'number' ? config.topK : undefined,
     maxOutputTokens: typeof config.maxOutputTokens === 'number' ? config.maxOutputTokens : undefined,
+    // Enable thinking for Gemini 3 models when reasoningEffort is set
+    ...(thinkingLevel ? { thinkingConfig: { thinkingLevel } } : {}),
   };
 
   const body: GeminiGenerateContentRequest = {
@@ -237,6 +293,13 @@ export class GeminiClient implements LLMClient {
       }
 
       for (const part of parts) {
+        // Extract thoughtSignature from any part (text or functionCall)
+        // Gemini 3 returns thoughtSignature on the first functionCall or on text parts
+        const signature = 'thoughtSignature' in part ? part.thoughtSignature : undefined;
+        if (signature) {
+          yield { type: 'thinking_signature', signature };
+        }
+
         const call = 'functionCall' in part ? (part.functionCall ?? undefined) : undefined;
         if (!call || typeof call !== 'object') continue;
         const toolCall = normalizeToolCall(call, toolCallIndex);

--- a/packages/agent-sdk-ts/src/sdk/llm/providerQuirks.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/providerQuirks.ts
@@ -9,6 +9,8 @@ import type { LLMConfiguration } from './types';
  * References:
  * - Anthropic Messages API: https://platform.claude.com/docs/en/api/messages.md
  * - Anthropic Extended Thinking: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking
+ * - Gemini Thought Signatures: https://ai.google.dev/gemini-api/docs/thought-signatures
+ * - Gemini 3 Models: https://ai.google.dev/gemini-api/docs/gemini-3
  */
 
 // =============================================================================
@@ -30,6 +32,27 @@ import type { LLMConfiguration } from './types';
 // 3. Thinking signature is required when sending thinking blocks back
 //    - The signature field from the response must be included
 //    - See: toAnthropicMessages() in anthropic.ts
+// =============================================================================
+
+// =============================================================================
+// Gemini 3 Thinking Constraints (Thought Signatures)
+// =============================================================================
+//
+// When using Gemini 3 models with thinking enabled:
+//
+// 1. thinkingLevel maps to reasoningEffort: 'NONE' | 'LOW' | 'MEDIUM' | 'HIGH'
+//    - Set via generationConfig.thinkingConfig.thinkingLevel
+//
+// 2. thoughtSignature MUST be passed back during function calling
+//    - Failure to include signatures results in 400 error
+//    - For parallel function calls, only the FIRST function call has the signature
+//    - For sequential function calls, ALL signatures must be preserved
+//    - See: https://ai.google.dev/gemini-api/docs/thought-signatures
+//
+// 3. Non-function-call responses may have optional signatures
+//    - Recommended to preserve for better reasoning quality
+//    - No validation error if omitted
+//
 // =============================================================================
 
 const ANTHROPIC_THINKING_MIN_BUDGET = 1024;


### PR DESCRIPTION
Add test script for Gemini 3 Flash with extended thinking support. Uses the SDK's LLMFactory similar to the Anthropic test.

Note: The Gemini client (gemini.ts) needs to be updated to support:
- thinkingConfig in requests
- thoughtSignature parsing in responses

API Documentation:
- Gemini Thought Signatures: https://ai.google.dev/gemini-api/docs/thought-signatures
- Gemini 3 Models: https://ai.google.dev/gemini-api/docs/gemini-3

Key Gemini 3 Thinking Quirks:
- thoughtSignature MUST be passed back during function calling (400 error)
- For parallel function calls, only the FIRST function call has the signature
- For sequential function calls, ALL signatures must be preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for advanced model "thinking" behavior with richer streaming diagnostics, preserved thought signatures across interactions, and improved tool-call handling during conversations.
* **Tests**
  * Added an end-to-end test validating multi-turn conversations with thinking enabled, real-time tool execution, streaming result aggregation, and diagnostic outputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->