### PR TITLE
agent-sdk-ts parity: workspace lifecycle APIs (isAlive/pause/resume) (#636)

### DIFF
--- a/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/BaseWorkspace.ts
@@ -21,4 +21,9 @@ export interface BaseWorkspace {
 
   gitStatus(): Promise<CommandResult>;
   gitDiff(paths?: string[]): Promise<CommandResult>;
+
+  isAlive(): Promise<boolean>;
+  pause(): Promise<void>;
+  resume(): Promise<void>;
+
 }

--- a/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts
@@ -698,6 +698,20 @@ export class LocalWorkspace implements BaseWorkspace {
       : 'git diff HEAD';
     return this.runCommand(command, { cwd: this.root });
   }
+
+
+  isAlive(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+
+  pause(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  resume(): Promise<void> {
+    return Promise.resolve();
+  }
+
 }
 
 export default LocalWorkspace;

--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -44,6 +44,15 @@ export interface RemoteWorkspaceOptions {
   workingDir?: string;
   pollIntervalMs?: number;
   httpTimeoutMs?: number;
+
+  /**
+   * Optional runtime API control surface (pause/resume).
+   *
+   * This matches Python's APIRemoteWorkspace behavior.
+   */
+  runtimeApiUrl?: string;
+  runtimeApiKey?: string;
+  runtimeId?: string;
 }
 
 interface StartBashCommandResponse {
@@ -97,6 +106,11 @@ export class RemoteWorkspace implements BaseWorkspace {
   private readonly pollIntervalMs: number;
   private readonly httpTimeoutMs: number;
 
+  private readonly runtimeApiUrl?: string;
+  private readonly runtimeApiKey?: string;
+  private readonly runtimeId?: string;
+
+
   private readonly allowedRoots = new Set<string>();
 
   constructor(options: RemoteWorkspaceOptions) {
@@ -105,6 +119,11 @@ export class RemoteWorkspace implements BaseWorkspace {
     this.root = normalizePosixRoot(options.workingDir ?? '/workspace');
     this.pollIntervalMs = typeof options.pollIntervalMs === 'number' ? Math.max(0, options.pollIntervalMs) : 100;
     this.httpTimeoutMs = typeof options.httpTimeoutMs === 'number' ? Math.max(0, options.httpTimeoutMs) : 60_000;
+
+    this.runtimeApiUrl = options.runtimeApiUrl ? normalizeRemoteHostUrl(options.runtimeApiUrl) : undefined;
+    this.runtimeApiKey = typeof options.runtimeApiKey === 'string' && options.runtimeApiKey.trim() ? options.runtimeApiKey.trim() : undefined;
+    this.runtimeId = typeof options.runtimeId === 'string' && options.runtimeId.trim() ? options.runtimeId.trim() : undefined;
+
     this.allowedRoots.add(this.root);
   }
 
@@ -335,6 +354,57 @@ export class RemoteWorkspace implements BaseWorkspace {
       : 'git diff HEAD';
     return this.runCommand(cmd, { cwd: this.root });
   }
+
+
+  async isAlive(): Promise<boolean> {
+    try {
+      const res = await this.fetchWithTimeout(`${this.host}/health`, { method: 'GET' }, 5_000);
+      return res.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async pause(): Promise<void> {
+    if (!this.runtimeApiUrl || !this.runtimeId) {
+      throw new Error('RemoteWorkspace.pause requires runtimeApiUrl + runtimeId');
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.runtimeApiKey) headers['X-API-Key'] = this.runtimeApiKey;
+
+    const res = await this.fetchWithTimeout(`${this.runtimeApiUrl}/pause`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ runtime_id: this.runtimeId }),
+    }, 30_000);
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`RemoteWorkspace.pause failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
+    }
+  }
+
+  async resume(): Promise<void> {
+    if (!this.runtimeApiUrl || !this.runtimeId) {
+      throw new Error('RemoteWorkspace.resume requires runtimeApiUrl + runtimeId');
+    }
+
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (this.runtimeApiKey) headers['X-API-Key'] = this.runtimeApiKey;
+
+    const res = await this.fetchWithTimeout(`${this.runtimeApiUrl}/resume`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ runtime_id: this.runtimeId }),
+    }, 30_000);
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`RemoteWorkspace.resume failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
+    }
+  }
+
 
   private async uploadBytes(absoluteDestinationPath: string, bytes: Buffer): Promise<void> {
     const encodedPath = encodePathForUrl(absoluteDestinationPath);

--- a/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
@@ -143,4 +143,42 @@ describe('RemoteWorkspace', () => {
     await ws.writeFile('hello.txt', 'hello');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('reports liveness via /health', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toBe('http://localhost:3000/health');
+      return { ok: true, status: 200, text: async () => 'OK' } as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const ws = new RemoteWorkspace({ host: 'http://localhost:3000', workingDir: '/workspace/project' });
+    await expect(ws.isAlive()).resolves.toBe(true);
+  });
+
+  it('calls runtime API pause/resume when configured', async () => {
+    const calls: Array<{ url: string; init: any }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      calls.push({ url, init });
+      return { ok: true, status: 200, text: async () => '' } as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const ws = new RemoteWorkspace({
+      host: 'http://localhost:3000',
+      workingDir: '/workspace/project',
+      runtimeApiUrl: 'http://runtime-api',
+      runtimeApiKey: 'runtime-key',
+      runtimeId: 'runtime-123',
+    });
+
+    await ws.pause();
+    await ws.resume();
+
+    expect(calls.map((c) => c.url)).toEqual(['http://runtime-api/pause', 'http://runtime-api/resume']);
+    for (const c of calls) {
+      expect(c.init?.method).toBe('POST');
+      expect(c.init?.headers?.['X-API-Key']).toBe('runtime-key');
+      expect(JSON.parse(c.init?.body ?? '{}')).toEqual({ runtime_id: 'runtime-123' });
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/workspace/index.ts
+++ b/packages/agent-sdk-ts/src/workspace/index.ts
@@ -15,6 +15,9 @@ export type WorkspaceFactoryOptions =
     apiKey?: string;
     workingDir?: string;
     workspaceRoot?: string;
+    runtimeApiUrl?: string;
+    runtimeApiKey?: string;
+    runtimeId?: string;
   };
 
 export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
@@ -27,5 +30,8 @@ export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
     host: options.serverUrl,
     apiKey: options.apiKey,
     workingDir,
+    runtimeApiUrl: options.runtimeApiUrl,
+    runtimeApiKey: options.runtimeApiKey,
+    runtimeId: options.runtimeId,
   });
 }


### PR DESCRIPTION
Implements #636 (stacked on #668).

### What changed
- Adds lifecycle APIs to `BaseWorkspace`:
  - `isAlive()`
  - `pause()` / `resume()`
- `LocalWorkspace`: implements lifecycle APIs as resolved no-ops.
- `RemoteWorkspace`:
  - `isAlive()` calls `GET /health` (5s timeout)
  - `pause()` / `resume()` optionally call runtime API `POST /pause` and `POST /resume` when `runtimeApiUrl + runtimeId` are provided.

### Tests
- Extended `remote.workspace.test.ts` to cover:
  - `/health` liveness
  - runtime pause/resume HTTP calls


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)