### PR TITLE
agent-sdk-ts parity: RemoteConversation.updateSecrets() (#643)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -817,6 +817,73 @@ describe('RemoteConversation', () => {
     await expect(conversation.condense()).rejects.toThrow('Failed to condense conversation (HTTP 400): no condenser configured');
   });
 
+  it('updateSecrets posts /secrets', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/secrets')) {
+        expect(init?.method).toBe('POST');
+        const body = JSON.parse(init?.body ?? '{}');
+        expect(body).toEqual({ secrets: { GITHUB_TOKEN: 'ghp_abc123' } });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.updateSecrets({ GITHUB_TOKEN: 'ghp_abc123' })).resolves.toBeUndefined();
+  });
+
+  it('updateSecrets throws on non-2xx response', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/secrets')) {
+        return {
+          ok: false,
+          status: 403,
+          json: async () => ({}),
+          text: async () => 'forbidden',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.updateSecrets({ GITHUB_TOKEN: 'ghp_abc123' })).rejects.toThrow('Failed to update secrets (HTTP 403): forbidden');
+  });
+
   it('getWorkspace exposes a RemoteWorkspace using sessionApiKey and invalidates on key change', async () => {
     let uploadCalls = 0;
     const fetchMock = vi.fn(async (url: string, init?: any) => {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -852,6 +852,15 @@ describe('RemoteConversation', () => {
     await expect(conversation.updateSecrets({ GITHUB_TOKEN: 'ghp_abc123' })).resolves.toBeUndefined();
   });
 
+  it('updateSecrets throws when no active conversation', async () => {
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await expect(conversation.updateSecrets({ GITHUB_TOKEN: 'ghp_abc123' })).rejects.toThrow(
+      'Cannot updateSecrets: no active conversation. Start or restore a conversation first.',
+    );
+  });
+
   it('updateSecrets throws on non-2xx response', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       if (url.includes('/events/search')) {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -416,6 +416,24 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
+  async updateSecrets(secrets: Record<string, string>): Promise<void> {
+    if (!this.conversationId) {
+      throw new Error('Cannot updateSecrets: no active conversation. Start or restore a conversation first.');
+    }
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/secrets`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ secrets }),
+    }, RemoteConversation.httpTimeoutMs);
+
+    if (!res.ok) {
+      const info = await res.text().catch(() => '');
+      throw new Error(`Failed to update secrets (HTTP ${res.status})${info ? `: ${info}` : ''}`);
+    }
+  }
 
   async askAgent(question: string): Promise<string> {
     if (!this.conversationId) {


### PR DESCRIPTION
Beads: oh-tab-3p8t

Adds `RemoteConversation.updateSecrets(secrets: Record<string,string>)` (POST `/api/conversations/{id}/secrets`).

Tests: `npx vitest run packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts`
