### PR TITLE
agent-sdk-ts parity: ConfirmationPolicy + SecurityAnalyzer abstractions (#659)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.security.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.security.test.ts
@@ -215,4 +215,42 @@ describe('Security analyzer + confirmation policy parity', () => {
     expect(events.some(isPauseEvent)).toBe(true);
     expect(events.some(isObservationEvent)).toBe(false);
   });
+
+  it('uses ActionEvent.security_risk when analyzer is disabled', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      {
+        type: 'tool_call_delta',
+        id: 'call_1',
+        name: 'echo',
+        arguments: '{"security_risk":"LOW","value":"hi"}',
+      },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: {
+        ...baseSettings,
+        agent: { enableSecurityAnalyzer: false },
+        confirmation: { policy: 'risky', riskyThreshold: 'MEDIUM', confirmUnknown: false },
+      },
+      events: log,
+      workspaceRoot: process.cwd(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run tool');
+
+    const events = log.list();
+    expect(events.some(isPauseEvent)).toBe(false);
+    expect(events.some(isObservationEvent)).toBe(true);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.security.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.security.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { Agent, EventLog } from '../runtime';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
+import { isAgentErrorEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
+import type { ToolDefinition } from '../types/tools';
+import type { OpenHandsSettings } from '../types/settings';
+import { createConfirmationPolicyFromSettings } from '../security';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+describe('Security analyzer + confirmation policy parity', () => {
+  it('requires security_risk when enableSecurityAnalyzer is true', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, agent: { enableSecurityAnalyzer: true } },
+      events: log,
+      workspaceRoot: process.cwd(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run tool');
+
+    const events = log.list();
+    expect(events.some(isObservationEvent)).toBe(false);
+    expect(events.some(isPauseEvent)).toBe(false);
+    expect(events.some(isAgentErrorEvent)).toBe(true);
+
+    const toolMessages = events.filter(isMessageEvent).filter((evt) => evt.llm_message.role === 'tool');
+    expect(toolMessages.length).toBe(1);
+  });
+
+  it('uses security_risk for ConfirmRisky decisions when analyzer is enabled', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      {
+        type: 'tool_call_delta',
+        id: 'call_1',
+        name: 'echo',
+        arguments: '{"security_risk":"LOW","value":"hi"}',
+      },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: {
+        ...baseSettings,
+        agent: { enableSecurityAnalyzer: true },
+        confirmation: { policy: 'risky', riskyThreshold: 'MEDIUM', confirmUnknown: true },
+      },
+      events: log,
+      workspaceRoot: process.cwd(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    await agent.run('run tool');
+
+    const events = log.list();
+    expect(events.some(isPauseEvent)).toBe(false);
+    expect(events.some(isObservationEvent)).toBe(true);
+  });
+
+  it('creates ConfirmRisky from settings with correct defaults', () => {
+    const policy = createConfirmationPolicyFromSettings({
+      policy: 'risky',
+      riskyThreshold: 'HIGH',
+      confirmUnknown: false,
+    });
+
+    expect(policy.kind).toBe('ConfirmRisky');
+    expect(policy.shouldConfirm('UNKNOWN')).toBe(false);
+    expect(policy.shouldConfirm('HIGH')).toBe(true);
+    expect(policy.shouldConfirm('MEDIUM')).toBe(false);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.security.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.security.test.ts
@@ -4,7 +4,7 @@ import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../llm';
 import { isAgentErrorEvent, isMessageEvent, isObservationEvent, isPauseEvent } from '../types';
 import type { ToolDefinition } from '../types/tools';
 import type { OpenHandsSettings } from '../types/settings';
-import { createConfirmationPolicyFromSettings } from '../security';
+import { createConfirmationPolicyFromSettings, LLMSecurityAnalyzer, type SecurityAnalyzer } from '../security';
 
 class MockLLM implements LLMClient {
   constructor(private readonly chunks: LLMStreamChunk[]) {}
@@ -109,5 +109,110 @@ describe('Security analyzer + confirmation policy parity', () => {
     expect(policy.shouldConfirm('HIGH')).toBe(true);
     expect(policy.shouldConfirm('MEDIUM')).toBe(false);
   });
-});
 
+  it('preserves runtime confirmation policy overrides across setSettings()', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, confirmation: { policy: 'always' } },
+      events: log,
+      workspaceRoot: process.cwd(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    agent.setConfirmationPolicy(createConfirmationPolicyFromSettings({ policy: 'never' }));
+    agent.setSettings({ ...baseSettings, confirmation: { policy: 'always' } });
+
+    await agent.run('run tool');
+
+    const events = log.list();
+    expect(events.some(isPauseEvent)).toBe(false);
+    expect(events.some(isObservationEvent)).toBe(true);
+  });
+
+  it('preserves runtime security analyzer overrides across setSettings()', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const agent = new Agent({
+      settings: { ...baseSettings, agent: { enableSecurityAnalyzer: false } },
+      events: log,
+      workspaceRoot: process.cwd(),
+      llmClient: llm,
+      tools: [tool],
+    });
+
+    agent.setSecurityAnalyzer(new LLMSecurityAnalyzer());
+    agent.setSettings({ ...baseSettings, agent: { enableSecurityAnalyzer: false } });
+
+    await agent.run('run tool');
+
+    const events = log.list();
+    expect(events.some(isObservationEvent)).toBe(false);
+    expect(events.some(isAgentErrorEvent)).toBe(true);
+  });
+
+  it('defaults analyzer errors to HIGH risk (confirmation required)', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"security_risk":"LOW","value":"hi"}' },
+      { type: 'finish' },
+    ]);
+
+    const throwingAnalyzer: SecurityAnalyzer = {
+      kind: 'ThrowingAnalyzer',
+      securityRisk: () => {
+        throw new Error('boom');
+      },
+      analyzeEvent: () => null,
+      analyzePendingActions: () => [],
+    };
+
+    const agent = new Agent({
+      settings: {
+        ...baseSettings,
+        confirmation: { policy: 'risky', riskyThreshold: 'HIGH', confirmUnknown: false },
+      },
+      events: log,
+      workspaceRoot: process.cwd(),
+      llmClient: llm,
+      tools: [tool],
+      securityAnalyzer: throwingAnalyzer,
+    });
+
+    await agent.run('run tool');
+
+    const events = log.list();
+    expect(events.some(isPauseEvent)).toBe(true);
+    expect(events.some(isObservationEvent)).toBe(false);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/index.ts
@@ -3,3 +3,4 @@ export * from './llm';
 export * from './runtime';
 export * from './conversation';
 export * from './context';
+export * from './security';

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -861,7 +861,7 @@ export class Agent extends EventEmitter {
       if (!properties.security_risk) {
         properties.security_risk = {
           type: 'string',
-          enum: ['LOW', 'MEDIUM', 'HIGH'],
+          enum: ['UNKNOWN', 'LOW', 'MEDIUM', 'HIGH'],
           description: 'Assessed safety risk of this tool call.',
         };
       }
@@ -1114,6 +1114,9 @@ export class Agent extends EventEmitter {
       } catch {
         risk = 'HIGH';
       }
+    }
+    if (risk === 'UNKNOWN') {
+      risk = action.security_risk ?? 'UNKNOWN';
     }
     return this.confirmationPolicy.shouldConfirm(risk);
   }

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -52,15 +52,11 @@ import { SecretMasker } from './secretMasker';
 import { ToolSummarizer } from './toolSummarizer';
 import { buildLlmRequestParametersForDebug } from '../llm/debug';
 import { StuckDetector } from '../conversation/stuckDetector';
+import type { ConfirmationPolicy, SecurityAnalyzer } from '../security';
+import { createConfirmationPolicyFromSettings, LLMSecurityAnalyzer } from '../security';
 
 
 export type AgentRunInput = string | Message;
-
-export interface ConfirmationPolicy {
-  policy?: 'never' | 'always' | 'risky';
-  riskyThreshold?: SecurityRisk;
-  confirmUnknown?: boolean;
-}
 
 export interface AgentOptions {
   settings: OpenHandsSettings;
@@ -80,9 +76,9 @@ export interface AgentOptions {
   onTerminalEvent?: (event: BashEvent) => void;
   registry?: import('../llm').LLMRegistry;
   conversationStats?: import('./ConversationStats').ConversationStats;
+  confirmationPolicy?: ConfirmationPolicy;
+  securityAnalyzer?: SecurityAnalyzer | null;
 }
-
-const SECURITY_RISK_ORDER: SecurityRisk[] = ['LOW', 'MEDIUM', 'HIGH'];
 
 // Condensation is token-budget based (maxInputTokens). When the next request would exceed that
 // budget (or the provider returns a context-limit error), we emit a `Condensation` event
@@ -115,7 +111,8 @@ export class Agent extends EventEmitter {
   private readonly secrets: SecretRegistry;
   private readonly secretMasker: SecretMasker;
   private readonly tools: Map<string, ToolDefinition<unknown, unknown>>;
-  private readonly confirmation: ConfirmationPolicy;
+  private confirmationPolicy: ConfirmationPolicy;
+  private securityAnalyzer: SecurityAnalyzer | null;
   private readonly lock = new AsyncLock();
   private llmClientPromise?: Promise<LLMClient>;
   private streamerPromise?: Promise<LLMStreamer>;
@@ -154,18 +151,25 @@ export class Agent extends EventEmitter {
     this.tools = new Map(toolsWithFinish.map((tool) => [tool.name, tool]));
     this.registry = options.registry;
     this.conversationStats = options.conversationStats;
-    this.confirmation = { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true };
+    this.confirmationPolicy = createConfirmationPolicyFromSettings(options.settings?.confirmation);
+    this.securityAnalyzer = options.settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
     this.agentContext = options.agentContext;
     this.debug = false;
     this.updateDerivedSettings(options.settings);
+
+    if (options.confirmationPolicy) {
+      this.confirmationPolicy = options.confirmationPolicy;
+    }
+    if (options.securityAnalyzer !== undefined) {
+      this.securityAnalyzer = options.securityAnalyzer;
+    }
 
     this.events.on((event) => this.emit('event', event));
   }
 
   private updateDerivedSettings(settings: OpenHandsSettings): void {
-    this.confirmation.policy = settings?.confirmation?.policy ?? 'never';
-    this.confirmation.riskyThreshold = settings?.confirmation?.riskyThreshold ?? 'MEDIUM';
-    this.confirmation.confirmUnknown = settings?.confirmation?.confirmUnknown ?? true;
+    this.confirmationPolicy = createConfirmationPolicyFromSettings(settings?.confirmation);
+    this.securityAnalyzer = settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
     this.debug = settings?.agent?.debug ?? false;
     this.toolSummarizer.updateSettings(settings, { debug: this.debug });
     this.syncToolSecrets(settings);
@@ -202,6 +206,20 @@ export class Agent extends EventEmitter {
       const newProfileId = settings?.llm?.profileId;
       console.log(`[Agent.setSettings] Settings updated. Profile: ${prevProfileId} -> ${newProfileId}, Model: ${prevModel} -> ${newModel}. Cleared streamerPromise.`);
 
+      return Promise.resolve();
+    });
+  }
+
+  setConfirmationPolicy(policy: ConfirmationPolicy): void {
+    void this.lock.acquire(() => {
+      this.confirmationPolicy = policy;
+      return Promise.resolve();
+    });
+  }
+
+  setSecurityAnalyzer(analyzer: SecurityAnalyzer | null): void {
+    void this.lock.acquire(() => {
+      this.securityAnalyzer = analyzer;
       return Promise.resolve();
     });
   }
@@ -895,8 +913,7 @@ export class Agent extends EventEmitter {
   }
 
   private shouldIncludeSecurityRiskAssessment(): boolean {
-    const policy = this.confirmation.policy ?? 'never';
-    return policy === 'always' || policy === 'risky';
+    return this.confirmationPolicy.kind !== 'NeverConfirm' || this.securityAnalyzer?.kind === 'LLMSecurityAnalyzer';
   }
 
   private async getPrimaryLlmClient(): Promise<LLMClient> {
@@ -1038,8 +1055,30 @@ export class Agent extends EventEmitter {
     try {
       const parsed: unknown = JSON.parse(raw);
       if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        const { security_risk, ...rest } = parsed as Record<string, unknown>;
-        return { args: rest, securityRisk: this.parseSecurityRisk(security_risk) };
+        const parsedObj = parsed as Record<string, unknown>;
+        const { security_risk, ...rest } = parsedObj;
+        const securityRisk = this.parseSecurityRisk(security_risk);
+
+        if (this.securityAnalyzer?.kind === 'LLMSecurityAnalyzer' && toolCall.function.name !== 'finish') {
+          if (security_risk === undefined) {
+            throw new Error(`Missing required security_risk for tool '${toolCall.function.name}'.`);
+          }
+          if (!securityRisk) {
+            const rawRisk =
+              typeof security_risk === 'string'
+                ? security_risk
+                : (() => {
+                    try {
+                      return JSON.stringify(security_risk);
+                    } catch {
+                      return '[unserializable]';
+                    }
+                  })();
+            throw new Error(`Invalid security_risk for tool '${toolCall.function.name}': ${rawRisk}`);
+          }
+        }
+
+        return { args: rest, securityRisk };
       }
       throw new Error('Tool arguments must be a JSON object.');
     } catch (e) {
@@ -1051,19 +1090,18 @@ export class Agent extends EventEmitter {
 
   private parseSecurityRisk(value: unknown): SecurityRisk | undefined {
     if (typeof value !== 'string') return undefined;
-    const normalized = value.toUpperCase() as SecurityRisk;
-    return SECURITY_RISK_ORDER.includes(normalized) ? normalized : undefined;
+    const normalized = value.toUpperCase();
+    if (normalized === 'UNKNOWN') return 'UNKNOWN';
+    if (normalized === 'LOW') return 'LOW';
+    if (normalized === 'MEDIUM') return 'MEDIUM';
+    if (normalized === 'HIGH') return 'HIGH';
+    return undefined;
   }
 
   private requiresConfirmation(action: ActionEvent): boolean {
     if (action.tool_name === 'finish') return false;
-    const policy = this.confirmation.policy ?? 'never';
-    if (policy === 'never') return false;
-    if (policy === 'always') return true;
-    const risk = action.security_risk;
-    if (!risk || risk === 'UNKNOWN') return this.confirmation.confirmUnknown ?? true;
-    const threshold = this.confirmation.riskyThreshold ?? 'MEDIUM';
-    return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(threshold);
+    const risk = this.securityAnalyzer?.securityRisk(action) ?? 'UNKNOWN';
+    return this.confirmationPolicy.shouldConfirm(risk);
   }
 
   private emitSkippedToolCall(toolCall: ToolCall, actionEvent: ActionEvent, reason: string): void {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -112,9 +112,9 @@ export class Agent extends EventEmitter {
   private readonly secretMasker: SecretMasker;
   private readonly tools: Map<string, ToolDefinition<unknown, unknown>>;
   private confirmationPolicyOverride?: ConfirmationPolicy;
-  private confirmationPolicy: ConfirmationPolicy;
+  private confirmationPolicy: ConfirmationPolicy = createConfirmationPolicyFromSettings({ policy: 'never' });
   private securityAnalyzerOverride?: SecurityAnalyzer | null;
-  private securityAnalyzer: SecurityAnalyzer | null;
+  private securityAnalyzer: SecurityAnalyzer | null = null;
   private readonly lock = new AsyncLock();
   private llmClientPromise?: Promise<LLMClient>;
   private streamerPromise?: Promise<LLMStreamer>;
@@ -163,8 +163,6 @@ export class Agent extends EventEmitter {
       this.securityAnalyzerOverride = options.securityAnalyzer;
     }
 
-    this.confirmationPolicy = createConfirmationPolicyFromSettings(options.settings?.confirmation);
-    this.securityAnalyzer = options.settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
     this.updateDerivedSettings(options.settings);
 
     this.events.on((event) => this.emit('event', event));

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -111,7 +111,9 @@ export class Agent extends EventEmitter {
   private readonly secrets: SecretRegistry;
   private readonly secretMasker: SecretMasker;
   private readonly tools: Map<string, ToolDefinition<unknown, unknown>>;
+  private confirmationPolicyOverride?: ConfirmationPolicy;
   private confirmationPolicy: ConfirmationPolicy;
+  private securityAnalyzerOverride?: SecurityAnalyzer | null;
   private securityAnalyzer: SecurityAnalyzer | null;
   private readonly lock = new AsyncLock();
   private llmClientPromise?: Promise<LLMClient>;
@@ -151,25 +153,30 @@ export class Agent extends EventEmitter {
     this.tools = new Map(toolsWithFinish.map((tool) => [tool.name, tool]));
     this.registry = options.registry;
     this.conversationStats = options.conversationStats;
-    this.confirmationPolicy = createConfirmationPolicyFromSettings(options.settings?.confirmation);
-    this.securityAnalyzer = options.settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
     this.agentContext = options.agentContext;
     this.debug = false;
-    this.updateDerivedSettings(options.settings);
 
     if (options.confirmationPolicy) {
-      this.confirmationPolicy = options.confirmationPolicy;
+      this.confirmationPolicyOverride = options.confirmationPolicy;
     }
     if (options.securityAnalyzer !== undefined) {
-      this.securityAnalyzer = options.securityAnalyzer;
+      this.securityAnalyzerOverride = options.securityAnalyzer;
     }
+
+    this.confirmationPolicy = createConfirmationPolicyFromSettings(options.settings?.confirmation);
+    this.securityAnalyzer = options.settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
+    this.updateDerivedSettings(options.settings);
 
     this.events.on((event) => this.emit('event', event));
   }
 
   private updateDerivedSettings(settings: OpenHandsSettings): void {
-    this.confirmationPolicy = createConfirmationPolicyFromSettings(settings?.confirmation);
-    this.securityAnalyzer = settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
+    const derivedConfirmationPolicy = createConfirmationPolicyFromSettings(settings?.confirmation);
+    const derivedSecurityAnalyzer = settings?.agent?.enableSecurityAnalyzer ? new LLMSecurityAnalyzer() : null;
+
+    this.confirmationPolicy = this.confirmationPolicyOverride ?? derivedConfirmationPolicy;
+    this.securityAnalyzer =
+      this.securityAnalyzerOverride !== undefined ? this.securityAnalyzerOverride : derivedSecurityAnalyzer;
     this.debug = settings?.agent?.debug ?? false;
     this.toolSummarizer.updateSettings(settings, { debug: this.debug });
     this.syncToolSecrets(settings);
@@ -212,6 +219,7 @@ export class Agent extends EventEmitter {
 
   setConfirmationPolicy(policy: ConfirmationPolicy): void {
     void this.lock.acquire(() => {
+      this.confirmationPolicyOverride = policy;
       this.confirmationPolicy = policy;
       return Promise.resolve();
     });
@@ -219,6 +227,7 @@ export class Agent extends EventEmitter {
 
   setSecurityAnalyzer(analyzer: SecurityAnalyzer | null): void {
     void this.lock.acquire(() => {
+      this.securityAnalyzerOverride = analyzer;
       this.securityAnalyzer = analyzer;
       return Promise.resolve();
     });
@@ -1100,7 +1109,14 @@ export class Agent extends EventEmitter {
 
   private requiresConfirmation(action: ActionEvent): boolean {
     if (action.tool_name === 'finish') return false;
-    const risk = this.securityAnalyzer?.securityRisk(action) ?? 'UNKNOWN';
+    let risk: SecurityRisk = 'UNKNOWN';
+    if (this.securityAnalyzer) {
+      try {
+        risk = this.securityAnalyzer.securityRisk(action);
+      } catch {
+        risk = 'HIGH';
+      }
+    }
     return this.confirmationPolicy.shouldConfirm(risk);
   }
 

--- a/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
@@ -21,6 +21,7 @@ export class LLMSecurityAnalyzer implements SecurityAnalyzer {
   }
 
   analyzePendingActions(pendingActions: ActionEvent[]): Array<{ action: ActionEvent; risk: SecurityRisk }> {
+    // Defensive: keep parity with Python analyzers; subclasses may override `securityRisk()` and throw.
     return pendingActions.map((action) => {
       try {
         return { action, risk: this.securityRisk(action) };

--- a/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
@@ -2,7 +2,7 @@ import type { ActionEvent, Event, SecurityRisk } from '../types';
 import { isActionEvent } from '../types';
 
 export interface SecurityAnalyzer {
-  kind: 'LLMSecurityAnalyzer';
+  kind: string;
   securityRisk(action: ActionEvent): SecurityRisk;
   analyzeEvent(event: Event): SecurityRisk | null;
   analyzePendingActions(pendingActions: ActionEvent[]): Array<{ action: ActionEvent; risk: SecurityRisk }>;
@@ -30,4 +30,3 @@ export class LLMSecurityAnalyzer implements SecurityAnalyzer {
     });
   }
 }
-

--- a/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
@@ -1,0 +1,33 @@
+import type { ActionEvent, Event, SecurityRisk } from '../types';
+import { isActionEvent } from '../types';
+
+export interface SecurityAnalyzer {
+  kind: 'LLMSecurityAnalyzer';
+  securityRisk(action: ActionEvent): SecurityRisk;
+  analyzeEvent(event: Event): SecurityRisk | null;
+  analyzePendingActions(pendingActions: ActionEvent[]): Array<{ action: ActionEvent; risk: SecurityRisk }>;
+}
+
+export class LLMSecurityAnalyzer implements SecurityAnalyzer {
+  readonly kind = 'LLMSecurityAnalyzer' as const;
+
+  securityRisk(action: ActionEvent): SecurityRisk {
+    return action.security_risk ?? 'UNKNOWN';
+  }
+
+  analyzeEvent(event: Event): SecurityRisk | null {
+    if (!isActionEvent(event)) return null;
+    return this.securityRisk(event);
+  }
+
+  analyzePendingActions(pendingActions: ActionEvent[]): Array<{ action: ActionEvent; risk: SecurityRisk }> {
+    return pendingActions.map((action) => {
+      try {
+        return { action, risk: this.securityRisk(action) };
+      } catch {
+        return { action, risk: 'HIGH' };
+      }
+    });
+  }
+}
+

--- a/packages/agent-sdk-ts/src/sdk/security/confirmationPolicy.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/confirmationPolicy.ts
@@ -1,0 +1,57 @@
+import type { ConfirmationSettings } from '../types/settings';
+import type { SecurityRisk } from '../types';
+
+const SECURITY_RISK_ORDER: Array<Exclude<SecurityRisk, 'UNKNOWN'>> = ['LOW', 'MEDIUM', 'HIGH'];
+
+export interface ConfirmationPolicy {
+  kind: 'AlwaysConfirm' | 'NeverConfirm' | 'ConfirmRisky';
+  shouldConfirm(risk?: SecurityRisk): boolean;
+}
+
+export class AlwaysConfirm implements ConfirmationPolicy {
+  readonly kind = 'AlwaysConfirm' as const;
+
+  shouldConfirm(_risk: SecurityRisk = 'UNKNOWN'): boolean {
+    return true;
+  }
+}
+
+export class NeverConfirm implements ConfirmationPolicy {
+  readonly kind = 'NeverConfirm' as const;
+
+  shouldConfirm(_risk: SecurityRisk = 'UNKNOWN'): boolean {
+    return false;
+  }
+}
+
+export class ConfirmRisky implements ConfirmationPolicy {
+  readonly kind = 'ConfirmRisky' as const;
+  readonly threshold: Exclude<SecurityRisk, 'UNKNOWN'>;
+  readonly confirmUnknown: boolean;
+
+  constructor(options?: { threshold?: Exclude<SecurityRisk, 'UNKNOWN'>; confirmUnknown?: boolean }) {
+    const threshold = options?.threshold ?? 'HIGH';
+    if (!SECURITY_RISK_ORDER.includes(threshold)) {
+      throw new Error('ConfirmRisky.threshold cannot be UNKNOWN.');
+    }
+    this.threshold = threshold;
+    this.confirmUnknown = options?.confirmUnknown ?? true;
+  }
+
+  shouldConfirm(risk: SecurityRisk = 'UNKNOWN'): boolean {
+    if (risk === 'UNKNOWN') return this.confirmUnknown;
+    return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(this.threshold);
+  }
+}
+
+export const createConfirmationPolicyFromSettings = (settings?: ConfirmationSettings): ConfirmationPolicy => {
+  const policy = settings?.policy ?? 'never';
+  if (policy === 'always') return new AlwaysConfirm();
+  if (policy === 'risky') {
+    const threshold = (settings?.riskyThreshold?.toUpperCase() as Exclude<SecurityRisk, 'UNKNOWN'> | undefined) ?? 'MEDIUM';
+    const confirmUnknown = settings?.confirmUnknown ?? true;
+    return new ConfirmRisky({ threshold, confirmUnknown });
+  }
+  return new NeverConfirm();
+};
+

--- a/packages/agent-sdk-ts/src/sdk/security/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/index.ts
@@ -1,0 +1,3 @@
+export * from './confirmationPolicy';
+export * from './analyzer';
+

--- a/src/extension/gitDiffSummary.ts
+++ b/src/extension/gitDiffSummary.ts
@@ -1,4 +1,5 @@
 import * as childProcess from 'child_process';
+import * as fs from 'node:fs/promises';
 import * as path from 'path';
 
 function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
@@ -23,7 +24,9 @@ export async function getGitHeadDiffSummaryForFile(filePath: string): Promise<st
     return '(no HEAD available)';
   }
 
-  const relative = path.relative(root, filePath);
+  const normalizedRoot = await fs.realpath(root).catch(() => root);
+  const normalizedFilePath = await fs.realpath(filePath).catch(() => filePath);
+  const relative = path.relative(normalizedRoot, normalizedFilePath);
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
     return '(no HEAD available)';
   }


### PR DESCRIPTION
Implements agent-sdk-ts parity abstractions for confirmation/security handling.

- Adds `ConfirmationPolicy` + built-in policies (`NeverConfirm`, `AlwaysConfirm`, `ConfirmRisky`) under `packages/agent-sdk-ts/src/sdk/security/`.
- Adds `SecurityAnalyzer` + `LLMSecurityAnalyzer` under `packages/agent-sdk-ts/src/sdk/security/`.
- Refactors `Agent` to use injected policy/analyzer and exposes runtime mutation APIs: `setConfirmationPolicy()` / `setSecurityAnalyzer()`.
- Adds unit tests covering analyzer-required `security_risk` and ConfirmRisky behavior.

Extra (test/bugfix):
- Fixes `getGitHeadDiffSummaryForFile()` path normalization on macOS (`/var` vs `/private/var`) so git diff summaries work inside temp repos.

Refs: GH #659, Beads `oh-tab-ne72`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced security risk assessment and confirmation policy framework for agent actions
  * Added configurable confirmation policies: always confirm, never confirm, or confirm based on risk level

* **Bug Fixes**
  * Improved Git path normalization to correctly handle symlink scenarios

* **Tests**
  * Added comprehensive test suite for security analyzer and confirmation policy integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->