### PR TITLE
fix: add system prompt for HAL summary to avoid Anthropic 400 error (oh-tab-58xt)

### DIFF
--- a/src/extension/summarizeWithLocalLlm.ts
+++ b/src/extension/summarizeWithLocalLlm.ts
@@ -25,7 +25,7 @@ export async function summarizeWithLocalLlm(
 
   const client = await factory.createClient();
   const request = {
-    systemPrompt: '',
+    systemPrompt: 'You are a very good summarizer.',
     messages: [
       {
         role: 'user' as const,


### PR DESCRIPTION
## Summary
- Fix HAL teleport summarization failing with Anthropic 400 error when using Claude-based profiles
- The `summarizeWithLocalLlm` function was sending an empty system prompt, which Anthropic rejects with "system: text content blocks must be non-empty"
- Changed empty string to `'You are a very good summarizer.'`

## Test plan
- [ ] Test HAL teleport summarization with a Claude/Anthropic profile
- [ ] Verify no 400 error occurs during summarization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced summarization feature with improved default settings to deliver higher quality summary results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->