### PR TITLE
fix: sync ConversationView dropdown when profile changed in LLM Profiles View (oh-tab-qh1i)

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -779,6 +779,7 @@ export function App() {
         deleteProfile={deleteLlmProfile}
         getApiKeyStatus={getLlmProfileApiKeyStatus}
         setApiKey={setLlmProfileApiKey}
+        onSelectActiveProfile={handleSelectLlmProfileId}
       />
 
       {/* History view (slide-over panel) */}

--- a/src/webview-src/components/LlmProfilesView.tsx
+++ b/src/webview-src/components/LlmProfilesView.tsx
@@ -74,6 +74,7 @@ export function LlmProfilesView(props: {
   deleteProfile: (profileId: string) => Promise<void>;
   getApiKeyStatus: (profileId: string, overrides?: LlmProfileApiKeyStatusOverrides) => Promise<LlmProfileApiKeyStatusInfo>;
   setApiKey: (profileId: string, apiKey: string) => Promise<void>;
+  onSelectActiveProfile?: (profileId: string) => void;
 }) {
   const {
     isOpen,
@@ -86,6 +87,7 @@ export function LlmProfilesView(props: {
     deleteProfile,
     getApiKeyStatus,
     setApiKey,
+    onSelectActiveProfile,
   } = props;
 
   const panelRef = useRef<HTMLDivElement>(null);
@@ -426,7 +428,8 @@ export function LlmProfilesView(props: {
       return;
     }
     void startEdit(next);
-  }, [startCreate, startEdit]);
+    onSelectActiveProfile?.(next);
+  }, [onSelectActiveProfile, startCreate, startEdit]);
 
   const handleSetApiKey = useCallback(async () => {
     if (!selectedProfileId) return;


### PR DESCRIPTION
## Summary
- When user selected a profile in LLM Profiles View dropdown, it only loaded the profile for editing but didn't set it as active
- ConversationView dropdown would still show the old profile after returning from LLM Profiles View
- Added `onSelectActiveProfile` callback prop to `LlmProfilesView` to notify parent when profile selection changes

## Test plan
- [ ] Open ConversationView, note current profile in dropdown
- [ ] Open LLM Profiles View via gear icon
- [ ] Select a different profile from the dropdown in LLM Profiles View
- [ ] Close LLM Profiles View
- [ ] Verify ConversationView dropdown now shows the newly selected profile
- [ ] Send a message and verify the new profile is used

Closes oh-tab-qh1i

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for triggering actions when selecting an active profile from the LLM profiles panel.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->