### PR TITLE
agent-sdk-ts parity: ConversationVisualizer + StuckDetector utilities (#637)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -552,4 +552,54 @@ describe('Agent loop control', () => {
     const allErrors = log.list().filter(isConversationErrorEvent).filter((e) => e.code === 'max_iterations_exceeded');
     expect(allErrors.length).toBe(1); // Still just the first one
   });
+
+
+  it('emits a ConversationErrorEvent when stuck detection triggers', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const seq = (id: string) => ([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id, name: 'echo', arguments: '{"value":"hi"}' },
+      { type: 'finish' },
+    ] as const);
+
+    const llm = new SequencedLLM([
+      [...seq('call_1')],
+      [...seq('call_2')],
+      // The third response should never be needed if stuck detection triggers.
+      [...seq('call_3')],
+    ]);
+
+    const agent = new Agent({
+      settings: {
+        ...baseSettings,
+        conversation: {
+          maxIterations: 50,
+          stuckDetection: true,
+          stuckThresholds: {
+            actionObservation: 2,
+            actionError: 2,
+            monologue: 2,
+            alternatingPattern: 4,
+          },
+        },
+      },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('start');
+
+    const stuckErrors = log.list().filter(isConversationErrorEvent).filter((e) => e.code === 'stuck_detected');
+    expect(stuckErrors.length).toBe(1);
+    expect(agent.state.snapshot.status).toBe('IDLE');
+  });
+
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/ConversationVisualizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/ConversationVisualizer.ts
@@ -1,0 +1,137 @@
+import type {
+  ActionEvent,
+  AgentErrorEvent,
+  Condensation,
+  ConversationErrorEvent,
+  Event,
+  MessageEvent,
+  ObservationEvent,
+  SystemPromptEvent,
+} from '../types';
+import {
+  isActionEvent,
+  isAgentErrorEvent,
+  isCondensation,
+  isConversationErrorEvent,
+  isConversationStateUpdateEvent,
+  isMessageEvent,
+  isObservationEvent,
+  isPauseEvent,
+  isSystemPromptEvent,
+} from '../types';
+
+export interface ConversationVisualizerOptions {
+  includeTimestamps?: boolean;
+  skipUserMessages?: boolean;
+  skipStateUpdates?: boolean;
+}
+
+const toText = (value: unknown): string => {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'symbol') return value.toString();
+  if (typeof value === 'function') return '<function>';
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value) ?? '';
+    } catch {
+      return '<unserializable>';
+    }
+  }
+  return '<unknown>';
+};
+
+const formatJson = (value: unknown): string => {
+  try {
+    return JSON.stringify(value, null, 2) ?? '';
+  } catch {
+    return '<unserializable>';
+  }
+};
+
+const codeBlock = (lang: string, content: string): string => {
+  const safe = content.trimEnd();
+  return `\n\n\`\`\`${lang}\n${safe}\n\`\`\`\n`;
+};
+
+const formatTimestamp = (event: Event): string =>
+  event.timestamp ? ` (${event.timestamp})` : '';
+
+export class ConversationVisualizer {
+  constructor(private readonly options: ConversationVisualizerOptions = {}) {}
+
+  render(events: Event[]): string {
+    const parts: string[] = [];
+
+    for (const event of events) {
+      if (this.options.skipStateUpdates && isConversationStateUpdateEvent(event)) continue;
+      if (this.options.skipUserMessages && isMessageEvent(event) && event.source === 'user') continue;
+      parts.push(this.renderEvent(event));
+    }
+
+    return parts.filter(Boolean).join('\n\n---\n\n');
+  }
+
+  renderEvent(event: Event): string {
+    const ts = this.options.includeTimestamps ? formatTimestamp(event) : '';
+
+    if (isSystemPromptEvent(event)) return this.renderSystemPrompt(event, ts);
+    if (isMessageEvent(event)) return this.renderMessage(event, ts);
+    if (isActionEvent(event)) return this.renderAction(event, ts);
+    if (isObservationEvent(event)) return this.renderObservation(event, ts);
+    if (isAgentErrorEvent(event)) return this.renderAgentError(event, ts);
+    if (isConversationErrorEvent(event)) return this.renderConversationError(event, ts);
+    if (isPauseEvent(event)) return `### Pause${ts}\n\nSource: ${event.source}`;
+    if (isCondensation(event)) return this.renderCondensation(event, ts);
+
+    return `### ${event.kind}${ts}`;
+  }
+
+  private renderSystemPrompt(event: SystemPromptEvent, ts: string): string {
+    return `### System prompt${ts}${codeBlock('text', toText(event.system_prompt?.text))}`;
+  }
+
+  private renderMessage(event: MessageEvent, ts: string): string {
+    const role = event.llm_message?.role;
+    const header = `### Message (${role ?? 'unknown'})${ts}`;
+    const content = (event.llm_message?.content ?? []).map((c) => ('text' in c ? c.text : '[image]')).join('\n');
+    return `${header}${codeBlock('text', content)}`;
+  }
+
+  private renderAction(event: ActionEvent, ts: string): string {
+    const header = `### Action (${event.tool_name})${ts}`;
+    const thought = event.thought?.map((t) => t.text).join('\n') ?? '';
+    const action = formatJson(event.action);
+    return `${header}${codeBlock('text', thought)}${codeBlock('json', action)}`;
+  }
+
+  private renderObservation(event: ObservationEvent, ts: string): string {
+    const header = `### Observation (${event.tool_name})${ts}`;
+    return `${header}${codeBlock('json', formatJson(event.observation))}`;
+  }
+
+  private renderAgentError(event: AgentErrorEvent, ts: string): string {
+    const header = `### Agent error (${event.tool_name})${ts}`;
+    return `${header}${codeBlock('text', event.error)}`;
+  }
+
+  private renderConversationError(event: ConversationErrorEvent, ts: string): string {
+    const header = `### Conversation error${ts}`;
+    const details = [`code: ${event.code ?? 'unknown'}`, `detail: ${event.detail ?? ''}`].join('\n');
+    return `${header}${codeBlock('text', details)}`;
+  }
+
+  private renderCondensation(event: Condensation, ts: string): string {
+    const header = `### Condensation${ts}`;
+    const details = {
+      forgotten_event_ids: event.forgotten_event_ids,
+      summary: event.summary,
+      summary_offset: event.summary_offset,
+    };
+    return `${header}${codeBlock('json', formatJson(details))}`;
+  }
+}
+
+export default ConversationVisualizer;

