### PR TITLE
Decouple server selection from new conversation

### DIFF
--- a/src/webview-src/__tests__/App.render.test.tsx
+++ b/src/webview-src/__tests__/App.render.test.tsx
@@ -22,7 +22,7 @@ describe('App render', () => {
     expect(screen.getByLabelText('Add context')).toBeInTheDocument();
   });
 
-  it('clears conversation UI when server selection changes', async () => {
+  it('keeps conversation UI when server selection changes', async () => {
     render(<App />);
 
     act(() => {
@@ -60,7 +60,7 @@ describe('App render', () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText('hello-server-switch')).not.toBeInTheDocument();
+      expect(screen.getAllByText('hello-server-switch').length).toBeGreaterThan(0);
     });
   });
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -212,7 +212,6 @@ export function App() {
     handleHalTeleportStarting,
     handleHalTeleportSuccess,
     handleConversationStarted,
-    resetForServerTargetChange,
   } = useHalFlow({
     conversationId,
     conversationIdRef,
@@ -280,7 +279,6 @@ export function App() {
     maybeUpdateHalFlow,
     pendingLlmProfilesRequestsRef,
     postMessage,
-    resetForServerTargetChange,
     setAgentStatus,
     setAttachments,
     setContextQuery,

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -809,12 +809,6 @@ export function useHalFlow(deps: {
     // Note: The HAL UI state will be reset by handleConversationStarted when the new conversation starts
   }, [deps.showStatusMessage]);
 
-  const resetForServerTargetChange = useCallback(() => {
-    setHalDisabledConversationId(null);
-    setHalVoiceConfirmFallbackKey(null);
-    cleanupHalVoiceConfirm();
-  }, [cleanupHalVoiceConfirm]);
-
   const handleConversationStarted = useCallback(() => {
     setHalDisabledConversationId(null);
     setHalVoiceConfirmFallbackKey(null);
@@ -876,6 +870,5 @@ export function useHalFlow(deps: {
     handleHalTeleportStarting,
     handleHalTeleportSuccess,
     handleConversationStarted,
-    resetForServerTargetChange,
   };
 }

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -65,7 +65,6 @@ export type HostMessageHandlerOptions = {
   maybeUpdateHalFlow: () => void;
   pendingLlmProfilesRequestsRef: RefObject<Map<string, PendingLlmProfilesRequest>>;
   postMessage: (msg: WebviewToHostMessage) => void;
-  resetForServerTargetChange: () => void;
   setAgentStatus: Dispatch<SetStateAction<string | undefined>>;
   setAttachments: Dispatch<SetStateAction<Array<{ uri: string; label: string; sizeBytes?: number }>>>;
   setContextQuery: Dispatch<SetStateAction<string>>;
@@ -126,7 +125,6 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     maybeUpdateHalFlow,
     pendingLlmProfilesRequestsRef,
     postMessage,
-    resetForServerTargetChange,
     setAgentStatus,
     setAttachments,
     setContextQuery,
@@ -259,8 +257,6 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
         case 'config': {
           const url = typeof payload.serverUrl === 'string' ? payload.serverUrl : null;
           const nextUrl = url ? url : undefined;
-          currentServerUrlRef.current = nextUrl;
-          setCurrentServerUrl(nextUrl);
 
           if (payload.mode === 'local') {
             lastModeRef.current = 'local';
@@ -272,6 +268,11 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
           } else if (payload.mode === 'remote') {
             lastModeRef.current = 'remote';
             setMode('remote');
+            currentServerUrlRef.current = nextUrl;
+            setCurrentServerUrl(nextUrl);
+          } else {
+            currentServerUrlRef.current = nextUrl;
+            setCurrentServerUrl(nextUrl);
           }
           break;
         }
@@ -718,7 +719,6 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     pendingActionsRef,
     postMessage,
     pendingLlmProfilesRequestsRef,
-    resetForServerTargetChange,
     setAgentStatus,
     setAttachments,
     setContextQuery,

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -8,7 +8,7 @@ import type { HalSettingsSnapshot } from './useHalFlow';
 import type { PendingLlmProfilesRequest } from './llmProfilesRequests';
 import type { StatusBannerState } from './useStatusMessages';
 import { isHalDecision, type HalDecision, type HalStateSnapshot } from '../../../shared/halTypes';
-import { INITIAL_CONVERSATION_TOTALS, type ConversationTotals } from './conversationTotals';
+import type { ConversationTotals } from './conversationTotals';
 
 type WebviewPersistedState = {
   conversationId?: string;
@@ -256,6 +256,25 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
           }
           break;
         }
+        case 'config': {
+          const url = typeof payload.serverUrl === 'string' ? payload.serverUrl : null;
+          const nextUrl = url ? url : undefined;
+          currentServerUrlRef.current = nextUrl;
+          setCurrentServerUrl(nextUrl);
+
+          if (payload.mode === 'local') {
+            lastModeRef.current = 'local';
+            setMode('local');
+            currentServerUrlRef.current = undefined;
+            setCurrentServerUrl(undefined);
+            setStatusBanner({ message: 'Local mode: running without remote server', level: 'info', dismissible: false });
+            postMessage({ type: 'requestTools' });
+          } else if (payload.mode === 'remote') {
+            lastModeRef.current = 'remote';
+            setMode('remote');
+          }
+          break;
+        }
         case 'llmProfilesUpdated': {
           if (Array.isArray(payload.profiles)) {
             setLlmProfiles(payload.profiles.filter((id): id is string => typeof id === 'string'));
@@ -396,29 +415,8 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
           }
           if (typeof payload.serverUrl === 'string') {
             const nextUrl = payload.serverUrl || undefined;
-            const prevUrl = currentServerUrlRef.current;
             currentServerUrlRef.current = nextUrl;
             setCurrentServerUrl(nextUrl);
-
-            // If the server target changed (Local ↔ Remote or remote server URL changed),
-            // start a fresh conversation UI instead of implicitly resuming prior state.
-            if (prevUrl !== nextUrl) {
-              resetForServerTargetChange();
-              conversationIdRef.current = undefined;
-              setConversationId(undefined);
-              setEvents([]);
-              pendingActionsRef.current = [];
-              setPendingActions([]);
-              agentStatusRef.current = undefined;
-              setAgentStatus(undefined);
-              setStreamingContent(null);
-              setConversationTotals(INITIAL_CONVERSATION_TOTALS);
-              hasLlmUsageRef.current = false;
-              eventId.current = 1;
-              const api = getVscodeApi();
-              api.setState?.({});
-              maybeUpdateHalFlow();
-            }
           }
           break;
         }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -1109,16 +1109,19 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'command': {
         switch (message.command) {
           case 'reconnect':
-            conversation?.reconnect();
+            // Use the VS Code command so we re-evaluate settings (local ↔ remote) before reconnecting.
+            await vscode.commands.executeCommand('openhands.reconnect');
             break;
           case 'pause':
             await conversation?.pause();
             break;
-          case 'startNewConversation':
-            await conversation?.startNewConversation();
-            if (isLocalConversationToolControls(conversation)) {
+          case 'startNewConversation': {
+            // Use the VS Code command so we re-evaluate settings (local ↔ remote) before starting.
+            await vscode.commands.executeCommand('openhands.startNewConversation');
+            const refreshedConversation = deps.getConversation();
+            if (isLocalConversationToolControls(refreshedConversation)) {
               try {
-                conversation.setTools(resolveLocalTools(getDefaultLocalToolIds()));
+                refreshedConversation.setTools(resolveLocalTools(getDefaultLocalToolIds()));
               } catch (err) {
                 const reason = err instanceof Error ? err.message : String(err);
                 outputChannel?.appendLine(`[tools] Failed to reset tools: ${reason}`);
@@ -1126,6 +1129,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
               postToolsList();
             }
             break;
+          }
           case 'approveAction':
             await conversation?.approveAction();
             break;


### PR DESCRIPTION
## Problem
Selecting a remote server could still leave the extension running a `LocalConversation` (e.g. `[conversation] active=local-...`) and then the "+" button would start a new conversation on the *existing* conversation instance. When that instance was local, there was no HTTP fetch attempt to the agent-server, which made the UI/selection confusing (remote server selected but local conversation in use).

## What changed
- **Server selection no longer triggers a new conversation/UI reset**: choosing a server only updates `openhands.serverUrl` and the server list; it does **not** clear the current conversation UI.
- **New conversation ("+") always re-evaluates local vs remote**: the webview command now routes through the VS Code command `openhands.startNewConversation`, which calls `ensureConversationAndConnection()` first. That guarantees we create a `RemoteConversation` when a server URL is configured, otherwise `LocalConversation`.
- **Reconnect does the same**: webview reconnect routes through `openhands.reconnect`, so it also re-checks settings before connecting.
- **Webview handles host `type: config` message** (returned by `getConfig`) so mode/serverUrl state stays consistent.

## User flows
- **Select server**: updates target server (persists `openhands.serverUrl`) but keeps the current conversation visible.
- **Start new conversation ("+")**: starts a fresh conversation using the currently selected target:
  - server URL set → remote conversation (HTTP/WS)
  - server URL empty → local conversation
- **Reconnect**: reconnects using the currently selected target (same rules).

## Local repro notes
To reproduce/debug, I ran the Python agent-server locally on `http://localhost:3000` and also restarted it in debug mode to capture logs at `/Users/enyst/repos/agent-sdk/logs/agent_server_3000.log`.

## Tests
- `npm run typecheck`
- `npm test`
- Targeted: `npx vitest run src/webview-src/__tests__/App.render.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server switching now preserves conversation history instead of clearing it.

* **New Features**
  * Added support for local and remote mode configuration.
  * Improved tool management initialization when starting new conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->