### PR TITLE
oh-tab-wik6: add default profile selection E2E

### DIFF
--- a/tests/e2e/defaultProfileSelection.test.ts
+++ b/tests/e2e/defaultProfileSelection.test.ts
@@ -1,0 +1,50 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-default-profile-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab default profile selection E2E', function () {
+  this.timeout(180000);
+
+  it('defaults profileId on fresh install and uses profile config', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
+    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir',
+        userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'defaultProfileSelection',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+        OPENAI_API_KEY: '',
+        ANTHROPIC_API_KEY: 'e2e-anthropic-key',
+        GEMINI_API_KEY: '',
+        OPENROUTER_API_KEY: '',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/defaultProfileSelection.test.ts
+++ b/tests/e2e/defaultProfileSelection.test.ts
@@ -10,6 +10,10 @@ const userDataDir = path.join(os.tmpdir(), `oh-tab-default-profile-${Date.now().
 describe('OpenHands-Tab default profile selection E2E', function () {
   this.timeout(180000);
 
+  after(async () => {
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  });
+
   it('defaults profileId on fresh install and uses profile config', async () => {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
@@ -47,4 +51,3 @@ describe('OpenHands-Tab default profile selection E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/suite/defaultProfileSelection.ts
+++ b/tests/e2e/suite/defaultProfileSelection.ts
@@ -11,7 +11,9 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands.open');
 
     await pollUntil(async () => {
-      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const diag = await vscode.commands.executeCommand<{ chat?: { hasView?: boolean; webviewReady?: boolean } }>(
+        'openhands._diagnostics',
+      );
       return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
     }, 15000);
 

--- a/tests/e2e/suite/defaultProfileSelection.ts
+++ b/tests/e2e/suite/defaultProfileSelection.ts
@@ -1,0 +1,71 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import { startMockLlmServer } from './mockLlmServer';
+import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
+
+export async function run(): Promise<void> {
+  const mock = await startMockLlmServer();
+
+  try {
+    await vscode.commands.executeCommand('openhands.open');
+
+    await pollUntil(async () => {
+      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+    }, 15000);
+
+    const cfg = vscode.workspace.getConfiguration();
+    const update = async (key: string, value: unknown): Promise<void> => {
+      await cfg.update(key, value, vscode.ConfigurationTarget.Global);
+    };
+
+    // Force local mode + short runs for E2E.
+    await update('openhands.serverUrl', '');
+    await update('openhands.conversation.maxIterations', 5);
+    await update('openhands.confirmation.policy', 'never');
+    await update('openhands.agent.enableSecurityAnalyzer', false);
+
+    // Ensure the default profile exists and points at the mock server (avoid real network).
+    const v1BaseUrl = `${mock.baseUrl}/v1`;
+    try {
+      await vscode.commands.executeCommand('openhands._updateProfile', {
+        profileId: 'sonnet-45',
+        patch: { baseUrl: v1BaseUrl, model: 'claude-e2e' },
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (!message.includes('not found')) throw error;
+      await vscode.commands.executeCommand('openhands._createProfile', {
+        profileId: 'sonnet-45',
+        profile: {
+          provider: 'anthropic',
+          model: 'claude-e2e',
+          baseUrl: v1BaseUrl,
+        },
+      });
+    }
+
+    // Clear selection and assert the extension defaults it back to a non-empty profileId.
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId: null });
+
+    await pollUntil(async () => {
+      const inspected = cfg.inspect<string>('openhands.llm.profileId');
+      return typeof inspected?.globalValue === 'string' && inspected.globalValue.length > 0;
+    }, 15000);
+
+    const inspected = cfg.inspect<string>('openhands.llm.profileId');
+    assert.strictEqual(inspected?.globalValue, 'sonnet-45');
+
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+
+    await sendAndWaitForRequestPath({
+      text: 'E2E default profile selection: anthropic (sonnet-45)',
+      expectedPath: '/v1/messages',
+      getRequests: () => mock.requests,
+    });
+  } finally {
+    await mock.close();
+  }
+}

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -64,6 +64,11 @@ export async function run(): Promise<void> {
     return runLlmProfilesTest();
   }
 
+  if (testName === 'defaultProfileSelection') {
+    const { run: runDefaultProfileSelectionTest } = await import('./defaultProfileSelection');
+    return runDefaultProfileSelectionTest();
+  }
+
   if (testName === 'terminalProgress') {
     const { run: runTerminalProgressTest } = await import('./terminalProgress');
     return runTerminalProgressTest();


### PR DESCRIPTION
Adds E2E coverage for fresh install defaulting `openhands.llm.profileId` and verifying the conversation uses the selected profile config (Anthropic `/v1/messages` via mock server).

Beads: `oh-tab-wik6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests that verify default profile selection on fresh installs. Tests cover UI flow, creating/updating profiles, enforcing local mode, interactions with a mock LLM server and request validation, isolated user-data environment and startup configuration, environment variable handling, and proper cleanup after execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->