### PR TITLE
Replace full-width stop bar with compact icon button in prompt controls

### DIFF
--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -56,6 +56,9 @@ interface InputAreaProps {
   onOpenMCP?: () => void;
   // Selection tracking (for mention-style context)
   onSelectionChange?: (start: number, end: number) => void;
+  // Stop agent (shown when running)
+  isRunning?: boolean;
+  onStopAgent?: () => void;
 }
 
 export function InputArea({
@@ -100,6 +103,8 @@ export function InputArea({
   onRemoveInlineImage,
   onOpenMCP,
   onSelectionChange,
+  isRunning = false,
+  onStopAgent,
 }: InputAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isFocused, setIsFocused] = useState(false);
@@ -214,6 +219,27 @@ export function InputArea({
           />
 
             <div className="absolute right-2 bottom-2 flex items-center gap-2">
+              {/* Stop button - shown when agent is running */}
+              {isRunning && onStopAgent && (
+                <button
+                  type="button"
+                  onClick={onStopAgent}
+                  className="
+                    h-9 w-9 rounded-lg
+                    flex items-center justify-center
+                    transition-all duration-200
+                    oh-focus-outline
+                    bg-red-500/20 text-red-400 border border-red-500/30
+                    hover:bg-red-500/30 hover:border-red-500/40 hover:text-red-300
+                  "
+                  aria-label="Stop the agent"
+                  title="Stop the agent"
+                  data-testid="stop-agent-button"
+                >
+                  <span className="codicon codicon-debug-stop" />
+                </button>
+              )}
+
               {/* Attachments button (icon-only) */}
               {onOpenAttachments && (
                 <button

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -224,14 +224,14 @@ export function InputArea({
                 <button
                   type="button"
                   onClick={onStopAgent}
-                  className="
+                  className={`
                     h-9 w-9 rounded-lg
                     flex items-center justify-center
                     transition-all duration-200
                     oh-focus-outline
                     bg-red-500/20 text-red-400 border border-red-500/30
                     hover:bg-red-500/30 hover:border-red-500/40 hover:text-red-300
-                  "
+                  `}
                   aria-label="Stop the agent"
                   title="Stop the agent"
                   data-testid="stop-agent-button"

--- a/src/webview-src/components/app/ConversationInputDock.tsx
+++ b/src/webview-src/components/app/ConversationInputDock.tsx
@@ -16,30 +16,7 @@ export function ConversationInputDock(props: {
 
   return (
     <div className="relative">
-      {/* Stop button - shown when agent is running */}
-      {isRunning && onStopAgent && (
-        <button
-          type="button"
-          onClick={onStopAgent}
-          className="
-            w-full px-4 py-3
-            flex items-center justify-center gap-2
-            bg-gradient-to-r from-red-500/15 to-red-600/10
-            border-t border-b border-red-500/20
-            text-red-300 hover:text-red-200
-            hover:from-red-500/20 hover:to-red-600/15
-            transition-all duration-200
-            text-sm font-medium
-          "
-          aria-label="Stop the agent"
-          data-testid="stop-agent-button"
-        >
-          <span className="codicon codicon-debug-stop" />
-          <span>Stop the agent</span>
-        </button>
-      )}
-
-      <InputArea {...inputAreaProps} />
+      <InputArea {...inputAreaProps} isRunning={isRunning} onStopAgent={onStopAgent} />
 
       {/* Bottom status bar (below prompt + controls) */}
       <div


### PR DESCRIPTION
## Summary

This PR fixes the stop UI by replacing the full-width stop bar with a compact icon button in the prompt input controls row.

## Changes

- **Removed** the full-width stop bar from `ConversationInputDock.tsx` that was overlapping conversation content
- **Added** a compact stop icon button in `InputArea.tsx`, positioned before the Attachments and Send buttons
- **Passed** `isRunning` and `onStopAgent` props from `ConversationInputDock` to `InputArea`

## UI Details

- Button uses consistent styling with other prompt control buttons (same size, rounded corners, hover effects)
- Uses the same `codicon-debug-stop` icon as before
- Red-tinted styling to indicate the stop action
- Maintains same visibility rule: only shown when agent state is `RUNNING`
- Same behavior: stops current agent run, agent resumes only when user sends a new message

## Acceptance Criteria

- ✅ No overlap with conversation content
- ✅ Stop button is discoverable, consistent with other prompt controls
- ✅ Correctly appears/disappears based on RUNNING state

## Testing

All 298 existing tests pass, including the stop button tests in `App.advanced.test.tsx` which verify:
- Stop button appears when agent is RUNNING
- Stop button sends pause command on click
- Stop button disappears when agent transitions from RUNNING to IDLE

Fixes #609

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f4e60535053f4283b86e0e9f1738bc10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a stop button in the input area that appears while an agent is running, enabling users to interrupt agent execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->