### PR TITLE
agent-sdk-ts parity: Export composeCallbacks() utility (#644)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/composeCallbacks.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/composeCallbacks.test.ts
@@ -7,7 +7,7 @@ describe('composeCallbacks', () => {
     const a = vi.fn((value: string) => calls.push(`a:${value}`));
     const b = vi.fn((value: string) => calls.push(`b:${value}`));
 
-    const composed = composeCallbacks<string>([a, null, undefined, b]);
+    const composed = composeCallbacks<[string]>([a, null, undefined, b]);
     composed('x');
 
     expect(a).toHaveBeenCalledTimes(1);
@@ -16,7 +16,7 @@ describe('composeCallbacks', () => {
   });
 
   it('works with an empty callback list', () => {
-    const composed = composeCallbacks<number>([]);
+    const composed = composeCallbacks<[number]>([]);
     expect(() => composed(123)).not.toThrow();
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/composeCallbacks.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/composeCallbacks.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { composeCallbacks } from '../utils/composeCallbacks';
+
+describe('composeCallbacks', () => {
+  it('invokes callbacks in order and skips null/undefined', () => {
+    const calls: string[] = [];
+    const a = vi.fn((value: string) => calls.push(`a:${value}`));
+    const b = vi.fn((value: string) => calls.push(`b:${value}`));
+
+    const composed = composeCallbacks<string>([a, null, undefined, b]);
+    composed('x');
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual(['a:x', 'b:x']);
+  });
+
+  it('works with an empty callback list', () => {
+    const composed = composeCallbacks<number>([]);
+    expect(() => composed(123)).not.toThrow();
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/index.ts
@@ -4,3 +4,4 @@ export * from './runtime';
 export * from './conversation';
 export * from './context';
 export * from './security';
+export * from './utils';

--- a/packages/agent-sdk-ts/src/sdk/utils/composeCallbacks.ts
+++ b/packages/agent-sdk-ts/src/sdk/utils/composeCallbacks.ts
@@ -1,0 +1,9 @@
+export type Callback<T> = ((arg: T) => void) | null | undefined;
+
+export function composeCallbacks<T>(callbacks: Array<Callback<T>>): (arg: T) => void {
+  return (arg: T) => {
+    for (const cb of callbacks) {
+      if (cb) cb(arg);
+    }
+  };
+}

--- a/packages/agent-sdk-ts/src/sdk/utils/composeCallbacks.ts
+++ b/packages/agent-sdk-ts/src/sdk/utils/composeCallbacks.ts
@@ -1,9 +1,11 @@
-export type Callback<T> = ((arg: T) => void) | null | undefined;
+export type Callback<TArgs extends unknown[]> = ((...args: TArgs) => void) | null | undefined;
 
-export function composeCallbacks<T>(callbacks: Array<Callback<T>>): (arg: T) => void {
-  return (arg: T) => {
+export function composeCallbacks<TArgs extends unknown[]>(
+  callbacks: ReadonlyArray<Callback<TArgs>>,
+): (...args: TArgs) => void {
+  return (...args: TArgs) => {
     for (const cb of callbacks) {
-      if (cb) cb(arg);
+      cb?.(...args);
     }
   };
 }

--- a/packages/agent-sdk-ts/src/sdk/utils/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './composeCallbacks';


### PR DESCRIPTION
Adds a small parity/ergonomics helper matching Python `compose_callbacks`:

- `composeCallbacks<T>(callbacks)` returns a callback that calls each non-null callback in order
- Exported from SDK entrypoint (`packages/agent-sdk-ts/src/sdk/index.ts`)
- Unit tests added

No behavior changes outside the helper; no profiles impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new utility for composing multiple callbacks into a single callback while safely skipping null and undefined entries.

* **Tests**
  * Added unit tests to verify the callback composition utility works correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->