### PR TITLE
agent-sdk-ts parity: includeDefaultTools option (#647)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts
@@ -44,6 +44,24 @@ const baseSettings: OpenHandsSettings = {
 const createDefaultTools = () => [new TerminalTool(), new FileEditorTool(), new TaskTrackerTool(), new BrowserTool()];
 
 describe('LocalConversation', () => {
+  it('uses default tools when tools are omitted', () => {
+    const llm = new RecordingLLM();
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm });
+    expect(conversation.getToolNames()).toEqual(['terminal', 'file_editor', 'task_tracker']);
+  });
+
+  it('supports includeDefaultTools=false to disable defaults when tools are omitted', () => {
+    const llm = new RecordingLLM();
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, includeDefaultTools: false });
+    expect(conversation.getToolNames()).toEqual([]);
+  });
+
+  it('supports includeDefaultTools subset selection when tools are omitted', () => {
+    const llm = new RecordingLLM();
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, includeDefaultTools: ['terminal'] });
+    expect(conversation.getToolNames()).toEqual(['terminal']);
+  });
+
   it('emits assistant messages when LLM responds without tools', async () => {
     const llm = new FakeLLM([[{ type: 'text', text: 'Hello world' }, { type: 'finish' }]]);
     const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, tools: createDefaultTools() });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -297,16 +297,16 @@ export class LocalConversation extends EventEmitter {
 
     const selectedDefaults = Array.isArray(includeDefaultTools)
       ? (() => {
-        const unique: string[] = [];
+        const uniqueNames = new Set<string>();
         for (const raw of includeDefaultTools) {
           const name = typeof raw === 'string' ? raw.trim() : '';
           if (!name) continue;
           if (!defaultNames.has(name)) {
             throw new Error(`includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(defaultNames).sort().join(', ')}`);
           }
-          if (!unique.includes(name)) unique.push(name);
+          uniqueNames.add(name);
         }
-        return defaultTools.filter((tool) => unique.includes(tool.name));
+        return defaultTools.filter((tool) => uniqueNames.has(tool.name));
       })()
       : defaultTools;
 
@@ -317,10 +317,7 @@ export class LocalConversation extends EventEmitter {
     const included = new Set<string>();
 
     for (const tool of selectedDefaults) {
-      const chosen = mergedByName.get(tool.name);
-      if (!chosen) continue;
-      if (included.has(tool.name)) continue;
-      result.push(chosen);
+      result.push(mergedByName.get(tool.name)!);
       included.add(tool.name);
     }
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -20,6 +20,7 @@ import { LLMRegistry } from '../llm';
 import type { RegistryEvent } from '../llm/registry';
 import type { ConfirmationPolicy } from '../security/confirmationPolicy';
 import type { SecurityAnalyzer } from '../security/analyzer';
+import { FileEditorTool, TaskTrackerTool, TerminalTool } from '../../tools';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime';
 import { AgentContext } from '../context';
@@ -38,6 +39,7 @@ export interface LocalConversationOptions {
   workspaceRoot?: string;
   llmClient?: LLMClient;
   tools?: ToolDefinition<unknown, unknown>[];
+  includeDefaultTools?: boolean | string[];
   secrets?: SecretRegistry;
   persistenceDir?: string;
   persistence?: ConversationPersistence;
@@ -55,6 +57,8 @@ export class LocalConversation extends EventEmitter {
   private readonly lock = new AsyncLock();
   private readonly customLlmClient?: LLMClient;
   private tools: ToolDefinition<unknown, unknown>[];
+  private readonly includeDefaultTools?: boolean | string[];
+  private readonly hasToolsOption: boolean;
   private readonly persistenceDir?: string;
   private persistence?: ConversationPersistence;
   private readonly agentContext?: AgentContext;
@@ -73,7 +77,9 @@ export class LocalConversation extends EventEmitter {
     this.events = new EventLog({ persistence: this.persistence });
     this.state = new ConversationState({ eventLog: this.events, persistence: this.persistence });
     this.customLlmClient = options.llmClient;
-    this.tools = options.tools ?? [];
+    this.includeDefaultTools = options.includeDefaultTools;
+    this.hasToolsOption = Object.prototype.hasOwnProperty.call(options, 'tools');
+    this.tools = this.resolveTools(this.hasToolsOption ? (options.tools ?? []) : undefined);
     this.secrets = options.secrets ?? new SecretRegistry();
     this.agentContext = options.agentContext;
     this.llmRegistry = new LLMRegistry();
@@ -107,7 +113,7 @@ export class LocalConversation extends EventEmitter {
     if (this.hasUserMessage) {
       throw new Error('Cannot change tools after the conversation has started');
     }
-    this.tools = tools;
+    this.tools = this.resolveTools(tools);
     this.agent = this.createAgent();
   }
 
@@ -272,12 +278,68 @@ export class LocalConversation extends EventEmitter {
     this.emit('status', status);
   }
 
+  private resolveTools(provided?: ToolDefinition<unknown, unknown>[]): ToolDefinition<unknown, unknown>[] {
+    const defaultTools: ToolDefinition<unknown, unknown>[] = [
+      new TerminalTool(),
+      new FileEditorTool(),
+      new TaskTrackerTool(),
+    ];
+    const defaultNames = new Set(defaultTools.map((tool) => tool.name));
+
+    const includeDefaultTools = this.includeDefaultTools;
+    if (includeDefaultTools === false) {
+      return provided ?? [];
+    }
+
+    if (includeDefaultTools === undefined) {
+      return provided ?? defaultTools;
+    }
+
+    const selectedDefaults = Array.isArray(includeDefaultTools)
+      ? (() => {
+        const unique: string[] = [];
+        for (const raw of includeDefaultTools) {
+          const name = typeof raw === 'string' ? raw.trim() : '';
+          if (!name) continue;
+          if (!defaultNames.has(name)) {
+            throw new Error(`includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(defaultNames).sort().join(', ')}`);
+          }
+          if (!unique.includes(name)) unique.push(name);
+        }
+        return defaultTools.filter((tool) => unique.includes(tool.name));
+      })()
+      : defaultTools;
+
+    const mergedByName = new Map<string, ToolDefinition<unknown, unknown>>(selectedDefaults.map((tool) => [tool.name, tool]));
+    for (const tool of provided ?? []) mergedByName.set(tool.name, tool);
+
+    const result: ToolDefinition<unknown, unknown>[] = [];
+    const included = new Set<string>();
+
+    for (const tool of selectedDefaults) {
+      const chosen = mergedByName.get(tool.name);
+      if (!chosen) continue;
+      if (included.has(tool.name)) continue;
+      result.push(chosen);
+      included.add(tool.name);
+    }
+
+    for (const tool of provided ?? []) {
+      if (included.has(tool.name)) continue;
+      result.push(tool);
+      included.add(tool.name);
+    }
+
+    return result;
+  }
+
   private createAgent(): Agent {
     return new Agent({
       settings: this.settings,
       workspace: this.workspace,
       llmClient: this.customLlmClient,
       tools: this.tools,
+      includeDefaultTools: this.includeDefaultTools,
       events: this.events,
       state: this.state,
       secrets: this.secrets,

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.test.ts
@@ -151,6 +151,96 @@ describe('RemoteConversation', () => {
     expect(parsed.workspace).toEqual({ kind: 'LocalWorkspace', working_dir: workspaceRoot });
   });
 
+  it('supports includeDefaultTools=false to disable default tools when tools are omitted', async () => {
+    vi.spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect').mockImplementation(() => {});
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      void _url;
+      void init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'conv-no-default-tools' }),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      includeDefaultTools: false,
+    });
+
+    await conversation.startNewConversation();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] } };
+    expect(parsed.agent.tools).toEqual([]);
+  });
+
+  it('supports includeDefaultTools subset selection when tools are omitted', async () => {
+    vi.spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect').mockImplementation(() => {});
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      void _url;
+      void init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'conv-subset-default-tools' }),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      includeDefaultTools: ['terminal'],
+    });
+
+    await conversation.startNewConversation();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] } };
+    expect(parsed.agent.tools).toEqual([{ name: 'terminal' }]);
+  });
+
+  it('supports includeDefaultTools=true to merge defaults with provided tools', async () => {
+    vi.spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect').mockImplementation(() => {});
+    const fetchSpy = vi.fn((_url: string, init?: RequestInit) => {
+      void _url;
+      void init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ id: 'conv-merge-default-tools' }),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      includeDefaultTools: true,
+      tools: [{ name: 'glob', params: { pattern: '**/*.ts' } }],
+    });
+
+    await conversation.startNewConversation();
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
+    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] } };
+    expect(parsed.agent.tools).toEqual([
+      { name: 'terminal' },
+      { name: 'file_editor' },
+      { name: 'task_tracker' },
+      { name: 'glob', params: { pattern: '**/*.ts' } },
+    ]);
+  });
+
   it('sends messages with run=false via HTTP', async () => {
     const connectSpy = vi
       .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -377,17 +377,15 @@ export class RemoteConversation extends EventEmitter {
         const included = new Set<string>();
 
         for (const tool of defaults) {
-          const chosen = byName.get(tool.name);
-          if (!chosen) continue;
-          if (included.has(tool.name)) continue;
-          result.push(chosen);
+          result.push(byName.get(tool.name)!);
           included.add(tool.name);
         }
 
         for (const tool of provided) {
-          if (included.has(tool.name)) continue;
-          result.push(tool);
-          included.add(tool.name);
+          if (!included.has(tool.name)) {
+            result.push(tool);
+            included.add(tool.name);
+          }
         }
 
         return result;
@@ -395,16 +393,16 @@ export class RemoteConversation extends EventEmitter {
 
       const resolveDefaultToolSubset = (selection: readonly string[]): RemoteConversationTool[] => {
         const allowed = new Set(defaultTools.map((tool) => tool.name));
-        const unique: string[] = [];
+        const uniqueNames = new Set<string>();
         for (const raw of selection) {
           const name = typeof raw === 'string' ? raw.trim() : '';
           if (!name) continue;
           if (!allowed.has(name)) {
             throw new Error(`includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(allowed).sort().join(', ')}`);
           }
-          if (!unique.includes(name)) unique.push(name);
+          uniqueNames.add(name);
         }
-        return defaultTools.filter((tool) => unique.includes(tool.name));
+        return defaultTools.filter((tool) => uniqueNames.has(tool.name));
       };
 
       const tools = (() => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -64,6 +64,7 @@ export interface RemoteConversationOptions {
   settings: OpenHandsSettings;
   workspaceRoot?: string;
   tools?: RemoteConversationTool[];
+  includeDefaultTools?: boolean | string[];
   workspace?: RemoteConversationWorkspace;
   conversationId?: string;
   profileStoreOptions?: LLMProfileStoreOptions;
@@ -93,6 +94,8 @@ export class RemoteConversation extends EventEmitter {
   private readonly maxReconnectRetries = 6;
   private readonly workspaceRoot: string;
   private readonly tools?: RemoteConversationTool[];
+  private readonly includeDefaultTools?: boolean | string[];
+  private readonly hasToolsOption: boolean;
   private readonly workspace?: RemoteConversationWorkspace;
   private readonly profileStoreOptions?: LLMProfileStoreOptions;
   private static readonly historyPageLimit = 100;
@@ -151,7 +154,9 @@ export class RemoteConversation extends EventEmitter {
     this.serverUrl = normalizeRemoteServerUrl(options.serverUrl);
     this.settings = options.settings;
     this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
+    this.hasToolsOption = Object.prototype.hasOwnProperty.call(options, 'tools');
     this.tools = options.tools;
+    this.includeDefaultTools = options.includeDefaultTools;
     this.workspace = options.workspace;
     this.profileStoreOptions = options.profileStoreOptions;
     if (options.conversationId) {
@@ -363,7 +368,64 @@ export class RemoteConversation extends EventEmitter {
         { name: 'task_tracker' },
       ];
       const workspace = this.workspace ?? { kind: 'LocalWorkspace', working_dir: this.workspaceRoot };
-      const tools = this.tools ?? defaultTools;
+
+      const mergeTools = (defaults: RemoteConversationTool[], provided: RemoteConversationTool[]): RemoteConversationTool[] => {
+        const byName = new Map<string, RemoteConversationTool>(defaults.map((tool) => [tool.name, tool]));
+        for (const tool of provided) byName.set(tool.name, tool);
+
+        const result: RemoteConversationTool[] = [];
+        const included = new Set<string>();
+
+        for (const tool of defaults) {
+          const chosen = byName.get(tool.name);
+          if (!chosen) continue;
+          if (included.has(tool.name)) continue;
+          result.push(chosen);
+          included.add(tool.name);
+        }
+
+        for (const tool of provided) {
+          if (included.has(tool.name)) continue;
+          result.push(tool);
+          included.add(tool.name);
+        }
+
+        return result;
+      };
+
+      const resolveDefaultToolSubset = (selection: readonly string[]): RemoteConversationTool[] => {
+        const allowed = new Set(defaultTools.map((tool) => tool.name));
+        const unique: string[] = [];
+        for (const raw of selection) {
+          const name = typeof raw === 'string' ? raw.trim() : '';
+          if (!name) continue;
+          if (!allowed.has(name)) {
+            throw new Error(`includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(allowed).sort().join(', ')}`);
+          }
+          if (!unique.includes(name)) unique.push(name);
+        }
+        return defaultTools.filter((tool) => unique.includes(tool.name));
+      };
+
+      const tools = (() => {
+        const provided = this.tools ?? [];
+        const includeDefaultTools = this.includeDefaultTools;
+
+        if (includeDefaultTools === undefined) {
+          if (this.hasToolsOption) return provided;
+          return defaultTools;
+        }
+
+        if (includeDefaultTools === false) {
+          return provided;
+        }
+
+        const selectedDefaults = Array.isArray(includeDefaultTools)
+          ? resolveDefaultToolSubset(includeDefaultTools)
+          : defaultTools;
+
+        return mergeTools(selectedDefaults, provided);
+      })();
       const req = {
         agent: {
           llm,

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -17,6 +17,7 @@ export interface ConversationFactoryOptions {
   workspaceRoot?: string;
   conversationId?: string;
   tools?: ToolDefinition<unknown, unknown>[];
+  includeDefaultTools?: boolean | string[];
   secrets?: SecretRegistry;
   persistenceDir?: string;
   agentContext?: AgentContext;
@@ -29,6 +30,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
       settings: options.settings,
       workspaceRoot: options.workspaceRoot,
       conversationId: options.conversationId,
+      includeDefaultTools: options.includeDefaultTools,
     }) as ConversationInstance;
   }
   return new LocalConversation({
@@ -37,6 +39,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     workspace: options.workspace,
     workspaceRoot: options.workspaceRoot,
     tools: options.tools,
+    includeDefaultTools: options.includeDefaultTools,
     secrets: options.secrets,
     persistenceDir: options.persistenceDir,
     agentContext: options.agentContext,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -68,6 +68,13 @@ export interface AgentOptions {
   workspaceRoot?: string;
   llmClient?: LLMClient;
   toolSummarizerClient?: LLMClient;
+  /**
+   * Controls whether the agent auto-registers builtin tools (e.g. FinishTool).
+   *
+   * - `false`: do not add any builtin tools automatically
+   * - otherwise: preserve legacy behavior (auto-add FinishTool when missing)
+   */
+  includeDefaultTools?: boolean | string[];
   tools?: ToolDefinition<unknown, unknown>[];
   events?: EventLog;
   state?: ConversationState;
@@ -147,9 +154,11 @@ export class Agent extends EventEmitter {
       injectedClient: options.toolSummarizerClient,
     });
     const providedTools = options.tools ?? [];
-    const toolsWithFinish = providedTools.some((tool) => tool.name === 'finish')
-      ? providedTools
-      : [...providedTools, new FinishTool()];
+    const toolsWithFinish = (() => {
+      if (options.includeDefaultTools === false) return providedTools;
+      if (providedTools.some((tool) => tool.name === 'finish')) return providedTools;
+      return [...providedTools, new FinishTool()];
+    })();
     this.tools = new Map(toolsWithFinish.map((tool) => [tool.name, tool]));
     this.registry = options.registry;
     this.conversationStats = options.conversationStats;


### PR DESCRIPTION
Implements `includeDefaultTools?: boolean | string[]` parity toggle across local + remote.

What changed
- `RemoteConversation`: supports disabling default tool payload, selecting a subset, or merging defaults with explicit tools when requested.
- `LocalConversation`: defaults to the same default tool set when `tools` is omitted; supports `includeDefaultTools` to disable/limit/merge.
- `Agent`: supports `includeDefaultTools=false` to disable builtin tool auto-registration (`FinishTool`).
- `Conversation()` factory: plumbs `includeDefaultTools` to both modes.

Notes / guardrails
- Backwards-compatible when callers explicitly pass `tools` (defaults are not auto-merged unless `includeDefaultTools` is explicitly set).
- No changes to LLM profile plumbing.

Tests
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `includeDefaultTools` configuration option across conversations and agents. Users can now control whether built-in tools are automatically included: disable entirely with `false`, enable with `true`, or selectively include specific tools by providing an array of tool names.

* **Tests**
  * Added comprehensive test coverage for the new `includeDefaultTools` option behavior in both local and remote conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->