### PR TITLE
agent-sdk-ts parity: Skills SKILL.md dirs + naming validation (#653)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
@@ -193,6 +193,18 @@ describe('AgentContext', () => {
       expect(suffix).not.toContain('Knowledge');
     });
 
+    it('excludes AgentSkills-format skills from system suffix even when trigger is null', () => {
+      const agentSkill = new Skill({
+        name: 'my-skill',
+        content: 'AgentSkills content (should not be injected)',
+        trigger: null,
+        isAgentSkillsFormat: true,
+      });
+
+      const context = new AgentContext({ skills: [agentSkill] });
+      expect(context.getSystemMessageSuffix()).toBeNull();
+    });
+
     it('appends custom system message suffix', () => {
       const repoSkill = new Skill({ name: 'repo', content: 'Repo', trigger: null });
 

--- a/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
@@ -87,7 +87,7 @@ export class AgentContext {
    * - Repository-specific instructions (collected from repo skills)
    */
   getSystemMessageSuffix(options?: { secretNames?: string[] }): string | null {
-    const repoSkills = this.skills.filter((s) => s.trigger === null);
+    const repoSkills = this.skills.filter((s) => s.trigger === null && !s.isAgentSkillsFormat);
 
     const parts: string[] = [];
 

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -250,6 +250,34 @@ Refactor \${target_file} using \${pattern}.`;
       expect(skill.inputs[1].name).toBe('pattern');
     });
 
+    it('loads AgentSkills-format SKILL.md using parent directory name', () => {
+      const skillRoot = join(tempDir, 'my-skill');
+      mkdirSync(skillRoot, { recursive: true });
+      const skillPath = join(skillRoot, 'SKILL.md');
+      writeFileSync(skillPath, `---
+description: Example skill
+---
+
+Agent skill content.`);
+
+      const skill = Skill.load({ path: skillPath });
+
+      expect(skill.name).toBe('my-skill');
+      expect(skill.isAgentSkillsFormat).toBe(true);
+      expect(skill.description).toBe('Example skill');
+      expect(skill.source).toBe(skillPath);
+    });
+
+    it('validates AgentSkills-format skill name strictly', () => {
+      const skillRoot = join(tempDir, 'BadSkill');
+      mkdirSync(skillRoot, { recursive: true });
+      const skillPath = join(skillRoot, 'skill.md');
+      writeFileSync(skillPath, 'Content');
+
+      expect(() => Skill.load({ path: skillPath })).toThrow(SkillValidationError);
+      expect(() => Skill.load({ path: skillPath })).toThrow("Invalid skill name 'BadSkill'");
+    });
+
     it('adds skill name trigger for task skills', () => {
       const skillPath = join(tempDir, 'mytask.md');
       const content = `---
@@ -394,6 +422,36 @@ Knowledge content`);
       const { repoSkills } = loadSkillsFromDir(skillDir);
 
       expect(repoSkills.has('subdir/nested-skill')).toBe(true);
+    });
+
+    it('loads AgentSkills-format skills from SKILL.md directories and excludes those dirs from legacy scanning', () => {
+      const agentSkillDir = join(skillDir, 'my-skill');
+      mkdirSync(agentSkillDir, { recursive: true });
+      writeFileSync(join(agentSkillDir, 'SKILL.md'), 'Agent skill content');
+
+      // This should NOT be treated as a legacy skill file.
+      writeFileSync(join(agentSkillDir, 'nested-skill.md'), 'Legacy nested content');
+
+      const { repoSkills, agentSkills } = loadSkillsFromDir(skillDir);
+
+      expect(agentSkills.has('my-skill')).toBe(true);
+      expect(agentSkills.get('my-skill')?.isAgentSkillsFormat).toBe(true);
+
+      expect(repoSkills.has('my-skill/nested-skill')).toBe(false);
+      expect(repoSkills.has('my-skill/SKILL')).toBe(false);
+    });
+
+    it('throws SkillValidationError when AgentSkills SKILL.md name does not match directory', () => {
+      const agentSkillDir = join(skillDir, 'good-skill');
+      mkdirSync(agentSkillDir, { recursive: true });
+      writeFileSync(join(agentSkillDir, 'SKILL.md'), `---
+name: other-skill
+---
+
+Content`);
+
+      expect(() => loadSkillsFromDir(skillDir)).toThrow(SkillValidationError);
+      expect(() => loadSkillsFromDir(skillDir)).toThrow("does not match directory 'good-skill'");
     });
 
     it('skips README.md files', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -274,8 +274,15 @@ Agent skill content.`);
       const skillPath = join(skillRoot, 'skill.md');
       writeFileSync(skillPath, 'Content');
 
-      expect(() => Skill.load({ path: skillPath })).toThrow(SkillValidationError);
-      expect(() => Skill.load({ path: skillPath })).toThrow("Invalid skill name 'BadSkill'");
+      let error: unknown;
+      try {
+        Skill.load({ path: skillPath });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(SkillValidationError);
+      expect((error as Error | undefined)?.message).toContain("Invalid skill name 'BadSkill'");
     });
 
     it('adds skill name trigger for task skills', () => {
@@ -450,8 +457,15 @@ name: other-skill
 
 Content`);
 
-      expect(() => loadSkillsFromDir(skillDir)).toThrow(SkillValidationError);
-      expect(() => loadSkillsFromDir(skillDir)).toThrow("does not match directory 'good-skill'");
+      let error: unknown;
+      try {
+        loadSkillsFromDir(skillDir);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(SkillValidationError);
+      expect((error as Error | undefined)?.message).toContain("does not match directory 'good-skill'");
     });
 
     it('skips README.md files', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -4,10 +4,17 @@
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
-import { basename, join, relative } from 'path';
+import { basename, dirname, join, relative } from 'path';
 import { homedir } from 'os';
 import frontmatter from 'front-matter';
 import type { InputMetadata, TriggerType } from './types';
+
+// Regex pattern for valid AgentSkills names (strict):
+// - 1-64 characters
+// - lowercase alphanumeric + single hyphens only (a-z, 0-9, -)
+// - must not start or end with hyphen
+// - must not contain consecutive hyphens (--)
+const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 /**
  * Error thrown when skill validation fails.
@@ -33,6 +40,8 @@ export class Skill {
   trigger: TriggerType;
   source: string | null;
   inputs: InputMetadata[];
+  isAgentSkillsFormat: boolean;
+  description: string | null;
 
   // Map third-party files to skill names
   public static readonly PATH_TO_THIRD_PARTY_SKILL_NAME: Record<string, string> = {
@@ -47,12 +56,16 @@ export class Skill {
     trigger: TriggerType;
     source?: string | null;
     inputs?: InputMetadata[];
+    isAgentSkillsFormat?: boolean;
+    description?: string | null;
   }) {
     this.name = params.name;
     this.content = params.content;
     this.trigger = params.trigger;
     this.source = params.source ?? null;
     this.inputs = params.inputs ?? [];
+    this.isAgentSkillsFormat = params.isAgentSkillsFormat ?? false;
+    this.description = params.description ?? null;
 
     // Append missing variables prompt for task skills
     if (this.trigger?.type === 'task' && this.requiresUserInput()) {
@@ -90,9 +103,13 @@ export class Skill {
   static load(params: { path: string; skillDir?: string | null; fileContent?: string | null }): Skill {
     const { path: filePath, skillDir, fileContent: providedContent } = params;
 
+    const isSkillMd = basename(filePath).toLowerCase() === 'skill.md';
+
     // Calculate derived name from relative path if skillDir is provided
     let skillName: string;
-    if (skillDir) {
+    if (isSkillMd) {
+      skillName = basename(dirname(filePath));
+    } else if (skillDir) {
       const baseName = basename(filePath).toLowerCase();
       skillName =
         this.PATH_TO_THIRD_PARTY_SKILL_NAME[baseName] ??
@@ -115,8 +132,22 @@ export class Skill {
     const content = parsed.body;
     const metadata = parsed.attributes || {};
 
-    // Use name from frontmatter if provided, otherwise use derived name
-    const name = (metadata.name as string) ?? skillName;
+    // Use name from frontmatter if provided, otherwise use derived name.
+    // For AgentSkills-format SKILL.md, the derived name is the parent directory name.
+    const name = (typeof metadata.name === 'string' && metadata.name.trim())
+      ? metadata.name.trim()
+      : skillName;
+
+    // AgentSkills-format strict name validation (Python parity).
+    if (isSkillMd) {
+      const directoryName = skillName;
+      const errors = validateAgentSkillName(name, directoryName);
+      if (errors.length) {
+        throw new SkillValidationError(`Invalid skill name '${name}': ${errors.join('; ')}`);
+      }
+    }
+
+    const description = typeof metadata.description === 'string' ? metadata.description : null;
 
     // Validate and parse trigger keywords from metadata
     const triggerMetadata = metadata.triggers;
@@ -154,6 +185,8 @@ export class Skill {
         name,
         content,
         source: filePath,
+        isAgentSkillsFormat: isSkillMd,
+        description,
         trigger: { type: 'task', triggers: keywords },
         inputs,
       });
@@ -162,6 +195,8 @@ export class Skill {
         name,
         content,
         source: filePath,
+        isAgentSkillsFormat: isSkillMd,
+        description,
         trigger: { type: 'keyword', keywords },
       });
     } else {
@@ -170,6 +205,8 @@ export class Skill {
         name,
         content,
         source: filePath,
+        isAgentSkillsFormat: isSkillMd,
+        description,
         trigger: null,
       });
     }
@@ -236,9 +273,11 @@ export class Skill {
 export function loadSkillsFromDir(skillDir: string): {
   repoSkills: Map<string, Skill>;
   knowledgeSkills: Map<string, Skill>;
+  agentSkills: Map<string, Skill>;
 } {
   const repoSkills = new Map<string, Skill>();
   const knowledgeSkills = new Map<string, Skill>();
+  const agentSkills = new Map<string, Skill>();
 
   // Get repo root (two levels up from skillDir)
   const repoRoot = join(skillDir, '..', '..');
@@ -255,8 +294,11 @@ export function loadSkillsFromDir(skillDir: string): {
     }
   }
 
-  // Collect .md files from skills directory if it exists
-  const mdFiles: string[] = [];
+  const agentSkillMdFiles = findSkillMdDirectories(skillDir);
+  const excludedDirs = new Set(agentSkillMdFiles.map((p) => dirname(p)));
+
+  // Collect legacy .md files from skills directory if it exists
+  const mdFiles: string[] = [...agentSkillMdFiles];
   if (existsSync(skillDir)) {
     const collectMarkdownFiles = (dir: string): void => {
       const entries = readdirSync(dir);
@@ -264,8 +306,9 @@ export function loadSkillsFromDir(skillDir: string): {
         const fullPath = join(dir, entry);
         const stat = statSync(fullPath);
         if (stat.isDirectory()) {
+          if (excludedDirs.has(fullPath)) continue;
           collectMarkdownFiles(fullPath);
-        } else if (entry.endsWith('.md') && entry !== 'README.md') {
+        } else if (entry.endsWith('.md') && entry !== 'README.md' && entry.toLowerCase() !== 'skill.md') {
           mdFiles.push(fullPath);
         }
       }
@@ -277,7 +320,10 @@ export function loadSkillsFromDir(skillDir: string): {
   for (const file of [...specialFiles, ...mdFiles]) {
     try {
       const skill = Skill.load({ path: file, skillDir });
-      if (skill.trigger === null) {
+      const isSkillMd = basename(file).toLowerCase() === 'skill.md';
+      if (isSkillMd) {
+        agentSkills.set(skill.name, skill);
+      } else if (skill.trigger === null) {
         repoSkills.set(skill.name, skill);
       } else {
         // KeywordTrigger and TaskTrigger skills
@@ -292,7 +338,7 @@ export function loadSkillsFromDir(skillDir: string): {
     }
   }
 
-  return { repoSkills, knowledgeSkills };
+  return { repoSkills, knowledgeSkills, agentSkills };
 }
 
 /**
@@ -320,10 +366,10 @@ export function loadUserSkills(): Skill[] {
     }
 
     try {
-      const { repoSkills, knowledgeSkills } = loadSkillsFromDir(skillsDir);
+      const { repoSkills, knowledgeSkills, agentSkills } = loadSkillsFromDir(skillsDir);
 
-      // Merge repo and knowledge skills
-      for (const skillsMap of [repoSkills, knowledgeSkills]) {
+      // Merge repo, knowledge, and agent skills (AgentSkills format)
+      for (const skillsMap of [repoSkills, knowledgeSkills, agentSkills]) {
         for (const [name, skill] of skillsMap.entries()) {
           if (!seenNames.has(name)) {
             allSkills.push(skill);
@@ -338,4 +384,51 @@ export function loadUserSkills(): Skill[] {
   }
 
   return allSkills;
+}
+
+function validateAgentSkillName(name: string, directoryName?: string): string[] {
+  const errors: string[] = [];
+
+  if (!name) {
+    errors.push('Name cannot be empty');
+    return errors;
+  }
+
+  if (name.length > 64) {
+    errors.push(`Name exceeds 64 characters: ${name.length}`);
+  }
+
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    errors.push('Name must be lowercase alphanumeric with single hyphens (e.g., \'my-skill\', \'pdf-tools\')');
+  }
+
+  if (directoryName && name !== directoryName) {
+    errors.push(`Name '${name}' does not match directory '${directoryName}'`);
+  }
+
+  return errors;
+}
+
+function findSkillMd(skillDir: string): string | null {
+  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
+  const entries = readdirSync(skillDir);
+  for (const entry of entries) {
+    const fullPath = join(skillDir, entry);
+    if (statSync(fullPath).isFile() && entry.toLowerCase() === 'skill.md') {
+      return fullPath;
+    }
+  }
+  return null;
+}
+
+function findSkillMdDirectories(skillsDir: string): string[] {
+  const results: string[] = [];
+  if (!existsSync(skillsDir) || !statSync(skillsDir).isDirectory()) return results;
+  for (const entry of readdirSync(skillsDir)) {
+    const fullPath = join(skillsDir, entry);
+    if (!statSync(fullPath).isDirectory()) continue;
+    const skillMd = findSkillMd(fullPath);
+    if (skillMd) results.push(skillMd);
+  }
+  return results;
 }


### PR DESCRIPTION
Implements Python parity for AgentSkills-format skills:

- Discover AgentSkills directories containing `SKILL.md` (case-insensitive)
- Strict AgentSkills name validation (<=64 chars, lowercase [a-z0-9] with single hyphens, name must match directory)
- Exclude SKILL.md directories from legacy `.md` skill scanning
- Mark `Skill.isAgentSkillsFormat` and ensure AgentSkills-format skills are never injected into `<REPO_CONTEXT>`

Tests:
- Added/updated unit tests in skills + AgentContext.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AgentSkills format with automatic skill name validation
  * Agent-formatted skills are now properly excluded from system message context

* **Chores**
  * Added tests for AgentSkills format loading and validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->