### PR TITLE
agent-sdk-ts parity: Tool error truncation policy (#651)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
@@ -8,28 +8,27 @@ const makeToolCall = (id: string, name: string, args = '{}') => ({
 });
 
 describe('toolCallErrorEvents truncation and normalization', () => {
-  it('normalizes whitespace in error messages', () => {
+  it('preserves raw whitespace in error messages (python parity)', () => {
     const toolCall = makeToolCall('t1', 'echo');
     const messy = 'line1\n\n\tline2    with   spaces\nline3';
     const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, messy);
 
-    expect(agentErrorEvent.error).toBe('line1 line2 with spaces line3');
+    expect(agentErrorEvent.error).toBe(messy);
 
     const text = (toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text;
-    expect(text).toBe('line1 line2 with spaces line3');
+    expect(text).toBe(messy);
   });
 
-  it('caps long error messages at exactly 4096 chars and appends suffix', () => {
+  it('clips long tool error messages for LLM using the shared tool-message clip marker', () => {
     const toolCall = makeToolCall('t2', 'echo');
     const longBase = 'A'.repeat(10_000);
     const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, longBase);
 
     const err = agentErrorEvent.error;
-    expect(err.length).toBe(4096);
-    expect(err.endsWith('(truncated)')).toBe(true);
+    expect(err).toBe(longBase);
 
     const toolErr = (toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text;
-    expect(toolErr.length).toBe(4096);
-    expect(toolErr.endsWith('(truncated)')).toBe(true);
+    expect(toolErr.length).toBeLessThanOrEqual(8000);
+    expect(toolErr).toContain('<response clipped>');
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/truncateError.unit.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/truncateError.unit.test.ts
@@ -13,24 +13,23 @@ describe('truncateError', () => {
     expect(truncateError('\n\t')).toBe('Unknown tool error');
   });
 
-  it('does not append suffix when max < suffix length; caps hard at max', () => {
+  it('hard-caps to max when too small for clip marker', () => {
     const input = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
-    // suffix length is 12; choose max smaller than suffix length
     const out = truncateError(input, 5);
     expect(out).toHaveLength(5);
     expect(out).toBe('ABCDE');
   });
 
-  it('appends suffix when there is room (max >= suffix length + 1)', () => {
+  it('clips long messages using the shared tool-message clip marker', () => {
     const input = '0123456789'.repeat(1000);
-    const out = truncateError(input, 50);
-    expect(out.endsWith('(truncated)')).toBe(true);
-    expect(out.length).toBe(50);
+    const out = truncateError(input, 200);
+    expect(out.length).toBeLessThanOrEqual(200);
+    expect(out).toContain('<response clipped>');
   });
 
-  it('normalizes whitespace before truncation', () => {
+  it('preserves whitespace before truncation (python parity)', () => {
     const input = 'a\n\n\t b     c';
     const out = truncateError(input, 100);
-    expect(out).toBe('a b c');
+    expect(out).toBe(input);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -1,9 +1,8 @@
 import type { AgentErrorEvent, MessageEvent, ToolCall } from '../types';
 import { TOOL_MESSAGE_CLIP_MARKER, TOOL_MESSAGE_MAX_CHARS, truncateToolMessage } from './toolResultTruncation';
 
-const normalizeErrorMessage = (input: unknown): string => {
-  const raw = typeof input === 'string' ? input : '';
-  return raw.trim().length ? raw : 'Unknown tool error';
+const normalizeErrorMessage = (input: string): string => {
+  return input.trim().length ? input : 'Unknown tool error';
 };
 
 export const truncateError = (input: string, maxChars: number = TOOL_MESSAGE_MAX_CHARS): string => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -1,31 +1,35 @@
 import type { AgentErrorEvent, MessageEvent, ToolCall } from '../types';
+import { TOOL_MESSAGE_CLIP_MARKER, TOOL_MESSAGE_MAX_CHARS, truncateToolMessage } from './toolResultTruncation';
 
-export const truncateError = (input: string, max: number = 4096): string => {
-  const suffix = ' (truncated)';
-  const normalizedRaw = (input ?? '').replace(/\s+/g, ' ').trim();
-  const normalized = normalizedRaw.length === 0 ? 'Unknown tool error' : normalizedRaw;
-  if (max <= 0) return '';
-  if (normalized.length <= max) return normalized;
-  const headLen = max - suffix.length;
-  if (headLen <= 0) {
-    // Not enough room for suffix; hard cap to max without suffix
-    return normalized.slice(0, max);
+const normalizeErrorMessage = (input: unknown): string => {
+  const raw = typeof input === 'string' ? input : '';
+  return raw.trim().length ? raw : 'Unknown tool error';
+};
+
+export const truncateError = (input: string, maxChars: number = TOOL_MESSAGE_MAX_CHARS): string => {
+  const message = normalizeErrorMessage(input);
+  if (maxChars <= 0) return '';
+  if (message.length <= maxChars) return message;
+
+  if (maxChars < TOOL_MESSAGE_CLIP_MARKER.length + 2) {
+    return message.slice(0, maxChars);
   }
-  return normalized.slice(0, headLen) + suffix;
+  return truncateToolMessage(message, maxChars);
 };
 
 export const createToolCallErrorEvents = (
   toolCall: ToolCall,
   error: string,
 ): { agentErrorEvent: AgentErrorEvent; toolMessageEvent: MessageEvent } => {
-  const message = truncateError(error);
+  const rawMessage = normalizeErrorMessage(error);
+  const message = truncateToolMessage(rawMessage);
   const toolName = toolCall.function.name;
   const toolCallId = toolCall.id;
 
   const agentErrorEvent: AgentErrorEvent = {
     kind: 'AgentErrorEvent',
     source: 'agent',
-    error: message,
+    error: rawMessage,
     tool_name: toolName,
     tool_call_id: toolCallId,
   };


### PR DESCRIPTION
Aligns AgentErrorEvent -> tool message conversion with Python parity expectations.

Changes
- Stop normalizing whitespace in tool error messages.
- Stop hard-capping at 4096 + "(truncated)".
- Keep full error text on `AgentErrorEvent.error`.
- Clip tool-message content using the shared `<response clipped>` mechanism (`truncateToolMessage`, max 8000) for consistency with other tool messages.

Tests
- Updated unit tests covering raw-whitespace preservation and clip marker behavior.
- `npm test -w @openhands/agent-sdk-ts` (passed)
- `npm run lint -w @openhands/agent-sdk-ts` (passed)
