### PR TITLE
agent-sdk-ts parity: Skills <available_skills> XML prompt (#655)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
@@ -176,12 +176,14 @@ describe('AgentContext', () => {
       );
     });
 
-    it('excludes knowledge skills from system suffix', () => {
+    it('lists triggered skills in <available_skills> without injecting full content', () => {
       const repoSkill = new Skill({ name: 'repo', content: 'Repo', trigger: null });
       const knowledgeSkill = new Skill({
         name: 'knowledge',
-        content: 'Knowledge',
+        content: 'FULL KNOWLEDGE CONTENT',
         trigger: { type: 'keyword', keywords: ['test'] },
+        description: 'Short knowledge description',
+        source: '/skills/knowledge.md',
       });
 
       const context = new AgentContext({ skills: [repoSkill, knowledgeSkill] });
@@ -190,19 +192,33 @@ describe('AgentContext', () => {
       expect(suffix).toContain('[BEGIN context from [repo]]');
       expect(suffix).toContain('Repo');
       expect(suffix).not.toContain('[BEGIN context from [knowledge]]');
-      expect(suffix).not.toContain('Knowledge');
+      expect(suffix).not.toContain('FULL KNOWLEDGE CONTENT');
+      expect(suffix).toContain('<SKILLS>');
+      expect(suffix).toContain('<available_skills>');
+      expect(suffix).toContain('<name>knowledge</name>');
+      expect(suffix).toContain('<description>Short knowledge description</description>');
+      expect(suffix).toContain('<location>/skills/knowledge.md</location>');
     });
 
-    it('excludes AgentSkills-format skills from system suffix even when trigger is null', () => {
+    it('lists AgentSkills-format skills in <available_skills> even when trigger is null', () => {
       const agentSkill = new Skill({
         name: 'my-skill',
         content: 'AgentSkills content (should not be injected)',
         trigger: null,
         isAgentSkillsFormat: true,
+        description: 'My description',
+        source: '/skills/my-skill/SKILL.md',
       });
 
       const context = new AgentContext({ skills: [agentSkill] });
-      expect(context.getSystemMessageSuffix()).toBeNull();
+      const suffix = context.getSystemMessageSuffix();
+
+      expect(suffix).toContain('<SKILLS>');
+      expect(suffix).toContain('<available_skills>');
+      expect(suffix).toContain('<name>my-skill</name>');
+      expect(suffix).toContain('<description>My description</description>');
+      expect(suffix).toContain('<location>/skills/my-skill/SKILL.md</location>');
+      expect(suffix).not.toContain('AgentSkills content (should not be injected)');
     });
 
     it('appends custom system message suffix', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
@@ -4,7 +4,7 @@
  */
 
 import type { Message, TextContent } from '../types';
-import { Skill, SkillKnowledge, loadUserSkills } from './skills';
+import { Skill, SkillKnowledge, loadUserSkills, toPrompt } from './skills';
 
 /**
  * AgentContext unifies all the contextual inputs that shape how the system
@@ -88,6 +88,7 @@ export class AgentContext {
    */
   getSystemMessageSuffix(options?: { secretNames?: string[] }): string | null {
     const repoSkills = this.skills.filter((s) => s.trigger === null && !s.isAgentSkillsFormat);
+    const availableSkills = this.skills.filter((s) => s.isAgentSkillsFormat || s.trigger !== null);
 
     const parts: string[] = [];
 
@@ -103,6 +104,21 @@ export class AgentContext {
           '',
           repoSkillContent,
           '</REPO_CONTEXT>',
+        ].join('\n'),
+      );
+    }
+
+    if (availableSkills.length) {
+      const availableSkillsPrompt = toPrompt(availableSkills);
+      parts.push(
+        [
+          '<SKILLS>',
+          'The following skills are available and may be triggered by keywords or task types in your messages.',
+          'When a skill is triggered, you will receive additional context and instructions.',
+          "You can also directly look up a skill's full content by reading its location path, and use the skill's guidance proactively when relevant to your task.",
+          '',
+          availableSkillsPrompt,
+          '</SKILLS>',
         ].join('\n'),
       );
     }

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/prompt.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/prompt.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { Skill, toPrompt } from '..';
+
+describe('skills.toPrompt', () => {
+  it('renders a placeholder when skills is empty', () => {
+    expect(toPrompt([])).toBe('<available_skills>\n  no available skills\n</available_skills>');
+  });
+
+  it('escapes XML and includes location when source is present', () => {
+    const skill = new Skill({
+      name: 'a&b',
+      content: 'ignored',
+      trigger: null,
+      description: 'Use <xml> & stuff',
+      source: '/path/<skill>',
+    });
+
+    const prompt = toPrompt([skill]);
+    expect(prompt).toContain('<name>a&amp;b</name>');
+    expect(prompt).toContain('<description>Use &lt;xml&gt; &amp; stuff</description>');
+    expect(prompt).toContain('<location>/path/&lt;skill&gt;</location>');
+  });
+
+  it('falls back to first non-header content line and reports truncated characters', () => {
+    const skill = new Skill({
+      name: 't',
+      content: '#\nX\nY',
+      trigger: null,
+      source: '/tmp/skill',
+    });
+
+    const prompt = toPrompt([skill]);
+    expect(prompt).toContain(
+      '<description>X... [2 characters truncated. View /tmp/skill for complete information]</description>',
+    );
+  });
+
+  it('truncates long descriptions and reports truncated characters', () => {
+    const skill = new Skill({
+      name: 't',
+      content: 'ignored',
+      trigger: null,
+      description: 'ABCDE',
+    });
+
+    const prompt = toPrompt([skill], { maxDescriptionLength: 3 });
+    expect(prompt).toContain('<description>ABC... [2 characters truncated]</description>');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/context/skills/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/index.ts
@@ -5,3 +5,4 @@
 
 export * from './types';
 export * from './skill';
+export * from './prompt';

--- a/packages/agent-sdk-ts/src/sdk/context/skills/prompt.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/prompt.ts
@@ -1,0 +1,73 @@
+import type { Skill } from './skill';
+
+const xmlEscape = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;');
+
+export function toPrompt(skills: Skill[], options?: { maxDescriptionLength?: number }): string {
+  const maxDescriptionLength = options?.maxDescriptionLength ?? 200;
+
+  if (skills.length === 0) {
+    return '<available_skills>\n  no available skills\n</available_skills>';
+  }
+
+  const lines: string[] = ['<available_skills>'];
+
+  for (const skill of skills) {
+    let description = skill.description;
+    let contentTruncated = 0;
+
+    if (!description) {
+      let charsBeforeDescription = 0;
+      for (const line of skill.content.split('\n')) {
+        const stripped = line.trim();
+        if (!stripped || stripped.startsWith('#')) {
+          charsBeforeDescription += line.length + 1;
+          continue;
+        }
+
+        description = stripped;
+        const descriptionEndPos = charsBeforeDescription + line.length;
+        contentTruncated = Math.max(0, skill.content.length - descriptionEndPos);
+        break;
+      }
+    }
+
+    description = description ?? '';
+
+    let totalTruncated = contentTruncated;
+
+    if (description.length > maxDescriptionLength) {
+      totalTruncated += description.length - maxDescriptionLength;
+      description = description.slice(0, maxDescriptionLength);
+    }
+
+    if (totalTruncated > 0) {
+      let truncationMessage = `... [${totalTruncated} characters truncated`;
+      if (skill.source) {
+        truncationMessage += `. View ${skill.source} for complete information`;
+      }
+      truncationMessage += ']';
+      description = `${description}${truncationMessage}`;
+    }
+
+    const escapedDescription = xmlEscape(description.trim());
+    const escapedName = xmlEscape(skill.name.trim());
+
+    lines.push('  <skill>');
+    lines.push(`    <name>${escapedName}</name>`);
+    lines.push(`    <description>${escapedDescription}</description>`);
+    if (skill.source) {
+      lines.push(`    <location>${xmlEscape(skill.source.trim())}</location>`);
+    }
+    lines.push('  </skill>');
+  }
+
+  lines.push('</available_skills>');
+  return lines.join('\n');
+}
+

--- a/packages/agent-sdk-ts/src/sdk/context/skills/prompt.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/prompt.ts
@@ -1,7 +1,46 @@
 import type { Skill } from './skill';
 
+const stripInvalidXmlChars = (value: string): string => {
+  let result = '';
+  for (const char of value) {
+    const codePoint = char.codePointAt(0);
+    if (codePoint === undefined) {
+      continue;
+    }
+
+    // XML 1.0 valid chars:
+    // - \t (0x9), \n (0xA), \r (0xD)
+    // - 0x20..0xD7FF
+    // - 0xE000..0xFFFD
+    // - 0x10000..0x10FFFF
+    if (codePoint === 0x9 || codePoint === 0xA || codePoint === 0xD) {
+      result += char;
+      continue;
+    }
+
+    if (codePoint < 0x20) {
+      continue;
+    }
+
+    if (codePoint >= 0xd800 && codePoint <= 0xdfff) {
+      continue;
+    }
+
+    if (codePoint === 0x7f || codePoint === 0xfffe || codePoint === 0xffff) {
+      continue;
+    }
+
+    if (codePoint > 0x10ffff) {
+      continue;
+    }
+
+    result += char;
+  }
+  return result;
+};
+
 const xmlEscape = (value: string): string =>
-  value
+  stripInvalidXmlChars(value)
     .replaceAll('&', '&amp;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;')
@@ -70,4 +109,3 @@ export function toPrompt(skills: Skill[], options?: { maxDescriptionLength?: num
   lines.push('</available_skills>');
   return lines.join('\n');
 }
-


### PR DESCRIPTION
Implements Python-parity `<available_skills>` prompt generation (progressive disclosure) and injects it into `AgentContext.getSystemMessageSuffix()`.

- Adds `toPrompt()` helper to generate AgentSkills-format XML with description fallback, truncation reporting, and XML escaping.
- Emits `<SKILLS>` wrapper + `<available_skills>` block for AgentSkills-format skills and triggered skills.
- Adds unit tests covering XML output + system suffix behavior.

Closes #655.

Reviewer: OrangeCastle (no merge until explicit approval via Agent Mail).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now support optional description and source metadata fields during construction
  * Added structured <SKILLS> block in system messages displaying available skills with metadata
  * New utility function for formatting skills into XML prompt format with configurable description truncation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->