### PR TITLE
agent-sdk-ts parity: RemoteConversation runtime policy setters (#642)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -908,6 +908,7 @@ describe('RemoteConversation', () => {
 
       if (url.includes('/confirmation_policy')) {
         expect(init?.method).toBe('POST');
+        expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
         const body = JSON.parse(init?.body ?? '{}');
         expect(body).toEqual({
           policy: { kind: 'ConfirmRisky', threshold: 'HIGH', confirm_unknown: false },
@@ -925,7 +926,10 @@ describe('RemoteConversation', () => {
     (globalThis as any).fetch = fetchMock;
 
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
-    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key' } },
+    });
 
     await conversation.restoreConversation('abc');
 
@@ -957,6 +961,7 @@ describe('RemoteConversation', () => {
       if (url.includes('/security_analyzer')) {
         call += 1;
         expect(init?.method).toBe('POST');
+        expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
         const body = JSON.parse(init?.body ?? '{}');
         if (call === 1) {
           expect(body).toEqual({ security_analyzer: { kind: 'LLMSecurityAnalyzer' } });
@@ -976,7 +981,10 @@ describe('RemoteConversation', () => {
     (globalThis as any).fetch = fetchMock;
 
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
-    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key' } },
+    });
 
     await conversation.restoreConversation('abc');
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -4,6 +4,8 @@ import os from 'os';
 import path from 'path';
 import type { Event } from '../types';
 import { saveProfile } from '../llm';
+import { ConfirmRisky } from '../security/confirmationPolicy';
+import { LLMSecurityAnalyzer } from '../security/analyzer';
 
 let wsInstances: MockWS[] = [];
 
@@ -891,6 +893,105 @@ describe('RemoteConversation', () => {
     await conversation.restoreConversation('abc');
 
     await expect(conversation.updateSecrets({ GITHUB_TOKEN: 'ghp_abc123' })).rejects.toThrow('Failed to update secrets (HTTP 403): forbidden');
+  });
+
+  it('setConfirmationPolicy posts /confirmation_policy', async () => {
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/confirmation_policy')) {
+        expect(init?.method).toBe('POST');
+        const body = JSON.parse(init?.body ?? '{}');
+        expect(body).toEqual({
+          policy: { kind: 'ConfirmRisky', threshold: 'HIGH', confirm_unknown: false },
+        });
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.setConfirmationPolicy(new ConfirmRisky({ threshold: 'HIGH', confirmUnknown: false }))).resolves.toBeUndefined();
+    conversation.disconnect();
+  });
+
+  it('setConfirmationPolicy throws when no active conversation', async () => {
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await expect(conversation.setConfirmationPolicy({ kind: 'NeverConfirm' })).rejects.toThrow(
+      'Cannot setConfirmationPolicy: no active conversation. Start or restore a conversation first.',
+    );
+  });
+
+  it('setSecurityAnalyzer posts /security_analyzer and supports null', async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/events/search')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ items: [], next_page_id: null }),
+          text: async () => '',
+        } as any;
+      }
+
+      if (url.includes('/security_analyzer')) {
+        call += 1;
+        expect(init?.method).toBe('POST');
+        const body = JSON.parse(init?.body ?? '{}');
+        if (call === 1) {
+          expect(body).toEqual({ security_analyzer: { kind: 'LLMSecurityAnalyzer' } });
+        } else {
+          expect(body).toEqual({ security_analyzer: null });
+        }
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({}),
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await conversation.restoreConversation('abc');
+
+    await expect(conversation.setSecurityAnalyzer(new LLMSecurityAnalyzer())).resolves.toBeUndefined();
+    await expect(conversation.setSecurityAnalyzer(null)).resolves.toBeUndefined();
+    conversation.disconnect();
+  });
+
+  it('setSecurityAnalyzer throws when no active conversation', async () => {
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
+
+    await expect(conversation.setSecurityAnalyzer(null)).rejects.toThrow(
+      'Cannot setSecurityAnalyzer: no active conversation. Start or restore a conversation first.',
+    );
   });
 
   it('getWorkspace exposes a RemoteWorkspace using sessionApiKey and invalidates on key change', async () => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -18,6 +18,8 @@ import type { BaseWorkspace } from '../../workspace';
 import { Workspace } from '../../workspace';
 import { LLMRegistry } from '../llm';
 import type { RegistryEvent } from '../llm/registry';
+import type { ConfirmationPolicy } from '../security/confirmationPolicy';
+import type { SecurityAnalyzer } from '../security/analyzer';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime';
 import { AgentContext } from '../context';
@@ -236,6 +238,16 @@ export class LocalConversation extends EventEmitter {
 
   async resume(): Promise<void> {
     await this.agent.resume();
+  }
+
+  setConfirmationPolicy(policy: ConfirmationPolicy): Promise<void> {
+    this.agent.setConfirmationPolicy(policy);
+    return Promise.resolve();
+  }
+
+  setSecurityAnalyzer(analyzer: SecurityAnalyzer | null): Promise<void> {
+    this.agent.setSecurityAnalyzer(analyzer);
+    return Promise.resolve();
   }
 
   approveAction(): Promise<void> {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -109,7 +109,7 @@ export class RemoteConversation extends EventEmitter {
     return value as Record<string, unknown>;
   }
 
-  private serializeConfirmationPolicy(policy: ConfirmationPolicy | RemoteConfirmationPolicyPayload): RemoteConfirmationPolicyPayload {
+  private serializeConfirmationPolicy(policy: ConfirmationPolicy): RemoteConfirmationPolicyPayload {
     if (policy.kind === 'AlwaysConfirm') return { kind: 'AlwaysConfirm' };
     if (policy.kind === 'NeverConfirm') return { kind: 'NeverConfirm' };
 
@@ -137,7 +137,7 @@ export class RemoteConversation extends EventEmitter {
     return { kind: 'ConfirmRisky', threshold: normalizedThreshold, confirm_unknown: normalizedConfirmUnknown };
   }
 
-  private serializeSecurityAnalyzer(analyzer: SecurityAnalyzer | RemoteSecurityAnalyzerPayload | null | undefined): RemoteSecurityAnalyzerPayload | null {
+  private serializeSecurityAnalyzer(analyzer: SecurityAnalyzer | null | undefined): RemoteSecurityAnalyzerPayload | null {
     if (analyzer === null || analyzer === undefined) return null;
     if (analyzer.kind === 'LLMSecurityAnalyzer') return { kind: 'LLMSecurityAnalyzer' };
     const kind = this.asRecord(analyzer)?.kind;
@@ -466,7 +466,7 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
-  async setConfirmationPolicy(policy: ConfirmationPolicy | RemoteConfirmationPolicyPayload): Promise<void> {
+  async setConfirmationPolicy(policy: ConfirmationPolicy): Promise<void> {
     if (!this.conversationId) {
       throw new Error('Cannot setConfirmationPolicy: no active conversation. Start or restore a conversation first.');
     }
@@ -485,7 +485,7 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
-  async setSecurityAnalyzer(analyzer: SecurityAnalyzer | RemoteSecurityAnalyzerPayload | null): Promise<void> {
+  async setSecurityAnalyzer(analyzer: SecurityAnalyzer | null): Promise<void> {
     if (!this.conversationId) {
       throw new Error('Cannot setSecurityAnalyzer: no active conversation. Start or restore a conversation first.');
     }

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -6,6 +6,8 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { LLMProfileStoreOptions } from '../llm/profiles';
 import { loadProfile } from '../llm/profiles';
 import type { LLMConfiguration } from '../llm/types';
+import type { ConfirmationPolicy } from '../security/confirmationPolicy';
+import type { SecurityAnalyzer } from '../security/analyzer';
 import { RemoteState } from './RemoteState';
 import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
 import type { BaseWorkspace } from '../../workspace/BaseWorkspace';
@@ -30,6 +32,14 @@ export type RemoteConversationWorkspace = {
   kind: string;
   [key: string]: unknown;
 };
+
+export type RemoteConfirmationPolicyPayload =
+  | { kind: 'AlwaysConfirm' }
+  | { kind: 'NeverConfirm' }
+  | { kind: 'ConfirmRisky'; threshold: 'LOW' | 'MEDIUM' | 'HIGH'; confirm_unknown: boolean };
+
+export type RemoteSecurityAnalyzerPayload =
+  | { kind: 'LLMSecurityAnalyzer' };
 
 const toStaticSecret = (value: unknown): StaticSecret | undefined => {
   if (typeof value !== 'string') return undefined;
@@ -93,6 +103,38 @@ export class RemoteConversation extends EventEmitter {
   readonly state: RemoteState;
   private workspaceClient?: RemoteWorkspace;
 
+
+  private serializeConfirmationPolicy(policy: ConfirmationPolicy | RemoteConfirmationPolicyPayload): RemoteConfirmationPolicyPayload {
+    if (policy.kind === 'AlwaysConfirm') return { kind: 'AlwaysConfirm' };
+    if (policy.kind === 'NeverConfirm') return { kind: 'NeverConfirm' };
+
+    if (policy.kind !== 'ConfirmRisky') {
+      throw new Error(`setConfirmationPolicy: unsupported policy kind '${String((policy as { kind: unknown }).kind)}'`);
+    }
+
+    const threshold = (policy as { threshold?: unknown }).threshold;
+    const confirmUnknown = (policy as { confirmUnknown?: unknown }).confirmUnknown;
+    const confirm_unknown = (policy as { confirm_unknown?: unknown }).confirm_unknown;
+
+    const normalizedThreshold = typeof threshold === 'string' ? threshold.toUpperCase() : undefined;
+    if (normalizedThreshold !== 'LOW' && normalizedThreshold !== 'MEDIUM' && normalizedThreshold !== 'HIGH') {
+      throw new Error('setConfirmationPolicy: ConfirmRisky.threshold must be one of LOW, MEDIUM, HIGH');
+    }
+
+    const normalizedConfirmUnknown = typeof confirmUnknown === 'boolean'
+      ? confirmUnknown
+      : typeof confirm_unknown === 'boolean'
+        ? confirm_unknown
+        : true;
+
+    return { kind: 'ConfirmRisky', threshold: normalizedThreshold, confirm_unknown: normalizedConfirmUnknown };
+  }
+
+  private serializeSecurityAnalyzer(analyzer: SecurityAnalyzer | RemoteSecurityAnalyzerPayload | null | undefined): RemoteSecurityAnalyzerPayload | null {
+    if (analyzer === null || analyzer === undefined) return null;
+    if (analyzer.kind === 'LLMSecurityAnalyzer') return { kind: 'LLMSecurityAnalyzer' };
+    throw new Error(`setSecurityAnalyzer: unsupported analyzer kind '${String((analyzer as { kind: unknown }).kind)}'`);
+  }
 
   constructor(options: RemoteConversationOptions) {
     super();
@@ -288,7 +330,7 @@ export class RemoteConversation extends EventEmitter {
       maybeSetSecret('CUSTOM_SECRET_2', s?.secrets.customSecret2);
       maybeSetSecret('CUSTOM_SECRET_3', s?.secrets.customSecret3);
 
-      const confirmation_policy: Record<string, unknown> = (() => {
+      const confirmation_policy: RemoteConfirmationPolicyPayload = (() => {
         const p = s?.confirmation.policy || 'never';
         if (p === 'always') return { kind: 'AlwaysConfirm' };
         if (p === 'risky') {
@@ -318,7 +360,7 @@ export class RemoteConversation extends EventEmitter {
         agent: {
           llm,
           tools,
-          security_analyzer: s?.agent.enableSecurityAnalyzer ? { kind: 'LLMSecurityAnalyzer' } : undefined,
+          security_analyzer: s?.agent.enableSecurityAnalyzer ? ({ kind: 'LLMSecurityAnalyzer' } satisfies RemoteSecurityAnalyzerPayload) : undefined,
         },
         workspace,
         secrets: typedSecrets,
@@ -413,6 +455,44 @@ export class RemoteConversation extends EventEmitter {
       }
     } catch (e) {
       this.emit('error', e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  async setConfirmationPolicy(policy: ConfirmationPolicy | RemoteConfirmationPolicyPayload): Promise<void> {
+    if (!this.conversationId) {
+      throw new Error('Cannot setConfirmationPolicy: no active conversation. Start or restore a conversation first.');
+    }
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/confirmation_policy`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ policy: this.serializeConfirmationPolicy(policy) }),
+    }, RemoteConversation.httpTimeoutMs);
+
+    if (!res.ok) {
+      const info = await res.text().catch(() => '');
+      throw new Error(`Failed to set confirmation policy (HTTP ${res.status})${info ? `: ${info}` : ''}`);
+    }
+  }
+
+  async setSecurityAnalyzer(analyzer: SecurityAnalyzer | RemoteSecurityAnalyzerPayload | null): Promise<void> {
+    if (!this.conversationId) {
+      throw new Error('Cannot setSecurityAnalyzer: no active conversation. Start or restore a conversation first.');
+    }
+
+    const base = this.serverUrl.replace(/\/$/, '');
+    const headers = this.getAuthHeaders();
+    const res = await this.fetchWithTimeout(`${base}/api/conversations/${this.conversationId}/security_analyzer`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ security_analyzer: this.serializeSecurityAnalyzer(analyzer) }),
+    }, RemoteConversation.httpTimeoutMs);
+
+    if (!res.ok) {
+      const info = await res.text().catch(() => '');
+      throw new Error(`Failed to set security analyzer (HTTP ${res.status})${info ? `: ${info}` : ''}`);
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -104,17 +104,24 @@ export class RemoteConversation extends EventEmitter {
   private workspaceClient?: RemoteWorkspace;
 
 
+  private asRecord(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    return value as Record<string, unknown>;
+  }
+
   private serializeConfirmationPolicy(policy: ConfirmationPolicy | RemoteConfirmationPolicyPayload): RemoteConfirmationPolicyPayload {
     if (policy.kind === 'AlwaysConfirm') return { kind: 'AlwaysConfirm' };
     if (policy.kind === 'NeverConfirm') return { kind: 'NeverConfirm' };
 
     if (policy.kind !== 'ConfirmRisky') {
-      throw new Error(`setConfirmationPolicy: unsupported policy kind '${String((policy as { kind: unknown }).kind)}'`);
+      const kind = this.asRecord(policy)?.kind;
+      throw new Error(`setConfirmationPolicy: unsupported policy kind '${typeof kind === 'string' ? kind : String(kind)}'`);
     }
 
-    const threshold = (policy as { threshold?: unknown }).threshold;
-    const confirmUnknown = (policy as { confirmUnknown?: unknown }).confirmUnknown;
-    const confirm_unknown = (policy as { confirm_unknown?: unknown }).confirm_unknown;
+    const record = this.asRecord(policy);
+    const threshold = record?.threshold;
+    const confirmUnknown = record?.confirmUnknown;
+    const confirm_unknown = record?.confirm_unknown;
 
     const normalizedThreshold = typeof threshold === 'string' ? threshold.toUpperCase() : undefined;
     if (normalizedThreshold !== 'LOW' && normalizedThreshold !== 'MEDIUM' && normalizedThreshold !== 'HIGH') {
@@ -133,7 +140,8 @@ export class RemoteConversation extends EventEmitter {
   private serializeSecurityAnalyzer(analyzer: SecurityAnalyzer | RemoteSecurityAnalyzerPayload | null | undefined): RemoteSecurityAnalyzerPayload | null {
     if (analyzer === null || analyzer === undefined) return null;
     if (analyzer.kind === 'LLMSecurityAnalyzer') return { kind: 'LLMSecurityAnalyzer' };
-    throw new Error(`setSecurityAnalyzer: unsupported analyzer kind '${String((analyzer as { kind: unknown }).kind)}'`);
+    const kind = this.asRecord(analyzer)?.kind;
+    throw new Error(`setSecurityAnalyzer: unsupported analyzer kind '${typeof kind === 'string' ? kind : String(kind)}'`);
   }
 
   constructor(options: RemoteConversationOptions) {


### PR DESCRIPTION
Implements python RemoteConversation runtime setters:
- `setConfirmationPolicy(...)` → POST `/api/conversations/{id}/confirmation_policy`
- `setSecurityAnalyzer(...)` → POST `/api/conversations/{id}/security_analyzer` (supports `null`)

Notes:
- Keeps profiles behavior unchanged (still does **not** send `profile_id` to server).
- Adds unit tests for both endpoints.

Local verification:
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run build:types -w @openhands/agent-sdk-ts`
- `npm test -w @openhands/agent-sdk-ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added methods to remotely configure confirmation policies and security analyzers in conversations
  - Introduced strict type definitions for enhanced validation of policy and analyzer payloads

* **Tests**
  - Added comprehensive test coverage for new configuration methods, including success and error scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->