### PR TITLE
agent-sdk-ts parity: Default ActionEvent.security_risk to UNKNOWN (#648)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1061,7 +1061,7 @@ export class Agent extends EventEmitter {
     if (policy === 'never') return false;
     if (policy === 'always') return true;
     const risk = action.security_risk;
-    if (!risk) return this.confirmation.confirmUnknown ?? true;
+    if (!risk || risk === 'UNKNOWN') return this.confirmation.confirmUnknown ?? true;
     const threshold = this.confirmation.riskyThreshold ?? 'MEDIUM';
     return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(threshold);
   }
@@ -1123,7 +1123,7 @@ export class Agent extends EventEmitter {
       tool_call_id: toolCall.id,
       tool_call: toolCall,
       llm_response_id: message.id ?? randomUUID(),
-      security_risk: securityRisk,
+      security_risk: securityRisk ?? 'UNKNOWN',
     };
   }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts
@@ -98,7 +98,7 @@ describe('Agent security risk handling', () => {
     }
   });
 
-  it('treats unknown tool-provided security_risk as undefined', async () => {
+  it('defaults unknown tool-provided security_risk to UNKNOWN', async () => {
     const log = new EventLog();
     const tool: ToolDefinition<Record<string, unknown>, { echoed: boolean }> = {
       name: 'echo',
@@ -129,7 +129,7 @@ describe('Agent security risk handling', () => {
 
     const events = log.list();
     const action = events.find(isActionEvent);
-    expect(action?.security_risk).toBeUndefined();
+    expect(action?.security_risk).toBe('UNKNOWN');
     expect(agent.state.snapshot.status).toBe('WAITING_FOR_CONFIRMATION');
     expect(agent.pendingActionId).toBeDefined();
   });


### PR DESCRIPTION
Beads: oh-tab-0o2b\n\nParity: Default ActionEvent.security_risk to 'UNKNOWN' when not provided, and treat 'UNKNOWN' as unknown for confirmation gating.\n\nTests: npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts