### PR TITLE
fix: apply LLM profile changes mid-run

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -422,3 +422,173 @@ describe('Agent loop control', () => {
     expect(assistantMessages.some((evt) => evt.llm_message.content.some((part) => part.type === 'text' && part.text.includes('OK')))).toBe(true);
   });
 });
+
+describe('Agent mid-run settings change', () => {
+  /** LLM that tracks client instance count for verifying rebuilds */
+  class ClientTrackingLLM implements LLMClient {
+    static instanceCount = 0;
+    instanceId: number;
+    private idx = 0;
+
+    constructor(private readonly sequences: LLMStreamChunk[][]) {
+      ClientTrackingLLM.instanceCount += 1;
+      this.instanceId = ClientTrackingLLM.instanceCount;
+    }
+
+    async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+      void _request;
+      const seq = this.sequences[this.idx] ?? [];
+      this.idx += 1;
+      for (const chunk of seq) {
+        yield chunk;
+      }
+    }
+  }
+
+  it('applies setSettings changes immediately (does not wait for lock)', async () => {
+    const log = new EventLog();
+    // Single iteration agent just to test setSettings() behavior
+    const llm = new ClientTrackingLLM([
+      [{ type: 'text', text: 'Done' }, { type: 'finish' }],
+    ]);
+
+    const initialSettings: OpenHandsSettings = {
+      llm: { model: 'model-v1' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+
+    const agent = new Agent({
+      settings: initialSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+    });
+
+    // Access internal state to verify settings version tracking
+    const getSettingsVersion = () => (agent as unknown as { settingsVersion: number }).settingsVersion;
+
+    const versionBefore = getSettingsVersion();
+
+    // Call setSettings - should apply immediately
+    agent.setSettings({
+      ...initialSettings,
+      llm: { model: 'model-v2' },
+    });
+
+    const versionAfter = getSettingsVersion();
+
+    // Settings version should have incremented immediately
+    expect(versionAfter).toBe(versionBefore + 1);
+  });
+
+  it('clears streamer promise when setSettings is called', async () => {
+    const log = new EventLog();
+    const llm = new ClientTrackingLLM([
+      [{ type: 'text', text: 'First' }, { type: 'finish' }],
+      [{ type: 'text', text: 'Second' }, { type: 'finish' }],
+    ]);
+
+    const initialSettings: OpenHandsSettings = {
+      llm: { model: 'model-v1' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+
+    const agent = new Agent({
+      settings: initialSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+    });
+
+    // Access internal streamerPromise to verify it gets cleared
+    const getStreamerPromise = () => (agent as unknown as { streamerPromise?: Promise<unknown> }).streamerPromise;
+
+    // Run once to initialize streamer
+    await agent.run('first');
+    const streamerAfterFirstRun = getStreamerPromise();
+    expect(streamerAfterFirstRun).toBeDefined();
+
+    // Call setSettings - should clear the streamer promise
+    agent.setSettings({
+      ...initialSettings,
+      llm: { model: 'model-v2' },
+    });
+
+    const streamerAfterSettings = getStreamerPromise();
+    expect(streamerAfterSettings).toBeUndefined();
+  });
+
+  it('rebuilds streamer mid-run when settings change (multi-iteration)', async () => {
+    const log = new EventLog();
+
+    // Tool that can trigger a settings change during execution
+    let settingsChangeCallback: (() => void) | null = null;
+    const tool: ToolDefinition<{ value: string }, { result: string }> = {
+      name: 'async_tool',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => {
+        // Trigger settings change during tool execution (simulating user action)
+        if (settingsChangeCallback) {
+          settingsChangeCallback();
+          settingsChangeCallback = null;
+        }
+        return { result: args.value };
+      },
+    };
+
+    const llm = new RecordingLLM([
+      // First iteration: call tool
+      [
+        { type: 'text', text: 'Calling tool' },
+        { type: 'tool_call_delta', id: 'call_1', name: 'async_tool', arguments: '{"value":"test1"}' },
+        { type: 'finish' },
+      ],
+      // Second iteration: after settings change - verify we continue
+      [
+        { type: 'text', text: 'Final response' },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const initialSettings: OpenHandsSettings = {
+      llm: { model: 'model-v1' },
+      agent: {},
+      conversation: { maxIterations: 3 },
+      confirmation: {},
+      secrets: {},
+    };
+
+    const agent = new Agent({
+      settings: initialSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    // Set up callback to change settings during first tool execution
+    settingsChangeCallback = () => {
+      agent.setSettings({
+        ...initialSettings,
+        llm: { model: 'model-v2' },
+      });
+    };
+
+    await agent.run('start');
+
+    // Verify the run completed with both iterations
+    expect(llm.requests.length).toBe(2);
+
+    // The second request should have been made after settings changed
+    // (verifying the loop continued after the settings change)
+    const messages = log.list().filter(isMessageEvent);
+    const assistantMessages = messages.filter((evt) => evt.llm_message.role === 'assistant');
+    expect(assistantMessages.length).toBe(2);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -177,13 +177,12 @@ export class Agent extends EventEmitter {
   /**
    * Updates the agent's settings at runtime.
    *
-   * Settings are applied immediately (for mid-run detection) and also under the
-   * agent lock to ensure they're fully applied when the run finishes.
-   * The settingsVersion is incremented so runLoop can detect changes and rebuild
-   * the LLM streamer mid-run if needed (e.g., when the user switches LLM profiles).
+   * Settings are applied immediately so the runLoop can detect changes mid-run
+   * via settingsVersion and rebuild the LLM streamer if needed (e.g., when the
+   * user switches LLM profiles).
    */
   setSettings(settings: OpenHandsSettings): void {
-    // Increment version immediately so runLoop can detect the change mid-run
+    // Increment version so runLoop can detect the change mid-run
     this.settingsVersion += 1;
 
     // Apply settings immediately for derived values (confirmation, debug, etc.)
@@ -193,13 +192,6 @@ export class Agent extends EventEmitter {
     // Force rebuild of LLM client/streamer on next use
     this.llmClientPromise = undefined;
     this.streamerPromise = undefined;
-
-    // Also acquire lock to ensure consistency after current run completes
-    void this.lock.acquire(() => {
-      // Re-apply in case another setSettings() was called while waiting
-      // (the latest settingsVersion wins)
-      return Promise.resolve();
-    });
   }
 
   get pendingActionId(): string | undefined {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -122,6 +122,8 @@ export class Agent extends EventEmitter {
   private readonly conversationStats?: import('./ConversationStats').ConversationStats;
   private debug: boolean;
   private readonly toolSummarizer: ToolSummarizer;
+  /** Incremented each time setSettings() is called; used to detect mid-run changes. */
+  private settingsVersion = 0;
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -175,17 +177,27 @@ export class Agent extends EventEmitter {
   /**
    * Updates the agent's settings at runtime.
    *
-   * Changes are applied under the agent lock so settings updates can't race with
-   * an active run. New settings take effect on the next run.
+   * Settings are applied immediately (for mid-run detection) and also under the
+   * agent lock to ensure they're fully applied when the run finishes.
+   * The settingsVersion is incremented so runLoop can detect changes and rebuild
+   * the LLM streamer mid-run if needed (e.g., when the user switches LLM profiles).
    */
   setSettings(settings: OpenHandsSettings): void {
-    void this.lock.acquire(() => {
-      this.options.settings = settings;
-      this.updateDerivedSettings(settings);
+    // Increment version immediately so runLoop can detect the change mid-run
+    this.settingsVersion += 1;
 
-      // Force the next run to rebuild the LLM client from updated settings.
-      this.llmClientPromise = undefined;
-      this.streamerPromise = undefined;
+    // Apply settings immediately for derived values (confirmation, debug, etc.)
+    this.options.settings = settings;
+    this.updateDerivedSettings(settings);
+
+    // Force rebuild of LLM client/streamer on next use
+    this.llmClientPromise = undefined;
+    this.streamerPromise = undefined;
+
+    // Also acquire lock to ensure consistency after current run completes
+    void this.lock.acquire(() => {
+      // Re-apply in case another setSettings() was called while waiting
+      // (the latest settingsVersion wins)
       return Promise.resolve();
     });
   }
@@ -382,6 +394,7 @@ export class Agent extends EventEmitter {
 
     const maxIterations = this.clampMaxIterations();
     let streamer: LLMStreamer;
+    let streamerSettingsVersion = this.settingsVersion;
     try {
       streamer = await this.getStreamer();
     } catch (error) {
@@ -396,6 +409,20 @@ export class Agent extends EventEmitter {
     let lastAssistantMessage: Message | undefined;
 
     while (!this.paused && !this.pendingAction && !this.cancelled && !this.finished && this.state.snapshot.iteration < maxIterations) {
+      // Check if settings changed mid-run (e.g., user switched LLM profile)
+      if (this.settingsVersion !== streamerSettingsVersion) {
+        try {
+          streamer = await this.getStreamer();
+          streamerSettingsVersion = this.settingsVersion;
+        } catch (error) {
+          const classified = classifyError(error, { stage: 'llm_init' });
+          this.events.push(this.toConversationErrorEvent(error, { code: classified.code }));
+          this.state.setStatus('IDLE');
+          this.llmClientPromise = undefined;
+          this.streamerPromise = undefined;
+          return lastAssistantMessage;
+        }
+      }
       this.state.setStatus('RUNNING');
       const llmConfig = this.getEffectiveLlmConfigForCondensation();
       let response: Awaited<ReturnType<LLMStreamer['runChat']>> | undefined;


### PR DESCRIPTION
## Summary
- Fixes issue where switching LLM profile during an agent run wouldn't take effect until the next run
- `setSettings()` now applies settings immediately (doesn't wait for lock)
- Added `settingsVersion` counter to detect mid-run settings changes
- The runLoop checks for version changes at the start of each iteration and rebuilds the streamer if needed

## Test plan
- [x] Added unit tests for settings version tracking
- [x] Added unit tests for streamer promise clearing
- [x] Added integration test for mid-run settings change
- [x] All existing tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)