### PR TITLE
agent-sdk-ts parity: RemoteConversation.condense() (#641)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -751,6 +751,72 @@ describe('RemoteConversation', () => {
     await expect(conversation.generateTitle()).rejects.toThrow('generateTitle: server response missing "title"');
   });
 
+  it('condense posts /condense', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/condense')) {
+        expect(init?.method).toBe('POST');
+        expect(init?.body).toBeUndefined();
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.condense()).resolves.toBeUndefined();
+  });
+
+  it('condense throws on non-2xx response', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/condense')) {
+        return {
+          ok: false,
+          status: 400,
+          json: async () => ({}),
+          text: async () => 'no condenser configured',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.condense()).rejects.toThrow('Failed to condense conversation (HTTP 400): no condenser configured');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -446,6 +446,25 @@ export class RemoteConversation extends EventEmitter {
     return title;
   }
 
+  async condense(): Promise<void> {
+    if (!this.conversationId) {
+      throw new Error('Cannot condense: no active conversation. Start or restore a conversation first.');
+    }
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    const res = await this.fetchWithTimeout(
+      `${base}/api/conversations/${this.conversationId}/condense`,
+      { method: 'POST', headers },
+      RemoteConversation.httpTimeoutMs,
+    );
+
+    if (!res.ok) {
+      const info = await res.text().catch(() => '');
+      throw new Error(`Failed to condense conversation (HTTP ${res.status})${info ? `: ${info}` : ''}`);
+    }
+  }
+
 
 
   async approveAction(): Promise<void> {


### PR DESCRIPTION
Implements GH #641 (Beads: oh-tab-s5ri).

- Adds `RemoteConversation.condense()` which POSTs `/api/conversations/{id}/condense`.
- Adds unit tests for success + non-2xx failure cases.

Profiles guardrail: no profile selection/resolution changes.

Tests: `npx vitest run packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `condense()` method for conversation management.

* **Tests**
  * Added comprehensive test coverage for the new condense method, including success cases and error handling validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->