### PR TITLE
fix: emit error and set IDLE when maxIterations exceeded (#oh-tab-a8sv)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { Agent, EventLog } from '../runtime';
 import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
-import { isActionEvent, isCondensation, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
+import { isActionEvent, isCondensation, isConversationErrorEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
 import type { ToolDefinition } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
 import { FileEditorTool } from '../../tools';
@@ -420,5 +420,136 @@ describe('Agent loop control', () => {
 
     const assistantMessages = log.list().filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'assistant');
     expect(assistantMessages.some((evt) => evt.llm_message.content.some((part) => part.type === 'text' && part.text.includes('OK')))).toBe(true);
+  });
+
+  it('emits ConversationErrorEvent and sets status to IDLE when maxIterations is reached', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    // LLM that always returns a tool call, forcing continuous iterations
+    const llm = new SequencedLLM([
+      [
+        { type: 'text', text: 'Calling tool 1' },
+        { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"1"}' },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'Calling tool 2' },
+        { type: 'tool_call_delta', id: 'call_2', name: 'echo', arguments: '{"value":"2"}' },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'Calling tool 3' },
+        { type: 'tool_call_delta', id: 'call_3', name: 'echo', arguments: '{"value":"3"}' },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, conversation: { maxIterations: 2 } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('keep iterating');
+
+    // Should have stopped after 2 iterations
+    expect(agent.state.snapshot.iteration).toBe(2);
+
+    // Should have emitted a ConversationErrorEvent with max_iterations_exceeded code
+    const errorEvents = log.list().filter(isConversationErrorEvent);
+    expect(errorEvents.length).toBe(1);
+    expect(errorEvents[0]?.code).toBe('max_iterations_exceeded');
+    expect(errorEvents[0]?.detail).toContain('maximum iteration limit');
+    expect(errorEvents[0]?.detail).toContain('2');
+
+    // Status should be IDLE, not stuck on RUNNING
+    expect(agent.state.snapshot.status).toBe('IDLE');
+  });
+
+  it('does not emit maxIterations error when loop exits for other reasons', async () => {
+    const log = new EventLog();
+    const llm = new MockLLM([
+      { type: 'text', text: 'Hello, done!' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, conversation: { maxIterations: 10 } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+    });
+
+    await agent.run('hi');
+
+    // Should complete after 1 iteration (no tool calls)
+    expect(agent.state.snapshot.iteration).toBe(1);
+
+    // Should NOT have a max_iterations_exceeded error
+    const errorEvents = log.list().filter(isConversationErrorEvent);
+    const maxIterErrors = errorEvents.filter((e) => e.code === 'max_iterations_exceeded');
+    expect(maxIterErrors.length).toBe(0);
+
+    // Status should be IDLE
+    expect(agent.state.snapshot.status).toBe('IDLE');
+  });
+
+  it('allows continuation after maxIterations is increased', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new SequencedLLM([
+      [
+        { type: 'text', text: 'Calling tool 1' },
+        { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"1"}' },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'Done now' },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const settings = { ...baseSettings, conversation: { maxIterations: 1 } };
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('start');
+
+    // First run hits maxIterations
+    expect(agent.state.snapshot.iteration).toBe(1);
+    expect(agent.state.snapshot.status).toBe('IDLE');
+    const firstErrors = log.list().filter(isConversationErrorEvent).filter((e) => e.code === 'max_iterations_exceeded');
+    expect(firstErrors.length).toBe(1);
+
+    // Increase maxIterations via setSettings
+    agent.setSettings({ ...settings, conversation: { maxIterations: 10 } });
+
+    // Continue conversation
+    await agent.run('continue please');
+
+    // Should have completed additional iterations
+    expect(agent.state.snapshot.iteration).toBe(2);
+    expect(agent.state.snapshot.status).toBe('IDLE');
+
+    // No new max_iterations_exceeded error
+    const allErrors = log.list().filter(isConversationErrorEvent).filter((e) => e.code === 'max_iterations_exceeded');
+    expect(allErrors.length).toBe(1); // Still just the first one
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -614,8 +614,13 @@ export class Agent extends EventEmitter {
       }
     }
 
-    // Check if we exited due to maxIterations being reached
+    // Check if we exited due to maxIterations being reached.
+    // We only emit the error if the agent is still RUNNING - because all normal exit paths
+    // (no tool calls, finish tool, errors) set status to IDLE before breaking.
+    // If status is still RUNNING and iteration >= maxIterations, it means the while loop
+    // condition failed due to the iteration limit.
     if (
+      this.state.snapshot.status === 'RUNNING' &&
       !this.paused &&
       !this.pendingAction &&
       !this.cancelled &&
@@ -627,7 +632,7 @@ export class Agent extends EventEmitter {
         source: 'agent',
         code: 'max_iterations_exceeded',
         detail: `Agent reached the maximum iteration limit (${maxIterations}). You can increase this limit in Settings > OpenHands > Conversation > Max Iterations and continue the conversation.`,
-      } as Event);
+      });
       this.state.setStatus('IDLE');
     }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -614,6 +614,23 @@ export class Agent extends EventEmitter {
       }
     }
 
+    // Check if we exited due to maxIterations being reached
+    if (
+      !this.paused &&
+      !this.pendingAction &&
+      !this.cancelled &&
+      !this.finished &&
+      this.state.snapshot.iteration >= maxIterations
+    ) {
+      this.events.push({
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        code: 'max_iterations_exceeded',
+        detail: `Agent reached the maximum iteration limit (${maxIterations}). You can increase this limit in Settings > OpenHands > Conversation > Max Iterations and continue the conversation.`,
+      } as Event);
+      this.state.setStatus('IDLE');
+    }
+
     return lastAssistantMessage;
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -381,6 +381,19 @@ export class Agent extends EventEmitter {
     }
 
     const maxIterations = this.clampMaxIterations();
+
+    // Check if we've already reached maxIterations
+    if (this.state.snapshot.iteration >= maxIterations) {
+      this.events.push({
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        code: 'max_iterations_exceeded',
+        detail: `Agent reached the maximum iteration limit (${maxIterations}). You can increase this limit in Settings > OpenHands > Conversation > Max Iterations and continue the conversation.`,
+      });
+      this.state.setStatus('IDLE');
+      return undefined;
+    }
+
     let streamer: LLMStreamer;
     try {
       streamer = await this.getStreamer();
@@ -612,28 +625,18 @@ export class Agent extends EventEmitter {
         this.state.setStatus('IDLE');
         continue;
       }
-    }
 
-    // Check if we exited due to maxIterations being reached.
-    // We only emit the error if the agent is still RUNNING - because all normal exit paths
-    // (no tool calls, finish tool, errors) set status to IDLE before breaking.
-    // If status is still RUNNING and iteration >= maxIterations, it means the while loop
-    // condition failed due to the iteration limit.
-    if (
-      this.state.snapshot.status === 'RUNNING' &&
-      !this.paused &&
-      !this.pendingAction &&
-      !this.cancelled &&
-      !this.finished &&
-      this.state.snapshot.iteration >= maxIterations
-    ) {
-      this.events.push({
-        kind: 'ConversationErrorEvent',
-        source: 'agent',
-        code: 'max_iterations_exceeded',
-        detail: `Agent reached the maximum iteration limit (${maxIterations}). You can increase this limit in Settings > OpenHands > Conversation > Max Iterations and continue the conversation.`,
-      });
-      this.state.setStatus('IDLE');
+      // Check if we've reached maxIterations
+      if (this.state.snapshot.iteration >= maxIterations) {
+        this.events.push({
+          kind: 'ConversationErrorEvent',
+          source: 'agent',
+          code: 'max_iterations_exceeded',
+          detail: `Agent reached the maximum iteration limit (${maxIterations}). You can increase this limit in Settings > OpenHands > Conversation > Max Iterations and continue the conversation.`,
+        });
+        this.state.setStatus('IDLE');
+        break;
+      }
     }
 
     return lastAssistantMessage;

--- a/src/settings/host/__tests__/createConfigurationChangeHandler.test.ts
+++ b/src/settings/host/__tests__/createConfigurationChangeHandler.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createConfigurationChangeHandler, type CreateConfigurationChangeHandlerDeps } from '../createConfigurationChangeHandler';
+
+// Mock vscode module
+vi.mock('vscode', () => ({
+  workspace: {
+    getConfiguration: vi.fn(() => ({
+      get: vi.fn(),
+    })),
+  },
+}));
+
+describe('createConfigurationChangeHandler', () => {
+  let deps: CreateConfigurationChangeHandlerDeps;
+  let handler: ReturnType<typeof createConfigurationChangeHandler>;
+
+  beforeEach(() => {
+    deps = {
+      ensureConversationAndConnection: vi.fn().mockResolvedValue(undefined),
+      getConversation: vi.fn().mockReturnValue(undefined),
+      setConversation: vi.fn(),
+      getConversationMode: vi.fn().mockReturnValue('local'),
+      getTerminal: vi.fn().mockReturnValue(undefined),
+      setTerminal: vi.fn(),
+      getTerminalLogPty: vi.fn().mockReturnValue(undefined),
+      setTerminalLogPty: vi.fn(),
+      setConversationStoreRoot: vi.fn(),
+      setVerboseEventLogging: vi.fn(),
+      getOutputChannel: vi.fn().mockReturnValue({ appendLine: vi.fn() }),
+      renderError: vi.fn((err) => String(err)),
+    };
+    handler = createConfigurationChangeHandler(deps);
+  });
+
+  describe('openhands.conversation.maxIterations', () => {
+    it('calls ensureConversationAndConnection when maxIterations changes', async () => {
+      const event = {
+        affectsConfiguration: (section: string) => section === 'openhands.conversation.maxIterations',
+      };
+
+      await handler(event as any);
+
+      expect(deps.ensureConversationAndConnection).toHaveBeenCalled();
+    });
+
+    it('logs appropriate message for local mode', async () => {
+      const appendLine = vi.fn();
+      deps.getOutputChannel = vi.fn().mockReturnValue({ appendLine });
+      deps.getConversationMode = vi.fn().mockReturnValue('local');
+      handler = createConfigurationChangeHandler(deps);
+
+      const event = {
+        affectsConfiguration: (section: string) => section === 'openhands.conversation.maxIterations',
+      };
+
+      await handler(event as any);
+
+      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('Max iterations setting updated'));
+      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('local mode'));
+    });
+
+    it('logs appropriate message for remote mode', async () => {
+      const appendLine = vi.fn();
+      deps.getOutputChannel = vi.fn().mockReturnValue({ appendLine });
+      deps.getConversationMode = vi.fn().mockReturnValue('remote');
+      handler = createConfigurationChangeHandler(deps);
+
+      const event = {
+        affectsConfiguration: (section: string) => section === 'openhands.conversation.maxIterations',
+      };
+
+      await handler(event as any);
+
+      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('Max iterations setting updated'));
+      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('remote mode'));
+    });
+
+    it('logs error when ensureConversationAndConnection fails', async () => {
+      const appendLine = vi.fn();
+      deps.getOutputChannel = vi.fn().mockReturnValue({ appendLine });
+      deps.ensureConversationAndConnection = vi.fn().mockRejectedValue(new Error('test error'));
+      handler = createConfigurationChangeHandler(deps);
+
+      const event = {
+        affectsConfiguration: (section: string) => section === 'openhands.conversation.maxIterations',
+      };
+
+      await handler(event as any);
+
+      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('Failed to apply max iterations update'));
+    });
+  });
+});

