### PR TITLE
fix: improve type safety in test mocks using satisfies keyword

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -135,22 +135,21 @@ function createMockContext(): Partial<vscode.ExtensionContext> {
     extensionUri: { fsPath: '/test/extension' } as vscode.Uri,
     workspaceState: {
       get: vi.fn(),
-      update: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
       keys: vi.fn(() => []),
-      setKeysForSync: vi.fn(),
-    } as any,
+    } satisfies vscode.Memento,
     globalState: {
       get: vi.fn(),
-      update: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
       keys: vi.fn(() => []),
       setKeysForSync: vi.fn(),
-    } as any,
+    } satisfies vscode.Memento & { setKeysForSync(keys: readonly string[]): void },
     secrets: {
-      get: vi.fn(),
-      store: vi.fn(),
-      delete: vi.fn(),
+      get: vi.fn().mockResolvedValue(undefined),
+      store: vi.fn().mockResolvedValue(undefined),
+      delete: vi.fn().mockResolvedValue(undefined),
       onDidChange: vi.fn(),
-    } as any,
+    } satisfies vscode.SecretStorage,
   };
 }
 


### PR DESCRIPTION
## Summary

This PR improves the type safety of test mocks in `extension.test.ts` by using TypeScript's `satisfies` keyword instead of `as any` casts.

## Changes

- **Remove `setKeysForSync` from `workspaceState` mock**: This property is not part of `vscode.Memento` (the type for `workspaceState`), so it was incorrectly included
- **Keep `setKeysForSync` in `globalState` mock**: This property is correctly part of the extended type `vscode.Memento & { setKeysForSync(keys: readonly string[]): void }`
- **Replace `as any` casts with `satisfies`**: This ensures mocks conform to their expected types without losing type safety
- **Add `mockResolvedValue(undefined)` to async methods**: The `update`, `get`, `store`, and `delete` methods return `Thenable<void>` or `Thenable<T>`, so proper mock return values are now provided

## Benefits

- Catches structural mismatches at compile time
- Makes tests more robust by ensuring mocks accurately reflect the vscode API types
- Improves maintainability by providing better type checking for mock objects

## Testing

All 214 tests in `src/__tests__/` pass with these changes.

Fixes #617

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/560f04afccc840feb771f5fe0341057c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved mock test setup to properly handle asynchronous operations and align with expected async behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->