### PR TITLE
fix: increase Gemini summary max chars to reduce truncation

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
@@ -181,4 +181,26 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
       expect(prompt.text.length).toBeLessThanOrEqual(maxPromptChars);
     }
   });
+
+  it('does not truncate summaries up to 2000 characters (oh-tab-qxzs)', async () => {
+    const secrets = new SecretRegistry();
+    // Create a summary that's close to but under 2000 chars (new default limit)
+    // Note: the summarizer trims the result, so we build a string without trailing spaces
+    const longSummary = 'The file was updated with new configuration. '.repeat(44).trim(); // ~1980 chars
+    const llm = new RecordingLLM(longSummary);
+
+    const summary = await summarizeFileChangesWithGeminiFlash(
+      {
+        kind: 'contents',
+        filePath: 'src/config.ts',
+        oldContent: 'const a = 1;\n',
+        newContent: 'const a = 2;\n',
+      },
+      { secrets, llmClient: llm }
+    );
+
+    // With default limit of 2000, this should not be truncated
+    expect(summary).toBe(longSummary);
+    expect(summary?.endsWith('…')).toBe(false);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
@@ -182,11 +182,11 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
     }
   });
 
-  it('does not truncate summaries up to 2000 characters (oh-tab-qxzs)', async () => {
+  it('does not truncate summaries up to 5000 characters (oh-tab-qxzs)', async () => {
     const secrets = new SecretRegistry();
-    // Create a summary that's close to but under 2000 chars (new default limit)
+    // Create a summary that's close to but under 5000 chars (new default limit)
     // Note: the summarizer trims the result, so we build a string without trailing spaces
-    const longSummary = 'The file was updated with new configuration. '.repeat(44).trim(); // ~1980 chars
+    const longSummary = 'The file was updated with new configuration. '.repeat(110).trim(); // ~4950 chars
     const llm = new RecordingLLM(longSummary);
 
     const summary = await summarizeFileChangesWithGeminiFlash(
@@ -199,7 +199,7 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
       { secrets, llmClient: llm }
     );
 
-    // With default limit of 2000, this should not be truncated
+    // With default limit of 5000, this should not be truncated
     expect(summary).toBe(longSummary);
     expect(summary.endsWith('…')).toBe(false);
   });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts
@@ -201,6 +201,6 @@ describe('summarizeFileChangesWithGeminiFlash', () => {
 
     // With default limit of 2000, this should not be truncated
     expect(summary).toBe(longSummary);
-    expect(summary?.endsWith('…')).toBe(false);
+    expect(summary.endsWith('…')).toBe(false);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -151,11 +151,11 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
     }
   });
 
-  it('does not truncate summaries up to 2000 characters (oh-tab-qxzs)', async () => {
+  it('does not truncate summaries up to 5000 characters (oh-tab-qxzs)', async () => {
     const secrets = new SecretRegistry();
-    // Create a summary that's close to but under 2000 chars (new default limit)
+    // Create a summary that's close to but under 5000 chars (new default limit)
     // Note: the summarizer trims the result, so we build a string without trailing spaces
-    const longSummary = 'The agent executed a git branch operation. '.repeat(45).trim(); // ~1980 chars
+    const longSummary = 'The agent executed a git branch operation. '.repeat(115).trim(); // ~4945 chars
     const llm = new RecordingLLM(longSummary);
 
     const summary = await summarizeTerminalObservationWithGeminiFlash(
@@ -163,7 +163,7 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
       { secrets, llmClient: llm }
     );
 
-    // With default limit of 2000, this should not be truncated
+    // With default limit of 5000, this should not be truncated
     expect(summary).toBe(longSummary);
     expect(summary.endsWith('…')).toBe(false);
   });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts
@@ -150,4 +150,21 @@ describe('summarizeTerminalObservationWithGeminiFlash', () => {
       expect(prompt.text.length).toBeLessThanOrEqual(maxPromptChars);
     }
   });
+
+  it('does not truncate summaries up to 2000 characters (oh-tab-qxzs)', async () => {
+    const secrets = new SecretRegistry();
+    // Create a summary that's close to but under 2000 chars (new default limit)
+    // Note: the summarizer trims the result, so we build a string without trailing spaces
+    const longSummary = 'The agent executed a git branch operation. '.repeat(45).trim(); // ~1980 chars
+    const llm = new RecordingLLM(longSummary);
+
+    const summary = await summarizeTerminalObservationWithGeminiFlash(
+      { command: 'git checkout -b new-branch', exit_code: 0, stdout: 'Switched to new branch\n', stderr: '' },
+      { secrets, llmClient: llm }
+    );
+
+    // With default limit of 2000, this should not be truncated
+    expect(summary).toBe(longSummary);
+    expect(summary.endsWith('…')).toBe(false);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -21,7 +21,7 @@ export interface SummarizeFileChangesOptions {
 
 const DEFAULT_MAX_PROMPT_CHARS = 4_000;
 // Increased from 1000 to reduce mid-sentence truncation (see oh-tab-qxzs)
-const DEFAULT_MAX_SUMMARY_CHARS = 2_000;
+const DEFAULT_MAX_SUMMARY_CHARS = 5_000;
 const CLIP_MARKER = '<diff clipped>';
 
 const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -20,7 +20,8 @@ export interface SummarizeFileChangesOptions {
 }
 
 const DEFAULT_MAX_PROMPT_CHARS = 4_000;
-const DEFAULT_MAX_SUMMARY_CHARS = 1_000;
+// Increased from 1000 to reduce mid-sentence truncation (see oh-tab-qxzs)
+const DEFAULT_MAX_SUMMARY_CHARS = 2_000;
 const CLIP_MARKER = '<diff clipped>';
 
 const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -22,7 +22,7 @@ export interface SummarizeTerminalObservationOptions {
 const DEFAULT_MAX_OUTPUT_CHARS = 4_000;
 const DEFAULT_MAX_PROMPT_CHARS = 6_000;
 // Increased from 1000 to reduce mid-sentence truncation (see oh-tab-qxzs)
-const DEFAULT_MAX_SUMMARY_CHARS = 2_000;
+const DEFAULT_MAX_SUMMARY_CHARS = 5_000;
 const CLIP_MARKER = '<output clipped>';
 
 const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -21,7 +21,8 @@ export interface SummarizeTerminalObservationOptions {
 
 const DEFAULT_MAX_OUTPUT_CHARS = 4_000;
 const DEFAULT_MAX_PROMPT_CHARS = 6_000;
-const DEFAULT_MAX_SUMMARY_CHARS = 1_000;
+// Increased from 1000 to reduce mid-sentence truncation (see oh-tab-qxzs)
+const DEFAULT_MAX_SUMMARY_CHARS = 2_000;
 const CLIP_MARKER = '<output clipped>';
 
 const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
@@ -13,7 +13,8 @@ import { ELLIPSIS, redactAndTruncateArgs } from './textSanitizers';
 
 const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
 const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
-const TOOL_SUMMARY_MAX_CHARS = 1_000;
+// Increased from 1000 to reduce mid-sentence truncation (see oh-tab-qxzs)
+const TOOL_SUMMARY_MAX_CHARS = 2_000;
 
 export class ToolSummarizer {
   private enabled = false;

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
@@ -14,7 +14,7 @@ import { ELLIPSIS, redactAndTruncateArgs } from './textSanitizers';
 const TOOL_SUMMARY_PROFILE_ID = 'gemini-flash-summarizer';
 const TOOL_SUMMARY_PROMPT_MAX_CHARS = 4_000;
 // Increased from 1000 to reduce mid-sentence truncation (see oh-tab-qxzs)
-const TOOL_SUMMARY_MAX_CHARS = 2_000;
+const TOOL_SUMMARY_MAX_CHARS = 5_000;
 
 export class ToolSummarizer {
   private enabled = false;

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolSummarizer.ts
@@ -189,7 +189,7 @@ export class ToolSummarizer {
     const summary = this.deps.secretMasker.maskText(text).trim();
     if (!summary) return undefined;
 
-    return summary.length > TOOL_SUMMARY_MAX_CHARS ? summary.slice(0, TOOL_SUMMARY_MAX_CHARS) + '…' : summary;
+    return summary.length > TOOL_SUMMARY_MAX_CHARS ? summary.slice(0, TOOL_SUMMARY_MAX_CHARS - 1) + '…' : summary;
   }
 
   public async getClient(): Promise<LLMClient> {


### PR DESCRIPTION
## Summary
- Increases the maximum summary length from 1000 to 2000 characters in all Gemini summarizers
- Fixes issue where tool summaries (terminal observations, file diffs) were being truncated mid-sentence
- The truncation was happening silently, leaving users with incomplete summaries like "The agent attempted to create a new branch … but it" (cut off)

## Test plan
- [x] Added test to terminalObservationSummarizer to verify summaries up to 2000 chars are not truncated
- [x] Added test to fileDiffSummarizer to verify summaries up to 2000 chars are not truncated
- [x] All existing tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes

## Files changed
- `toolSummarizer.ts`: Increased TOOL_SUMMARY_MAX_CHARS from 1000 to 2000
- `terminalObservationSummarizer.ts`: Increased DEFAULT_MAX_SUMMARY_CHARS from 1000 to 2000
- `fileDiffSummarizer.ts`: Increased DEFAULT_MAX_SUMMARY_CHARS from 1000 to 2000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased summary character limit from 1,000 to 5,000 across file diff, terminal observation, and tool summaries to reduce mid-sentence truncation.

* **Tests**
  * Added test cases verifying summaries are not truncated when under the character limit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->