--- a/src/settings/host/createConfigurationChangeHandler.ts
+++ b/src/settings/host/createConfigurationChangeHandler.ts
@@ -105,5 +105,18 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
         deps.getOutputChannel()?.appendLine(`[settings] Failed to apply confirmation settings update: ${deps.renderError(err)}`);
       }
     }
+
+    if (e.affectsConfiguration('openhands.conversation.maxIterations')) {
+      try {
+        await deps.ensureConversationAndConnection();
+        if (deps.getConversationMode() === 'remote') {
+          deps.getOutputChannel()?.appendLine('[settings] Max iterations setting updated (remote mode: applies on next conversation)');
+        } else {
+          deps.getOutputChannel()?.appendLine('[settings] Max iterations setting updated (local mode: applies on next run)');
+        }
+      } catch (err: unknown) {
+        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply max iterations update: ${deps.renderError(err)}`);
+      }
+    }
   };
 }


### PR DESCRIPTION
## Summary

- When the agent's iteration count reaches `maxIterations`, the runLoop now properly emits a `ConversationErrorEvent` with code `max_iterations_exceeded` and sets status to `IDLE`
- Added configuration change handler for `openhands.conversation.maxIterations` so changes apply without requiring VS Code reload
- Added tests for maxIterations handling in agent loop

## Test plan

- [x] Run `npm test` - all existing tests pass
- [x] Run `npm run typecheck` - passes
- [x] Run `npm run lint` - passes
- [x] New tests added for:
  - maxIterations exceeded emits error and sets IDLE
  - Normal exit doesn't emit maxIterations error
  - Conversation can continue after increasing maxIterations
  - Configuration change handler responds to maxIterations changes

## Related

Fixes oh-tab-a8sv

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforce maximum iteration limits in agent conversations: agents stop and transition to idle when the limit is reached, and emit an error event.
  * Support dynamic updates to the max-iterations setting during active conversations.

* **Bug Fixes**
  * Prevents agents from continuing past the configured iteration cap, including after tool calls.

* **Tests**
  * Added tests covering max-iteration behavior and config-change scenarios.

* **Chores**
  * Exported a conversation-error helper for use in tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->