### PR TITLE
agent-sdk-ts parity: RemoteConversation RemoteState (execution status, policy, stats) (#638)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -420,6 +420,53 @@ describe('RemoteConversation', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('maintains RemoteState from ConversationStateUpdateEvent history + stream', async () => {
+    const history: Event[] = [
+      {
+        id: 's-1',
+        kind: 'ConversationStateUpdateEvent',
+        source: 'environment',
+        key: 'full_state',
+        value: {
+          execution_status: 'running',
+          confirmation_policy: { kind: 'NeverConfirm' },
+          stats: { llm: { total_cost: 0 } },
+        },
+      } as Event,
+    ];
+
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain('/events/search');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: history, next_page_id: null }),
+        text: async () => '',
+      } as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    expect(conversation.state.executionStatus).toBe('running');
+    expect(conversation.state.confirmationPolicy).toEqual({ kind: 'NeverConfirm' });
+
+    const ws = getEventWS();
+    ws.open();
+    ws.message({
+      id: 's-2',
+      kind: 'ConversationStateUpdateEvent',
+      source: 'environment',
+      key: 'execution_status',
+      value: 'paused',
+    });
+
+    expect(conversation.state.executionStatus).toBe('paused');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -6,6 +6,8 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { LLMProfileStoreOptions } from '../llm/profiles';
 import { loadProfile } from '../llm/profiles';
 import type { LLMConfiguration } from '../llm/types';
+import { RemoteState } from './RemoteState';
+
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
@@ -85,8 +87,13 @@ export class RemoteConversation extends EventEmitter {
   private static readonly httpTimeoutMs = 15_000;
   private hasEverConnected = false;
 
+  readonly state: RemoteState;
+
+
   constructor(options: RemoteConversationOptions) {
     super();
+    this.state = new RemoteState();
+
     this.serverUrl = normalizeRemoteServerUrl(options.serverUrl);
     this.settings = options.settings;
     this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
@@ -96,6 +103,7 @@ export class RemoteConversation extends EventEmitter {
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
+      this.state.reset();
       this.emit('conversationStarted', this.conversationId);
       void this.replayHistory().then((ok) => {
         if (!ok) {
@@ -134,6 +142,7 @@ export class RemoteConversation extends EventEmitter {
       }
       this.clearWsHandshakeTimer();
       this.seenEventIds.clear();
+      this.state.reset();
       this.setStatus('connecting');
       const base = this.serverUrl.replace(/\/$/, '');
       const s = this.settings;
@@ -302,6 +311,7 @@ export class RemoteConversation extends EventEmitter {
   async restoreConversation(id: string) {
     this.conversationId = id;
     this.seenEventIds.clear();
+    this.state.reset();
     this.setStatus('connecting');
     this.emit('conversationStarted', id);
     const ok = await this.replayHistory();
@@ -557,6 +567,7 @@ export class RemoteConversation extends EventEmitter {
       if (this.seenEventIds.has(event.id)) return;
       this.seenEventIds.add(event.id);
     }
+    this.state.applyEvent(event);
     this.emit('event', event);
   }
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteState.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteState.ts
@@ -1,0 +1,84 @@
+import type { Event } from '../types';
+import { isConversationStateUpdateEvent } from '../types';
+
+export interface RemoteStateSnapshot {
+  executionStatus?: string;
+  agentStatus?: string;
+  confirmationPolicy?: unknown;
+  securityAnalyzer?: unknown;
+  maxIterations?: number;
+  stuckDetection?: boolean;
+  stats?: unknown;
+  [key: string]: unknown;
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export class RemoteState {
+  private readonly raw: Record<string, unknown> = {};
+
+  reset(): void {
+    for (const key of Object.keys(this.raw)) {
+      delete this.raw[key];
+    }
+  }
+
+  applyEvent(event: Event): void {
+    if (!isConversationStateUpdateEvent(event)) return;
+
+    if (typeof event.agent_status === 'string') {
+      this.raw.agent_status = event.agent_status;
+    }
+    if (typeof event.iteration === 'number') {
+      this.raw.iteration = event.iteration;
+    }
+
+    const key = typeof event.key === 'string' ? event.key : undefined;
+    const value = event.value;
+
+    if (!key) return;
+
+    if (key === 'full_state' && isRecord(value)) {
+      Object.assign(this.raw, value);
+      return;
+    }
+
+    this.raw[key] = value;
+  }
+
+  applySnapshot(snapshot: unknown): void {
+    if (!isRecord(snapshot)) return;
+    Object.assign(this.raw, snapshot);
+  }
+
+  get snapshot(): RemoteStateSnapshot {
+    const executionStatus = typeof this.raw.execution_status === 'string' ? this.raw.execution_status : undefined;
+    const agentStatus = typeof this.raw.agent_status === 'string' ? this.raw.agent_status : undefined;
+
+    return {
+      ...this.raw,
+      executionStatus,
+      agentStatus,
+      confirmationPolicy: this.raw.confirmation_policy,
+      securityAnalyzer: this.raw.security_analyzer,
+      maxIterations: typeof this.raw.max_iterations === 'number' ? this.raw.max_iterations : undefined,
+      stuckDetection: typeof this.raw.stuck_detection === 'boolean' ? this.raw.stuck_detection : undefined,
+      stats: this.raw.stats,
+    };
+  }
+
+  get executionStatus(): string | undefined {
+    return this.snapshot.executionStatus;
+  }
+
+  get confirmationPolicy(): unknown {
+    return this.snapshot.confirmationPolicy;
+  }
+
+  get stats(): unknown {
+    return this.snapshot.stats;
+  }
+}
+
+export default RemoteState;

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -41,7 +41,6 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
 }
 
 export { LocalConversation, RemoteConversation };
-
+export * from './RemoteState';
 export * from './ConversationVisualizer';
 export * from './stuckDetector';
-


### PR DESCRIPTION
Implements #638.

### What changed
- Adds `RemoteState` (conversation state cache) that replays `ConversationStateUpdateEvent` history and updates incrementally for streamed events.
- Exposes `remoteConversation.state` with convenience getters:
  - `executionStatus`
  - `confirmationPolicy`
  - `stats`
  - plus `snapshot` for raw access.
- Resets the state cache on `startNewConversation()` / `restoreConversation()` / constructor attach.

### Tests
- Extends `remoteConversation.test.ts` to verify state is populated from history `full_state` + updated via streamed `ConversationStateUpdateEvent`.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RemoteConversation now exposes a `state` property providing access to real-time conversation state, including execution status, agent status, and confirmation policies, synchronized with incoming events.

* **Tests**
  * Added comprehensive test to verify state consistency is maintained throughout the conversation lifecycle and across streamed events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->