### PR TITLE
fix: restructure HAL teleport flow for clean state management

### DIFF
--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -168,7 +168,7 @@ Settings:
 - **Reject**: reject the current confirmation and continue (or pause) as the normal confirmation flow would.
 - **Teleport to remote runtime**:
   - Pick the **first** configured remote server in the ServerSelect list.
-    - If no server is available (empty list): **abort the HAL flow** (exit overlay/audio), show "No remote server configured. Add a server in the Server Selection menu to enable teleport.", then proceed with the normal Reject path (including the usual reject-reason prompt).
+    - If no server is available (empty list): **abort the HAL flow** (exit overlay/audio), show "No server configured. Add one in Server Selection.", then proceed with the normal Reject path (including the usual reject-reason prompt).
   - **Connection-first approach** (critical for clean state management):
     1. Show "Connecting to (server name)…" status message.
     2. Attempt to connect to the remote server **first**.
@@ -180,12 +180,12 @@ Settings:
     4. **If connection fails**:
        - Do **NOT** cancel/reject the local confirmation (the local agent remains active with the pending action).
        - Do **NOT** prepare or send any summary.
-       - Show a user-friendly error message (e.g., "Server is unreachable. Please check that the server is running and the URL is correct.").
+       - Show a short, user-friendly error message (e.g., "Server unreachable. Check if it is running.").
        - Return to the local conversation state (HAL flow resets to error phase).
   - Summary message content (only prepared after successful connection):
     - If summarization succeeds: intro + summary.
     - If summarization fails: intro + note that summarization failed + last 10 events (Action/Observation/Message only; exclude system prompt/tools/skills).
-    - Intro includes: repo name, branch name, and a note that uncommitted local changes may not be present in remote.
+    - Intro includes: repo name, branch name, remote URL (if configured), and a note that uncommitted local changes may not be present in remote.
     - Do **not** send the system prompt, tool list, or skills list (the remote agent/runtime has its own).
     - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn't emit them today).
   - Show the "Teleporting…" overlay and play the "Rhapsody in Blue…" snippet while waiting for the remote conversation to be ready.

--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -167,17 +167,28 @@ Settings:
 - **Approve locally**: approve the current confirmation and continue the local run.
 - **Reject**: reject the current confirmation and continue (or pause) as the normal confirmation flow would.
 - **Teleport to remote runtime**:
-  - Cancel the local confirmation (do not execute the risky local action).
   - Pick the **first** configured remote server in the ServerSelect list.
-    - If no server is available (empty list): **abort the HAL flow** (exit overlay/audio), show “No server available”, then proceed with the normal Reject path (including the usual reject-reason prompt).
-  - Before starting the new remote conversation:
-    - Run a one-shot **local** LLM summarization and send **only the summary** as the first user message in the remote conversation (not full JSON event history).
-    - If summarization fails: still teleport; send a note that summarization failed **plus the last 10 events** (Action/Observation/Message only; exclude system prompt/tools/skills).
-    - Include repo name + branch name, and a note that uncommitted local changes may not be present in remote.
+    - If no server is available (empty list): **abort the HAL flow** (exit overlay/audio), show "No remote server configured. Add a server in the Server Selection menu to enable teleport.", then proceed with the normal Reject path (including the usual reject-reason prompt).
+  - **Connection-first approach** (critical for clean state management):
+    1. Show "Connecting to (server name)…" status message.
+    2. Attempt to connect to the remote server **first**.
+    3. **Only if connection succeeds**:
+       - Cancel the local confirmation (reject the risky local action with reason "Teleported to remote runtime").
+       - Run a one-shot **local** LLM summarization.
+       - Start a new remote conversation and send the summary as the first user message.
+       - Show "Teleported to (server name)!" success message.
+    4. **If connection fails**:
+       - Do **NOT** cancel/reject the local confirmation (the local agent remains active with the pending action).
+       - Do **NOT** prepare or send any summary.
+       - Show a user-friendly error message (e.g., "Server is unreachable. Please check that the server is running and the URL is correct.").
+       - Return to the local conversation state (HAL flow resets to error phase).
+  - Summary message content (only prepared after successful connection):
+    - If summarization succeeds: intro + summary.
+    - If summarization fails: intro + note that summarization failed + last 10 events (Action/Observation/Message only; exclude system prompt/tools/skills).
+    - Intro includes: repo name, branch name, and a note that uncommitted local changes may not be present in remote.
     - Do **not** send the system prompt, tool list, or skills list (the remote agent/runtime has its own).
