### PR TITLE
(deferred) Remote LLM switching via agent-server /llm

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -116,7 +116,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - `openhands.serverUrl` - agent-server URL (blank for local mode)
 - `openhands.servers` - saved server list [{ url, label? }] for quick selection
 - `openhands.terminal.renderProgress` - coalesce carriage-return progress in terminal output
-- `openhands.llm.profileId` - selected LLM profile id from `~/.openhands/llm-profiles` (local alias; remote mode expands into `agent.llm` fields, no `profile_id` sent)
+- `openhands.llm.profileId` - selected LLM profile id from `~/.openhands/llm-profiles` (local alias; remote mode expands into `agent.llm` fields and updates the active conversation via `POST /api/conversations/{id}/llm`)
 - `openhands.confirmation.policy` - never/always/risky; `risky.threshold` default MEDIUM; `risky.confirmUnknown`
 - `openhands.conversation.maxIterations` - iteration limit
 
@@ -125,7 +125,7 @@ For internal diagnostics and the dev logging bridge, see docs/vscode_local_setup
 ### Connection & Conversation Lifecycle
 - Local mode: SDK runs agent in-process
 - Remote mode: WebSocket to agent-server
-- LLM Profiles (remote): agent-server schema is strict and rejects unknown fields (e.g. `llm.profile_id`), so the extension/SDK resolves `openhands.llm.profileId` locally and expands it into the existing `agent.llm` payload (model/baseUrl/etc).
+- LLM Profiles (remote): profiles are local-only, so the extension resolves `profileId` locally and sends an expanded `agent.llm` payload to the server; profile switches call `POST /api/conversations/{id}/llm` to update the active remote conversation.
 - Conversation ID stored in workspaceState
 - Auto-reconnect with exponential backoff
 

--- a/docs/llm_profiles.md
+++ b/docs/llm_profiles.md
@@ -12,7 +12,7 @@ Related docs:
 - The user can **switch profiles at runtime**; the change applies to the **next** LLM request only (in-flight requests keep streaming).
 - Profiles are a **local-only** concept in VS Code:
   - Local mode: the SDK resolves `profileId` locally and uses it directly.
-  - Remote mode: the extension resolves `profileId` locally and **expands** it into server-supported `agent.llm` fields (do not send `profile_id` until the agent-server supports it).
+  - Remote mode: the extension resolves `profileId` locally, **expands** it into server-supported `agent.llm` fields, and updates the active remote conversation via `POST /api/conversations/{id}/llm` (sending an inline `llm` payload; no `profile_id`).
 
 Non-goals:
 - “Freezing”/diffing the agent state (`diff_from_deserialized`, etc.) is explicitly out of scope.
@@ -136,4 +136,3 @@ User-facing errors should **not** include internal diagnostic fields like:
 
 Internal diagnostics (full request payload, effective resolution details) belong in:
 - Debug logs / Output channel gated behind a debug setting, not in normal UI error blocks.
-

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -75,10 +75,10 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
   - Profiles live at `~/.openhands/llm-profiles/<profileId>.json`.
   - `profileId` is a file name, not a server-side identifier.
 - Remote compatibility constraint
-  - The agent-server `StartConversationRequest` schema is strict and currently rejects unknown fields like `llm.profile_id`.
-  - Therefore, treat `openhands.llm.profileId` as a **local alias only** for now.
-  - In remote mode, the extension/SDK must load the profile locally and expand it into the existing `agent.llm` payload (only server-supported fields).
-  - Do **not** send `profile_id` to the server until the agent-server supports it.
+  - `profileId` is a **local alias** (a filename stem), not a server-side identifier.
+  - In remote mode, the extension resolves the profile locally and expands it into a server-supported `agent.llm` payload.
+  - Runtime switching (remote): when the user changes `profileId`, the extension updates the active remote conversation via `POST /api/conversations/{id}/llm` with an inline `llm` payload (no `profile_id`).
+  - Server-side `profile_id` switching is supported by the Python agent-server, but it requires the profile files to exist on the server.
 - Merge rules
   - Profile config is canonical for provider/model/baseUrl/openaiApiMode and generation parameters.
   - The only remaining VS Code LLM setting is `openhands.llm.profileId`.

--- a/package.json
+++ b/package.json
@@ -470,7 +470,7 @@
     "vscode:prepublish": "npm run build",
     "package": "node scripts/run-vsce-package.cjs",
     "e2e": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/**/*.test.js",
-    "e2e:agent-server": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/agentServerRemote.test.js",
+    "e2e:agent-server": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run build -w @openhands/agent-sdk-ts && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/agentServerRemote.test.js",
     "test": "npm test -w @openhands/agent-sdk-ts && vitest run --dir src",
     "test:watch": "vitest",
     "typecheck": "tsc -p . && tsc -p tsconfig.webview.json",

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
@@ -74,6 +74,69 @@ describe('RemoteConversation', () => {
     }
   });
 
