### PR TITLE
debug: add logging for mid-run LLM profile switching (oh-tab-rw1k)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -179,6 +179,8 @@ export class Agent extends EventEmitter {
    * an active run. New settings take effect on the next run.
    */
   setSettings(settings: OpenHandsSettings): void {
+    const prevModel = this.options.settings?.llm?.model;
+    const prevProfileId = this.options.settings?.llm?.profileId;
     void this.lock.acquire(() => {
       this.options.settings = settings;
       this.updateDerivedSettings(settings);
@@ -186,6 +188,12 @@ export class Agent extends EventEmitter {
       // Force the next run to rebuild the LLM client from updated settings.
       this.llmClientPromise = undefined;
       this.streamerPromise = undefined;
+
+      // Debug logging for mid-run settings changes (oh-tab-rw1k)
+      const newModel = settings?.llm?.model;
+      const newProfileId = settings?.llm?.profileId;
+      console.log(`[Agent.setSettings] Settings updated. Profile: ${prevProfileId} -> ${newProfileId}, Model: ${prevModel} -> ${newModel}. Cleared streamerPromise.`);
+
       return Promise.resolve();
     });
   }
@@ -398,6 +406,13 @@ export class Agent extends EventEmitter {
     while (!this.paused && !this.pendingAction && !this.cancelled && !this.finished && this.state.snapshot.iteration < maxIterations) {
       this.state.setStatus('RUNNING');
       const llmConfig = this.getEffectiveLlmConfigForCondensation();
+
+      // Debug logging for mid-run settings tracking (oh-tab-rw1k)
+      const currentModel = this.options.settings?.llm?.model;
+      const currentProfileId = this.options.settings?.llm?.profileId;
+      const hasStreamerPromise = !!this.streamerPromise;
+      console.log(`[Agent.runLoop] Iteration ${this.state.snapshot.iteration}. Settings: profile=${currentProfileId}, model=${currentModel}. streamerPromise cached=${hasStreamerPromise}`);
+
       let response: Awaited<ReturnType<LLMStreamer['runChat']>> | undefined;
 
       // Condensation is token-budget based: before calling the LLM (and again if we hit a context-limit
@@ -840,10 +855,15 @@ export class Agent extends EventEmitter {
 
   private async getStreamer(): Promise<LLMStreamer> {
     if (!this.streamerPromise) {
+      const model = this.options.settings?.llm?.model;
+      const profileId = this.options.settings?.llm?.profileId;
+      console.log(`[Agent.getStreamer] Creating new streamer. Profile: ${profileId}, Model: ${model}`);
       this.streamerPromise = (async () => {
         const client = await this.getPrimaryLlmClient();
         return new LLMStreamer(client, { events: this.events, state: this.state });
       })();
+    } else {
+      console.log(`[Agent.getStreamer] Reusing cached streamer.`);
     }
 
     return this.streamerPromise;


### PR DESCRIPTION
## Summary

Adds diagnostic logging to investigate whether mid-run LLM profile changes are applied correctly.

## The Issue (oh-tab-rw1k)

When switching LLM profile while the agent is running, the change should apply to the next LLM request. However, the current implementation may not do this.

## Execution Model Explained

| Term | Definition |
|------|------------|
| **Conversation** | Multiple turns (user messages + agent responses) |
| **Run** | One agent "turn" - starts when user sends a message, ends when agent finishes (calls finish tool, sends message to user, or pauses) |
| **runLoop iteration** | One LLM request/response cycle within a run |
| **Step** | Processing of one streaming response from the LLM |

## The Problem

Looking at `Agent.ts`, here's the `runLoop` execution path:

```
runLoop() called when user sends message
    │
    ├─► streamer = await this.getStreamer()  // LINE 386: Get streamer ONCE
    │   └── if (this.streamerPromise) return cached; else create new
    │
    └─► while (not paused/finished/cancelled) {  // LINE 406: Run loop
            │
            ├─► Build request with current settings
            ├─► response = streamer.runChat(request)  // Uses the SAME streamer
            ├─► Process response (tool calls, messages)
            └─► Loop continues with same `streamer` variable
        }
```

**The bug:** The `streamer` variable is obtained ONCE at line 386, BEFORE the while loop. Even if `setSettings()` clears `this.streamerPromise`, the while loop continues using the cached local `streamer` variable until the ENTIRE run ends.

## When "run ends" means

- **Does NOT mean**: End of one LLM response (step)
- **Does NOT mean**: End of one iteration (one request/response cycle)
- **MEANS**: Agent finishes the entire turn - e.g., calls finish tool, sends final message, or pauses

So if the agent does 10 tool calls before finishing, a profile change at tool call #3 won't take effect until a NEW run starts (next user message).

## Logging Added

1. **`Agent.setSettings`**: Logs when profile/model changes and `streamerPromise` is cleared
2. **`Agent.getStreamer`**: Logs when creating new vs reusing cached streamer
3. **`Agent.runLoop`**: Logs each iteration with current profile/model settings

## How to Test

1. Build the extension with this branch
2. Start a conversation and send a message
3. While the agent is running (doing tool calls), switch the LLM profile
4. Watch the output channel for logs showing whether the streamer was rebuilt

Expected logs showing the bug:
```
[Agent.setSettings] Settings updated. Profile: profile-a -> profile-b. Cleared streamerPromise.
[Agent.runLoop] Iteration 4. Settings: profile=profile-b. streamerPromise cached=true
```

Note: `streamerPromise cached=true` even though we just cleared it, because the runLoop is using the local `streamer` variable.

## Related

- Bead: oh-tab-rw1k
- Original PR #605 attempted to fix this with a settings version counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)