### PR TITLE
fix: truncate encrypted LLM API fields for display in Output View

### DIFF
--- a/src/__tests__/safeStringify.test.ts
+++ b/src/__tests__/safeStringify.test.ts
@@ -6,5 +6,69 @@ describe('safeStringify', () => {
     expect(safeStringify({ 'x-goog-api-key': 'abc123' })).toBe('{"x-goog-api-key":"[REDACTED]"}');
     expect(safeStringify({ 'xi-api-key': 'def456' })).toBe('{"xi-api-key":"[REDACTED]"}');
   });
-});
 
+  describe('LLM API encrypted/signature field truncation', () => {
+    it('truncates encrypted_content from OpenAI Responses API', () => {
+      const longEncryptedContent = 'gAAAAABpUroThZmuFVDx9jCG_CfsHbzZ3NNNWgUw3rTfZqZfy-e67LNymJDgbJRzXt9CQJyUb_bM-EFopvT0xMH3Cvh4HrNAI-I92zBfp53G32xsAiigUbm1kXzgrfebpgKduvBC_3nmq9uNh4uihuzXEyXhF-N8lm-mNaV1aI2SSwomgPRYqjB86HoffwBLgDNNhcCdabbosIu-i0J85ghQH94uHjGLRBjreu5LTTzqQcqtzXCzcb8wJp1TZpDBm2PusbdsdaygAiuqu1uWZOuu6lEADGGMTntRyH8uDL9FhP8eRy4nLnq9Kh72ZITQbTTgl_sAZWV8YUQhsCIILd0GI62P9OfaIoMfe4-8DvCE2DQq7UGFHgLSIqGDEARbX_22pgWLFD0M1tN6DETqLmPNdi7354yFUEnsgPZBQnUKPQkw0WQL5OE501KJ9NZJ2kWiFS8XTi9BshRakJTyi5NNYC34oMhgiSp6qTIycvWdMGLqZ7EvFRz2h74uGvVHLqbahwLO0L5jtz4rFlwWwv8PhqJTGOT_nk-oCPNm5P9MTW9Q5xfqMaM7aUDfgzPlh4P9xdEk-_DJC_iM-OJOYs2jRvIWSHEP7_qAwOKd14eyWxdx72I42adI_nb5CIxGvwcNVClXflPtA1ZXZmVruWtWl17bpIF21GTY-jyRjONEMiEf30beQJw2LVok_qCB4hxrJMayZY1cgBWlxUp1BgS_ds16durKGOsVdev9kRLvdmCVUCswmD7qyLCoorM2yGuYCMSIfn5sU2Vzyz_vc9odNyPnEoa8Gk-CHI-3ZeErXj2t_jtRHQBz2fv5qY2Debpd4xDZsecwOdXnCrYIeYDsQ0PAHH41fA2qDCHe6qb5dtAt3rf1Jl5xHwBaWL3SrgS1IaO76C4BD_Ed17XTjPjmOVubBrwmwaEs2NhwesElM7MUy1mBZrui_OxwhOtt_Ic4y61k-H2KoceXRZZoIqMcvooXMWoyp_WgnNJTv2hj5UYTPN9hVkJDpnSpmf2jAFg1Zzup8oMRgVVMlIRrnMYbC6_pOA24QfY8KGUyonrb6JUp9RtUms40ww3iFdrvWbvYIMTHNCvqNThDGpLLsUVr-IUnYeigxoGZc_9GUk-Ii9uH5J3IdsjRaUNg05-Xkfzq5Xzy44b86q9gVrjMsCrOCf1cPg0ZklRHwGUVUPxCTJzWPEVhfmMTIO-7os5uPS-ZsTQah-ZUFbmBo2n9qaMgG7fAyEwYIaD_b7NhK6ygQtG8cnkJgy6HdXKWZgYWkizM-JWJYvGCni-FE-E74wuB9yptizi208ypJZYRZapu1wvGYONUpvzdEhBg5S2i5bl6VAjnx3upZU7u4WldaGOl7ujJv21VrCbLMG5WhDCeph1fxVQAUtHM18Faa4rHPRgyWULZ_eek_Wks0iUb9remTOvdX9ag9MZchgip2GDxByuXWS6gfXZcoM_kX24xCtATC3mRm7k_5KbCcE_PARcr5yECMFSr2IHd0DkOZyhlJIIAnUlwq4o9N8-fdWEtIRqGEGZFTBfJfSj5tm91ygNcOM-T7008Sh4RSZUR61B92S_p7hxsILPhjVK7P3Z-MZLjcwqxYZ96WYjcOjbLEEar6pIOfb4O5gxEQANo_1MRklrmV25HSSkTt2yIwtWG8rkMaxtiAZDGXJMUTS2Zq_hjYYhTOMTUhzBcP24bYjPYTvM8RW_ML2JzACWzZXt02Ymo2PGzWl0kDKrep5-SlQjmysMYI943lO1XnixxO9szpZt6aCeYGtAqhUqZvgK8hPdyOAUYV4KC_bn0CQC909J4wtsSKK3XOFkbnd2WcLrUJg9byxD5JPP4SORs7FlTByKfXgOp_E_kxe2WYIwuE-vWE2RdFcPZG-87SYsdCQajRkhDcP6Eo0v_TdJeffVq7_lTKNIMVhkSS1VIUPAWQp-UHB751KFmZ8arTwBQweHRluIegWJin5Dw_METliGZImm1E58ejO4bD4r3clCNbIIu9XW5kdyk9Hq9qd_5QQMfRU_hwwHuD1iPNZheUjZzyWcu3XLOj6JAUoHP_QayMCNXgjFR3Sdvwm13arwyed1LjfK7rZAKxQ4=';
+      const event = {
+        kind: 'MessageEvent',
+        llm_message: {
+          responses_reasoning_item: {
+            id: 'rs_0ef1339168cb2c8a016952ba0d6580819db96b1a735d062c97',
+            encrypted_content: longEncryptedContent,
+          },
+        },
+      };
+      const result = safeStringify(event);
+      expect(result).toContain('"encrypted_content":"gAAA...xQ4="');
+      expect(result).not.toContain(longEncryptedContent);
+    });
+
+    it('truncates thinking_signature from Anthropic extended thinking', () => {
+      const longSignature = 'ErUBCkYIARgCIkCPmFLBW8L3T5X9vK2mN7qR4sD6wY1hJ0uZ3xA8bC5fG2iE9jK4lM7nO0pQ3rS6tU9vW2xY5zA8bC1dE4fG';
+      const message = {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello' }],
+        thinking_signature: longSignature,
+      };
+      const result = safeStringify(message);
+      expect(result).toContain('"thinking_signature":"ErUB...E4fG"');
+      expect(result).not.toContain(longSignature);
+    });
+
+    it('truncates signature from Anthropic thinking blocks', () => {
+      const longSignature = 'AbCdEfGhIjKlMnOpQrStUvWxYz0123456789AbCdEfGhIjKlMnOpQrStUvWxYz0123456789';
+      const thinkingBlock = {
+        type: 'thinking',
+        thinking: 'Let me think about this...',
+        signature: longSignature,
+      };
+      const result = safeStringify(thinkingBlock);
+      expect(result).toContain('"signature":"AbCd...6789"');
+      expect(result).not.toContain(longSignature);
+    });
+
+    it('does not truncate short encrypted_content values', () => {
+      const shortValue = 'short';
+      const event = { encrypted_content: shortValue };
+      const result = safeStringify(event);
+      expect(result).toBe('{"encrypted_content":"short"}');
+    });
+
+    it('does not truncate values at the minimum length boundary', () => {
+      // Minimum length is 11 (4 + 3 + 4), so 10 chars should not be truncated
+      const tenChars = '0123456789';
+      const event = { encrypted_content: tenChars };
+      const result = safeStringify(event);
+      expect(result).toBe('{"encrypted_content":"0123456789"}');
+    });
+
+    it('truncates values just above the minimum length', () => {
+      // 11 chars should be truncated
+      const elevenChars = '01234567890';
+      const event = { encrypted_content: elevenChars };
+      const result = safeStringify(event);
+      expect(result).toBe('{"encrypted_content":"0123...7890"}');
+    });
+  });
+});