--- a/packages/agent-sdk-ts/src/sdk/conversation/__tests__/ConversationVisualizer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/__tests__/ConversationVisualizer.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { Event } from '../../types';
+import { ConversationVisualizer } from '..';
+
+describe('ConversationVisualizer', () => {
+  it('renders basic markdown sections', () => {
+    const events: Event[] = [
+      {
+        kind: 'MessageEvent',
+        source: 'user',
+        llm_message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      } as Event,
+      {
+        kind: 'ActionEvent',
+        source: 'agent',
+        thought: [{ type: 'text', text: 'do thing' }],
+        action: { command: 'pwd' },
+        tool_name: 'terminal',
+        tool_call_id: 'tc-1',
+        tool_call: { id: 'tc-1', type: 'function', function: { name: 'terminal', arguments: '{}' } },
+        llm_response_id: 'r-1',
+      } as Event,
+    ];
+
+    const viz = new ConversationVisualizer({ includeTimestamps: false, skipStateUpdates: true });
+    const markdown = viz.render(events);
+
+    expect(markdown).toContain('### Message (user)');
+    expect(markdown).toContain('hi');
+    expect(markdown).toContain('### Action (terminal)');
+    expect(markdown).toContain('"command": "pwd"');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -41,3 +41,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
 }
 
 export { LocalConversation, RemoteConversation };
+
+export * from './ConversationVisualizer';
+export * from './stuckDetector';
+

--- a/packages/agent-sdk-ts/src/sdk/conversation/stuckDetector.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/stuckDetector.ts
@@ -1,0 +1,241 @@
+import type {
+  ActionEvent,
+  AgentErrorEvent,
+  Event,
+  MessageEvent,
+  ObservationEvent,
+} from '../types';
+import {
+  isActionEvent,
+  isAgentErrorEvent,
+  isCondensation,
+  isMessageEvent,
+  isObservationEvent,
+} from '../types';
+import type { StuckDetectionThresholds } from '../types/settings';
+
+export interface StuckDetectionResult {
+  stuck: boolean;
+  reason?: string;
+}
+
+const DEFAULT_THRESHOLDS: Required<StuckDetectionThresholds> = {
+  actionObservation: 4,
+  actionError: 3,
+  monologue: 3,
+  alternatingPattern: 6,
+};
+
+const clampInt = (value: unknown, fallback: number): number => {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.trunc(value));
+};
+
+const stableStringify = (value: unknown, depth = 0, maxDepth = 6): string => {
+  if (depth > maxDepth) return '"<max-depth>"';
+  if (value === null) return 'null';
+  if (value === undefined) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'bigint') return JSON.stringify(value.toString());
+  if (typeof value === 'symbol') return JSON.stringify(value.toString());
+  if (typeof value === 'function') return JSON.stringify('<function>');
+  if (Array.isArray(value)) return `[${value.map((v) => stableStringify(v, depth + 1, maxDepth)).join(',')}]`;
+  if (typeof value !== 'object') return 'null';
+
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+  const body = entries
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v, depth + 1, maxDepth)}`)
+    .join(',');
+  return `{${body}}`;
+};
+
+const actionKey = (event: ActionEvent): string =>
+  stableStringify({
+    source: event.source,
+    thought: event.thought,
+    action: event.action,
+    tool_name: event.tool_name,
+  });
+
+const observationKey = (event: ObservationEvent): string =>
+  stableStringify({ source: event.source, observation: event.observation, tool_name: event.tool_name });
+
+const errorKey = (event: AgentErrorEvent): string =>
+  stableStringify({ source: event.source, error: event.error, tool_name: event.tool_name });
+
+const isUserMessage = (event: Event): event is MessageEvent =>
+  isMessageEvent(event) && event.source === 'user' && event.llm_message?.role === 'user';
+
+export class StuckDetector {
+  readonly thresholds: Required<StuckDetectionThresholds>;
+
+  constructor(thresholds: StuckDetectionThresholds = {}) {
+    this.thresholds = {
+      actionObservation: clampInt(thresholds.actionObservation, DEFAULT_THRESHOLDS.actionObservation),
+      actionError: clampInt(thresholds.actionError, DEFAULT_THRESHOLDS.actionError),
+      monologue: clampInt(thresholds.monologue, DEFAULT_THRESHOLDS.monologue),
+      alternatingPattern: clampInt(thresholds.alternatingPattern, DEFAULT_THRESHOLDS.alternatingPattern),
+    };
+  }
+
+  detect(events: Event[]): StuckDetectionResult {
+    const lastUserMessageIndex = (() => {
+      for (let i = events.length - 1; i >= 0; i -= 1) {
+        const ev = events[i];
+        if (ev && isUserMessage(ev)) return i;
+      }
+      return -1;
+    })();
+
+    if (lastUserMessageIndex === -1) {
+      return { stuck: false };
+    }
+
+    const tail = events.slice(lastUserMessageIndex + 1);
+    const minThreshold = Math.min(this.thresholds.actionObservation, this.thresholds.actionError, this.thresholds.monologue);
+    if (tail.length < minThreshold) return { stuck: false };
+
+    const maxNeeded = Math.max(this.thresholds.actionObservation, this.thresholds.actionError);
+    const lastActions: ActionEvent[] = [];
+    const lastObservations: Array<ObservationEvent | AgentErrorEvent> = [];
+
+    for (let i = tail.length - 1; i >= 0; i -= 1) {
+      const ev = tail[i];
+      if (isActionEvent(ev) && lastActions.length < maxNeeded) {
+        lastActions.push(ev);
+      } else if ((isObservationEvent(ev) || isAgentErrorEvent(ev)) && lastObservations.length < maxNeeded) {
+        lastObservations.push(ev);
+      }
+
+      if (lastActions.length >= maxNeeded && lastObservations.length >= maxNeeded) break;
+    }
+
+    if (this.isRepeatingActionObservation(lastActions, lastObservations)) {
+      return { stuck: true, reason: 'Action/observation loop detected' };
+    }
+
+    if (this.isRepeatingActionError(lastActions, lastObservations)) {
+      return { stuck: true, reason: 'Action/error loop detected' };
+    }
+
+    if (this.isMonologue(tail)) {
+      return { stuck: true, reason: 'Agent monologue detected' };
+    }
+
+    if (tail.length >= this.thresholds.alternatingPattern && this.isAlternatingActionObservation(tail)) {
+      return { stuck: true, reason: 'Alternating action/observation loop detected' };
+    }
+
+    return { stuck: false };
+  }
+
+  private isRepeatingActionObservation(
+    lastActions: ActionEvent[],
+    lastObservations: Array<ObservationEvent | AgentErrorEvent>,
+  ): boolean {
+    const threshold = this.thresholds.actionObservation;
+    if (lastActions.length < threshold || lastObservations.length < threshold) return false;
+
+    const firstAction = lastActions[0];
+    const firstObservation = lastObservations[0];
+    if (!firstAction || !firstObservation) return false;
+
+    const action0 = actionKey(firstAction);
+    const obs0 = isObservationEvent(firstObservation) ? observationKey(firstObservation) : errorKey(firstObservation);
+
+    const actionsEqual = lastActions.slice(0, threshold).every((ev) => actionKey(ev) === action0);
+    const observationsEqual = lastObservations.slice(0, threshold).every((ev) => {
+      if (isObservationEvent(ev)) return observationKey(ev) === obs0;
+      if (isAgentErrorEvent(ev)) return errorKey(ev) === obs0;
+      return false;
+    });
+
+    return actionsEqual && observationsEqual;
+  }
+
+  private isRepeatingActionError(
+    lastActions: ActionEvent[],
+    lastObservations: Array<ObservationEvent | AgentErrorEvent>,
+  ): boolean {
+    const threshold = this.thresholds.actionError;
+    if (lastActions.length < threshold || lastObservations.length < threshold) return false;
+
+    const firstAction = lastActions[0];
+    if (!firstAction) return false;
+
+    const action0 = actionKey(firstAction);
+    const actionsEqual = lastActions.slice(0, threshold).every((ev) => actionKey(ev) === action0);
+    const errorsOnly = lastObservations.slice(0, threshold).every(isAgentErrorEvent);
+    return actionsEqual && errorsOnly;
+  }
+
+  private isMonologue(events: Event[]): boolean {
+    const threshold = this.thresholds.monologue;
+    if (events.length < threshold) return false;
+
+    let agentMessageCount = 0;
+
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const ev = events[i];
+      if (!ev) continue;
+
+      if (isMessageEvent(ev)) {
+        if (ev.source === 'agent') {
+          agentMessageCount += 1;
+          continue;
+        }
+        if (ev.source === 'user') break;
+        break;
+      }
+
+      if (isCondensation(ev)) {
+        continue;
+      }
+
+      break;
+    }
+
+    return agentMessageCount >= threshold;
+  }
+
+  private isAlternatingActionObservation(events: Event[]): boolean {
+    const threshold = this.thresholds.alternatingPattern;
+
+    const lastActions: ActionEvent[] = [];
+    const lastObservations: Array<ObservationEvent | AgentErrorEvent> = [];
+
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      const ev = events[i];
+      if (!ev) continue;
+      if (isActionEvent(ev) && lastActions.length < threshold) {
+        lastActions.push(ev);
+      } else if ((isObservationEvent(ev) || isAgentErrorEvent(ev)) && lastObservations.length < threshold) {
+        lastObservations.push(ev);
+      }
+      if (lastActions.length === threshold && lastObservations.length === threshold) break;
+    }
+
+    if (lastActions.length !== threshold || lastObservations.length !== threshold) return false;
+
+    for (let i = 0; i < threshold - 2; i += 1) {
+      const a0 = lastActions[i];
+      const a2 = lastActions[i + 2];
+      if (!a0 || !a2) return false;
+      if (actionKey(a0) !== actionKey(a2)) return false;
+    }
+
+    for (let i = 0; i < threshold - 2; i += 1) {
+      const obsA = lastObservations[i];
+      const obsB = lastObservations[i + 2];
+      if (!obsA || !obsB) return false;
+      const keyA = isObservationEvent(obsA) ? observationKey(obsA) : errorKey(obsA);
+      const keyB = isObservationEvent(obsB) ? observationKey(obsB) : errorKey(obsB);
+      if (keyA !== keyB) return false;
+    }
+
+    return true;
+  }
+}
+
+export default StuckDetector;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -50,6 +50,8 @@ import { deepTruncate, truncateToolMessage } from './toolResultTruncation';
 import { SecretMasker } from './secretMasker';
 import { ToolSummarizer } from './toolSummarizer';
 import { buildLlmRequestParametersForDebug } from '../llm/debug';
+import { StuckDetector } from '../conversation/stuckDetector';
+
 
 export type AgentRunInput = string | Message;
 
@@ -416,8 +418,29 @@ export class Agent extends EventEmitter {
     }
     let lastAssistantMessage: Message | undefined;
 
+    const stuckDetector = this.options.settings?.conversation?.stuckDetection
+      ? new StuckDetector(this.options.settings?.conversation?.stuckThresholds ?? {})
+      : undefined;
+
+
     while (!this.paused && !this.pendingAction && !this.cancelled && !this.finished && this.state.snapshot.iteration < maxIterations) {
       this.state.setStatus('RUNNING');
+
+
+      if (stuckDetector) {
+        const stuck = stuckDetector.detect(this.events.list());
+        if (stuck.stuck) {
+          this.events.push({
+            kind: 'ConversationErrorEvent',
+            source: 'agent',
+            code: 'stuck_detected',
+            detail: stuck.reason ?? 'Agent appears to be stuck in a loop.',
+          } as Event);
+          this.state.setStatus('IDLE');
+          break;
+        }
+      }
+
       const llmConfig = this.getEffectiveLlmConfigForCondensation();
 
       // Debug logging for mid-run settings tracking (oh-tab-rw1k)

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -84,8 +84,17 @@ export type AgentSettings = {
   summarizeToolCalls?: boolean;
 };
 
+export type StuckDetectionThresholds = {
+  actionObservation?: number;
+  actionError?: number;
+  monologue?: number;
+  alternatingPattern?: number;
+};
+
 export type ConversationSettings = {
   maxIterations?: number;
+  stuckDetection?: boolean;
+  stuckThresholds?: StuckDetectionThresholds;
 };
 
 export type ConfirmationSettings = {


### PR DESCRIPTION
Implements #637.

### What changed
- Adds `ConversationVisualizer` (markdown rendering helper) under `src/sdk/conversation/ConversationVisualizer.ts`.
- Adds `StuckDetector` under `src/sdk/conversation/stuckDetector.ts` with thresholds matching Python defaults.
- Adds optional stuck-detection integration in `Agent.runLoop`:
  - Enable via `settings.conversation.stuckDetection: true`
  - Optional custom thresholds via `settings.conversation.stuckThresholds`
  - Emits a deterministic `ConversationErrorEvent` with `code: 'stuck_detected'` and stops the loop.
- Extends `ConversationSettings` type to include the above options.

### Tests
- Adds unit tests for the visualizer.
- Adds an agent loop test ensuring stuck detection emits the expected `ConversationErrorEvent`.

### Notes
- This is intentionally lightweight (markdown output) but keeps the same core stuck patterns as the Python SDK.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversation event visualizer with customizable formatting (timestamps, message filtering, state updates)
  * Stuck-detection system to identify repetitive agent loops with configurable thresholds

* **Tests**
  * Added tests for stuck detection and event visualization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->