### PR TITLE
agent-sdk-ts parity: BaseWorkspace abstraction + Workspace() factory (#633)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -14,7 +14,8 @@ import type { BashEvent, Event } from '../types';
 import { clearRawLlmFieldsWhenProfileSelected } from '../types/settings';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
-import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import type { BaseWorkspace } from '../../workspace';
+import { Workspace } from '../../workspace';
 import { LLMRegistry } from '../llm';
 import type { RegistryEvent } from '../llm/registry';
 import path from 'path';
@@ -31,6 +32,7 @@ export type ConversationStatus = 'online' | 'offline' | 'connecting';
 export interface LocalConversationOptions {
   settings: OpenHandsSettings;
   conversationId?: string;
+  workspace?: BaseWorkspace;
   workspaceRoot?: string;
   llmClient?: LLMClient;
   tools?: ToolDefinition<unknown, unknown>[];
@@ -44,7 +46,7 @@ export class LocalConversation extends EventEmitter {
   private status: ConversationStatus = 'offline';
   private conversationId?: string;
   private settings: OpenHandsSettings;
-  private readonly workspace: LocalWorkspace;
+  private readonly workspace: BaseWorkspace;
   private events: EventLog;
   private state: ConversationState;
   private readonly secrets: SecretRegistry;
@@ -63,7 +65,7 @@ export class LocalConversation extends EventEmitter {
     super();
     this.settings = options.settings;
     this.conversationId = options.conversationId;
-    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.workspace = options.workspace ?? Workspace({ kind: 'local', root: options.workspaceRoot });
     this.persistenceDir = options.persistenceDir;
     this.persistence = options.persistence;
     this.events = new EventLog({ persistence: this.persistence });
@@ -261,7 +263,7 @@ export class LocalConversation extends EventEmitter {
   private createAgent(): Agent {
     return new Agent({
       settings: this.settings,
-      workspaceRoot: this.workspace.root,
+      workspace: this.workspace,
       llmClient: this.customLlmClient,
       tools: this.tools,
       events: this.events,

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -2,6 +2,7 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import type { AgentContext } from '../context';
 import type { SecretRegistry } from '../runtime';
+import type { BaseWorkspace } from '../../workspace';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
 
@@ -12,6 +13,7 @@ export type ConversationInstance = (LocalConversation | RemoteConversation) & { 
 export interface ConversationFactoryOptions {
   serverUrl?: string | null;
   settings: OpenHandsSettings;
+  workspace?: BaseWorkspace;
   workspaceRoot?: string;
   conversationId?: string;
   tools?: ToolDefinition<unknown, unknown>[];
@@ -32,6 +34,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
   return new LocalConversation({
     settings: options.settings,
     conversationId: options.conversationId,
+    workspace: options.workspace,
     workspaceRoot: options.workspaceRoot,
     tools: options.tools,
     secrets: options.secrets,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -29,7 +29,8 @@ import {
 } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
-import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import type { BaseWorkspace } from '../../workspace';
+import { Workspace } from '../../workspace';
 import { FinishTool } from '../../tools/FinishTool';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
@@ -61,6 +62,11 @@ export interface ConfirmationPolicy {
 
 export interface AgentOptions {
   settings: OpenHandsSettings;
+  /**
+   * Optional workspace instance. When omitted, the agent constructs a local workspace
+   * rooted at workspaceRoot (or process.cwd()).
+   */
+  workspace?: BaseWorkspace;
   workspaceRoot?: string;
   llmClient?: LLMClient;
   toolSummarizerClient?: LLMClient;
@@ -101,7 +107,7 @@ function stringifyErrorWithCause(error: unknown, maxDepth = 4): string {
 
 
 export class Agent extends EventEmitter {
-  private readonly workspace: LocalWorkspace;
+  private readonly workspace: BaseWorkspace;
   private readonly events: EventLog;
   readonly state: ConversationState;
   private readonly secrets: SecretRegistry;
@@ -125,7 +131,7 @@ export class Agent extends EventEmitter {
 
   constructor(private readonly options: AgentOptions) {
     super();
-    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.workspace = options.workspace ?? Workspace({ kind: 'local', root: options.workspaceRoot });
     this.events = options.events ?? new EventLog();
     this.state = options.state ?? new ConversationState({ eventLog: this.events });
     this.state.attachEventLog(this.events);

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.workspace.test.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+import { LocalWorkspace } from '../../../workspace/LocalWorkspace';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-workspace-inject-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('Agent workspace option', () => {
+  it('passes the provided workspace instance to tools', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+
+    const workspace = new LocalWorkspace(createWorkspaceRoot());
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async (_args, context) => {
+        expect(context.workspace).toBe(workspace);
+        return { exit_code: 0, stdout: '', stderr: '' };
+      },
+    };
+
+    const llm = new MockLLM([
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: new EventLog(),
+      workspace,
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/types/tools.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/tools.ts
@@ -1,10 +1,10 @@
 import type { EventLog } from '../runtime/EventLog';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import type { LLMToolDefinition } from '../llm';
-import type { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import type { BaseWorkspace } from '../../workspace';
 
 export interface ToolContext {
-  workspace: LocalWorkspace;
+  workspace: BaseWorkspace;
   events?: EventLog;
   secrets?: SecretRegistry;
 }

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import os from 'os';
 import type { Pseudoterminal } from 'vscode';
-import type { CommandResult } from '../workspace/LocalWorkspace';
+import type { CommandResult } from '../workspace/types';
 import type { LocalWorkspace } from '../workspace/LocalWorkspace';
 
 const loadVscode = (): typeof import('vscode') | null => {

--- a/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
@@ -1,0 +1,24 @@
+import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
+
+export type WorkspaceKind = 'local' | 'remote';
+
+export interface BaseWorkspace {
+  kind: WorkspaceKind;
+  root: string;
+
+  allowPath(targetPath: string): void;
+  isPathAllowed(targetPath: string): boolean;
+  resolvePath(targetPath: string): string;
+
+  readFile(targetPath: string, encoding?: WorkspaceEncoding): Promise<string>;
+  readFileBytes(targetPath: string, options?: { maxBytes?: number }): Promise<Buffer>;
+  writeFile(targetPath: string, content: string | Buffer): Promise<void>;
+  remove(targetPath: string): Promise<void>;
+  list(targetPath?: string): Promise<DirectoryEntry[]>;
+  ensureDirectory(targetPath: string): Promise<string>;
+
+  runCommand(command: string, options?: CommandOptions): Promise<CommandResult>;
+
+  gitStatus(): Promise<CommandResult>;
+  gitDiff(paths?: string[]): Promise<CommandResult>;
+}

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -4,45 +4,15 @@ import * as fs from 'fs';
 import { readFile as readFileAsync, mkdir, rm, readdir } from 'node:fs/promises';
 import path from 'path';
 import os from 'os';
+import type { BaseWorkspace } from './BaseWorkspace';
+import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
 
-type WorkspaceEncoding =
-  | 'ascii'
-  | 'utf8'
-  | 'utf-8'
-  | 'utf16le'
-  | 'ucs2'
-  | 'ucs-2'
-  | 'base64'
-  | 'base64url'
-  | 'latin1'
-  | 'binary'
-  | 'hex';
 type EnvVars = Record<string, string | undefined>;
-
-export interface CommandOptions {
-  cwd?: string;
-  env?: EnvVars;
-  timeoutMs?: number;
-  shell?: string | boolean;
-}
-
-export interface CommandResult {
-  command: string;
-  cwd: string;
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-export interface DirectoryEntry {
-  name: string;
-  path: string;
-  isDirectory: boolean;
-}
 
 type AllowedRootKind = 'dir' | 'file';
 
-export class LocalWorkspace {
+export class LocalWorkspace implements BaseWorkspace {
+  readonly kind = 'local' as const;
   readonly root: string;
   private readonly allowedRoots = new Map<string, AllowedRootKind>();
 

--- a/packages/agent-sdk-ts/src/workspace/__tests__/workspace.factory.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/workspace.factory.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { LocalWorkspace, Workspace } from '..';
+
+describe('Workspace() factory', () => {
+  it('creates a local workspace by default', () => {
+    const ws = Workspace();
+    expect(ws.kind).toBe('local');
+    expect(ws).toBeInstanceOf(LocalWorkspace);
+  });
+
+  it('rejects remote workspaces until RemoteWorkspace is implemented', () => {
+    expect(() => Workspace({ kind: 'remote', serverUrl: 'http://example.com' })).toThrowError(/not implemented/i);
+  });
+});

--- a/packages/agent-sdk-ts/src/workspace/index.ts
+++ b/packages/agent-sdk-ts/src/workspace/index.ts
@@ -1,1 +1,19 @@
+import { LocalWorkspace } from './LocalWorkspace';
+import type { BaseWorkspace } from './BaseWorkspace';
+
+export * from './BaseWorkspace';
+export * from './types';
 export * from './LocalWorkspace';
+
+export type WorkspaceFactoryOptions =
+  | { kind?: 'local'; root?: string }
+  | { kind: 'remote'; serverUrl: string; workspaceRoot?: string };
+
+export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
+  if (!options || options.kind === 'local' || options.kind === undefined) {
+    return new LocalWorkspace(options?.root);
+  }
+
+  // Placeholder for #635 (RemoteWorkspace parity)
+  throw new Error('RemoteWorkspace is not implemented yet');
+}

--- a/packages/agent-sdk-ts/src/workspace/types.ts
+++ b/packages/agent-sdk-ts/src/workspace/types.ts
@@ -1,0 +1,34 @@
+export type WorkspaceEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf-8'
+  | 'utf16le'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+
+
+export interface CommandOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  shell?: string | boolean;
+}
+
+export interface CommandResult {
+  command: string;
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface DirectoryEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}


### PR DESCRIPTION
Implements #633.

### What changed
- Introduces `BaseWorkspace` + `Workspace()` factory (currently local-only; remote throws placeholder error).
- Refactors Agent + LocalConversation + ToolContext to depend on `BaseWorkspace` instead of `LocalWorkspace`.
- Extracts shared workspace types (`CommandOptions`, `CommandResult`, `DirectoryEntry`, `WorkspaceEncoding`) into `workspace/types.ts`.

### Tests
- Added unit tests:
  - `src/workspace/__tests__/workspace.factory.test.ts`
  - `src/sdk/runtime/__tests__/Agent.workspace.test.ts`
- Ran: `npm test -w @openhands/agent-sdk-ts`, `npm run lint`, `npm run typecheck`


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents and Conversations now accept optional workspace parameters for flexible workspace configuration
  * Introduced a Workspace factory function simplifying workspace creation and supporting future extensibility

* **Refactor**
  * Reorganized workspace-related types for improved module structure and maintainability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->