### PR TITLE
agent-sdk-ts parity: Workspace helpers + CommandResult parity (#634) (deferred) DO NOT MERGE

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -14,7 +14,8 @@ import type { BashEvent, Event } from '../types';
 import { clearRawLlmFieldsWhenProfileSelected } from '../types/settings';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
-import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import type { BaseWorkspace } from '../../workspace';
+import { Workspace } from '../../workspace';
 import { LLMRegistry } from '../llm';
 import type { RegistryEvent } from '../llm/registry';
 import path from 'path';
@@ -31,6 +32,7 @@ export type ConversationStatus = 'online' | 'offline' | 'connecting';
 export interface LocalConversationOptions {
   settings: OpenHandsSettings;
   conversationId?: string;
+  workspace?: BaseWorkspace;
   workspaceRoot?: string;
   llmClient?: LLMClient;
   tools?: ToolDefinition<unknown, unknown>[];
@@ -44,7 +46,7 @@ export class LocalConversation extends EventEmitter {
   private status: ConversationStatus = 'offline';
   private conversationId?: string;
   private settings: OpenHandsSettings;
-  private readonly workspace: LocalWorkspace;
+  private readonly workspace: BaseWorkspace;
   private events: EventLog;
   private state: ConversationState;
   private readonly secrets: SecretRegistry;
@@ -63,7 +65,7 @@ export class LocalConversation extends EventEmitter {
     super();
     this.settings = options.settings;
     this.conversationId = options.conversationId;
-    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.workspace = options.workspace ?? Workspace({ kind: 'local', root: options.workspaceRoot });
     this.persistenceDir = options.persistenceDir;
     this.persistence = options.persistence;
     this.events = new EventLog({ persistence: this.persistence });
@@ -261,7 +263,7 @@ export class LocalConversation extends EventEmitter {
   private createAgent(): Agent {
     return new Agent({
       settings: this.settings,
-      workspaceRoot: this.workspace.root,
+      workspace: this.workspace,
       llmClient: this.customLlmClient,
       tools: this.tools,
       events: this.events,

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -2,6 +2,7 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import type { AgentContext } from '../context';
 import type { SecretRegistry } from '../runtime';
+import type { BaseWorkspace } from '../../workspace';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
 
@@ -12,6 +13,7 @@ export type ConversationInstance = (LocalConversation | RemoteConversation) & { 
 export interface ConversationFactoryOptions {
   serverUrl?: string | null;
   settings: OpenHandsSettings;
+  workspace?: BaseWorkspace;
   workspaceRoot?: string;
   conversationId?: string;
   tools?: ToolDefinition<unknown, unknown>[];
@@ -32,6 +34,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
   return new LocalConversation({
     settings: options.settings,
     conversationId: options.conversationId,
+    workspace: options.workspace,
     workspaceRoot: options.workspaceRoot,
     tools: options.tools,
     secrets: options.secrets,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -29,7 +29,8 @@ import {
 } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
-import { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import type { BaseWorkspace } from '../../workspace';
+import { Workspace } from '../../workspace';
 import { FinishTool } from '../../tools/FinishTool';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
@@ -61,6 +62,11 @@ export interface ConfirmationPolicy {
 
 export interface AgentOptions {
   settings: OpenHandsSettings;
+  /**
+   * Optional workspace instance. When omitted, the agent constructs a local workspace
+   * rooted at workspaceRoot (or process.cwd()).
+   */
+  workspace?: BaseWorkspace;
   workspaceRoot?: string;
   llmClient?: LLMClient;
   toolSummarizerClient?: LLMClient;
@@ -101,7 +107,7 @@ function stringifyErrorWithCause(error: unknown, maxDepth = 4): string {
 
 
 export class Agent extends EventEmitter {
-  private readonly workspace: LocalWorkspace;
+  private readonly workspace: BaseWorkspace;
   private readonly events: EventLog;
   readonly state: ConversationState;
   private readonly secrets: SecretRegistry;
@@ -125,7 +131,7 @@ export class Agent extends EventEmitter {
 
   constructor(private readonly options: AgentOptions) {
     super();
-    this.workspace = new LocalWorkspace(options.workspaceRoot);
+    this.workspace = options.workspace ?? Workspace({ kind: 'local', root: options.workspaceRoot });
     this.events = options.events ?? new EventLog();
     this.state = options.state ?? new ConversationState({ eventLog: this.events });
     this.state.attachEventLog(this.events);

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.workspace.test.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+import { LocalWorkspace } from '../../../workspace/LocalWorkspace';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const workspaceRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-workspace-inject-'));
+  workspaceRoots.push(root);
+  return root;
+};
+
+afterEach(() => {
+  for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe('Agent workspace option', () => {
+  it('passes the provided workspace instance to tools', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: {},
+      secrets: {},
+    };
+
+    const workspace = new LocalWorkspace(createWorkspaceRoot());
+
+    const tool: ToolDefinition<Record<string, unknown>, Record<string, unknown>> = {
+      name: 'terminal',
+      validate: (input) => input as Record<string, unknown>,
+      execute: async (_args, context) => {
+        expect(context.workspace).toBe(workspace);
+        return { exit_code: 0, stdout: '', stderr: '' };
+      },
+    };
+
+    const llm = new MockLLM([
+      { type: 'tool_call_delta', id: 'call_terminal', name: 'terminal', arguments: '{}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings,
+      events: new EventLog(),
+      workspace,
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/types/tools.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/tools.ts
@@ -1,10 +1,10 @@
 import type { EventLog } from '../runtime/EventLog';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import type { LLMToolDefinition } from '../llm';
-import type { LocalWorkspace } from '../../workspace/LocalWorkspace';
+import type { BaseWorkspace } from '../../workspace';
 
 export interface ToolContext {
-  workspace: LocalWorkspace;
+  workspace: BaseWorkspace;
   events?: EventLog;
   secrets?: SecretRegistry;
 }

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -131,6 +131,7 @@ export class IntegratedTerminalRunner {
           stdout,
           stderr,
           exitCode,
+          timeoutOccurred: timedOut,
         });
       });
     });
@@ -188,6 +189,7 @@ export class IntegratedTerminalRunner {
           stdout,
           stderr,
           exitCode: timedOut || aborted ? code ?? -1 : code ?? 0,
+          timeoutOccurred: timedOut,
         });
       });
     });

--- a/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
+++ b/packages/agent-sdk-ts/src/tools/IntegratedTerminalRunner.ts
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import os from 'os';
 import type { Pseudoterminal } from 'vscode';
-import type { CommandResult } from '../workspace/LocalWorkspace';
+import type { CommandResult } from '../workspace/types';
 import type { LocalWorkspace } from '../workspace/LocalWorkspace';
 
 const loadVscode = (): typeof import('vscode') | null => {

--- a/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
@@ -1,0 +1,24 @@
+import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
+
+export type WorkspaceKind = 'local' | 'remote';
+
+export interface BaseWorkspace {
+  kind: WorkspaceKind;
+  root: string;
+
+  allowPath(targetPath: string): void;
+  isPathAllowed(targetPath: string): boolean;
+  resolvePath(targetPath: string): string;
+
+  readFile(targetPath: string, encoding?: WorkspaceEncoding): Promise<string>;
+  readFileBytes(targetPath: string, options?: { maxBytes?: number }): Promise<Buffer>;
+  writeFile(targetPath: string, content: string | Buffer): Promise<void>;
+  remove(targetPath: string): Promise<void>;
+  list(targetPath?: string): Promise<DirectoryEntry[]>;
+  ensureDirectory(targetPath: string): Promise<string>;
+
+  runCommand(command: string, options?: CommandOptions): Promise<CommandResult>;
+
+  gitStatus(): Promise<CommandResult>;
+  gitDiff(paths?: string[]): Promise<CommandResult>;
+}

--- a/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
@@ -1,4 +1,11 @@
-import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
+import type {
+  CommandOptions,
+  CommandResult,
+  DirectoryEntry,
+  FileOperationResult,
+  GitChange,
+  WorkspaceEncoding,
+} from './types';
 
 export type WorkspaceKind = 'local' | 'remote';
 
@@ -16,6 +23,13 @@ export interface BaseWorkspace {
   remove(targetPath: string): Promise<void>;
   list(targetPath?: string): Promise<DirectoryEntry[]>;
   ensureDirectory(targetPath: string): Promise<string>;
+
+  copyToWorkspace(sourcePath: string, destinationPath: string): Promise<FileOperationResult>;
+  fileUpload(localPath: string, workspacePath: string): Promise<FileOperationResult>;
+  fileDownload(workspacePath: string, localPath: string): Promise<FileOperationResult>;
+
+  gitChanges(paths?: string[]): Promise<GitChange[]>;
+
 
   runCommand(command: string, options?: CommandOptions): Promise<CommandResult>;
 

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -4,45 +4,15 @@ import * as fs from 'fs';
 import { readFile as readFileAsync, mkdir, rm, readdir } from 'node:fs/promises';
 import path from 'path';
 import os from 'os';
+import type { BaseWorkspace } from './BaseWorkspace';
+import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
 
-type WorkspaceEncoding =
-  | 'ascii'
-  | 'utf8'
-  | 'utf-8'
-  | 'utf16le'
-  | 'ucs2'
-  | 'ucs-2'
-  | 'base64'
-  | 'base64url'
-  | 'latin1'
-  | 'binary'
-  | 'hex';
 type EnvVars = Record<string, string | undefined>;
-
-export interface CommandOptions {
-  cwd?: string;
-  env?: EnvVars;
-  timeoutMs?: number;
-  shell?: string | boolean;
-}
-
-export interface CommandResult {
-  command: string;
-  cwd: string;
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
-
-export interface DirectoryEntry {
-  name: string;
-  path: string;
-  isDirectory: boolean;
-}
 
 type AllowedRootKind = 'dir' | 'file';
 
-export class LocalWorkspace {
+export class LocalWorkspace implements BaseWorkspace {
+  readonly kind = 'local' as const;
   readonly root: string;
   private readonly allowedRoots = new Map<string, AllowedRootKind>();
 

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -5,7 +5,14 @@ import { readFile as readFileAsync, mkdir, rm, readdir } from 'node:fs/promises'
 import path from 'path';
 import os from 'os';
 import type { BaseWorkspace } from './BaseWorkspace';
-import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
+import type {
+  CommandOptions,
+  CommandResult,
+  DirectoryEntry,
+  FileOperationResult,
+  GitChange,
+  WorkspaceEncoding,
+} from './types';
 
 type EnvVars = Record<string, string | undefined>;
 
@@ -625,6 +632,92 @@ export class LocalWorkspace implements BaseWorkspace {
     return resolved;
   }
 
+  async copyToWorkspace(sourcePath: string, destinationPath: string): Promise<FileOperationResult> {
+    try {
+      const stat = await fs.promises.stat(sourcePath);
+      if (!stat.isFile()) {
+        return { success: false, path: destinationPath, error: `Source is not a file: ${sourcePath}` };
+      }
+      const buf = await fs.promises.readFile(sourcePath);
+      await this.writeFile(destinationPath, buf);
+      return { success: true, path: destinationPath };
+    } catch (error) {
+      return {
+        success: false,
+        path: destinationPath,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async fileUpload(localPath: string, workspacePath: string): Promise<FileOperationResult> {
+    return this.copyToWorkspace(localPath, workspacePath);
+  }
+
+  async fileDownload(workspacePath: string, localPath: string): Promise<FileOperationResult> {
+    try {
+      const buf = await this.readFileBytes(workspacePath);
+      await fs.promises.mkdir(path.dirname(localPath), { recursive: true });
+      await fs.promises.writeFile(localPath, buf);
+      return { success: true, path: localPath };
+    } catch (error) {
+      return {
+        success: false,
+        path: localPath,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  async gitChanges(paths?: string[]): Promise<GitChange[]> {
+    const sanitizedPaths = paths?.map((p) => this.resolvePath(p));
+    const relativePaths = sanitizedPaths?.map((p) => path.relative(this.root, p));
+    const command = relativePaths?.length
+      ? `git status --porcelain -- ${relativePaths.map((p) => JSON.stringify(p)).join(' ')}`
+      : 'git status --porcelain';
+
+    const result = await this.runCommand(command, { cwd: this.root });
+    if (result.exitCode !== 0) {
+      const detail = result.stderr.trim() || result.stdout.trim();
+      throw new Error(`gitChanges failed (exit code ${result.exitCode})${detail ? `: ${detail}` : ''}`);
+    }
+
+    const lines = result.stdout.split('\n').map((line) => line.trimEnd()).filter((line) => line.trim().length > 0);
+    const changes: GitChange[] = [];
+
+    for (const line of lines) {
+      const prefix = line.slice(0, 2);
+      const rest = line.slice(2).trim();
+
+      if (prefix === '??') {
+        changes.push({ path: rest, status: 'untracked' });
+        continue;
+      }
+
+      const statusChars = prefix.replaceAll(' ', '');
+      const status = (() => {
+        if (statusChars.includes('R')) return 'renamed' as const;
+        if (statusChars.includes('A')) return 'added' as const;
+        if (statusChars.includes('D')) return 'deleted' as const;
+        if (statusChars.includes('M')) return 'modified' as const;
+        return 'unknown' as const;
+      })();
+
+      if (status === 'renamed' && rest.includes('->')) {
+        const [prevRaw, nextRaw] = rest.split('->').map((part) => part.trim());
+        if (nextRaw) {
+          changes.push({ path: nextRaw, previousPath: prevRaw || undefined, status });
+          continue;
+        }
+      }
+
+      changes.push({ path: rest, status });
+    }
+
+    return changes;
+  }
+
+
   async runCommand(command: string, options: CommandOptions = {}): Promise<CommandResult> {
     const cwd = options.cwd ? this.resolvePath(options.cwd) : this.root;
     return new Promise<CommandResult>((resolve) => {
@@ -645,8 +738,10 @@ export class LocalWorkspace implements BaseWorkspace {
 
       let stdout = '';
       let stderr = '';
+      let timeoutOccurred = false;
       const timeout = options.timeoutMs
         ? setTimeout(() => {
+            timeoutOccurred = true;
             if (os.platform() === 'win32') {
               // On Windows, best-effort kill the entire process tree.
               // `child.kill()` may only terminate the parent process, leaving payloads running.
@@ -681,6 +776,7 @@ export class LocalWorkspace implements BaseWorkspace {
           stdout,
           stderr,
           exitCode: code ?? -1,
+          timeoutOccurred,
         });
       });
     });

--- a/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts
@@ -422,5 +422,50 @@ describe('LocalWorkspace', () => {
         expect(printedDir).toBe(realDir);
       }
     });
+
+
+    it('reports timeoutOccurred when a command exceeds timeoutMs', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      const result = await workspace.runCommand('sleep 1', { timeoutMs: 10 });
+      expect(result.timeoutOccurred).toBe(true);
+      expect(result.exitCode).toBe(-1);
+    });
+
   });
+
+
+  describe('workspace helpers', () => {
+    it('uploads and downloads files', async () => {
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      const externalDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-ws-transfer-'));
+      created.push(externalDir);
+
+      const sourcePath = path.join(externalDir, 'source.txt');
+      await fs.promises.writeFile(sourcePath, 'hello', 'utf8');
+
+      const upload = await workspace.fileUpload(sourcePath, 'uploaded.txt');
+      expect(upload.success).toBe(true);
+      await expect(workspace.readFile('uploaded.txt')).resolves.toBe('hello');
+
+      const downloadPath = path.join(externalDir, 'downloaded.txt');
+      const download = await workspace.fileDownload('uploaded.txt', downloadPath);
+      expect(download.success).toBe(true);
+      await expect(fs.promises.readFile(downloadPath, 'utf8')).resolves.toBe('hello');
+    });
+
+    it('reports git changes for untracked files', async () => {
+      if (process.platform === 'win32') return;
+
+      const { workspace } = await makeWorkspace((value) => created.push(value));
+      const init = await workspace.runCommand('git init');
+      expect(init.exitCode).toBe(0);
+
+      await workspace.writeFile('untracked.txt', 'hello');
+      const changes = await workspace.gitChanges();
+      expect(changes).toContainEqual({ path: 'untracked.txt', status: 'untracked' });
+    });
+  });
+
 });

--- a/packages/agent-sdk-ts/src/workspace/__tests__/workspace.factory.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/workspace.factory.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { LocalWorkspace, Workspace } from '..';
+
+describe('Workspace() factory', () => {
+  it('creates a local workspace by default', () => {
+    const ws = Workspace();
+    expect(ws.kind).toBe('local');
+    expect(ws).toBeInstanceOf(LocalWorkspace);
+  });
+
+  it('rejects remote workspaces until RemoteWorkspace is implemented', () => {
+    expect(() => Workspace({ kind: 'remote', serverUrl: 'http://example.com' })).toThrowError(/not implemented/i);
+  });
+});

--- a/packages/agent-sdk-ts/src/workspace/index.ts
+++ b/packages/agent-sdk-ts/src/workspace/index.ts
@@ -1,1 +1,19 @@
+import { LocalWorkspace } from './LocalWorkspace';
+import type { BaseWorkspace } from './BaseWorkspace';
+
+export * from './BaseWorkspace';
+export * from './types';
 export * from './LocalWorkspace';
+
+export type WorkspaceFactoryOptions =
+  | { kind?: 'local'; root?: string }
+  | { kind: 'remote'; serverUrl: string; workspaceRoot?: string };
+
+export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
+  if (!options || options.kind === 'local' || options.kind === undefined) {
+    return new LocalWorkspace(options?.root);
+  }
+
+  // Placeholder for #635 (RemoteWorkspace parity)
+  throw new Error('RemoteWorkspace is not implemented yet');
+}

--- a/packages/agent-sdk-ts/src/workspace/types.ts
+++ b/packages/agent-sdk-ts/src/workspace/types.ts
@@ -1,0 +1,34 @@
+export type WorkspaceEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf-8'
+  | 'utf16le'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+
+
+export interface CommandOptions {
+  cwd?: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs?: number;
+  shell?: string | boolean;
+}
+
+export interface CommandResult {
+  command: string;
+  cwd: string;
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface DirectoryEntry {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+}

--- a/packages/agent-sdk-ts/src/workspace/types.ts
+++ b/packages/agent-sdk-ts/src/workspace/types.ts
@@ -25,6 +25,7 @@ export interface CommandResult {
   stdout: string;
   stderr: string;
   exitCode: number;
+  timeoutOccurred: boolean;
 }
 
 export interface DirectoryEntry {
@@ -32,3 +33,18 @@ export interface DirectoryEntry {
   path: string;
   isDirectory: boolean;
 }
+
+export interface FileOperationResult {
+  success: boolean;
+  path: string;
+  error?: string;
+}
+
+export type GitChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed' | 'untracked' | 'unknown';
+
+export interface GitChange {
+  path: string;
+  status: GitChangeStatus;
+  previousPath?: string;
+}
+


### PR DESCRIPTION
Implements #634 (stacked on #666).

### What changed
- Adds `timeoutOccurred` to `CommandResult` and populates it in LocalWorkspace + IntegratedTerminalRunner.
- Adds local-only workspace helpers:
  - `copyToWorkspace`, `fileUpload`, `fileDownload` (returning typed `FileOperationResult`)
  - `gitChanges()` (parses `git status --porcelain` into typed `GitChange[]`)

### Tests
- Extended `src/workspace/__tests__/local.workspace.test.ts` to cover:
  - `timeoutOccurred`
  - upload/download helpers
  - `gitChanges()` for untracked files

### Notes
- Remote implementations will be added in #635.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)