### PR TITLE
agent-sdk-ts parity: ConversationErrorEvent visualization helper (#652)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { visualizeConversationErrorEvent, type ConversationErrorEvent } from '../index';
+import { DEFAULT_CONVERSATION_ERROR_MESSAGE, visualizeConversationErrorEvent, type ConversationErrorEvent } from '../index';
 
 describe('visualizeConversationErrorEvent', () => {
   it('renders code + detail when present', () => {
@@ -30,7 +30,6 @@ describe('visualizeConversationErrorEvent', () => {
       source: 'agent',
     };
 
-    expect(visualizeConversationErrorEvent(event)).toBe('Conversation error');
+    expect(visualizeConversationErrorEvent(event)).toBe(DEFAULT_CONVERSATION_ERROR_MESSAGE);
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { visualizeConversationErrorEvent, type ConversationErrorEvent } from '../index';
+
+describe('visualizeConversationErrorEvent', () => {
+  it('renders code + detail when present', () => {
+    const event: ConversationErrorEvent = {
+      kind: 'ConversationErrorEvent',
+      source: 'agent',
+      code: 'context_limit',
+      detail: 'Model context window exceeded',
+    };
+
+    expect(visualizeConversationErrorEvent(event)).toBe('code: context_limit\ndetail: Model context window exceeded');
+  });
+
+  it('renders only code when detail is empty', () => {
+    const event: ConversationErrorEvent = {
+      kind: 'ConversationErrorEvent',
+      source: 'agent',
+      code: 'timeout',
+      detail: '   ',
+    };
+
+    expect(visualizeConversationErrorEvent(event)).toBe('code: timeout');
+  });
+
+  it('falls back to a generic label when code/detail are missing', () => {
+    const event: ConversationErrorEvent = {
+      kind: 'ConversationErrorEvent',
+      source: 'agent',
+    };
+
+    expect(visualizeConversationErrorEvent(event)).toBe('Conversation error');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -114,6 +114,15 @@ export interface ConversationErrorEvent extends EventBase {
   detail?: string;
 }
 
+export const visualizeConversationErrorEvent = (event: ConversationErrorEvent): string => {
+  const lines: string[] = [];
+  const code = typeof event.code === 'string' ? event.code.trim() : '';
+  const detail = typeof event.detail === 'string' ? event.detail.trim() : '';
+  if (code) lines.push(`code: ${code}`);
+  if (detail) lines.push(`detail: ${detail}`);
+  return lines.length ? lines.join('\n') : 'Conversation error';
+};
+
 // PauseEvent - shown in visualizer
 export interface PauseEvent extends EventBase {
   kind: 'PauseEvent';

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -114,13 +114,15 @@ export interface ConversationErrorEvent extends EventBase {
   detail?: string;
 }
 
+export const DEFAULT_CONVERSATION_ERROR_MESSAGE = 'Conversation error';
+
 export const visualizeConversationErrorEvent = (event: ConversationErrorEvent): string => {
   const lines: string[] = [];
-  const code = typeof event.code === 'string' ? event.code.trim() : '';
-  const detail = typeof event.detail === 'string' ? event.detail.trim() : '';
+  const code = event.code?.trim() ?? '';
+  const detail = event.detail?.trim() ?? '';
   if (code) lines.push(`code: ${code}`);
   if (detail) lines.push(`detail: ${detail}`);
-  return lines.length ? lines.join('\n') : 'Conversation error';
+  return lines.length ? lines.join('\n') : DEFAULT_CONVERSATION_ERROR_MESSAGE;
 };
 
 // PauseEvent - shown in visualizer


### PR DESCRIPTION
Adds `visualizeConversationErrorEvent(event)` helper for consistent host/UI formatting.

- New helper exported from `src/sdk/types/index.ts`.
- Unit tests added.

Validation
- `npx vitest run packages/agent-sdk-ts/src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts`
- `npm run lint -w @openhands/agent-sdk-ts`
