### PR TITLE
agent-sdk-ts parity: RemoteConversation.askAgent() (#639)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -467,6 +467,46 @@ describe('RemoteConversation', () => {
     expect(conversation.state.executionStatus).toBe('paused');
   });
 
+  it('askAgent posts /ask_agent and returns response without emitting events', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/ask_agent')) {
+        expect(init?.method).toBe('POST');
+        const body = JSON.parse(init?.body ?? '{}');
+        expect(body).toEqual({ question: 'What is 2+2?' });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ response: '4' }),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    const received: Event[] = [];
+    conversation.on('event', (e) => received.push(e));
+
+    await conversation.restoreConversation('abc');
+    received.length = 0;
+
+    await expect(conversation.askAgent('What is 2+2?')).resolves.toBe('4');
+    expect(received).toEqual([]);
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -507,6 +507,102 @@ describe('RemoteConversation', () => {
     expect(received).toEqual([]);
   });
 
+  it('askAgent throws when server returns null JSON', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/ask_agent')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => null,
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('askAgent: server response missing "response"');
+  });
+
+  it('askAgent throws when server response is missing "response"', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/ask_agent')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('askAgent: server response missing "response"');
+  });
+
+  it('askAgent throws on non-2xx response', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/ask_agent')) {
+        return {
+          ok: false,
+          status: 503,
+          json: async () => ({ response: 'ignored' }),
+          text: async () => 'unavailable',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('Failed to ask agent (HTTP 503): unavailable');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -360,6 +360,40 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
+
+  async askAgent(question: string): Promise<string> {
+    if (!this.conversationId) {
+      throw new Error('Cannot askAgent: no active conversation. Start or restore a conversation first.');
+    }
+
+    const trimmed = question.trim();
+    if (!trimmed) {
+      throw new Error('askAgent: question must be a non-empty string');
+    }
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = { ...this.getAuthHeaders({ 'Content-Type': 'application/json' }) };
+    const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/ask_agent`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ question: trimmed }),
+    }, RemoteConversation.httpTimeoutMs);
+
+    if (!res.ok) {
+      const info = await res.text().catch(() => '');
+      throw new Error(`Failed to ask agent (HTTP ${res.status})${info ? `: ${info}` : ''}`);
+    }
+
+    const json = await res.json().catch(() => ({})) as { response?: unknown };
+    const response = typeof json.response === 'string' ? json.response : undefined;
+    if (!response) {
+      throw new Error('askAgent: server response missing "response"');
+    }
+
+    return response;
+  }
+
+
   async approveAction(): Promise<void> {
     await this.respondToConfirmation(true);
   }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -372,7 +372,7 @@ export class RemoteConversation extends EventEmitter {
     }
 
     const base = this.serverUrl.replace(/\/$/, '');
-    const headers = { ...this.getAuthHeaders({ 'Content-Type': 'application/json' }) };
+    const headers = this.getAuthHeaders();
     const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/ask_agent`, {
       method: 'POST',
       headers,
@@ -384,8 +384,10 @@ export class RemoteConversation extends EventEmitter {
       throw new Error(`Failed to ask agent (HTTP ${res.status})${info ? `: ${info}` : ''}`);
     }
 
-    const json = await res.json().catch(() => ({})) as { response?: unknown };
-    const response = typeof json.response === 'string' ? json.response : undefined;
+    const json = await res.json().catch(() => null) as unknown;
+    const response = typeof (json as { response?: unknown } | null)?.response === 'string'
+      ? (json as { response: string }).response
+      : undefined;
     if (!response) {
       throw new Error('askAgent: server response missing "response"');
     }


### PR DESCRIPTION
Implements #639 (stacked on #671).

### What changed
- Adds `RemoteConversation.askAgent(question: string): Promise<string>` implemented via `POST /api/conversations/{id}/ask_agent`.
- Validates non-empty input and parses `{ response }` from the server.
- Does **not** emit or record conversation events.

### Tests
- Adds a unit test in `remoteConversation.test.ts` asserting correct request shape + that no events are emitted.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)