### PR TITLE
agent-sdk-ts parity: Default LLM timeout 300s (#650)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/timeoutDefaults.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/timeoutDefaults.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_TIMEOUT_MS } from '../types';
+
+describe('LLM timeout defaults', () => {
+  it('defaults to 300s (Python parity)', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(300_000);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -86,7 +86,7 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
   retryOn: (status: number): boolean => [408, 409, 425, 429, 500, 502, 503, 504].includes(status),
 };
 
-export const DEFAULT_TIMEOUT_MS = 60_000;
+export const DEFAULT_TIMEOUT_MS = 300_000;
 
 /**
  * Result from applying a tool call delta to the accumulator.


### PR DESCRIPTION
Beads: oh-tab-iwm7

Change default LLM request timeout from 60s to 300s (Python parity) by updating `DEFAULT_TIMEOUT_MS` in `packages/agent-sdk-ts/src/sdk/llm/types.ts`.

Test: `npx vitest run packages/agent-sdk-ts/src/sdk/llm/__tests__/timeoutDefaults.test.ts`