-    - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn’t emit them today).
-  - Switch to remote mode and start a new conversation on that server.
-  - Show the “Teleporting…” overlay and play the “Rhapsody in Blue…” snippet until the remote conversation is ready.
+    - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn't emit them today).
+  - Show the "Teleporting…" overlay and play the "Rhapsody in Blue…" snippet while waiting for the remote conversation to be ready.
 
 ## Testing plan
 ### Unit tests (webview)

--- a/src/extension/gitDiffSummary.ts
+++ b/src/extension/gitDiffSummary.ts
@@ -46,15 +46,21 @@ export async function getGitHeadDiffSummaryForFile(filePath: string): Promise<st
   }
 }
 
-export async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ repoName: string; branchName: string }> {
+export async function resolveGitContext(workspaceRoot: string | undefined): Promise<{ repoName: string; branchName: string; remoteUrl: string }> {
   const fallbackRepo = workspaceRoot ? path.basename(workspaceRoot) : 'unknown';
-  if (!workspaceRoot) return { repoName: fallbackRepo, branchName: 'unknown' };
+  if (!workspaceRoot) return { repoName: fallbackRepo, branchName: 'unknown', remoteUrl: '' };
 
   try {
     const root = (await execFileText('git', ['rev-parse', '--show-toplevel'], workspaceRoot)).trim();
     const branch = (await execFileText('git', ['rev-parse', '--abbrev-ref', 'HEAD'], root)).trim();
-    return { repoName: path.basename(root) || fallbackRepo, branchName: branch || 'unknown' };
+    let remoteUrl = '';
+    try {
+      remoteUrl = (await execFileText('git', ['remote', 'get-url', 'origin'], root)).trim();
+    } catch {
+      // No remote configured, that's fine
+    }
+    return { repoName: path.basename(root) || fallbackRepo, branchName: branch || 'unknown', remoteUrl };
   } catch {
-    return { repoName: fallbackRepo, branchName: 'unknown' };
+    return { repoName: fallbackRepo, branchName: 'unknown', remoteUrl: '' };
   }
 }

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -256,4 +256,134 @@ describe('registerHalCommands', () => {
       serverUrl: 'https://example.com',
     });
   });
+
+  it('does NOT reject local action when connection fails', async () => {
+    mockSettings = {
+      serverUrl: '',
+      servers: [{ url: 'https://example.com' }],
+      llm: {},
+    };
+
+    const mockWebview = {
+      postMessage: vi.fn().mockResolvedValue(true),
+    };
+    const mockChatView = {
+      webview: mockWebview,
+    };
+    mockDeps.getChatView = vi.fn().mockReturnValue(mockChatView);
+    mockDeps.getChatWebviewReady = vi.fn().mockReturnValue(true);
+
+    const mockConversation = {
+      rejectAction: vi.fn().mockResolvedValue(undefined),
+      startNewConversation: vi.fn().mockResolvedValue(undefined),
+      sendUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDeps.getConversation = vi.fn().mockReturnValue(mockConversation);
+
+    // Make ensureConversationAndConnection throw - simulating connection failure
+    mockDeps.ensureConversationAndConnection = vi.fn().mockRejectedValue(new Error('Connection failed'));
+
+    registerHalCommands(mockDeps);
+
+    const teleportCommand = registeredCommands.get('openhands._teleportToRemoteRuntime');
+    await teleportCommand!();
+
+    // The local action should NOT be rejected because connection failed
+    expect(mockConversation.rejectAction).not.toHaveBeenCalled();
+  });
+
+  it('posts halTeleportSuccess on successful teleport', async () => {
+    mockSettings = {
+      serverUrl: '',
+      servers: [{ url: 'https://example.com', label: 'My Server' }],
+      llm: {},
+    };
+
+    const mockWebview = {
+      postMessage: vi.fn().mockResolvedValue(true),
+    };
+    const mockChatView = {
+      webview: mockWebview,
+    };
+    mockDeps.getChatView = vi.fn().mockReturnValue(mockChatView);
+    mockDeps.getChatWebviewReady = vi.fn().mockReturnValue(true);
+
+    const mockConversation = {
+      rejectAction: vi.fn().mockResolvedValue(undefined),
+      startNewConversation: vi.fn().mockResolvedValue(undefined),
+      sendUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    mockDeps.getConversation = vi.fn().mockReturnValue(mockConversation);
+
+    // Connection succeeds
+    mockDeps.ensureConversationAndConnection = vi.fn().mockResolvedValue(undefined);
+
+    registerHalCommands(mockDeps);
+
+    const teleportCommand = registeredCommands.get('openhands._teleportToRemoteRuntime');
+    await teleportCommand!();
+
+    // Check that halTeleportSuccess was posted
+    expect(mockWebview.postMessage).toHaveBeenCalledWith({
+      type: 'halTeleportSuccess',
+      serverUrl: 'https://example.com',
+      serverLabel: 'My Server',
+    });
+
+    // The local action SHOULD be rejected because connection succeeded
+    expect(mockConversation.rejectAction).toHaveBeenCalledWith('Teleported to remote runtime');
+  });
+
+  it('rejects local action only after successful connection', async () => {
+    mockSettings = {
+      serverUrl: '',
+      servers: [{ url: 'https://example.com' }],
+      llm: {},
+    };
+
+    const mockWebview = {
+      postMessage: vi.fn().mockResolvedValue(true),
+    };
+    const mockChatView = {
+      webview: mockWebview,
+    };
+    mockDeps.getChatView = vi.fn().mockReturnValue(mockChatView);
+    mockDeps.getChatWebviewReady = vi.fn().mockReturnValue(true);
+
+    const callOrder: string[] = [];
+
+    const mockConversation = {
+      rejectAction: vi.fn().mockImplementation(() => {
+        callOrder.push('rejectAction');
+        return Promise.resolve(undefined);
+      }),
+      startNewConversation: vi.fn().mockImplementation(() => {
+        callOrder.push('startNewConversation');
+        return Promise.resolve(undefined);
+      }),
+      sendUserMessage: vi.fn().mockImplementation(() => {
+        callOrder.push('sendUserMessage');
+        return Promise.resolve(undefined);
+      }),
+    };
+    mockDeps.getConversation = vi.fn().mockReturnValue(mockConversation);
+
+    mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(() => {
+      callOrder.push('ensureConversationAndConnection');
+      return Promise.resolve(undefined);
+    });
+
+    registerHalCommands(mockDeps);
+
+    const teleportCommand = registeredCommands.get('openhands._teleportToRemoteRuntime');
+    await teleportCommand!();
+
+    // Verify the order: connection first, then reject, then new conversation
+    expect(callOrder).toEqual([
+      'ensureConversationAndConnection',
+      'rejectAction',
+      'startNewConversation',
+      'sendUserMessage',
+    ]);
+  });
 });

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -56,55 +56,55 @@ function createMockContext(): Partial<vscode.ExtensionContext> {
 describe('formatTeleportError', () => {
   it('formats ECONNREFUSED errors', () => {
     expect(formatTeleportError('Error: connect ECONNREFUSED 127.0.0.1:3000')).toBe(
-      'Server is unreachable. Please check that the server is running and the URL is correct.'
+      'Server unreachable. Check if it is running.'
     );
   });
 
   it('formats connection refused errors', () => {
     expect(formatTeleportError('Connection refused by server')).toBe(
-      'Server is unreachable. Please check that the server is running and the URL is correct.'
+      'Server unreachable. Check if it is running.'
     );
   });
 
   it('formats timeout errors', () => {
     expect(formatTeleportError('Error: ETIMEDOUT')).toBe(
-      'Connection timed out. The server may be down or experiencing high load.'
+      'Connection timed out. Server may be down.'
     );
     expect(formatTeleportError('Request timed out after 30s')).toBe(
-      'Connection timed out. The server may be down or experiencing high load.'
+      'Connection timed out. Server may be down.'
     );
   });
 
   it('formats DNS resolution errors', () => {
     expect(formatTeleportError('Error: getaddrinfo ENOTFOUND example.com')).toBe(
-      'Server address not found. Please verify the server URL is correct.'
+      'Server not found. Check the URL.'
     );
   });
 
   it('formats network unreachable errors', () => {
     expect(formatTeleportError('Error: ENETUNREACH')).toBe(
-      'Network unreachable. Please check your internet connection.'
+      'Network unreachable. Check your connection.'
     );
   });
 
   it('formats SSL/TLS errors', () => {
     expect(formatTeleportError('SSL certificate problem')).toBe(
-      'SSL/TLS connection error. The server may have an invalid certificate.'
+      'SSL/TLS error. Invalid certificate?'
     );
     expect(formatTeleportError('TLS handshake failed')).toBe(
-      'SSL/TLS connection error. The server may have an invalid certificate.'
+      'SSL/TLS error. Invalid certificate?'
     );
   });
 
   it('formats connection reset errors', () => {
     expect(formatTeleportError('Error: ECONNRESET')).toBe(
-      'Connection was reset by the server. Please try again.'
+      'Connection reset. Try again.'
     );
   });
 
   it('formats WebSocket errors', () => {
     expect(formatTeleportError('WebSocket connection failed')).toBe(
-      'WebSocket connection failed. The server may not be accepting connections.'
+      'WebSocket failed. Server not accepting connections.'
     );
   });
 
@@ -145,7 +145,7 @@ describe('registerHalCommands', () => {
       getConversation: vi.fn().mockReturnValue(undefined),
       getOutputChannel: vi.fn().mockReturnValue(undefined),
       renderError: vi.fn((err: unknown) => String(err)),
-      resolveGitContext: vi.fn().mockResolvedValue({ repoName: 'test-repo', branchName: 'main' }),
+      resolveGitContext: vi.fn().mockResolvedValue({ repoName: 'test-repo', branchName: 'main', remoteUrl: 'https://github.com/test/test-repo.git' }),
       summarizeWithLocalLlm: vi.fn().mockResolvedValue('Test summary'),
     };
   });
@@ -185,10 +185,10 @@ describe('registerHalCommands', () => {
     await teleportCommand!();
 
     expect(mockOutputChannel.appendLine).toHaveBeenCalledWith(
-      expect.stringContaining('No remote server configured')
+      expect.stringContaining('No server configured')
     );
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-      'No remote server configured. Add a server in the Server Selection menu to enable teleport.'
+      'No server configured. Add one in Server Selection.'
     );
   });
 
@@ -252,7 +252,7 @@ describe('registerHalCommands', () => {
     // Check that halTeleportFailed was posted with formatted error and serverUrl
     expect(mockWebview.postMessage).toHaveBeenCalledWith({
       type: 'halTeleportFailed',
-      error: 'Server is unreachable. Please check that the server is running and the URL is correct.',
+      error: 'Server unreachable. Check if it is running.',
       serverUrl: 'https://example.com',
     });
   });

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -87,6 +87,8 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
     let targetServerUrl: string | undefined;
     let targetServerLabel: string | undefined;
+    let connectionEstablished = false;
+
     try {
       const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
       const settings = await settingsMgr.get();
@@ -105,6 +107,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
 
       targetServerUrl = firstServerUrl;
       targetServerLabel = typeof firstServer?.label === 'string' ? firstServer.label.trim() : undefined;
+      const serverDisplayName = targetServerLabel || targetServerUrl;
 
       // Notify webview that teleport is starting with server info
       await postToWebview({
@@ -113,6 +116,29 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         serverLabel: targetServerLabel,
       });
 
+      // STEP 1: Try to connect to the remote server FIRST
+      // This must succeed before we do anything else (reject local action, prepare summary, etc.)
+      deps.getOutputChannel()?.appendLine(`[hal.teleport] Attempting connection to ${serverDisplayName}...`);
+
+      // Ensure we always start a new remote conversation instead of restoring a prior one.
+      await deps.context.workspaceState.update('openhands.conversationId.remote', undefined);
+
+      await settingsMgr.update({ serverUrl: firstServerUrl });
+      await deps.ensureConversationAndConnection({ uiJustCreated: true });
+
+      // Connection succeeded - mark it so we know we can proceed
+      connectionEstablished = true;
+      deps.getOutputChannel()?.appendLine(`[hal.teleport] Connection established to ${serverDisplayName}`);
+
+      // STEP 2: Now that connection is established, reject the local action
+      // This is safe because we know the remote server is available
+      try {
+        await deps.getConversation()?.rejectAction('Teleported to remote runtime');
+      } catch (err) {
+        deps.getOutputChannel()?.appendLine(`[hal.teleport] Failed to reject local confirmation: ${deps.renderError(err)}`);
+      }
+
+      // STEP 3: Prepare the summary message (only after connection is established)
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
       const { repoName, branchName } = await deps.resolveGitContext(workspaceRoot);
       const introLines = [
@@ -141,24 +167,29 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary failed: ${reason}\n\nLast 10 events (Action/Observation/Message only):\n\n${block}`;
       }
 
-      try {
-        await deps.getConversation()?.rejectAction('Teleported to remote runtime');
-      } catch (err) {
-        deps.getOutputChannel()?.appendLine(`[hal.teleport] Failed to reject local confirmation: ${deps.renderError(err)}`);
-      }
-
-      // Ensure we always start a new remote conversation instead of restoring a prior one.
-      await deps.context.workspaceState.update('openhands.conversationId.remote', undefined);
-
-      await settingsMgr.update({ serverUrl: firstServerUrl });
-      await deps.ensureConversationAndConnection({ uiJustCreated: true });
+      // STEP 4: Start new conversation and send the summary
       deps.sentTestEvents.length = 0;
       deps.printedExitFor.clear();
       await deps.getConversation()?.startNewConversation();
       await deps.getConversation()?.sendUserMessage(firstRemoteMessage);
+
+      // STEP 5: Notify success
+      deps.getOutputChannel()?.appendLine(`[hal.teleport] Teleport successful to ${serverDisplayName}`);
+      await postToWebview({
+        type: 'halTeleportSuccess',
+        serverUrl: targetServerUrl,
+        serverLabel: targetServerLabel,
+      });
     } catch (err) {
       const reason = formatTeleportError(deps.renderError(err));
       deps.getOutputChannel()?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
+
+      // If connection was never established, we haven't touched the local conversation
+      // The local agent is still active and the pending action is still pending
+      if (!connectionEstablished) {
+        deps.getOutputChannel()?.appendLine('[hal.teleport] Connection failed - local conversation unchanged');
+      }
+
       const posted = await postToWebview({ type: 'halTeleportFailed', error: reason, serverUrl: targetServerUrl });
       if (!posted) {
         void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -11,7 +11,7 @@ type EnsureConversationAndConnection = (options?: { uiJustCreated?: boolean; mod
 
 type RenderError = (err: unknown) => string;
 
-type ResolveGitContext = (workspaceRoot: string | undefined) => Promise<{ repoName: string; branchName: string }>;
+type ResolveGitContext = (workspaceRoot: string | undefined) => Promise<{ repoName: string; branchName: string; remoteUrl: string }>;
 
 type SummarizeWithLocalLlm = (settings: OpenHandsSettings, prompt: string, secrets: SecretRegistry) => Promise<string>;
 
@@ -33,44 +33,44 @@ export type RegisterHalCommandsDeps = {
 
 /**
  * Formats teleport error messages to be more user-friendly.
- * Converts technical error messages into actionable guidance.
+ * Converts technical error messages into short, actionable guidance.
  */
 export function formatTeleportError(rawError: string): string {
   const lower = rawError.toLowerCase();
 
   // Connection refused / unreachable
   if (lower.includes('econnrefused') || lower.includes('connection refused')) {
-    return 'Server is unreachable. Please check that the server is running and the URL is correct.';
+    return 'Server unreachable. Check if it is running.';
   }
 
   // Timeout errors
   if (lower.includes('timeout') || lower.includes('etimedout') || lower.includes('timed out')) {
-    return 'Connection timed out. The server may be down or experiencing high load.';
+    return 'Connection timed out. Server may be down.';
   }
 
   // DNS resolution failures
   if (lower.includes('enotfound') || lower.includes('getaddrinfo') || lower.includes('dns')) {
-    return 'Server address not found. Please verify the server URL is correct.';
+    return 'Server not found. Check the URL.';
   }
 
   // Network unreachable
   if (lower.includes('enetunreach') || lower.includes('network unreachable')) {
-    return 'Network unreachable. Please check your internet connection.';
+    return 'Network unreachable. Check your connection.';
   }
 
   // SSL/TLS errors
   if (lower.includes('ssl') || lower.includes('tls') || lower.includes('certificate')) {
-    return 'SSL/TLS connection error. The server may have an invalid certificate.';
+    return 'SSL/TLS error. Invalid certificate?';
   }
 
   // Connection reset
   if (lower.includes('econnreset') || lower.includes('connection reset')) {
-    return 'Connection was reset by the server. Please try again.';
+    return 'Connection reset. Try again.';
   }
 
   // WebSocket errors
   if (lower.includes('websocket') || lower.includes('ws://') || lower.includes('wss://')) {
-    return 'WebSocket connection failed. The server may not be accepting connections.';
+    return 'WebSocket failed. Server not accepting connections.';
   }
 
   // Return original if no pattern matched
@@ -96,7 +96,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       const firstServer = settings.servers?.[0];
       const firstServerUrl = typeof firstServer?.url === 'string' ? firstServer.url.trim() : '';
       if (!firstServerUrl) {
-        const message = 'No remote server configured. Add a server in the Server Selection menu to enable teleport.';
+        const message = 'No server configured. Add one in Server Selection.';
         deps.getOutputChannel()?.appendLine(`[hal.teleport] ${message}`);
         const posted = await postToWebview({ type: 'halTeleportUnavailable', error: message });
         if (!posted) {
@@ -140,13 +140,16 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
 
       // STEP 3: Prepare the summary message (only after connection is established)
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-      const { repoName, branchName } = await deps.resolveGitContext(workspaceRoot);
+      const { repoName, branchName, remoteUrl } = await deps.resolveGitContext(workspaceRoot);
       const introLines = [
         'Teleported from the local VS Code runtime after a HIGH-risk confirmation.',
         `Repo: ${repoName}`,
         `Branch: ${branchName}`,
-        'Note: uncommitted local changes may not be present remotely.',
       ];
+      if (remoteUrl) {
+        introLines.push(`Remote: ${remoteUrl}`);
+      }
+      introLines.push('Note: uncommitted local changes may not be present remotely.');
       const intro = introLines.join('\n');
 
       const backlogEvents = Array.from(deps.iterConversationEventBacklog(), (item) => item.event);

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -66,6 +66,7 @@ export type HostToWebviewMessage =
   | { type: 'halTeleportUnavailable'; error: string }
   | { type: 'halTeleportFailed'; error: string; serverUrl?: string }
   | { type: 'halTeleportStarting'; serverUrl: string; serverLabel?: string }
+  | { type: 'halTeleportSuccess'; serverUrl: string; serverLabel?: string }
   | { type: 'halTtsResponse'; requestId: string; ok: true; audioBase64: string; volume: number }
   | { type: 'halTtsResponse'; requestId: string; ok: false; error: string; shouldNotify?: boolean; disabled?: boolean }
   | { type: 'halVoiceConfirmResponse'; requestId: string; ok: true; decision: string }

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -210,6 +210,7 @@ export function App() {
     handleHalTeleportUnavailable,
     handleHalTeleportFailed,
     handleHalTeleportStarting,
+    handleHalTeleportSuccess,
     handleConversationStarted,
     resetForServerTargetChange,
   } = useHalFlow({
@@ -273,6 +274,7 @@ export function App() {
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTeleportStarting,
+    handleHalTeleportSuccess,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,
     maybeUpdateHalFlow,

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -803,6 +803,12 @@ export function useHalFlow(deps: {
     deps.showStatusMessage('info', `Connecting to ${displayName}…`);
   }, [deps.showStatusMessage]);
 
+  const handleHalTeleportSuccess = useCallback((serverUrl: string, serverLabel?: string) => {
+    const displayName = serverLabel || serverUrl;
+    deps.showStatusMessage('info', `Teleported to ${displayName}!`);
+    // Note: The HAL UI state will be reset by handleConversationStarted when the new conversation starts
+  }, [deps.showStatusMessage]);
+
   const resetForServerTargetChange = useCallback(() => {
     setHalDisabledConversationId(null);
     setHalVoiceConfirmFallbackKey(null);
@@ -868,6 +874,7 @@ export function useHalFlow(deps: {
     handleHalTeleportUnavailable,
     handleHalTeleportFailed,
     handleHalTeleportStarting,
+    handleHalTeleportSuccess,
     handleConversationStarted,
     resetForServerTargetChange,
   };

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -59,6 +59,7 @@ export type HostMessageHandlerOptions = {
   handleHalTeleportFailed: (error: unknown, serverUrl?: string) => void;
   handleHalTeleportUnavailable: (error: unknown) => void;
   handleHalTeleportStarting: (serverUrl: string, serverLabel?: string) => void;
+  handleHalTeleportSuccess: (serverUrl: string, serverLabel?: string) => void;
   handleHalTtsResponse: (payload: Record<string, unknown>) => void;
   handleHalVoiceConfirmResponse: (payload: Record<string, unknown>) => void;
   maybeUpdateHalFlow: () => void;
@@ -119,6 +120,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTeleportStarting,
+    handleHalTeleportSuccess,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,
     maybeUpdateHalFlow,
@@ -478,6 +480,12 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
           }
           break;
         }
+        case 'halTeleportSuccess': {
+          if (typeof payload.serverUrl === 'string') {
+            handleHalTeleportSuccess(payload.serverUrl, payload.serverLabel);
+          }
+          break;
+        }
         case 'conversationStarted':
           if (typeof payload.conversationId === 'string') {
             handleConversationStarted();
@@ -703,6 +711,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTeleportStarting,
+    handleHalTeleportSuccess,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,
     mentionStartRef,

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -199,7 +199,7 @@ export async function run(): Promise<void> {
 
   await pollUntil(async () => {
     const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
-    return hal?.phase === 'awaiting_user' && typeof hal?.lastError === 'string' && hal.lastError.includes('No server available');
+    return hal?.phase === 'awaiting_user' && typeof hal?.lastError === 'string' && hal.lastError.includes('No remote server configured');
   }, 15000);
 
   await vscode.commands.executeCommand('openhands._webviewAction', {

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -199,7 +199,7 @@ export async function run(): Promise<void> {
 
   await pollUntil(async () => {
     const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
-    return hal?.phase === 'awaiting_user' && typeof hal?.lastError === 'string' && hal.lastError.includes('No remote server configured');
+    return hal?.phase === 'awaiting_user' && typeof hal?.lastError === 'string' && hal.lastError.includes('No server configured');
   }, 15000);
 
   await vscode.commands.executeCommand('openhands._webviewAction', {


### PR DESCRIPTION
## Summary

This PR fixes issue #619 by restructuring the HAL teleport flow to use a **connection-first approach**. This ensures clean state management when teleport fails.

## Problem

Previously, the teleport flow would:
1. Prepare the summary message
2. Reject the local action
3. Try to connect to the remote server
4. Start new conversation and send summary

This was problematic because if step 3 (connection) failed, we had already:
- Rejected the local action (step 2)
- Prepared the summary (step 1)

This left the user in a broken state where the local action was rejected but no remote conversation was started.

## Solution

The new flow follows a **connection-first approach**:

1. **Attempt to connect to the remote server FIRST**
2. **Only if connection succeeds**:
   - Reject the local action (with reason "Teleported to remote runtime")
   - Prepare the summary message
   - Start new remote conversation
   - Send the summary as the first message
   - Show "Teleported to (server name)!" success message
3. **If connection fails**:
   - Do **NOT** reject the local action (local agent remains active with pending action)
   - Do **NOT** prepare or send any summary
   - Show user-friendly error message
   - Return to local conversation state (HAL flow resets to error phase)

## Changes

### Core Flow Changes (`src/hal/registerHalCommands.ts`)
- Restructured `teleportToRemoteRuntime` command to connect first
- Added `connectionEstablished` flag to track state
- Only reject local action and prepare summary after successful connection
- Added `halTeleportSuccess` message posting on success

### New Message Type (`src/shared/webviewMessages.ts`)
- Added `halTeleportSuccess` message type with `serverUrl` and `serverLabel`

### Webview Handlers
- Added `handleHalTeleportSuccess` in `useHalFlow.ts`
- Shows "Teleported to (server name)!" status message on success
- Updated `useHostMessages.ts` and `App.tsx` to wire up the new handler

### Documentation (`docs/hal/elevenlabs_prd.md`)
- Updated "Decision outcomes" section with detailed connection-first flow
- Documented behavior for both success and failure cases

### Tests (`src/hal/__tests__/registerHalCommands.test.ts`)
- Added test: "does NOT reject local action when connection fails"
- Added test: "posts halTeleportSuccess on successful teleport"
- Added test: "rejects local action only after successful connection" (verifies order)

## Testing

All 17 tests in `registerHalCommands.test.ts` pass, including 3 new tests for the flow changes.

Fixes #619

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/98ef50cc397f478eb9a15a236b2c1fa4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Teleportation now validates remote server connection first before initiating transfer
  * Success notification confirms successful remote transfer with server details
  
* **Bug Fixes**
  * Improved error messages when remote server is unavailable or not configured
  * Better handling of connection failures to preserve local conversation state

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->