### PR TITLE
agent-sdk-ts parity: SecretStorage wiring (#660)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.secretStorage.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.secretStorage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SecretStorage } from 'vscode';
+import type { ChatCompletionRequest, LLMClient } from '../llm';
+import type { OpenHandsSettings } from '../types/settings';
+
+vi.mock('../llm', async () => {
+  const actual = await vi.importActual<typeof import('../llm')>('../llm');
+
+  class MockLLMFactory {
+    constructor(
+      _config: unknown,
+      private readonly options: { secrets: { get: (name: string) => Promise<string | undefined> } },
+    ) {
+      void _config;
+    }
+
+    async createClient(): Promise<LLMClient> {
+      const key = await this.options.secrets.get('OPENAI_API_KEY');
+      if (key !== 'sk-storage') {
+        throw new Error(`Expected SecretStorage to supply OPENAI_API_KEY; got '${key ?? ''}'`);
+      }
+
+      return {
+        // eslint-disable-next-line @typescript-eslint/require-await
+        async *streamChat(_request: ChatCompletionRequest) {
+          void _request;
+          yield { type: 'finish' };
+        },
+      };
+    }
+  }
+
+  return { ...actual, LLMFactory: MockLLMFactory };
+});
+
+import { LocalConversation } from './LocalConversation';
+
+const baseSettings: OpenHandsSettings = {
+  llm: { provider: 'openai', model: 'gpt-5-mini' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+describe('LocalConversation SecretStorage wiring', () => {
+  it('passes secretStorage into the default SecretRegistry when secrets is omitted', async () => {
+    const getSpy = vi.fn((key: string) => Promise.resolve(key === 'OPENAI_API_KEY' ? 'sk-storage' : undefined));
+    const secretStorage = { get: getSpy } as unknown as SecretStorage;
+
+    const conversation = new LocalConversation({
+      settings: baseSettings,
+      secretStorage,
+      tools: [],
+    });
+
+    await conversation.sendUserMessage('hi');
+    expect(getSpy).toHaveBeenCalledWith('OPENAI_API_KEY');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.secretStorage.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.secretStorage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { SecretStorage } from 'vscode';
+import type { Event, SecretStorage, SecretStorageChangeEvent } from 'vscode';
 import type { ChatCompletionRequest, LLMClient } from '../llm';
 import type { OpenHandsSettings } from '../types/settings';
 
@@ -46,7 +46,14 @@ const baseSettings: OpenHandsSettings = {
 describe('LocalConversation SecretStorage wiring', () => {
   it('passes secretStorage into the default SecretRegistry when secrets is omitted', async () => {
     const getSpy = vi.fn((key: string) => Promise.resolve(key === 'OPENAI_API_KEY' ? 'sk-storage' : undefined));
-    const secretStorage = { get: getSpy } as unknown as SecretStorage;
+
+    const onDidChange: Event<SecretStorageChangeEvent> = () => ({ dispose: () => {} });
+    const secretStorage: SecretStorage = {
+      get: getSpy,
+      store: vi.fn(() => Promise.resolve()),
+      delete: vi.fn(() => Promise.resolve()),
+      onDidChange,
+    };
 
     const conversation = new LocalConversation({
       settings: baseSettings,

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -21,6 +21,7 @@ import type { RegistryEvent } from '../llm/registry';
 import type { ConfirmationPolicy } from '../security/confirmationPolicy';
 import type { SecurityAnalyzer } from '../security/analyzer';
 import { FileEditorTool, TaskTrackerTool, TerminalTool } from '../../tools';
+import type { SecretStorage } from 'vscode';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime';
 import { AgentContext } from '../context';
@@ -41,6 +42,7 @@ export interface LocalConversationOptions {
   tools?: ToolDefinition<unknown, unknown>[];
   includeDefaultTools?: boolean | string[];
   secrets?: SecretRegistry;
+  secretStorage?: SecretStorage;
   persistenceDir?: string;
   persistence?: ConversationPersistence;
   agentContext?: AgentContext;
@@ -80,7 +82,7 @@ export class LocalConversation extends EventEmitter {
     this.includeDefaultTools = options.includeDefaultTools;
     this.hasToolsOption = Object.prototype.hasOwnProperty.call(options, 'tools');
     this.tools = this.resolveTools(this.hasToolsOption ? (options.tools ?? []) : undefined);
-    this.secrets = options.secrets ?? new SecretRegistry();
+    this.secrets = options.secrets ?? new SecretRegistry(options.secretStorage);
     this.agentContext = options.agentContext;
     this.llmRegistry = new LLMRegistry();
     this.stats = new ConversationStats();

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -2,6 +2,7 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import type { AgentContext } from '../context';
 import type { SecretRegistry } from '../runtime';
+import type { SecretStorage } from 'vscode';
 import type { BaseWorkspace } from '../../workspace';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
@@ -19,6 +20,7 @@ export interface ConversationFactoryOptions {
   tools?: ToolDefinition<unknown, unknown>[];
   includeDefaultTools?: boolean | string[];
   secrets?: SecretRegistry;
+  secretStorage?: SecretStorage;
   persistenceDir?: string;
   agentContext?: AgentContext;
 }
@@ -41,6 +43,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     tools: options.tools,
     includeDefaultTools: options.includeDefaultTools,
     secrets: options.secrets,
+    secretStorage: options.secretStorage,
     persistenceDir: options.persistenceDir,
     agentContext: options.agentContext,
   }) as ConversationInstance;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts
@@ -79,5 +79,5 @@ describe('SecretRegistry', () => {
 
     await expect(registry.get(secretName)).resolves.toBe('from-env');
   });
-});
 
+});


### PR DESCRIPTION
Adds a first-class `secretStorage?: SecretStorage` option to the SDK Conversation/LocalConversation surface so VS Code hosts can provide `context.secrets` without manually constructing a `SecretRegistry`.

Changes
- `ConversationFactoryOptions.secretStorage` plumbed to `LocalConversation`.
- `LocalConversationOptions.secretStorage` used when `secrets` is omitted (creates `new SecretRegistry(secretStorage)`).
- Unit test verifies LocalConversation passes SecretStorage through to LLM creation.

Validation
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for integrating secure secret storage with conversation initialization, enabling secure credential management for API keys and sensitive configuration.

* **Tests**
  * Added comprehensive unit tests to validate secret storage integration and secure credential provisioning.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->