### PR TITLE
agent-sdk-ts parity: RemoteConversation.generateTitle() (#640)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -655,6 +655,102 @@ describe('RemoteConversation', () => {
     })).resolves.toBe('My title');
   });
 
+  it('generateTitle throws when server returns null JSON', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/generate_title')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => null,
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.generateTitle()).rejects.toThrow('generateTitle: server response missing "title"');
+  });
+
+  it('generateTitle throws when server response is missing "title"', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/generate_title')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.generateTitle()).rejects.toThrow('generateTitle: server response missing "title"');
+  });
+
+  it('generateTitle throws when server response has a non-string title', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/generate_title')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ title: 123 }),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.generateTitle()).rejects.toThrow('generateTitle: server response missing "title"');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -603,6 +603,58 @@ describe('RemoteConversation', () => {
     await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('Failed to ask agent (HTTP 503): unavailable');
   });
 
+  it('generateTitle posts /generate_title and returns the title', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/generate_title')) {
+        expect(init?.method).toBe('POST');
+        const body = JSON.parse(init?.body ?? '{}');
+        expect(body.max_length).toBe(12);
+        expect(body.llm).toEqual({
+          usage_id: 'agent',
+          model: 'custom-model',
+          base_url: 'https://llm.example',
+          api_version: '2025-01-01',
+          api_key: 'llm-key',
+          timeout: 10,
+        });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ title: 'My title' }),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.generateTitle({
+      maxLength: 12,
+      llm: {
+        model: 'custom-model',
+        apiKey: 'llm-key',
+        baseUrl: 'https://llm.example',
+        apiVersion: '2025-01-01',
+        timeoutSeconds: 10,
+      },
+    })).resolves.toBe('My title');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -396,6 +396,58 @@ export class RemoteConversation extends EventEmitter {
   }
 
 
+  async generateTitle(options?: { maxLength?: number; llm?: LLMConfiguration | null }): Promise<string> {
+    if (!this.conversationId) {
+      throw new Error('Cannot generateTitle: no active conversation. Start or restore a conversation first.');
+    }
+
+    const maxLength = typeof options?.maxLength === 'number' && Number.isFinite(options.maxLength)
+      ? Math.max(1, Math.trunc(options.maxLength))
+      : 50;
+
+    const llm = options?.llm;
+    const llmPayload = llm ? {
+      usage_id: llm.usageId ?? 'agent',
+      model: llm.model,
+      ...(llm.baseUrl ? { base_url: llm.baseUrl } : {}),
+      ...(llm.apiVersion ? { api_version: llm.apiVersion } : {}),
+      ...(llm.apiKey ? { api_key: llm.apiKey } : {}),
+      ...(typeof llm.timeoutSeconds === 'number' ? { timeout: llm.timeoutSeconds } : {}),
+      ...(typeof llm.temperature === 'number' ? { temperature: llm.temperature } : {}),
+      ...(typeof llm.topP === 'number' ? { top_p: llm.topP } : {}),
+      ...(typeof llm.topK === 'number' ? { top_k: llm.topK } : {}),
+      ...(typeof llm.maxInputTokens === 'number' ? { max_input_tokens: llm.maxInputTokens } : {}),
+      ...(typeof llm.maxOutputTokens === 'number' ? { max_output_tokens: llm.maxOutputTokens } : {}),
+      ...(typeof llm.reasoningEffort === 'string' ? { reasoning_effort: llm.reasoningEffort } : {}),
+      ...(typeof llm.reasoningSummary === 'string' ? { reasoning_summary: llm.reasoningSummary } : {}),
+    } : null;
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/generate_title`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ max_length: maxLength, llm: llmPayload }),
+    }, RemoteConversation.httpTimeoutMs);
+
+    if (!res.ok) {
+      const info = await res.text().catch(() => '');
+      throw new Error(`Failed to generate title (HTTP ${res.status})${info ? `: ${info}` : ''}`);
+    }
+
+    const json = await res.json().catch(() => null) as unknown;
+    const title = typeof (json as { title?: unknown } | null)?.title === 'string'
+      ? (json as { title: string }).title
+      : undefined;
+    if (!title) {
+      throw new Error('generateTitle: server response missing "title"');
+    }
+
+    return title;
+  }
+
+
+
   async approveAction(): Promise<void> {
     await this.respondToConfirmation(true);
   }


### PR DESCRIPTION
Implements #640 (stacked on #672).

### What changed
- Adds `RemoteConversation.generateTitle({ maxLength?, llm? }?)` implemented via `POST /api/conversations/{id}/generate_title`.
- Supports optional custom LLM config (mapped to agent-server snake_case fields) and maxLength.
- Works purely via HTTP and does not require an active WebSocket connection.

### Tests
- Adds a unit test in `remoteConversation.test.ts` asserting request payload mapping and returned title.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)