+  it('updates active conversation LLM via POST /api/conversations/{id}/llm when settings change', async () => {
+    const connectSpy = vi
+      .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')
+      .mockImplementation(() => {});
+
+    const fetchSpy = vi.fn((url: string, init?: RequestInit) => {
+      if (url === 'http://localhost:3000/api/conversations') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'conv-switch' }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      if (url === 'http://localhost:3000/api/conversations/conv-switch/llm') {
+        const parsed = JSON.parse(init?.body as string) as { llm: Record<string, unknown> };
+        expect(parsed.llm.profile_id).toBeUndefined();
+        expect(parsed.llm.model).toBe('gpt-4o');
+        expect(parsed.llm.base_url).toBe('http://profile-b.example');
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ success: true }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const profilesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'remote-llm-update-'));
+    try {
+      saveProfile(
+        'profile-a',
+        { provider: 'openai', model: 'gpt-5', baseUrl: 'http://profile-a.example' },
+        { rootDir: profilesRoot }
+      );
+      saveProfile(
+        'profile-b',
+        { provider: 'openai', model: 'gpt-4o', baseUrl: 'http://profile-b.example' },
+        { rootDir: profilesRoot }
+      );
+
+      const conversation = new RemoteConversation({
+        serverUrl: 'http://localhost:3000',
+        settings: { ...baseSettings, llm: { profileId: 'profile-a' } },
+        profileStoreOptions: { rootDir: profilesRoot },
+      });
+
+      await conversation.startNewConversation();
+      conversation.setSettings({ ...baseSettings, llm: { profileId: 'profile-b' } });
+
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+      });
+      expect(connectSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(profilesRoot, { recursive: true, force: true });
+    }
+  });
+
   it('passes provided tools and workspace through to POST /api/conversations', async () => {
     const connectSpy = vi
       .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -33,6 +33,15 @@ const toStaticSecret = (value: unknown): StaticSecret | undefined => {
   return { kind: 'StaticSecret', value: trimmed };
 };
 
+const toOptionalString = (value: unknown): string | undefined => {
+  if (typeof value === 'string') return value.trim() || undefined;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    const text = String(value).trim();
+    return text.length > 0 ? text : undefined;
+  }
+  return undefined;
+};
+
 const normalizeRemoteServerUrl = (raw: string): string => {
   let url = raw.trim();
   if (!url) return url;
@@ -84,6 +93,10 @@ export class RemoteConversation extends EventEmitter {
   private static readonly wsHandshakeTimeoutMs = 10_000;
   private static readonly httpTimeoutMs = 15_000;
   private hasEverConnected = false;
+  private desiredLlmSignature?: string;
+  private desiredLlmPayload?: Record<string, unknown>;
+  private lastAppliedLlmSignature?: string;
+  private llmUpdateInFlight?: Promise<void>;
 
   constructor(options: RemoteConversationOptions) {
     super();
@@ -96,15 +109,18 @@ export class RemoteConversation extends EventEmitter {
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
+      this.desiredLlmPayload = undefined;
+      this.desiredLlmSignature = undefined;
+      this.lastAppliedLlmSignature = undefined;
       this.emit('conversationStarted', this.conversationId);
       void this.replayHistory().then((ok) => {
         if (!ok) {
           this.setStatus('offline');
           return;
         }
-        if (this.conversationId === options.conversationId) {
-          this.connect();
-        }
+        if (this.conversationId !== options.conversationId) return;
+        this.captureDesiredRemoteLlm();
+        this.connect();
       }).catch((err) => {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       });
@@ -119,10 +135,141 @@ export class RemoteConversation extends EventEmitter {
 
   setSettings(settings: OpenHandsSettings) {
     this.settings = settings;
+    this.queueRemoteLlmUpdate();
   }
 
   setServerUrl(url: string) {
     this.serverUrl = normalizeRemoteServerUrl(url);
+  }
+
+  private buildAgentLlmPayload(): Record<string, unknown> {
+    const s = this.settings;
+    const llm: Record<string, unknown> = {};
+
+    const profileId = toOptionalString(s?.llm.profileId);
+    const model = toOptionalString(s?.llm.model);
+    const baseUrl = toOptionalString(s?.llm.baseUrl);
+    const apiVersion = toOptionalString(s?.llm.apiVersion);
+
+    const profileConfig: LLMConfiguration | null = (() => {
+      if (!profileId) return null;
+      try {
+        const profile = loadProfile(profileId, this.profileStoreOptions);
+        return profile.config;
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to load LLM profile '${profileId}': ${reason}`);
+      }
+    })();
+
+    const profileModel = profileConfig ? toOptionalString(profileConfig.model) : undefined;
+    const profileBaseUrl = toOptionalString(profileConfig?.baseUrl);
+    const profileApiVersion = toOptionalString(profileConfig?.apiVersion);
+
+    const effectiveUsageId = 'agent';
+    const effectiveModel = profileModel ?? model;
+    const effectiveBaseUrl = profileBaseUrl ?? baseUrl;
+    const effectiveApiVersion = profileApiVersion ?? apiVersion;
+
+    llm.usage_id = effectiveUsageId;
+    if (effectiveModel) llm.model = effectiveModel;
+    if (effectiveBaseUrl) llm.base_url = effectiveBaseUrl;
+    if (effectiveApiVersion) llm.api_version = effectiveApiVersion;
+
+    const effectiveTimeout = profileConfig?.timeoutSeconds ?? s?.llm.timeout;
+    if (typeof effectiveTimeout === 'number' && Number.isFinite(effectiveTimeout)) {
+      llm.timeout = effectiveTimeout;
+    }
+    const effectiveTemperature = profileConfig?.temperature ?? s?.llm.temperature;
+    if (typeof effectiveTemperature === 'number' && Number.isFinite(effectiveTemperature)) {
+      llm.temperature = effectiveTemperature;
+    }
+    const effectiveTopP = profileConfig?.topP ?? s?.llm.topP;
+    if (typeof effectiveTopP === 'number' && Number.isFinite(effectiveTopP)) {
+      llm.top_p = effectiveTopP;
+    }
+    const effectiveTopK = profileConfig?.topK ?? s?.llm.topK;
+    if (typeof effectiveTopK === 'number' && Number.isFinite(effectiveTopK)) {
+      llm.top_k = effectiveTopK;
+    }
+
+    const maxInputTokens = profileConfig?.maxInputTokens ?? s?.llm.maxInputTokens;
+    if (typeof maxInputTokens === 'number' && Number.isFinite(maxInputTokens) && maxInputTokens > 0) {
+      llm.max_input_tokens = Math.trunc(maxInputTokens);
+    }
+    const maxOutputTokens = profileConfig?.maxOutputTokens ?? s?.llm.maxOutputTokens;
+    if (typeof maxOutputTokens === 'number' && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0) {
+      llm.max_output_tokens = Math.trunc(maxOutputTokens);
+    }
+
+    const effectiveReasoningEffort = profileConfig?.reasoningEffort ?? s?.llm.reasoningEffort;
+    if (typeof effectiveReasoningEffort === 'string' && effectiveReasoningEffort) {
+      llm.reasoning_effort = effectiveReasoningEffort;
+    }
+    if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;
+    if (s?.secrets.awsAccessKeyId) llm.aws_access_key_id = s.secrets.awsAccessKeyId;
+    if (s?.secrets.awsSecretAccessKey) llm.aws_secret_access_key = s.secrets.awsSecretAccessKey;
+
+    return llm;
+  }
+
+  private captureDesiredRemoteLlm(): void {
+    if (!this.conversationId) return;
+    let llm: Record<string, unknown>;
+    try {
+      llm = this.buildAgentLlmPayload();
+    } catch (err) {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    const signature = JSON.stringify(llm);
+    this.desiredLlmSignature = signature;
+    this.desiredLlmPayload = llm;
+  }
+
+  private queueRemoteLlmUpdate(): void {
+    this.captureDesiredRemoteLlm();
+    const signature = this.desiredLlmSignature;
+    if (!signature) return;
+    if (signature === this.lastAppliedLlmSignature) return;
+    if (this.llmUpdateInFlight) return;
+    void this.flushRemoteLlmUpdate();
+  }
+
+  private async flushRemoteLlmUpdate(): Promise<void> {
+    if (!this.conversationId) return;
+    if (this.llmUpdateInFlight) {
+      await this.llmUpdateInFlight;
+      return this.flushRemoteLlmUpdate();
+    }
+    const signature = this.desiredLlmSignature;
+    const llm = this.desiredLlmPayload;
+    if (!signature || !llm) return;
+    if (signature === this.lastAppliedLlmSignature) return;
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    this.llmUpdateInFlight = this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/llm`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ llm }),
+    }, RemoteConversation.httpTimeoutMs).then(async (res) => {
+      if (!res.ok) {
+        const info = await res.text().catch(() => '');
+        throw new Error(`Failed to update conversation LLM (HTTP ${res.status})${info ? `: ${info}` : ''}`);
+      }
+      this.lastAppliedLlmSignature = signature;
+    }).catch((err) => {
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+    }).finally(() => {
+      this.llmUpdateInFlight = undefined;
+    });
+
+    await this.llmUpdateInFlight;
+    if (this.desiredLlmSignature && this.desiredLlmSignature !== this.lastAppliedLlmSignature) {
+      await this.flushRemoteLlmUpdate();
+    }
   }
 
   async startNewConversation(): Promise<string | undefined> {
@@ -134,83 +281,14 @@ export class RemoteConversation extends EventEmitter {
       }
       this.clearWsHandshakeTimer();
       this.seenEventIds.clear();
+      this.desiredLlmPayload = undefined;
+      this.desiredLlmSignature = undefined;
+      this.lastAppliedLlmSignature = undefined;
       this.setStatus('connecting');
       const base = this.serverUrl.replace(/\/$/, '');
       const s = this.settings;
-      const llm: Record<string, unknown> = {};
-      const toOptionalString = (value: unknown): string | undefined => {
-        if (typeof value === 'string') return value.trim() || undefined;
-        if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
-          const text = String(value).trim();
-          return text.length > 0 ? text : undefined;
-        }
-        return undefined;
-      };
-      const profileId = toOptionalString(s?.llm.profileId);
-      const model = toOptionalString(s?.llm.model);
-      const baseUrl = toOptionalString(s?.llm.baseUrl);
-      const apiVersion = toOptionalString(s?.llm.apiVersion);
-
-      const profileConfig: LLMConfiguration | null = (() => {
-        if (!profileId) return null;
-        try {
-          const profile = loadProfile(profileId, this.profileStoreOptions);
-          return profile.config;
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          throw new Error(`Failed to load LLM profile '${profileId}': ${reason}`);
-        }
-      })();
-
-      // NOTE: profileId is a local alias only. Remote agent-server rejects unknown llm fields
-      // (like `profile_id`) with strict schema validation.
-      const profileModel = profileConfig ? toOptionalString(profileConfig.model) : undefined;
-      const profileBaseUrl = toOptionalString(profileConfig?.baseUrl);
-      const profileApiVersion = toOptionalString(profileConfig?.apiVersion);
-
-      const effectiveUsageId = 'agent';
-      const effectiveModel = profileModel ?? model;
-      const effectiveBaseUrl = profileBaseUrl ?? baseUrl;
-      const effectiveApiVersion = profileApiVersion ?? apiVersion;
-
-      llm.usage_id = effectiveUsageId;
-      if (effectiveModel) llm.model = effectiveModel;
-      if (effectiveBaseUrl) llm.base_url = effectiveBaseUrl;
-      if (effectiveApiVersion) llm.api_version = effectiveApiVersion;
-
-      const effectiveTimeout = profileConfig?.timeoutSeconds ?? s?.llm.timeout;
-      if (typeof effectiveTimeout === 'number' && Number.isFinite(effectiveTimeout)) {
-        llm.timeout = effectiveTimeout;
-      }
-      const effectiveTemperature = profileConfig?.temperature ?? s?.llm.temperature;
-      if (typeof effectiveTemperature === 'number' && Number.isFinite(effectiveTemperature)) {
-        llm.temperature = effectiveTemperature;
-      }
-      const effectiveTopP = profileConfig?.topP ?? s?.llm.topP;
-      if (typeof effectiveTopP === 'number' && Number.isFinite(effectiveTopP)) {
-        llm.top_p = effectiveTopP;
-      }
-      const effectiveTopK = profileConfig?.topK ?? s?.llm.topK;
-      if (typeof effectiveTopK === 'number' && Number.isFinite(effectiveTopK)) {
-        llm.top_k = effectiveTopK;
-      }
-
-      const maxInputTokens = profileConfig?.maxInputTokens ?? s?.llm.maxInputTokens;
-      if (typeof maxInputTokens === 'number' && Number.isFinite(maxInputTokens) && maxInputTokens > 0) {
-        llm.max_input_tokens = Math.trunc(maxInputTokens);
-      }
-      const maxOutputTokens = profileConfig?.maxOutputTokens ?? s?.llm.maxOutputTokens;
-      if (typeof maxOutputTokens === 'number' && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0) {
-        llm.max_output_tokens = Math.trunc(maxOutputTokens);
-      }
-
-      const effectiveReasoningEffort = profileConfig?.reasoningEffort ?? s?.llm.reasoningEffort;
-      if (typeof effectiveReasoningEffort === 'string' && effectiveReasoningEffort) {
-        llm.reasoning_effort = effectiveReasoningEffort;
-      }
-      if (s?.secrets.llmApiKey) llm.api_key = s.secrets.llmApiKey;
-      if (s?.secrets.awsAccessKeyId) llm.aws_access_key_id = s.secrets.awsAccessKeyId;
-      if (s?.secrets.awsSecretAccessKey) llm.aws_secret_access_key = s.secrets.awsSecretAccessKey;
+      const llm = this.buildAgentLlmPayload();
+      const llmSignature = JSON.stringify(llm);
 
       const typedSecrets: Record<string, StaticSecret> = {};
       const maybeSetSecret = (key: string, value: unknown) => {
@@ -284,6 +362,9 @@ export class RemoteConversation extends EventEmitter {
       if (!this.conversationId) {
         throw new Error('Server response missing conversation ID. Check agent-server logs.');
       }
+      this.desiredLlmSignature = llmSignature;
+      this.desiredLlmPayload = llm;
+      this.lastAppliedLlmSignature = llmSignature;
       this.emit('conversationStarted', this.conversationId);
       this.connect();
       return this.conversationId;
@@ -302,6 +383,9 @@ export class RemoteConversation extends EventEmitter {
   async restoreConversation(id: string) {
     this.conversationId = id;
     this.seenEventIds.clear();
+    this.desiredLlmPayload = undefined;
+    this.desiredLlmSignature = undefined;
+    this.lastAppliedLlmSignature = undefined;
     this.setStatus('connecting');
     this.emit('conversationStarted', id);
     const ok = await this.replayHistory();
@@ -309,6 +393,7 @@ export class RemoteConversation extends EventEmitter {
       this.setStatus('offline');
       return;
     }
+    this.captureDesiredRemoteLlm();
     this.connect();
   }
 
@@ -338,6 +423,8 @@ export class RemoteConversation extends EventEmitter {
     }
     const base = this.serverUrl.replace(/\/$/, '');
     try {
+      this.queueRemoteLlmUpdate();
+      await this.flushRemoteLlmUpdate();
       const headers = this.getAuthHeaders();
       const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/run`, { method: 'POST', headers }, RemoteConversation.httpTimeoutMs);
       if (!res.ok) {
@@ -366,6 +453,8 @@ export class RemoteConversation extends EventEmitter {
     }
     const base = this.serverUrl.replace(/\/$/, '');
     try {
+      this.queueRemoteLlmUpdate();
+      await this.flushRemoteLlmUpdate();
       const headers = this.getAuthHeaders();
 
       const payload: { accept: boolean; reason?: string } = { accept };
@@ -392,6 +481,9 @@ export class RemoteConversation extends EventEmitter {
     if (!this.conversationId) {
       const id = await this.startNewConversation();
       if (!id) return;
+    } else {
+      this.queueRemoteLlmUpdate();
+      await this.flushRemoteLlmUpdate();
     }
     const messagePayload: Message = { role: 'user', content: [{ type: 'text', text }] };
     if (run && this.ws && this.ws.readyState === WebSocket.OPEN) {

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -538,6 +538,28 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     }
   });
 
+  const restoreConversation = vscode.commands.registerCommand('openhands._restoreConversation', async (raw: unknown) => {
+    const nestedId = (raw as { conversationId?: unknown; id?: unknown } | undefined)?.conversationId
+      ?? (raw as { conversationId?: unknown; id?: unknown } | undefined)?.id;
+    const idRaw = nestedId === undefined ? raw : nestedId;
+    if (typeof idRaw !== 'string') {
+      throw new Error('conversationId must be a string');
+    }
+    const conversationId = idRaw.trim();
+    if (!conversationId) throw new Error('conversationId is required');
+
+    if (!deps.getConversation()) {
+      await deps.ensureConversationAndConnection();
+    }
+
+    const conversation = deps.getConversation();
+    if (!conversation) throw new Error('Conversation not initialized');
+
+    const maybe = conversation.restoreConversation(conversationId);
+    await Promise.resolve(maybe);
+    return { ok: true, conversationId };
+  });
+
   return [
     diag,
     serversGet,
@@ -558,5 +580,6 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     setProfileApiKey,
     setProviderApiKey,
     injectTerminalEvent,
+    restoreConversation,
   ];
 }

--- a/src/settings/host/createConfigurationChangeHandler.ts
+++ b/src/settings/host/createConfigurationChangeHandler.ts
@@ -84,7 +84,7 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
       try {
         await deps.ensureConversationAndConnection();
         if (deps.getConversationMode() === 'remote') {
-          deps.getOutputChannel()?.appendLine('[settings] LLM settings updated (remote mode: applies on next conversation)');
+          deps.getOutputChannel()?.appendLine('[settings] LLM settings updated (remote mode: applies on next request)');
         } else {
           deps.getOutputChannel()?.appendLine('[settings] LLM settings updated (local mode: applies immediately)');
         }

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -200,6 +200,10 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       const extensionTestsPath = path.resolve(__dirname, './suite');
       const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-server-${Date.now()}`);
 
+      // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
+      await fs.promises.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+      await fs.promises.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+
       await runTests({
         vscodeExecutablePath,
         extensionDevelopmentPath,
@@ -209,12 +213,15 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
           '--user-data-dir', userDataDir,
           '--disable-gpu',
           '--disable-dev-shm-usage',
+          '--use-inmemory-secretstorage',
           '--disable-software-rasterizer',
           extensionDevelopmentPath
         ],
         extensionTestsEnv: {
           TEST_NAME: 'agentServerRemote',
           AGENT_SERVER_URL: serverUrl,
+          HOME: userDataDir,
+          USERPROFILE: userDataDir,
         }
       });
 

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 import { downloadVSCodeWithRetry } from './testHelpers';
+import { startMockLlmServer } from './suite/mockLlmServer';
 
 function getDefaultAgentSdkDir(): string {
   return path.join(os.homedir(), 'repos', 'agent-sdk');
@@ -193,36 +194,56 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
     }
 
     const { child, serverUrl, output } = await startAgentServerWithRetry(agentSdkDir, env, 3);
+    const mockA = await startMockLlmServer();
+    const mockB = await startMockLlmServer();
 
     try {
       const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
       const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
       const extensionTestsPath = path.resolve(__dirname, './suite');
       const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-server-${Date.now()}`);
+      const stateFile = path.join(userDataDir, 'agent-server-remote-state.json');
 
       // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
       await fs.promises.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+      await fs.promises.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+
+      const launchArgs = [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ];
+
+      const baseEnv = {
+        AGENT_SERVER_URL: serverUrl,
+        E2E_STATE_FILE: stateFile,
+        E2E_MOCK_LLM_A_BASE_URL: mockA.baseUrl,
+        E2E_MOCK_LLM_B_BASE_URL: mockB.baseUrl,
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+      };
+
+      await runTests({
+        vscodeExecutablePath,
+        extensionDevelopmentPath,
+        extensionTestsPath,
+        launchArgs,
+        extensionTestsEnv: { TEST_NAME: 'agentServerRemote', ...baseEnv },
+      });
+
+      // VS Code may mutate argv.json; rewrite to avoid spurious parse warnings in the second run.
       await fs.promises.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
 
       await runTests({
         vscodeExecutablePath,
         extensionDevelopmentPath,
         extensionTestsPath,
-        launchArgs: [
-          '--no-sandbox',
-          '--user-data-dir', userDataDir,
-          '--disable-gpu',
-          '--disable-dev-shm-usage',
-          '--use-inmemory-secretstorage',
-          '--disable-software-rasterizer',
-          extensionDevelopmentPath
-        ],
-        extensionTestsEnv: {
-          TEST_NAME: 'agentServerRemote',
-          AGENT_SERVER_URL: serverUrl,
-          HOME: userDataDir,
-          USERPROFILE: userDataDir,
-        }
+        launchArgs,
+        extensionTestsEnv: { TEST_NAME: 'agentServerRemoteRestore', ...baseEnv },
       });
 
       assert.ok(true);
@@ -230,6 +251,8 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       console.error('agent-server output (tail):\n', output.dump());
       throw err;
     } finally {
+      await mockA.close();
+      await mockB.close();
       await killProcessTree(child);
     }
   });

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import { startMockLlmServer } from './mockLlmServer';
 
 type DiagnosticsInfo = {
   chat?: { hasView?: boolean; webviewReady?: boolean };
@@ -57,6 +58,10 @@ export async function run(): Promise<void> {
     throw new Error('Missing required env var: AGENT_SERVER_URL');
   }
 
+  const mockA = await startMockLlmServer();
+  const mockB = await startMockLlmServer();
+
+  try {
   const markerPrefix = `e2e_remote_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
   const markerFor = (index: number) => `${markerPrefix}_${index.toString().padStart(2, '0')}`;
 
@@ -91,8 +96,9 @@ export async function run(): Promise<void> {
   const profileB = `${markerPrefix}_profile_b`;
   const modelA = `openai/${markerPrefix}_a`;
   const modelB = `openai/${markerPrefix}_b`;
-  const baseUrlA = 'http://127.0.0.1:1';
-  const baseUrlB = 'http://127.0.0.1:2';
+  const baseUrlA = `${mockA.baseUrl}/v1`;
+  const baseUrlB = `${mockB.baseUrl}/v1`;
+  const normalizeUrl = (value: unknown): string => typeof value === 'string' ? value.replace(/\/+$/, '') : '';
 
   const fetchConversationInfo = async (conversationId: string): Promise<ConversationInfoResponse> => {
     const base = serverUrl.replace(/\/+$/, '');
@@ -115,6 +121,7 @@ export async function run(): Promise<void> {
     throw new Error(`Failed to set up test LLM profiles: ${err instanceof Error ? err.message : String(err)}`);
   }
 
+  await sleep(250);
   await vscode.commands.executeCommand('openhands.startNewConversation');
 
   await pollUntil(async () => {
@@ -126,32 +133,40 @@ export async function run(): Promise<void> {
   const conversationId = typeof diagStarted?.conversationId === 'string' ? diagStarted.conversationId : '';
   if (!conversationId) throw new Error('Missing conversationId after startNewConversation');
 
-  await pollUntil(async () => {
-    const info = await fetchConversationInfo(conversationId);
-    return info.agent?.llm?.model === modelA && info.agent?.llm?.base_url === baseUrlA;
-  }, 15000);
+  const matches = (info: ConversationInfoResponse, model: string, baseUrl: string): boolean => {
+    return info.agent?.llm?.model === model && normalizeUrl(info.agent?.llm?.base_url) === normalizeUrl(baseUrl);
+  };
+
+  let lastA: ConversationInfoResponse | undefined;
+  try {
+    await pollUntil(async () => {
+      lastA = await fetchConversationInfo(conversationId);
+      return matches(lastA, modelA, baseUrlA);
+    }, 20000);
+  } catch (err) {
+    const lastModel = lastA?.agent?.llm?.model;
+    const lastBaseUrl = lastA?.agent?.llm?.base_url;
+    throw new Error(
+      `Timed out waiting for server to start on profileA. lastModel=${String(lastModel)} lastBaseUrl=${String(lastBaseUrl)} (${String(err)})`
+    );
+  }
 
   await vscode.commands.executeCommand('openhands._selectProfile', { profileId: profileB });
-  await pollUntil(async () => {
-    const info = await fetchConversationInfo(conversationId);
-    return info.agent?.llm?.model === modelB && info.agent?.llm?.base_url === baseUrlB;
-  }, 20000);
+  let lastB: ConversationInfoResponse | undefined;
+  try {
+    await pollUntil(async () => {
+      lastB = await fetchConversationInfo(conversationId);
+      return matches(lastB, modelB, baseUrlB);
+    }, 20000);
+  } catch (err) {
+    const lastModel = lastB?.agent?.llm?.model;
+    const lastBaseUrl = lastB?.agent?.llm?.base_url;
+    throw new Error(
+      `Timed out waiting for server to switch to profileB. lastModel=${String(lastModel)} lastBaseUrl=${String(lastBaseUrl)} (${String(err)})`
+    );
+  }
 
-  // Force a RemoteConversation re-create + restore path by mutating serverUrl (still the same server).
-  await vscode.workspace.getConfiguration().update('openhands.serverUrl', `${serverUrl.replace(/\/+$/, '')}/`, vscode.ConfigurationTarget.Global);
-  await pollUntil(async () => {
-    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
-    const normalize = (value: unknown): string => typeof value === 'string' ? value.replace(/\/+$/, '') : '';
-    return diag?.mode === 'remote'
-      && normalize(diag?.serverUrl) === normalize(serverUrl)
-      && diag?.status === 'online'
-      && diag?.conversationId === conversationId;
-  }, 45000);
-
-  await pollUntil(async () => {
-    const info = await fetchConversationInfo(conversationId);
-    return info.agent?.llm?.model === modelB && info.agent?.llm?.base_url === baseUrlB;
-  }, 15000);
+  const mockBeforeB = mockB.requests.length;
 
   const before = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const beforeCount = typeof before?.count === 'number' ? before.count : 0;
@@ -188,6 +203,8 @@ export async function run(): Promise<void> {
     );
     return hasUserMessage && hasRemoteResponse;
   }, 60000);
+
+  await pollUntil(async () => mockB.requests.length > mockBeforeB, 10000, 200);
 
   const afterRemote = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const baselineCount = typeof afterRemote?.count === 'number' ? afterRemote.count : 0;
@@ -366,4 +383,8 @@ export async function run(): Promise<void> {
   );
 
   console.log('✓ Remote agent-server E2E test passed');
+} finally {
+  await mockA.close();
+  await mockB.close();
+}
 }

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -20,6 +20,15 @@ type WebviewActionResult = {
   sent?: boolean;
 };
 
+type ConversationInfoResponse = {
+  agent?: {
+    llm?: {
+      model?: unknown;
+      base_url?: unknown;
+    };
+  };
+};
+
 type RenderedEventSnapshot = {
   type?: unknown;
   marker?: unknown;
@@ -78,12 +87,71 @@ export async function run(): Promise<void> {
     return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
   }, 15000);
 
+  const profileA = `${markerPrefix}_profile_a`;
+  const profileB = `${markerPrefix}_profile_b`;
+  const modelA = `openai/${markerPrefix}_a`;
+  const modelB = `openai/${markerPrefix}_b`;
+  const baseUrlA = 'http://127.0.0.1:1';
+  const baseUrlB = 'http://127.0.0.1:2';
+
+  const fetchConversationInfo = async (conversationId: string): Promise<ConversationInfoResponse> => {
+    const base = serverUrl.replace(/\/+$/, '');
+    const res = await fetch(`${base}/api/conversations/${conversationId}`, { method: 'GET' });
+    if (!res.ok) throw new Error(`GET /api/conversations/${conversationId} failed: HTTP ${res.status}`);
+    return await res.json() as ConversationInfoResponse;
+  };
+
+  try {
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: profileA,
+      profile: { provider: 'openai', model: modelA, baseUrl: baseUrlA },
+    });
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId: profileB,
+      profile: { provider: 'openai', model: modelB, baseUrl: baseUrlB },
+    });
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: profileA });
+  } catch (err) {
+    throw new Error(`Failed to set up test LLM profiles: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
   await vscode.commands.executeCommand('openhands.startNewConversation');
 
   await pollUntil(async () => {
     const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
   }, 45000);
+
+  const diagStarted = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  const conversationId = typeof diagStarted?.conversationId === 'string' ? diagStarted.conversationId : '';
+  if (!conversationId) throw new Error('Missing conversationId after startNewConversation');
+
+  await pollUntil(async () => {
+    const info = await fetchConversationInfo(conversationId);
+    return info.agent?.llm?.model === modelA && info.agent?.llm?.base_url === baseUrlA;
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._selectProfile', { profileId: profileB });
+  await pollUntil(async () => {
+    const info = await fetchConversationInfo(conversationId);
+    return info.agent?.llm?.model === modelB && info.agent?.llm?.base_url === baseUrlB;
+  }, 20000);
+
+  // Force a RemoteConversation re-create + restore path by mutating serverUrl (still the same server).
+  await vscode.workspace.getConfiguration().update('openhands.serverUrl', `${serverUrl.replace(/\/+$/, '')}/`, vscode.ConfigurationTarget.Global);
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    const normalize = (value: unknown): string => typeof value === 'string' ? value.replace(/\/+$/, '') : '';
+    return diag?.mode === 'remote'
+      && normalize(diag?.serverUrl) === normalize(serverUrl)
+      && diag?.status === 'online'
+      && diag?.conversationId === conversationId;
+  }, 45000);
+
+  await pollUntil(async () => {
+    const info = await fetchConversationInfo(conversationId);
+    return info.agent?.llm?.model === modelB && info.agent?.llm?.base_url === baseUrlB;
+  }, 15000);
 
   const before = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const beforeCount = typeof before?.count === 'number' ? before.count : 0;

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
-import { startMockLlmServer } from './mockLlmServer';
+import * as fs from 'fs';
 
 type DiagnosticsInfo = {
   chat?: { hasView?: boolean; webviewReady?: boolean };
@@ -58,10 +58,17 @@ export async function run(): Promise<void> {
     throw new Error('Missing required env var: AGENT_SERVER_URL');
   }
 
-  const mockA = await startMockLlmServer();
-  const mockB = await startMockLlmServer();
+  const mockABase = process.env.E2E_MOCK_LLM_A_BASE_URL;
+  const mockBBase = process.env.E2E_MOCK_LLM_B_BASE_URL;
+  if (typeof mockABase !== 'string' || !mockABase.trim()) {
+    throw new Error('Missing required env var: E2E_MOCK_LLM_A_BASE_URL');
+  }
+  if (typeof mockBBase !== 'string' || !mockBBase.trim()) {
+    throw new Error('Missing required env var: E2E_MOCK_LLM_B_BASE_URL');
+  }
 
-  try {
+  const stateFile = process.env.E2E_STATE_FILE;
+
   const markerPrefix = `e2e_remote_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
   const markerFor = (index: number) => `${markerPrefix}_${index.toString().padStart(2, '0')}`;
 
@@ -96,8 +103,8 @@ export async function run(): Promise<void> {
   const profileB = `${markerPrefix}_profile_b`;
   const modelA = `openai/${markerPrefix}_a`;
   const modelB = `openai/${markerPrefix}_b`;
-  const baseUrlA = `${mockA.baseUrl}/v1`;
-  const baseUrlB = `${mockB.baseUrl}/v1`;
+  const baseUrlA = `${mockABase.replace(/\/+$/, '')}/v1`;
+  const baseUrlB = `${mockBBase.replace(/\/+$/, '')}/v1`;
   const normalizeUrl = (value: unknown): string => typeof value === 'string' ? value.replace(/\/+$/, '') : '';
 
   const fetchConversationInfo = async (conversationId: string): Promise<ConversationInfoResponse> => {
@@ -105,6 +112,14 @@ export async function run(): Promise<void> {
     const res = await fetch(`${base}/api/conversations/${conversationId}`, { method: 'GET' });
     if (!res.ok) throw new Error(`GET /api/conversations/${conversationId} failed: HTTP ${res.status}`);
     return await res.json() as ConversationInfoResponse;
+  };
+
+  const fetchMockRequestCount = async (base: string): Promise<number> => {
+    const res = await fetch(`${base.replace(/\/+$/, '')}/__log`, { method: 'GET' });
+    if (!res.ok) throw new Error(`GET ${base}/__log failed: HTTP ${res.status}`);
+    const data = await res.json() as { requests?: unknown };
+    const requests = Array.isArray(data?.requests) ? data.requests : [];
+    return requests.length;
   };
 
   try {
@@ -132,6 +147,22 @@ export async function run(): Promise<void> {
   const diagStarted = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
   const conversationId = typeof diagStarted?.conversationId === 'string' ? diagStarted.conversationId : '';
   if (!conversationId) throw new Error('Missing conversationId after startNewConversation');
+
+  if (typeof stateFile === 'string' && stateFile.trim()) {
+    fs.writeFileSync(
+      stateFile,
+      JSON.stringify({
+        conversationId,
+        profileA,
+        profileB,
+        modelA,
+        modelB,
+        baseUrlA,
+        baseUrlB,
+      }, null, 2),
+      'utf8'
+    );
+  }
 
   const matches = (info: ConversationInfoResponse, model: string, baseUrl: string): boolean => {
     return info.agent?.llm?.model === model && normalizeUrl(info.agent?.llm?.base_url) === normalizeUrl(baseUrl);
@@ -166,7 +197,7 @@ export async function run(): Promise<void> {
     );
   }
 
-  const mockBeforeB = mockB.requests.length;
+  const mockBeforeB = await fetchMockRequestCount(mockBBase);
 
   const before = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const beforeCount = typeof before?.count === 'number' ? before.count : 0;
@@ -204,7 +235,7 @@ export async function run(): Promise<void> {
     return hasUserMessage && hasRemoteResponse;
   }, 60000);
 
-  await pollUntil(async () => mockB.requests.length > mockBeforeB, 10000, 200);
+  await pollUntil(async () => (await fetchMockRequestCount(mockBBase)) > mockBeforeB, 10000, 200);
 
   const afterRemote = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
   const baselineCount = typeof afterRemote?.count === 'number' ? afterRemote.count : 0;
@@ -383,8 +414,4 @@ export async function run(): Promise<void> {
   );
 
   console.log('✓ Remote agent-server E2E test passed');
-} finally {
-  await mockA.close();
-  await mockB.close();
-}
 }

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -114,6 +114,44 @@ export async function run(): Promise<void> {
     return await res.json() as ConversationInfoResponse;
   };
 
+  const postConversationEvent = async (conversationId: string, text: string): Promise<void> => {
+    const base = serverUrl.replace(/\/+$/, '');
+    const res = await fetch(`${base}/api/conversations/${conversationId}/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        role: 'user',
+        content: [{ type: 'text', text }],
+        run: false,
+      }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`POST /api/conversations/${conversationId}/events failed: HTTP ${res.status} ${body}`);
+    }
+  };
+
+  const fetchEventCount = async (conversationId: string): Promise<number> => {
+    const base = serverUrl.replace(/\/+$/, '');
+    const res = await fetch(`${base}/api/conversations/${conversationId}/events/count`, { method: 'GET' });
+    if (!res.ok) throw new Error(`GET /api/conversations/${conversationId}/events/count failed: HTTP ${res.status}`);
+    const raw = await res.text();
+    const n = Number(raw);
+    if (!Number.isFinite(n)) throw new Error(`Invalid events/count response: ${raw}`);
+    return n;
+  };
+
+  const fetchEventsFirstPage = async (conversationId: string): Promise<{ count: number; hasNextPage: boolean }> => {
+    const base = serverUrl.replace(/\/+$/, '');
+    const url = new URL(`${base}/api/conversations/${conversationId}/events/search`);
+    url.searchParams.set('limit', '100');
+    const res = await fetch(url.toString(), { method: 'GET' });
+    if (!res.ok) throw new Error(`GET /api/conversations/${conversationId}/events/search failed: HTTP ${res.status}`);
+    const json = await res.json() as { items?: unknown; next_page_id?: unknown };
+    const items = Array.isArray(json?.items) ? json.items : [];
+    return { count: items.length, hasNextPage: typeof json?.next_page_id === 'string' && json.next_page_id.length > 0 };
+  };
+
   const fetchMockRequestCount = async (base: string): Promise<number> => {
     const res = await fetch(`${base.replace(/\/+$/, '')}/__log`, { method: 'GET' });
     if (!res.ok) throw new Error(`GET ${base}/__log failed: HTTP ${res.status}`);
@@ -148,6 +186,13 @@ export async function run(): Promise<void> {
   const conversationId = typeof diagStarted?.conversationId === 'string' ? diagStarted.conversationId : '';
   if (!conversationId) throw new Error('Missing conversationId after startNewConversation');
 
+  // Pre-populate a realistic number of events on the server without triggering LLM calls.
+  // This exercises restore + pagination in the remote client (agent-sdk-ts / VS Code).
+  const historyEventCount = 120;
+  for (let i = 0; i < historyEventCount / 2; i += 1) {
+    await postConversationEvent(conversationId, `E2E history pre-switch ${i}`);
+  }
+
   if (typeof stateFile === 'string' && stateFile.trim()) {
     fs.writeFileSync(
       stateFile,
@@ -159,6 +204,7 @@ export async function run(): Promise<void> {
         modelB,
         baseUrlA,
         baseUrlB,
+        historyEventCount,
       }, null, 2),
       'utf8'
     );
@@ -195,6 +241,20 @@ export async function run(): Promise<void> {
     throw new Error(
       `Timed out waiting for server to switch to profileB. lastModel=${String(lastModel)} lastBaseUrl=${String(lastBaseUrl)} (${String(err)})`
     );
+  }
+
+  // Add more history after switching to ensure the conversation has a sizable log under both LLM configs.
+  for (let i = 0; i < historyEventCount / 2; i += 1) {
+    await postConversationEvent(conversationId, `E2E history post-switch ${i}`);
+  }
+
+  const serverCount = await fetchEventCount(conversationId);
+  if (serverCount < historyEventCount) {
+    throw new Error(`Expected server to have >=${historyEventCount} events, got ${serverCount}`);
+  }
+  const firstPage = await fetchEventsFirstPage(conversationId);
+  if (firstPage.count !== 100 || !firstPage.hasNextPage) {
+    throw new Error(`Expected first page to have 100 items and a next_page_id (got count=${firstPage.count}, hasNextPage=${firstPage.hasNextPage})`);
   }
 
   const mockBeforeB = await fetchMockRequestCount(mockBBase);

--- a/tests/e2e/suite/agentServerRemoteRestore.ts
+++ b/tests/e2e/suite/agentServerRemoteRestore.ts
@@ -8,6 +8,7 @@ type DiagnosticsInfo = {
   serverUrl?: string;
   status?: string;
   conversationId?: string;
+  eventBacklog?: { size?: number };
 };
 
 type WebviewActionResult = {
@@ -28,6 +29,7 @@ type SavedState = {
   profileA: string;
   modelA: string;
   baseUrlA: string;
+  historyEventCount?: number;
 };
 
 export async function run(): Promise<void> {
@@ -54,6 +56,7 @@ export async function run(): Promise<void> {
   const profileA = typeof state.profileA === 'string' ? state.profileA : '';
   const modelA = typeof state.modelA === 'string' ? state.modelA : '';
   const baseUrlA = typeof state.baseUrlA === 'string' ? state.baseUrlA : '';
+  const historyEventCount = typeof state.historyEventCount === 'number' ? state.historyEventCount : 0;
   if (!conversationId || !profileA || !modelA || !baseUrlA) {
     throw new Error(`Invalid state file: ${stateFile}`);
   }
@@ -63,6 +66,16 @@ export async function run(): Promise<void> {
     const res = await fetch(`${base}/api/conversations/${id}`, { method: 'GET' });
     if (!res.ok) throw new Error(`GET /api/conversations/${id} failed: HTTP ${res.status}`);
     return await res.json() as ConversationInfoResponse;
+  };
+
+  const fetchEventCount = async (id: string): Promise<number> => {
+    const base = serverUrl.replace(/\/+$/, '');
+    const res = await fetch(`${base}/api/conversations/${id}/events/count`, { method: 'GET' });
+    if (!res.ok) throw new Error(`GET /api/conversations/${id}/events/count failed: HTTP ${res.status}`);
+    const raw = await res.text();
+    const n = Number(raw);
+    if (!Number.isFinite(n)) throw new Error(`Invalid events/count response: ${raw}`);
+    return n;
   };
 
   const fetchMockRequestCount = async (base: string): Promise<number> => {
@@ -108,6 +121,19 @@ export async function run(): Promise<void> {
     return diag?.mode === 'remote' && diag?.status === 'online' && diag?.conversationId === conversationId;
   }, 60000);
 
+  if (historyEventCount > 0) {
+    await pollUntil(async () => {
+      const serverCount = await fetchEventCount(conversationId);
+      return serverCount >= historyEventCount;
+    }, 30000);
+
+    await pollUntil(async () => {
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+      const backlog = typeof diag?.eventBacklog?.size === 'number' ? diag.eventBacklog.size : 0;
+      return backlog >= historyEventCount;
+    }, 60000);
+  }
+
   await vscode.commands.executeCommand('openhands._selectProfile', { profileId: profileA });
 
   const normalizeUrl = (value: unknown): string => typeof value === 'string' ? value.replace(/\/+$/, '') : '';
@@ -128,4 +154,3 @@ export async function run(): Promise<void> {
 
   console.log('✓ Remote agent-server restore + LLM switch E2E test passed');
 }
-

--- a/tests/e2e/suite/agentServerRemoteRestore.ts
+++ b/tests/e2e/suite/agentServerRemoteRestore.ts
@@ -1,0 +1,131 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import { pollUntil } from './pollUntil';
+
+type DiagnosticsInfo = {
+  chat?: { hasView?: boolean; webviewReady?: boolean };
+  mode?: string;
+  serverUrl?: string;
+  status?: string;
+  conversationId?: string;
+};
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+type ConversationInfoResponse = {
+  agent?: {
+    llm?: {
+      model?: unknown;
+      base_url?: unknown;
+    };
+  };
+};
+
+type SavedState = {
+  conversationId: string;
+  profileA: string;
+  modelA: string;
+  baseUrlA: string;
+};
+
+export async function run(): Promise<void> {
+  const serverUrl = process.env.AGENT_SERVER_URL;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) {
+    throw new Error('Missing required env var: AGENT_SERVER_URL');
+  }
+
+  const mockABase = process.env.E2E_MOCK_LLM_A_BASE_URL;
+  if (typeof mockABase !== 'string' || !mockABase.trim()) {
+    throw new Error('Missing required env var: E2E_MOCK_LLM_A_BASE_URL');
+  }
+
+  const stateFile = process.env.E2E_STATE_FILE;
+  if (typeof stateFile !== 'string' || !stateFile.trim()) {
+    throw new Error('Missing required env var: E2E_STATE_FILE');
+  }
+  if (!fs.existsSync(stateFile)) {
+    throw new Error(`Missing state file: ${stateFile}`);
+  }
+
+  const state = JSON.parse(fs.readFileSync(stateFile, 'utf8')) as Partial<SavedState>;
+  const conversationId = typeof state.conversationId === 'string' ? state.conversationId : '';
+  const profileA = typeof state.profileA === 'string' ? state.profileA : '';
+  const modelA = typeof state.modelA === 'string' ? state.modelA : '';
+  const baseUrlA = typeof state.baseUrlA === 'string' ? state.baseUrlA : '';
+  if (!conversationId || !profileA || !modelA || !baseUrlA) {
+    throw new Error(`Invalid state file: ${stateFile}`);
+  }
+
+  const fetchConversationInfo = async (id: string): Promise<ConversationInfoResponse> => {
+    const base = serverUrl.replace(/\/+$/, '');
+    const res = await fetch(`${base}/api/conversations/${id}`, { method: 'GET' });
+    if (!res.ok) throw new Error(`GET /api/conversations/${id} failed: HTTP ${res.status}`);
+    return await res.json() as ConversationInfoResponse;
+  };
+
+  const fetchMockRequestCount = async (base: string): Promise<number> => {
+    const res = await fetch(`${base.replace(/\/+$/, '')}/__log`, { method: 'GET' });
+    if (!res.ok) throw new Error(`GET ${base}/__log failed: HTTP ${res.status}`);
+    const data = await res.json() as { requests?: unknown };
+    const requests = Array.isArray(data?.requests) ? data.requests : [];
+    return requests.length;
+  };
+
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands._serversSet', { servers: [serverUrl], serverUrl: '' });
+  await vscode.workspace.getConfiguration().update(
+    'openhands.conversation.maxIterations',
+    1,
+    vscode.ConfigurationTarget.Global
+  );
+
+  const selectServer = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'selectServer',
+    payload: { url: serverUrl },
+  });
+  if (!selectServer?.sent) {
+    throw new Error(`selectServer action was not sent: ${JSON.stringify(selectServer)}`);
+  }
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
+  }, 15000);
+
+  const mockBeforeA = await fetchMockRequestCount(mockABase);
+
+  await vscode.commands.executeCommand('openhands._restoreConversation', { conversationId });
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.status === 'online' && diag?.conversationId === conversationId;
+  }, 60000);
+
+  await vscode.commands.executeCommand('openhands._selectProfile', { profileId: profileA });
+
+  const normalizeUrl = (value: unknown): string => typeof value === 'string' ? value.replace(/\/+$/, '') : '';
+  await pollUntil(async () => {
+    const info = await fetchConversationInfo(conversationId);
+    return info.agent?.llm?.model === modelA && normalizeUrl(info.agent?.llm?.base_url) === normalizeUrl(baseUrlA);
+  }, 20000);
+
+  const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text: 'Hello from E2E (agent-server remote restore + new LLM).' }
+  });
+  if (!send?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+  }
+
+  await pollUntil(async () => (await fetchMockRequestCount(mockABase)) > mockBeforeA, 15000, 200);
+
+  console.log('✓ Remote agent-server restore + LLM switch E2E test passed');
+}
+

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -49,6 +49,11 @@ export async function run(): Promise<void> {
     return runAgentServerRemoteTest();
   }
 
+  if (testName === 'agentServerRemoteRestore') {
+    const { run: runAgentServerRemoteRestoreTest } = await import('./agentServerRemoteRestore');
+    return runAgentServerRemoteRestoreTest();
+  }
+
   if (testName === 'terminalLog') {
     const { run: runTerminalLogTest } = await import('./terminalLog');
     return runTerminalLogTest();

--- a/tests/e2e/suite/mockLlmServer.ts
+++ b/tests/e2e/suite/mockLlmServer.ts
@@ -52,14 +52,14 @@ function sendOpenAiChatCompletionsSse(res: http.ServerResponse, text: string): v
     'Cache-Control': 'no-cache',
     Connection: 'keep-alive',
   });
-  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: [{ type: 'text', text }] } }] })}\n`);
+  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: [{ type: 'text', text }] } }] })}\n\n`);
   res.write(
     `data: ${JSON.stringify({
       choices: [{ delta: {}, finish_reason: 'stop' }],
       usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
+    })}\n\n`,
   );
-  res.write('data: [DONE]\n');
+  res.write('data: [DONE]\n\n');
   res.end();
 }
 
@@ -70,12 +70,39 @@ function sendAnthropicMessagesSse(res: http.ServerResponse, text: string): void 
     Connection: 'keep-alive',
   });
   res.write('event: message_start\n');
-  res.write(`data: ${JSON.stringify({ message: { usage: { input_tokens: 1, output_tokens: 1 } } })}\n`);
+  res.write(`data: ${JSON.stringify({ message: { usage: { input_tokens: 1, output_tokens: 1 } } })}\n\n`);
   res.write('event: content_block_delta\n');
-  res.write(`data: ${JSON.stringify({ delta: { type: 'text_delta', text } })}\n`);
+  res.write(`data: ${JSON.stringify({ delta: { type: 'text_delta', text } })}\n\n`);
   res.write('event: message_delta\n');
-  res.write(`data: ${JSON.stringify({ delta: { stop_reason: 'end_turn' } })}\n`);
+  res.write(`data: ${JSON.stringify({ delta: { stop_reason: 'end_turn' } })}\n\n`);
   res.end();
+}
+
+function sendOpenAiChatCompletionsJson(res: http.ServerResponse, text: string): void {
+  const payload = {
+    id: 'chatcmpl_mock',
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    choices: [{ index: 0, message: { role: 'assistant', content: text }, finish_reason: 'stop' }],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+function sendAnthropicMessagesJson(res: http.ServerResponse, text: string): void {
+  const payload = {
+    id: 'msg_mock',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+    model: 'claude-mock',
+    stop_reason: 'end_turn',
+    stop_sequence: null,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
 }
 
 function sendOpenAiResponsesJson(res: http.ServerResponse, text: string): void {
@@ -152,6 +179,13 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
         ...(json !== undefined ? { json } : {}),
       });
 
+      const wantsStream = Boolean(
+        json &&
+          typeof json === 'object' &&
+          'stream' in (json as Record<string, unknown>) &&
+          (json as Record<string, unknown>).stream === true
+      );
+
       if (method !== 'POST') {
         res.writeHead(405, { 'Content-Type': 'text/plain' });
         res.end('Method not allowed');
@@ -162,7 +196,11 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
       const normalizedPath = prefix ? path.slice(prefix.length) : path;
 
       if (normalizedPath === '/chat/completions') {
-        sendOpenAiChatCompletionsSse(res, 'OK (chat_completions)');
+        if (wantsStream) {
+          sendOpenAiChatCompletionsSse(res, 'OK (chat_completions)');
+        } else {
+          sendOpenAiChatCompletionsJson(res, 'OK (chat_completions)');
+        }
         return;
       }
 
@@ -172,7 +210,11 @@ export async function startMockLlmServer(): Promise<MockLlmServer> {
       }
 
       if (normalizedPath === '/messages') {
-        sendAnthropicMessagesSse(res, 'OK (anthropic)');
+        if (wantsStream) {
+          sendAnthropicMessagesSse(res, 'OK (anthropic)');
+        } else {
+          sendAnthropicMessagesJson(res, 'OK (anthropic)');
+        }
         return;
       }
 


### PR DESCRIPTION
Updates the VS Code client (agent-sdk-ts `RemoteConversation`) to support runtime LLM switching against the Python agent-server.
- On profile changes, POSTs `POST /api/conversations/{id}/llm` with an inline `llm` payload (TS profiles are local-only).
- Remote agent-server E2E: creates two profiles and asserts server-side LLM updates + subsequent LLM request hits the mock server.
- E2E runner builds `@openhands/agent-sdk-ts` before compiling the extension to avoid stale dist artifacts.
- Docs updated to reflect the new server API.\n\nRestore across restart is covered by OpenHands/software-agent-sdk#1544 (wsproto tests + remote example).

Pairs with OpenHands/software-agent-sdk#1544.