### PR TITLE
agent-sdk-ts parity: RemoteConversation workspace helpers beyond events (#645)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -817,6 +817,46 @@ describe('RemoteConversation', () => {
     await expect(conversation.condense()).rejects.toThrow('Failed to condense conversation (HTTP 400): no condenser configured');
   });
 
+  it('getWorkspace exposes a RemoteWorkspace using sessionApiKey and invalidates on key change', async () => {
+    let uploadCalls = 0;
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/api/file/upload')) {
+        expect(init?.method).toBe('POST');
+        uploadCalls += 1;
+        expect(init?.headers?.['X-Session-API-Key']).toBe(uploadCalls === 1 ? 'session-key-1' : 'session-key-2');
+        return {
+          ok: true,
+          status: 200,
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      workspaceRoot: '/workspace',
+      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key-1' } },
+    });
+
+    const w1 = conversation.getWorkspace();
+    const w2 = conversation.getWorkspace();
+    expect(w1).toBe(w2);
+    expect(w1.kind).toBe('remote');
+    expect(w1.root).toBe('/workspace');
+
+    await w1.writeFile('notes.txt', 'hello');
+
+    conversation.setSettings({ ...baseSettings, secrets: { sessionApiKey: 'session-key-2' } });
+    const w3 = conversation.getWorkspace();
+    expect(w3).not.toBe(w1);
+
+    await w3.writeFile('notes.txt', 'hello');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -125,10 +125,8 @@ export class RemoteConversation extends EventEmitter {
 
   getWorkspace(): BaseWorkspace {
     if (!this.workspaceClient) {
-      const workspace = this.workspace as unknown as { working_dir?: unknown } | undefined;
-      const workingDir = typeof workspace?.working_dir === 'string'
-        ? workspace.working_dir
-        : this.workspaceRoot;
+      const rawWorkingDir = this.workspace?.['working_dir'];
+      const workingDir = typeof rawWorkingDir === 'string' ? rawWorkingDir : this.workspaceRoot;
       const apiKey = this.settings?.secrets.sessionApiKey;
       this.workspaceClient = new RemoteWorkspace({ host: this.serverUrl, apiKey, workingDir });
     }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -7,6 +7,9 @@ import type { LLMProfileStoreOptions } from '../llm/profiles';
 import { loadProfile } from '../llm/profiles';
 import type { LLMConfiguration } from '../llm/types';
 import { RemoteState } from './RemoteState';
+import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
+import type { BaseWorkspace } from '../../workspace/BaseWorkspace';
+import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from '../../workspace/types';
 
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
@@ -88,6 +91,7 @@ export class RemoteConversation extends EventEmitter {
   private hasEverConnected = false;
 
   readonly state: RemoteState;
+  private workspaceClient?: RemoteWorkspace;
 
 
   constructor(options: RemoteConversationOptions) {
@@ -117,6 +121,54 @@ export class RemoteConversation extends EventEmitter {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
       });
     }
+  }
+
+  getWorkspace(): BaseWorkspace {
+    if (!this.workspaceClient) {
+      const maybeWorkingDir = typeof (this.workspace as { working_dir?: unknown } | undefined)?.working_dir === 'string'
+        ? (this.workspace as { working_dir: string }).working_dir
+        : undefined;
+      const workingDir = maybeWorkingDir ?? this.workspaceRoot;
+      const apiKey = this.settings?.secrets.sessionApiKey;
+      this.workspaceClient = new RemoteWorkspace({ host: this.serverUrl, apiKey, workingDir });
+    }
+    return this.workspaceClient;
+  }
+
+  runCommand(command: string, options: CommandOptions = {}): Promise<CommandResult> {
+    return this.getWorkspace().runCommand(command, options);
+  }
+
+  readFile(targetPath: string, encoding?: WorkspaceEncoding): Promise<string> {
+    return this.getWorkspace().readFile(targetPath, encoding);
+  }
+
+  readFileBytes(targetPath: string, options?: { maxBytes?: number }): Promise<Buffer> {
+    return this.getWorkspace().readFileBytes(targetPath, options);
+  }
+
+  writeFile(targetPath: string, content: string | Buffer): Promise<void> {
+    return this.getWorkspace().writeFile(targetPath, content);
+  }
+
+  remove(targetPath: string): Promise<void> {
+    return this.getWorkspace().remove(targetPath);
+  }
+
+  list(targetPath?: string): Promise<DirectoryEntry[]> {
+    return this.getWorkspace().list(targetPath);
+  }
+
+  ensureDirectory(targetPath: string): Promise<string> {
+    return this.getWorkspace().ensureDirectory(targetPath);
+  }
+
+  gitStatus(): Promise<CommandResult> {
+    return this.getWorkspace().gitStatus();
+  }
+
+  gitDiff(paths?: string[]): Promise<CommandResult> {
+    return this.getWorkspace().gitDiff(paths);
   }
 
   get mode(): 'remote' { return 'remote'; }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -125,10 +125,10 @@ export class RemoteConversation extends EventEmitter {
 
   getWorkspace(): BaseWorkspace {
     if (!this.workspaceClient) {
-      const maybeWorkingDir = typeof (this.workspace as { working_dir?: unknown } | undefined)?.working_dir === 'string'
-        ? (this.workspace as { working_dir: string }).working_dir
-        : undefined;
-      const workingDir = maybeWorkingDir ?? this.workspaceRoot;
+      const workspace = this.workspace as unknown as { working_dir?: unknown } | undefined;
+      const workingDir = typeof workspace?.working_dir === 'string'
+        ? workspace.working_dir
+        : this.workspaceRoot;
       const apiKey = this.settings?.secrets.sessionApiKey;
       this.workspaceClient = new RemoteWorkspace({ host: this.serverUrl, apiKey, workingDir });
     }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -176,11 +176,17 @@ export class RemoteConversation extends EventEmitter {
   getStatus(): ConversationStatus { return this.status; }
 
   setSettings(settings: OpenHandsSettings) {
+    const oldApiKey = this.settings?.secrets.sessionApiKey;
+    const newApiKey = settings?.secrets.sessionApiKey;
     this.settings = settings;
+    if (this.workspaceClient && oldApiKey !== newApiKey) {
+      this.workspaceClient = undefined;
+    }
   }
 
   setServerUrl(url: string) {
     this.serverUrl = normalizeRemoteServerUrl(url);
+    this.workspaceClient = undefined;
   }
 
   async startNewConversation(): Promise<string | undefined> {


### PR DESCRIPTION
Implements GH #645 (Beads: oh-tab-3i6c).

- Exposes a typed remote workspace API from `RemoteConversation` via `getWorkspace()` (caches a `RemoteWorkspace`).
- Adds pass-through helpers on `RemoteConversation` for commands/files/git.
- Adds a unit test that asserts the workspace uses `sessionApiKey` for auth.

Profiles guardrail: no profile selection/resolution changes.

Tests: `npx vitest run packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RemoteConversation now supports integrated workspace operations including command execution, file reading/writing, directory management, and Git operations.
  * Workspace instances automatically refresh when authentication credentials change.

* **Tests**
  * Added validation tests for workspace lifecycle and session management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->