### PR TITLE
refactor: move HAL teleport command from dev/diagnostics to hal/

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -1,10 +1,8 @@
 import * as vscode from 'vscode';
 import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
-import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from '../shared/halTeleport';
 import { DEFAULT_HAL_STATE } from '../shared/halDefaults';
 import { resolveConfiguredLlmLabel } from '../shared/llmProfiles';
-import { safeStringify } from '../shared/safeStringify';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
@@ -54,10 +52,6 @@ type EnsureConversationAndConnection = (options?: { uiJustCreated?: boolean; mod
 
 type RenderError = (err: unknown) => string;
 
-type ResolveGitContext = (workspaceRoot: string | undefined) => Promise<{ repoName: string; branchName: string }>;
-
-type SummarizeWithLocalLlm = (settings: OpenHandsSettings, prompt: string, secrets: SecretRegistry) => Promise<string>;
-
 type RegisterDiagnosticsCommandsDeps = {
   context: vscode.ExtensionContext;
   getChatView: () => vscode.WebviewView | undefined;
@@ -73,7 +67,6 @@ type RegisterDiagnosticsCommandsDeps = {
   pendingUiStateRequests: Map<string, (info: UiStateSnapshot) => void>;
   pendingHalStateRequests: Map<string, (info: HalStateSnapshot) => void>;
   ensureConversationAndConnection: EnsureConversationAndConnection;
-  printedExitFor: Map<string, true>;
   secretRegistry: SecretRegistry;
   getConversation: () => ConversationInstance | undefined;
   getConversationMode: () => 'local' | 'remote';
@@ -83,8 +76,6 @@ type RegisterDiagnosticsCommandsDeps = {
   getRecentTerminalEvents?: (max?: number) => Array<{ type?: string; timestamp: number }>;
   getOutputChannel: () => vscode.OutputChannel | undefined;
   renderError: RenderError;
-  resolveGitContext: ResolveGitContext;
-  summarizeWithLocalLlm: SummarizeWithLocalLlm;
   onTerminalEvent: (event: BashEvent) => void;
 };
 
@@ -361,75 +352,6 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     }
   );
 
-  const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
-    try {
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
-      const settings = await settingsMgr.get();
-
-      const firstServerUrl = typeof settings.servers?.[0]?.url === 'string' ? settings.servers[0].url.trim() : '';
-      if (!firstServerUrl) {
-        const message = 'No server available';
-        deps.getOutputChannel()?.appendLine(`[hal.teleport] ${message}`);
-        const posted = await postToWebview({ type: 'halTeleportUnavailable', error: message });
-        if (!posted) {
-          void vscode.window.showErrorMessage(message);
-        }
-        return;
-      }
-
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-      const { repoName, branchName } = await deps.resolveGitContext(workspaceRoot);
-      const introLines = [
-        'Teleported from the local VS Code runtime after a HIGH-risk confirmation.',
-        `Repo: ${repoName}`,
-        `Branch: ${branchName}`,
-        'Note: uncommitted local changes may not be present remotely.',
-      ];
-      const intro = introLines.join('\n');
-
-      const backlogEvents = Array.from(deps.iterConversationEventBacklog(), (item) => item.event);
-      const summaryEvents = takeLastTeleportableEvents(backlogEvents, TELEPORT_SUMMARY_EVENT_LIMIT);
-      const prompt = renderCondensationSummarizingPrompt({
-        previousSummary: '',
-        eventStrings: summaryEvents.map((e) => safeStringify(e)),
-      });
-
-      let firstRemoteMessage: string;
-      try {
-        const summary = await deps.summarizeWithLocalLlm(settings, prompt, deps.secretRegistry);
-        firstRemoteMessage = `${intro}\n\n---\n\n${summary}`;
-      } catch (err) {
-        const last10 = takeLastTeleportableEvents(backlogEvents, TELEPORT_FALLBACK_EVENT_LIMIT).map((e) => safeStringify(e));
-        const reason = deps.renderError(err);
-        const block = last10.map((e) => `<EVENT>\n${e}\n</EVENT>`).join('\n\n');
-        firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary failed: ${reason}\n\nLast 10 events (Action/Observation/Message only):\n\n${block}`;
-      }
-
-      try {
-        await deps.getConversation()?.rejectAction('Teleported to remote runtime');
-      } catch (err) {
-        deps.getOutputChannel()?.appendLine(`[hal.teleport] Failed to reject local confirmation: ${deps.renderError(err)}`);
-      }
-
-      // Ensure we always start a new remote conversation instead of restoring a prior one.
-      await deps.context.workspaceState.update('openhands.conversationId.remote', undefined);
-
-      await settingsMgr.update({ serverUrl: firstServerUrl });
-      await deps.ensureConversationAndConnection({ uiJustCreated: true });
-      deps.sentTestEvents.length = 0;
-      deps.printedExitFor.clear();
-      await deps.getConversation()?.startNewConversation();
-      await deps.getConversation()?.sendUserMessage(firstRemoteMessage);
-    } catch (err) {
-      const reason = deps.renderError(err);
-      deps.getOutputChannel()?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
-      const posted = await postToWebview({ type: 'halTeleportFailed', error: reason });
-      if (!posted) {
-        void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
-      }
-    }
-  });
-
   const getProfileApiKeySecretKey = (profileId: string): string => `openhands.llmProfileApiKey.${profileId}`;
 
   const broadcastLlmProfilesUpdated = async (): Promise<void> => {
@@ -628,7 +550,6 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     queryUiState,
     queryHalState,
     webviewAction,
-    teleportToRemoteRuntime,
     openProfilesView,
     createProfile,
     updateProfile,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { transformEventForWebview as transformEventForWebviewWithPastedImages } 
 import { ConversationEventBacklog, type BufferedConversationEvent } from './conversation/eventBacklog';
 import { OpenHandsTerminalLogPseudoterminal } from './terminal/OpenHandsTerminalLogPseudoterminal';
 import { registerDiagnosticsCommands, type RenderedEventsInfo, type UiStateSnapshot } from './dev/registerDiagnosticsCommands';
+import { registerHalCommands } from './hal/registerHalCommands';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS, type HostToWebviewMessage } from './shared/webviewMessages';
 import { resolveLocalTools } from './shared/localTools';
 import { createDevBridgeLogger, createMaskedOutputChannel } from './extension/devBridgeLogger';
@@ -536,7 +537,6 @@ export function activate(context: vscode.ExtensionContext) {
     pendingUiStateRequests,
     pendingHalStateRequests,
     ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
-    printedExitFor,
     secretRegistry: secrets,
     getConversation: () => conversation,
     getConversationMode: () => conversationMode,
@@ -545,7 +545,20 @@ export function activate(context: vscode.ExtensionContext) {
     getReceivedTerminalEventsCount: () => receivedTerminalEvents.length,
     getRecentTerminalEvents: (max = 10) => receivedTerminalEvents.slice(-Math.max(0, Math.min(max, MAX_TERMINAL_EVENTS))),
     onTerminalEvent: (event) => handleTerminalEvent(event),
+    getOutputChannel: () => outputChannel,
+    renderError,
+  });
 
+  const halCommands = registerHalCommands({
+    context,
+    getChatView: () => chatView,
+    getChatWebviewReady: () => chatWebviewReady,
+    iterConversationEventBacklog,
+    sentTestEvents,
+    ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
+    printedExitFor,
+    secretRegistry: secrets,
+    getConversation: () => conversation,
     getOutputChannel: () => outputChannel,
     renderError,
     resolveGitContext,
@@ -637,6 +650,7 @@ export function activate(context: vscode.ExtensionContext) {
     open,
     explainSelection,
     ...diagnosticsCommands,
+    ...halCommands,
     startNew,
     configure,
     ...secretCommands,

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -28,8 +28,33 @@ vi.mock('../../settings/VscodeSettingsAdapter', () => ({
 
 import { registerHalCommands, type RegisterHalCommandsDeps } from '../registerHalCommands';
 
+function createMockContext(): Partial<vscode.ExtensionContext> {
+  return {
+    subscriptions: [],
+    extensionUri: { fsPath: '/test/extension' } as vscode.Uri,
+    workspaceState: {
+      get: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+      keys: vi.fn(() => []),
+      setKeysForSync: vi.fn(),
+    } as any,
+    globalState: {
+      get: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+      keys: vi.fn(() => []),
+      setKeysForSync: vi.fn(),
+    } as any,
+    secrets: {
+      get: vi.fn().mockResolvedValue(undefined),
+      store: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
+      onDidChange: vi.fn(),
+    } as any,
+  };
+}
+
 describe('registerHalCommands', () => {
-  let mockContext: vscode.ExtensionContext;
+  let mockContext: any;
   let mockSecretRegistry: SecretRegistry;
   let mockDeps: RegisterHalCommandsDeps;
   let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
@@ -43,39 +68,7 @@ describe('registerHalCommands', () => {
       return { dispose: vi.fn() };
     });
 
-    mockContext = {
-      subscriptions: [],
-      secrets: {
-        get: vi.fn().mockResolvedValue(undefined),
-        store: vi.fn().mockResolvedValue(undefined),
-        delete: vi.fn().mockResolvedValue(undefined),
-        onDidChange: vi.fn(),
-      },
-      workspaceState: {
-        get: vi.fn(),
-        update: vi.fn().mockResolvedValue(undefined),
-        keys: vi.fn().mockReturnValue([]),
-      },
-      globalState: {
-        get: vi.fn(),
-        update: vi.fn().mockResolvedValue(undefined),
-        keys: vi.fn().mockReturnValue([]),
-        setKeysForSync: vi.fn(),
-      },
-      extensionPath: '/test/extension',
-      extensionUri: { fsPath: '/test/extension' } as vscode.Uri,
-      globalStorageUri: { fsPath: '/test/global-storage' } as vscode.Uri,
-      storageUri: { fsPath: '/test/storage' } as vscode.Uri,
-      logUri: { fsPath: '/test/log' } as vscode.Uri,
-      extensionMode: 2, // vscode.ExtensionMode.Test
-      asAbsolutePath: vi.fn((p: string) => `/test/extension/${p}`),
-      storagePath: '/test/storage',
-      globalStoragePath: '/test/global-storage',
-      logPath: '/test/log',
-      extension: {} as vscode.Extension<unknown>,
-      environmentVariableCollection: {} as vscode.GlobalEnvironmentVariableCollection,
-      languageModelAccessInformation: {} as vscode.LanguageModelAccessInformation,
-    } as unknown as vscode.ExtensionContext;
+    mockContext = createMockContext();
 
     mockSecretRegistry = new SecretRegistry(mockContext.secrets);
 

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest';
+import * as vscode from 'vscode';
+import { SecretRegistry } from '@openhands/agent-sdk-ts';
+
+const defaultMockSettings = {
+  serverUrl: '',
+  servers: [],
+  llm: {},
+};
+
+let mockSettings = structuredClone(defaultMockSettings);
+
+vi.mock('../../settings/SettingsManager', () => ({
+  SettingsManager: vi.fn(function (this: any) {
+    this.get = vi.fn(async () => mockSettings);
+    this.update = vi.fn(async (partial: any) => {
+      mockSettings = { ...mockSettings, ...partial };
+    });
+    return this;
+  }),
+}));
+
+vi.mock('../../settings/VscodeSettingsAdapter', () => ({
+  VscodeSettingsAdapter: vi.fn(function (this: any) {
+    return this;
+  }),
+}));
+
+import { registerHalCommands, type RegisterHalCommandsDeps } from '../registerHalCommands';
+
+describe('registerHalCommands', () => {
+  let mockContext: vscode.ExtensionContext;
+  let mockSecretRegistry: SecretRegistry;
+  let mockDeps: RegisterHalCommandsDeps;
+  let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
+
+  beforeEach(() => {
+    mockSettings = structuredClone(defaultMockSettings);
+    registeredCommands = new Map();
+
+    (vscode.commands.registerCommand as Mock).mockImplementation((name: string, callback: (...args: unknown[]) => unknown) => {
+      registeredCommands.set(name, callback);
+      return { dispose: vi.fn() };
+    });
+
+    mockContext = {
+      subscriptions: [],
+      secrets: {
+        get: vi.fn().mockResolvedValue(undefined),
+        store: vi.fn().mockResolvedValue(undefined),
+        delete: vi.fn().mockResolvedValue(undefined),
+        onDidChange: vi.fn(),
+      },
+      workspaceState: {
+        get: vi.fn(),
+        update: vi.fn().mockResolvedValue(undefined),
+        keys: vi.fn().mockReturnValue([]),
+      },
+      globalState: {
+        get: vi.fn(),
+        update: vi.fn().mockResolvedValue(undefined),
+        keys: vi.fn().mockReturnValue([]),
+        setKeysForSync: vi.fn(),
+      },
+      extensionPath: '/test/extension',
+      extensionUri: { fsPath: '/test/extension' } as vscode.Uri,
+      globalStorageUri: { fsPath: '/test/global-storage' } as vscode.Uri,
+      storageUri: { fsPath: '/test/storage' } as vscode.Uri,
+      logUri: { fsPath: '/test/log' } as vscode.Uri,
+      extensionMode: 2, // vscode.ExtensionMode.Test
+      asAbsolutePath: vi.fn((p: string) => `/test/extension/${p}`),
+      storagePath: '/test/storage',
+      globalStoragePath: '/test/global-storage',
+      logPath: '/test/log',
+      extension: {} as vscode.Extension<unknown>,
+      environmentVariableCollection: {} as vscode.GlobalEnvironmentVariableCollection,
+      languageModelAccessInformation: {} as vscode.LanguageModelAccessInformation,
+    } as unknown as vscode.ExtensionContext;
+
+    mockSecretRegistry = new SecretRegistry(mockContext.secrets);
+
+    mockDeps = {
+      context: mockContext,
+      getChatView: vi.fn().mockReturnValue(undefined),
+      getChatWebviewReady: vi.fn().mockReturnValue(false),
+      iterConversationEventBacklog: vi.fn().mockReturnValue([]),
+      sentTestEvents: [],
+      ensureConversationAndConnection: vi.fn().mockResolvedValue(undefined),
+      printedExitFor: new Map(),
+      secretRegistry: mockSecretRegistry,
+      getConversation: vi.fn().mockReturnValue(undefined),
+      getOutputChannel: vi.fn().mockReturnValue(undefined),
+      renderError: vi.fn((err: unknown) => String(err)),
+      resolveGitContext: vi.fn().mockResolvedValue({ repoName: 'test-repo', branchName: 'main' }),
+      summarizeWithLocalLlm: vi.fn().mockResolvedValue('Test summary'),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    registeredCommands.clear();
+  });
+
+  it('registers the teleportToRemoteRuntime command', () => {
+    const disposables = registerHalCommands(mockDeps);
+
+    expect(disposables).toHaveLength(1);
+    expect(registeredCommands.has('openhands._teleportToRemoteRuntime')).toBe(true);
+  });
+
+  it('returns disposables for all registered commands', () => {
+    const disposables = registerHalCommands(mockDeps);
+
+    expect(disposables).toHaveLength(1);
+    disposables.forEach((d) => {
+      expect(d).toHaveProperty('dispose');
+    });
+  });
+
+  it('teleport command shows error when no server is available', async () => {
+    const mockOutputChannel = {
+      appendLine: vi.fn(),
+    };
+    mockDeps.getOutputChannel = vi.fn().mockReturnValue(mockOutputChannel);
+
+    registerHalCommands(mockDeps);
+
+    const teleportCommand = registeredCommands.get('openhands._teleportToRemoteRuntime');
+    expect(teleportCommand).toBeDefined();
+
+    await teleportCommand!();
+
+    expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
+      expect.stringContaining('No server available')
+    );
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith('No server available');
+  });
+});

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -1,0 +1,113 @@
+import * as vscode from 'vscode';
+import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsManager';
+import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
+import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from '../shared/halTeleport';
+import { safeStringify } from '../shared/safeStringify';
+import type { HostToWebviewMessage } from '../shared/webviewMessages';
+import type { BufferedConversationEvent } from '../conversation/eventBacklog';
+import type { ConversationInstance, Event, SecretRegistry } from '@openhands/agent-sdk-ts';
+
+type EnsureConversationAndConnection = (options?: { uiJustCreated?: boolean; modeSwitched?: boolean }) => Promise<void>;
+
+type RenderError = (err: unknown) => string;
+
+type ResolveGitContext = (workspaceRoot: string | undefined) => Promise<{ repoName: string; branchName: string }>;
+
+type SummarizeWithLocalLlm = (settings: OpenHandsSettings, prompt: string, secrets: SecretRegistry) => Promise<string>;
+
+export type RegisterHalCommandsDeps = {
+  context: vscode.ExtensionContext;
+  getChatView: () => vscode.WebviewView | undefined;
+  getChatWebviewReady: () => boolean;
+  iterConversationEventBacklog: () => Iterable<BufferedConversationEvent>;
+  sentTestEvents: Event[];
+  ensureConversationAndConnection: EnsureConversationAndConnection;
+  printedExitFor: Map<string, true>;
+  secretRegistry: SecretRegistry;
+  getConversation: () => ConversationInstance | undefined;
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  renderError: RenderError;
+  resolveGitContext: ResolveGitContext;
+  summarizeWithLocalLlm: SummarizeWithLocalLlm;
+};
+
+export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Disposable[] {
+  const postToWebview = async (message: HostToWebviewMessage): Promise<boolean> => {
+    const chatView = deps.getChatView();
+    if (!chatView || !deps.getChatWebviewReady()) return false;
+    return chatView.webview.postMessage(message);
+  };
+
+  const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+      const settings = await settingsMgr.get();
+
+      const firstServerUrl = typeof settings.servers?.[0]?.url === 'string' ? settings.servers[0].url.trim() : '';
+      if (!firstServerUrl) {
+        const message = 'No server available';
+        deps.getOutputChannel()?.appendLine(`[hal.teleport] ${message}`);
+        const posted = await postToWebview({ type: 'halTeleportUnavailable', error: message });
+        if (!posted) {
+          void vscode.window.showErrorMessage(message);
+        }
+        return;
+      }
+
+      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const { repoName, branchName } = await deps.resolveGitContext(workspaceRoot);
+      const introLines = [
+        'Teleported from the local VS Code runtime after a HIGH-risk confirmation.',
+        `Repo: ${repoName}`,
+        `Branch: ${branchName}`,
+        'Note: uncommitted local changes may not be present remotely.',
+      ];
+      const intro = introLines.join('\n');
+
+      const backlogEvents = Array.from(deps.iterConversationEventBacklog(), (item) => item.event);
+      const summaryEvents = takeLastTeleportableEvents(backlogEvents, TELEPORT_SUMMARY_EVENT_LIMIT);
+      const prompt = renderCondensationSummarizingPrompt({
+        previousSummary: '',
+        eventStrings: summaryEvents.map((e) => safeStringify(e)),
+      });
+
+      let firstRemoteMessage: string;
+      try {
+        const summary = await deps.summarizeWithLocalLlm(settings, prompt, deps.secretRegistry);
+        firstRemoteMessage = `${intro}\n\n---\n\n${summary}`;
+      } catch (err) {
+        const last10 = takeLastTeleportableEvents(backlogEvents, TELEPORT_FALLBACK_EVENT_LIMIT).map((e) => safeStringify(e));
+        const reason = deps.renderError(err);
+        const block = last10.map((e) => `<EVENT>\n${e}\n</EVENT>`).join('\n\n');
+        firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary failed: ${reason}\n\nLast 10 events (Action/Observation/Message only):\n\n${block}`;
+      }
+
+      try {
+        await deps.getConversation()?.rejectAction('Teleported to remote runtime');
+      } catch (err) {
+        deps.getOutputChannel()?.appendLine(`[hal.teleport] Failed to reject local confirmation: ${deps.renderError(err)}`);
+      }
+
+      // Ensure we always start a new remote conversation instead of restoring a prior one.
+      await deps.context.workspaceState.update('openhands.conversationId.remote', undefined);
+
+      await settingsMgr.update({ serverUrl: firstServerUrl });
+      await deps.ensureConversationAndConnection({ uiJustCreated: true });
+      deps.sentTestEvents.length = 0;
+      deps.printedExitFor.clear();
+      await deps.getConversation()?.startNewConversation();
+      await deps.getConversation()?.sendUserMessage(firstRemoteMessage);
+    } catch (err) {
+      const reason = deps.renderError(err);
+      deps.getOutputChannel()?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
+      const posted = await postToWebview({ type: 'halTeleportFailed', error: reason });
+      if (!posted) {
+        void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
+      }
+    }
+  });
+
+  return [
+    teleportToRemoteRuntime,
+  ];
+}


### PR DESCRIPTION
## Summary

Move the HAL teleport command (`openhands._teleportToRemoteRuntime`) from `src/dev/registerDiagnosticsCommands.ts` to a new `src/hal/registerHalCommands.ts` file.

HAL is a production feature and should not live in dev/diagnostics. This refactor addresses the architectural smell where production features were mixed with dev/debug diagnostics.

## Changes

- Create `src/hal/registerHalCommands.ts` with the teleport command
- Remove teleport command from `registerDiagnosticsCommands.ts`
- Update `extension.ts` to register HAL commands separately
- Add tests for `registerHalCommands`

## Testing

- All existing tests pass
- Added new tests for `registerHalCommands` module
- No behavior change - the command name and functionality remain identical

Fixes #614

oh-tab-rcup

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1528775b66524de78d5394f3560060c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated HAL-related commands into the extension command surface

* **Refactor**
  * Reorganized and consolidated the teleport-to-remote-runtime functionality as part of HAL integration, improving command architecture and dependency management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->