--- a/src/shared/safeStringify.ts
+++ b/src/shared/safeStringify.ts
@@ -1,5 +1,26 @@
 const REDACTED = '[REDACTED]';
 
+// Keys containing encrypted/signature data from LLM APIs that should be truncated for display
+// These are opaque blobs that must be round-tripped exactly but are meaningless to display in full
+const TRUNCATE_FOR_DISPLAY_KEYS = new Set([
+  'encrypted_content',    // OpenAI Responses API reasoning
+  'thinking_signature',   // Anthropic extended thinking signature
+  'signature',            // Anthropic thinking block signature
+]);
+
+const TRUNCATE_HEAD_CHARS = 4;
+const TRUNCATE_TAIL_CHARS = 4;
+const TRUNCATE_MIN_LENGTH = TRUNCATE_HEAD_CHARS + TRUNCATE_TAIL_CHARS + 3; // "xxxx...xxxx"
+
+function truncateForDisplay(value: string): string {
+  if (value.length < TRUNCATE_MIN_LENGTH) return value;
+  return `${value.slice(0, TRUNCATE_HEAD_CHARS)}...${value.slice(-TRUNCATE_TAIL_CHARS)}`;
+}
+
+function shouldTruncateForDisplay(key: string): boolean {
+  return TRUNCATE_FOR_DISPLAY_KEYS.has(key);
+}
+
 function shouldRedactKey(key: string): boolean {
   const k = key.toLowerCase().replace(/[^a-z0-9]/g, '');
   return (
@@ -45,6 +66,10 @@ export function safeStringify(value: unknown): string {
       (key, val) => {
         if (typeof val === 'bigint') return val.toString();
         if (typeof key === 'string' && shouldRedactKey(key)) return REDACTED;
+        // Truncate encrypted/signature fields from LLM APIs for display (first 4...last 4 chars)
+        if (typeof key === 'string' && typeof val === 'string' && shouldTruncateForDisplay(key)) {
+          return truncateForDisplay(val);
+        }
         if (typeof val === 'string') return redactStringHeuristics(val);
         return val;
       }


### PR DESCRIPTION
## Summary

Truncate encrypted/signature fields from LLM APIs for display in the Output View. These opaque blobs are necessary for round-tripping to LLM APIs but meaningless to display in full and clutter the view.

## Changes

Modified `safeStringify` to truncate the following fields to `first 4 chars...last 4 chars` format:

- `encrypted_content` - OpenAI Responses API reasoning (e.g., `gAAA...xQ4=`)
- `thinking_signature` - Anthropic extended thinking signature
- `signature` - Anthropic thinking block signature

## Example

Before:
```
"encrypted_content":"gAAAAABpUroThZmuFVDx9jCG_CfsHbzZ3NNNWgUw3rTfZqZfy-e67LNymJDgbJRzXt9CQJyUb_bM-EFopvT0xMH3Cvh4HrNAI-I92zBfp53G32xsAiigUbm1kXzgrfebpgKduvBC_3nmq9uNh4uihuzXEyXhF-N8lm-mNaV1aI2SSwomgPRYqjB86HoffwBLgDNNhcCdabbosIu-i0J85ghQH94uHjGLRBjreu5LTTzqQcqtzXCzcb8wJp1TZpDBm2PusbdsdaygAiuqu1uWZOuu6lEADGGMTntRyH8uDL9FhP8eRy4nLnq9Kh72ZITQbTTgl_sAZWV8YUQhsCIILd0GI62P9OfaIoMfe4-8DvCE2DQq7UGFHgLSIqGDEARbX_22pgWLFD0M1tN6DETqLmPNdi7354yFUEnsgPZBQnUKPQkw0WQL5OE501KJ9NZJ2kWiFS8XTi9BshRakJTyi5NNYC34oMhgiSp6qTIycvWdMGLqZ7EvFRz2h74uGvVHLqbahwLO0L5jtz4rFlwWwv8PhqJTGOT_nk-oCPNm5P9MTW9Q5xfqMaM7aUDfgzPlh4P9xdEk-_DJC_iM-OJOYs2jRvIWSHEP7_qAwOKd14eyWxdx72I42adI_nb5CIxGvwcNVClXflPtA1ZXZmVruWtWl17bpIF21GTY-jyRjONEMiEf30beQJw2LVok_qCB4hxrJMayZY1cgBWlxUp1BgS_ds16durKGOsVdev9kRLvdmCVUCswmD7qyLCoorM2yGuYCMSIfn5sU2Vzyz_vc9odNyPnEoa8Gk-CHI-3ZeErXj2t_jtRHQBz2fv5qY2Debpd4xDZsecwOdXnCrYIeYDsQ0PAHH41fA2qDCHe6qb5dtAt3rf1Jl5xHwBaWL3SrgS1IaO76C4BD_Ed17XTjPjmOVubBrwmwaEs2NhwesElM7MUy1mBZrui_OxwhOtt_Ic4y61k-H2KoceXRZZoIqMcvooXMWoyp_WgnNJTv2hj5UYTPN9hVkJDpnSpmf2jAFg1Zzup8oMRgVVMlIRrnMYbC6_pOA24QfY8KGUyonrb6JUp9RtUms40ww3iFdrvWbvYIMTHNCvqNThDGpLLsUVr-IUnYeigxoGZc_9GUk-Ii9uH5J3IdsjRaUNg05-Xkfzq5Xzy44b86q9gVrjMsCrOCf1cPg0ZklRHwGUVUPxCTJzWPEVhfmMTIO-7os5uPS-ZsTQah-ZUFbmBo2n9qaMgG7fAyEwYIaD_b7NhK6ygQtG8cnkJgy6HdXKWZgYWkizM-JWJYvGCni-FE-E74wuB9yptizi208ypJZYRZapu1wvGYONUpvzdEhBg5S2i5bl6VAjnx3upZU7u4WldaGOl7ujJv21VrCbLMG5WhDCeph1fxVQAUtHM18Faa4rHPRgyWULZ_eek_Wks0iUb9remTOvdX9ag9MZchgip2GDxByuXWS6gfXZcoM_kX24xCtATC3mRm7k_5KbCcE_PARcr5yECMFSr2IHd0DkOZyhlJIIAnUlwq4o9N8-fdWEtIRqGEGZFTBfJfSj5tm91ygNcOM-T7008Sh4RSZUR61B92S_p7hxsILPhjVK7P3Z-MZLjcwqxYZ96WYjcOjbLEEar6pIOfb4O5gxEQANo_1MRklrmV25HSSkTt2yIwtWG8rkMaxtiAZDGXJMUTS2Zq_hjYYhTOMTUhzBcP24bYjPYTvM8RW_ML2JzACWzZXt02Ymo2PGzWl0kDKrep5-SlQjmysMYI943lO1XnixxO9szpZt6aCeYGtAqhUqZvgK8hPdyOAUYV4KC_bn0CQC909J4wtsSKK3XOFkbnd2WcLrUJg9byxD5JPP4SORs7FlTByKfXgOp_E_kxe2WYIwuE-vWE2RdFcPZG-87SYsdCQajRkhDcP6Eo0v_TdJeffVq7_lTKNIMVhkSS1VIUPAWQp-UHB751KFmZ8arTwBQweHRluIegWJin5Dw_METliGZImm1E58ejO4bD4r3clCNbIIu9XW5kdyk9Hq9qd_5QQMfRU_hwwHuD1iPNZheUjZzyWcu3XLOj6JAUoHP_QayMCNXgjFR3Sdvwm13arwyed1LjfK7rZAKxQ4="
```

After:
```
"encrypted_content":"gAAA...xQ4="
```

## Testing

Added tests for:
- Truncating `encrypted_content` from OpenAI Responses API
- Truncating `thinking_signature` from Anthropic extended thinking
- Truncating `signature` from Anthropic thinking blocks
- Not truncating short values (below minimum length)
- Boundary conditions

All new tests pass.

Fixes #621

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c7b6fd624be443f6b821e7d8db71c1c4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improves display of long encrypted or signature fields by truncating them to a short prefix and suffix with an ellipsis, enhancing readability while preserving privacy. Applies to select LLM response fields (e.g., encrypted content and thinking/signature values).
* **Tests**
  * Adds comprehensive tests covering truncation behavior, including nested structures, minimum-length boundaries, non-truncation for short values, and exact boundary cases to ensure consistent and secure output formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->