### PR TITLE
fix: strip additionalProperties from Gemini tool schemas (oh-tab-xknw)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/gemini.stripUnsupportedSchemaProps.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/gemini.stripUnsupportedSchemaProps.test.ts
@@ -143,14 +143,26 @@ describe('stripUnsupportedSchemaProps', () => {
     };
 
     const result = stripUnsupportedSchemaProps(schema) as Record<string, unknown>;
-
-    // Verify no additionalProperties at any level
-    expect(result).not.toHaveProperty('additionalProperties');
-    const properties = result['properties'] as Record<string, unknown>;
-    const action = properties['action'] as Record<string, unknown>;
-    expect(action).not.toHaveProperty('additionalProperties');
-    const actionProps = action['properties'] as Record<string, unknown>;
-    const params = actionProps['params'] as Record<string, unknown>;
-    expect(params).not.toHaveProperty('additionalProperties');
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        action: {
+          type: 'object',
+          properties: {
+            type: { type: 'string', enum: ['read', 'write'] },
+            params: {
+              type: 'object',
+              properties: {
+                file: { type: 'string' },
+                content: { type: 'string' }
+              },
+              required: ['file']
+            }
+          },
+          required: ['type', 'params']
+        }
+      },
+      required: ['action']
+    });
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/gemini.stripUnsupportedSchemaProps.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/gemini.stripUnsupportedSchemaProps.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { stripUnsupportedSchemaProps } from '../gemini';
+
+describe('stripUnsupportedSchemaProps', () => {
+  it('returns primitives unchanged', () => {
+    expect(stripUnsupportedSchemaProps(null)).toBe(null);
+    expect(stripUnsupportedSchemaProps(undefined)).toBe(undefined);
+    expect(stripUnsupportedSchemaProps('string')).toBe('string');
+    expect(stripUnsupportedSchemaProps(123)).toBe(123);
+    expect(stripUnsupportedSchemaProps(true)).toBe(true);
+  });
+
+  it('strips additionalProperties from top-level object', () => {
+    const schema = {
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+      additionalProperties: false,
+    };
+    const result = stripUnsupportedSchemaProps(schema);
+    expect(result).toEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+      required: ['name'],
+    });
+  });
+
+  it('strips additionalProperties from nested objects', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: { id: { type: 'number' } },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    };
+    const result = stripUnsupportedSchemaProps(schema);
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: { id: { type: 'number' } },
+        },
+      },
+    });
+  });
+
+  it('strips additionalProperties from array items', () => {
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+        additionalProperties: false,
+      },
+    };
+    const result = stripUnsupportedSchemaProps(schema);
+    expect(result).toEqual({
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { value: { type: 'string' } },
+      },
+    });
+  });
+
+  it('handles arrays at top level', () => {
+    const schema = [
+      { type: 'string', additionalProperties: false },
+      { type: 'number' },
+    ];
+    const result = stripUnsupportedSchemaProps(schema);
+    expect(result).toEqual([
+      { type: 'string' },
+      { type: 'number' },
+    ]);
+  });
+
+  it('preserves all other schema properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        command: {
+          type: 'string',
+          enum: ['view', 'create'],
+          description: 'The command to run',
+        },
+        path: {
+          type: 'string',
+          description: 'Path to file',
+        },
+      },
+      required: ['command', 'path'],
+      additionalProperties: false,
+    };
+    const result = stripUnsupportedSchemaProps(schema);
+    expect(result).toEqual({
+      type: 'object',
+      properties: {
+        command: {
+          type: 'string',
+          enum: ['view', 'create'],
+          description: 'The command to run',
+        },
+        path: {
+          type: 'string',
+          description: 'Path to file',
+        },
+      },
+      required: ['command', 'path'],
+    });
+  });
+
+  it('handles deeply nested structures from zod-to-json-schema', () => {
+    // Simulate a realistic schema from zod-to-json-schema
+    const schema = {
+      type: 'object',
+      properties: {
+        action: {
+          type: 'object',
+          properties: {
+            type: { type: 'string', enum: ['read', 'write'] },
+            params: {
+              type: 'object',
+              properties: {
+                file: { type: 'string' },
+                content: { type: 'string' },
+              },
+              required: ['file'],
+              additionalProperties: false,
+            },
+          },
+          required: ['type', 'params'],
+          additionalProperties: false,
+        },
+      },
+      required: ['action'],
+      additionalProperties: false,
+    };
+
+    const result = stripUnsupportedSchemaProps(schema) as Record<string, unknown>;
+
+    // Verify no additionalProperties at any level
+    expect(result).not.toHaveProperty('additionalProperties');
+    const properties = result['properties'] as Record<string, unknown>;
+    const action = properties['action'] as Record<string, unknown>;
+    expect(action).not.toHaveProperty('additionalProperties');
+    const actionProps = action['properties'] as Record<string, unknown>;
+    const params = actionProps['params'] as Record<string, unknown>;
+    expect(params).not.toHaveProperty('additionalProperties');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -168,12 +168,30 @@ const toGeminiContents = (messages: Message[]): GeminiContent[] => {
   return contents;
 };
 
+/**
+ * Recursively strip unsupported JSON Schema properties for Gemini.
+ * Gemini's function calling API rejects additionalProperties and other
+ * OpenAI-style schema fields that zod-to-json-schema adds automatically.
+ */
+export const stripUnsupportedSchemaProps = (schema: unknown): unknown => {
+  if (schema === null || typeof schema !== 'object') return schema;
+  if (Array.isArray(schema)) return schema.map(stripUnsupportedSchemaProps);
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(schema as Record<string, unknown>)) {
+    // Skip properties Gemini doesn't support
+    if (key === 'additionalProperties') continue;
+    result[key] = stripUnsupportedSchemaProps(value);
+  }
+  return result;
+};
+
 const toGeminiTools = (tools: ChatCompletionRequest['tools']): GeminiGenerateContentRequest['tools'] | undefined => {
   if (!tools?.length) return undefined;
   const functionDeclarations: GeminiFunctionDeclaration[] = tools.map((tool) => ({
     name: tool.function.name,
     description: tool.function.description,
-    parameters: tool.function.parameters,
+    parameters: stripUnsupportedSchemaProps(tool.function.parameters),
   }));
   return [{ functionDeclarations }];
 };


### PR DESCRIPTION
## Summary
- Gemini 2.5 Flash rejects tool schemas containing `additionalProperties` (HTTP 400)
- The `zod-to-json-schema` library adds `additionalProperties: false` automatically when converting Zod schemas
- Added `stripUnsupportedSchemaProps()` helper in `gemini.ts` to recursively remove unsupported JSON Schema properties before sending to Gemini API

## Test plan
- [x] Added 7 unit tests for `stripUnsupportedSchemaProps()` covering primitives, nested objects, arrays, and realistic zod-to-json-schema output
- [x] All 298 existing tests pass
- [x] Typecheck passes
- [x] Lint passes
- [ ] Manual test: select `gemini-flash` profile and verify tool calls work without HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)