### PR TITLE
agent-sdk-ts parity: Skills resources + .mcp.json parsing (#654)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -329,6 +329,44 @@ Some content`,
       }
     });
 
+    it('expands variables safely when values contain backslashes/quotes', () => {
+      const skillRoot = join(tempDir, 'my-skill');
+      mkdirSync(skillRoot, { recursive: true });
+
+      const skillPath = join(skillRoot, 'SKILL.md');
+      writeFileSync(skillPath, `---\ndescription: Demo\n---\n\ncontent`);
+
+      const envValue = String.raw`C:\Users\test\path\"quotes\"`;
+      const previousEnv = process.env.MCP_TEST_VALUE;
+      process.env.MCP_TEST_VALUE = envValue;
+      try {
+        writeFileSync(
+          join(skillRoot, '.mcp.json'),
+          JSON.stringify(
+            {
+              mcpServers: {
+                demo: {
+                  type: 'http',
+                  url: '${MCP_TEST_VALUE}',
+                },
+              },
+            },
+            null,
+            2,
+          ),
+        );
+
+        const skill = Skill.load({ path: skillPath });
+        expect(skill.mcpTools?.mcpServers.demo.url).toBe(envValue);
+      } finally {
+        if (previousEnv === undefined) {
+          delete process.env.MCP_TEST_VALUE;
+        } else {
+          process.env.MCP_TEST_VALUE = previousEnv;
+        }
+      }
+    });
+
     it('fails fast on invalid .mcp.json in SKILL.md directories', () => {
       const skillRoot = join(tempDir, 'bad-skill');
       mkdirSync(skillRoot, { recursive: true });

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -268,6 +268,101 @@ Agent skill content.`);
       expect(skill.source).toBe(skillPath);
     });
 
+    it('loads AgentSkills resources and .mcp.json from the SKILL.md directory', () => {
+      const skillRoot = join(tempDir, 'my-skill');
+      mkdirSync(join(skillRoot, 'scripts', 'nested'), { recursive: true });
+      mkdirSync(join(skillRoot, 'references'), { recursive: true });
+      mkdirSync(join(skillRoot, 'assets'), { recursive: true });
+
+      const skillPath = join(skillRoot, 'SKILL.md');
+      writeFileSync(
+        skillPath,
+        `---
+description: Demo skill
+---
+
+# Header
+
+Some content`,
+      );
+
+      writeFileSync(join(skillRoot, 'scripts', 'run.sh'), '#!/bin/sh\necho hi');
+      writeFileSync(join(skillRoot, 'scripts', 'nested', 'inner.sh'), '#!/bin/sh\necho inner');
+      writeFileSync(join(skillRoot, 'references', 'README.md'), 'ref');
+      writeFileSync(join(skillRoot, 'assets', 'data.json'), '{"ok":true}');
+
+      const previousEnv = process.env.MCP_TEST_URL;
+      process.env.MCP_TEST_URL = 'http://example.test/mcp';
+      try {
+        writeFileSync(
+          join(skillRoot, '.mcp.json'),
+          JSON.stringify(
+            {
+              mcpServers: {
+                demo: {
+                  type: 'http',
+                  url: '${MCP_TEST_URL:-http://default.invalid/mcp}',
+                  headers: { 'X-Skill-Root': '${SKILL_ROOT}' },
+                },
+              },
+            },
+            null,
+            2,
+          ),
+        );
+
+        const skill = Skill.load({ path: skillPath });
+
+        expect(skill.resources?.skillRoot).toBe(skillRoot);
+        expect(skill.resources?.scripts).toEqual(['nested/inner.sh', 'run.sh']);
+        expect(skill.resources?.references).toEqual(['README.md']);
+        expect(skill.resources?.assets).toEqual(['data.json']);
+
+        expect(skill.mcpTools?.mcpServers.demo.url).toBe('http://example.test/mcp');
+        expect(skill.mcpTools?.mcpServers.demo.headers?.['X-Skill-Root']).toBe(skillRoot);
+      } finally {
+        if (previousEnv === undefined) {
+          delete process.env.MCP_TEST_URL;
+        } else {
+          process.env.MCP_TEST_URL = previousEnv;
+        }
+      }
+    });
+
+    it('fails fast on invalid .mcp.json in SKILL.md directories', () => {
+      const skillRoot = join(tempDir, 'bad-skill');
+      mkdirSync(skillRoot, { recursive: true });
+
+      const skillPath = join(skillRoot, 'SKILL.md');
+      writeFileSync(skillPath, `---\nname: bad-skill\ndescription: Bad\n---\n\ncontent`);
+      writeFileSync(join(skillRoot, '.mcp.json'), JSON.stringify({ mcpServers: [] }));
+
+      expect(() => Skill.load({ path: skillPath })).toThrow(SkillValidationError);
+    });
+
+    it('loads legacy mcp_tools from frontmatter and ignores .mcp.json', () => {
+      // If legacy attempted to parse .mcp.json, this would fail the load.
+      writeFileSync(join(tempDir, '.mcp.json'), 'not-json');
+
+      const legacyPath = join(tempDir, 'legacy-skill.md');
+      writeFileSync(
+        legacyPath,
+        `---
+name: legacy-skill
+mcp_tools:
+  mcpServers:
+    demo:
+      type: http
+      url: http://example.test/mcp
+---
+
+Legacy content`,
+      );
+
+      const skill = Skill.load({ path: legacyPath });
+      expect(skill.mcpTools?.mcpServers.demo.url).toBe('http://example.test/mcp');
+    });
+
     it('validates AgentSkills-format skill name strictly', () => {
       const skillRoot = join(tempDir, 'BadSkill');
       mkdirSync(skillRoot, { recursive: true });

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { mkdirSync, writeFileSync, rmSync, existsSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { Skill, SkillValidationError, loadSkillsFromDir, loadUserSkills, USER_SKILLS_DIRS } from '../skill';
@@ -327,6 +327,24 @@ Some content`,
           process.env.MCP_TEST_URL = previousEnv;
         }
       }
+    });
+
+    it('does not traverse symlinked resource directories', () => {
+      const skillRoot = join(tempDir, 'my-skill');
+      const scriptsDir = join(skillRoot, 'scripts');
+      const outsideDir = join(tempDir, 'outside');
+      mkdirSync(scriptsDir, { recursive: true });
+      mkdirSync(outsideDir, { recursive: true });
+
+      writeFileSync(join(outsideDir, 'secret.txt'), 'should not be included');
+      symlinkSync(outsideDir, join(scriptsDir, 'linked'));
+      writeFileSync(join(scriptsDir, 'run.sh'), '#!/bin/sh\necho ok');
+
+      const skillPath = join(skillRoot, 'SKILL.md');
+      writeFileSync(skillPath, `---\ndescription: Demo\n---\n\ncontent`);
+
+      const skill = Skill.load({ path: skillPath });
+      expect(skill.resources?.scripts).toEqual(['run.sh']);
     });
 
     it('expands variables safely when values contain backslashes/quotes', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/exceptions.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/exceptions.ts
@@ -1,0 +1,10 @@
+/**
+ * Error thrown when skill validation fails.
+ */
+export class SkillValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SkillValidationError';
+  }
+}
+

--- a/packages/agent-sdk-ts/src/sdk/context/skills/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/index.ts
@@ -6,3 +6,6 @@
 export * from './types';
 export * from './skill';
 export * from './prompt';
+export * from './mcp';
+export * from './resources';
+export * from './exceptions';

--- a/packages/agent-sdk-ts/src/sdk/context/skills/mcp.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/mcp.ts
@@ -36,16 +36,19 @@ function expandMcpVariables(
 ): unknown {
   const configStr = JSON.stringify(config);
 
+  const escapeForJsonString = (value: string): string => JSON.stringify(value).slice(1, -1);
+
   const varPattern = /\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}/g;
   const expanded = configStr.replace(varPattern, (_match, name: string, defaultValue?: string) => {
     if (Object.prototype.hasOwnProperty.call(variables, name)) {
-      return variables[name];
+      return escapeForJsonString(variables[name]);
     }
     const envValue = env[name];
     if (typeof envValue === 'string') {
-      return envValue;
+      return escapeForJsonString(envValue);
     }
     if (typeof defaultValue === 'string') {
+      // Default is captured from JSON.stringify output, so it is already JSON-escaped.
       return defaultValue;
     }
     return _match;

--- a/packages/agent-sdk-ts/src/sdk/context/skills/mcp.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/mcp.ts
@@ -1,0 +1,146 @@
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import type { McpConfig, McpServerConfig } from './types';
+import { SkillValidationError } from './exceptions';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isStringRecord = (value: unknown): value is Record<string, string> => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  for (const v of Object.values(value)) {
+    if (typeof v !== 'string') {
+      return false;
+    }
+  }
+  return true;
+};
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every((v) => typeof v === 'string');
+
+export function findMcpConfig(skillRoot: string): string | null {
+  const fullPath = join(resolve(skillRoot), '.mcp.json');
+  if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+    return null;
+  }
+  return fullPath;
+}
+
+function expandMcpVariables(
+  config: unknown,
+  variables: Record<string, string>,
+  env: Record<string, string | undefined>,
+): unknown {
+  const configStr = JSON.stringify(config);
+
+  const varPattern = /\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}/g;
+  const expanded = configStr.replace(varPattern, (_match, name: string, defaultValue?: string) => {
+    if (Object.prototype.hasOwnProperty.call(variables, name)) {
+      return variables[name];
+    }
+    const envValue = env[name];
+    if (typeof envValue === 'string') {
+      return envValue;
+    }
+    if (typeof defaultValue === 'string') {
+      return defaultValue;
+    }
+    return _match;
+  });
+
+  return JSON.parse(expanded) as unknown;
+}
+
+function validateMcpServerConfig(serverName: string, value: unknown): McpServerConfig {
+  if (!isRecord(value)) {
+    throw new SkillValidationError(`Invalid MCP server '${serverName}': expected object`);
+  }
+
+  const type = typeof value.type === 'string' ? value.type : undefined;
+  const command = typeof value.command === 'string' ? value.command : undefined;
+  const url = typeof value.url === 'string' ? value.url : undefined;
+  const args = value.args === undefined ? undefined : value.args;
+  const env = value.env === undefined ? undefined : value.env;
+  const headers = value.headers === undefined ? undefined : value.headers;
+  const cwd = value.cwd === undefined ? undefined : value.cwd;
+
+  if (!command && !url) {
+    throw new SkillValidationError(
+      `Invalid MCP server '${serverName}': expected 'command' (stdio) or 'url' (http/sse)`,
+    );
+  }
+
+  if (args !== undefined && !isStringArray(args)) {
+    throw new SkillValidationError(`Invalid MCP server '${serverName}': 'args' must be a string[]`);
+  }
+
+  if (env !== undefined && !isStringRecord(env)) {
+    throw new SkillValidationError(`Invalid MCP server '${serverName}': 'env' must be a record<string,string>`);
+  }
+
+  if (headers !== undefined && !isStringRecord(headers)) {
+    throw new SkillValidationError(`Invalid MCP server '${serverName}': 'headers' must be a record<string,string>`);
+  }
+
+  if (cwd !== undefined && typeof cwd !== 'string') {
+    throw new SkillValidationError(`Invalid MCP server '${serverName}': 'cwd' must be a string`);
+  }
+
+  return {
+    type,
+    command,
+    args: isStringArray(args) ? args : undefined,
+    env: isStringRecord(env) ? env : undefined,
+    cwd: typeof cwd === 'string' ? cwd : undefined,
+    url,
+    headers: isStringRecord(headers) ? headers : undefined,
+  };
+}
+
+export function validateMcpConfigObject(value: unknown): McpConfig {
+  if (!isRecord(value)) {
+    throw new SkillValidationError(`Invalid .mcp.json format: expected object, got ${Array.isArray(value) ? 'array' : typeof value}`);
+  }
+
+  if (!('mcpServers' in value)) {
+    throw new SkillValidationError("Invalid MCP configuration: missing required key 'mcpServers'");
+  }
+
+  const serversRaw = value.mcpServers;
+  if (!isRecord(serversRaw)) {
+    throw new SkillValidationError("Invalid MCP configuration: 'mcpServers' must be an object");
+  }
+
+  const mcpServers: Record<string, McpServerConfig> = {};
+  for (const [name, cfg] of Object.entries(serversRaw)) {
+    if (!name.trim()) {
+      throw new SkillValidationError('Invalid MCP configuration: mcpServers contains an empty key');
+    }
+    mcpServers[name] = validateMcpServerConfig(name, cfg);
+  }
+
+  return { mcpServers };
+}
+
+export function loadMcpConfig(mcpJsonPath: string, options?: { skillRoot?: string }): McpConfig {
+  const resolvedPath = resolve(mcpJsonPath);
+
+  let config: unknown;
+  try {
+    config = JSON.parse(readFileSync(resolvedPath, 'utf-8')) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new SkillValidationError(`Invalid JSON in ${resolvedPath}: ${message}`);
+  }
+
+  const variables: Record<string, string> = {};
+  if (options?.skillRoot) {
+    variables.SKILL_ROOT = resolve(options.skillRoot);
+  }
+
+  const expanded = expandMcpVariables(config, variables, process.env);
+  return validateMcpConfigObject(expanded);
+}

--- a/packages/agent-sdk-ts/src/sdk/context/skills/resources.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/resources.ts
@@ -1,0 +1,51 @@
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import type { SkillResources } from './types';
+
+const RESOURCE_DIRECTORIES = ['scripts', 'references', 'assets'] as const;
+
+const listFilesRecursively = (dir: string): string[] => {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      for (const nested of listFilesRecursively(fullPath)) {
+        files.push(join(entry, nested));
+      }
+    } else if (stat.isFile()) {
+      files.push(entry);
+    }
+  }
+  return files;
+};
+
+export function discoverSkillResources(skillRoot: string): SkillResources {
+  const resolvedRoot = resolve(skillRoot);
+
+  const resources: SkillResources = {
+    skillRoot: resolvedRoot,
+    scripts: [],
+    references: [],
+    assets: [],
+  };
+
+  for (const kind of RESOURCE_DIRECTORIES) {
+    const resourceDir = join(resolvedRoot, kind);
+    if (!existsSync(resourceDir) || !statSync(resourceDir).isDirectory()) {
+      continue;
+    }
+
+    try {
+      resources[kind] = listFilesRecursively(resourceDir).sort();
+    } catch {
+      resources[kind] = [];
+    }
+  }
+
+  return resources;
+}
+
+export function hasSkillResources(resources: SkillResources): boolean {
+  return Boolean(resources.scripts.length || resources.references.length || resources.assets.length);
+}

--- a/packages/agent-sdk-ts/src/sdk/context/skills/resources.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/resources.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, statSync } from 'fs';
+import { existsSync, lstatSync, readdirSync } from 'fs';
 import { join, resolve } from 'path';
 import type { SkillResources } from './types';
 
@@ -8,7 +8,13 @@ const listFilesRecursively = (dir: string): string[] => {
   const files: string[] = [];
   for (const entry of readdirSync(dir)) {
     const fullPath = join(dir, entry);
-    const stat = statSync(fullPath);
+    const stat = lstatSync(fullPath);
+
+    // Never follow symlinks; they can escape the skill root or form loops.
+    if (stat.isSymbolicLink()) {
+      continue;
+    }
+
     if (stat.isDirectory()) {
       for (const nested of listFilesRecursively(fullPath)) {
         files.push(join(entry, nested));
@@ -32,11 +38,11 @@ export function discoverSkillResources(skillRoot: string): SkillResources {
 
   for (const kind of RESOURCE_DIRECTORIES) {
     const resourceDir = join(resolvedRoot, kind);
-    if (!existsSync(resourceDir) || !statSync(resourceDir).isDirectory()) {
-      continue;
-    }
+    if (!existsSync(resourceDir)) continue;
 
     try {
+      const stat = lstatSync(resourceDir);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
       resources[kind] = listFilesRecursively(resourceDir).sort();
     } catch {
       resources[kind] = [];

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -8,6 +8,10 @@ import { basename, dirname, join, relative } from 'path';
 import { homedir } from 'os';
 import frontmatter from 'front-matter';
 import type { InputMetadata, TriggerType } from './types';
+import type { McpConfig, SkillResources } from './types';
+import { SkillValidationError } from './exceptions';
+import { discoverSkillResources, hasSkillResources } from './resources';
+import { findMcpConfig, loadMcpConfig, validateMcpConfigObject } from './mcp';
 
 // Regex pattern for valid AgentSkills names (strict):
 // - 1-64 characters
@@ -16,15 +20,7 @@ import type { InputMetadata, TriggerType } from './types';
 // - must not contain consecutive hyphens (--)
 const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
-/**
- * Error thrown when skill validation fails.
- */
-export class SkillValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = 'SkillValidationError';
-  }
-}
+export { SkillValidationError } from './exceptions';
 
 /**
  * A skill provides specialized knowledge or functionality.
@@ -42,6 +38,8 @@ export class Skill {
   inputs: InputMetadata[];
   isAgentSkillsFormat: boolean;
   description: string | null;
+  mcpTools: McpConfig | null;
+  resources: SkillResources | null;
 
   // Map third-party files to skill names
   public static readonly PATH_TO_THIRD_PARTY_SKILL_NAME: Record<string, string> = {
@@ -58,6 +56,8 @@ export class Skill {
     inputs?: InputMetadata[];
     isAgentSkillsFormat?: boolean;
     description?: string | null;
+    mcpTools?: McpConfig | null;
+    resources?: SkillResources | null;
   }) {
     this.name = params.name;
     this.content = params.content;
@@ -66,6 +66,8 @@ export class Skill {
     this.inputs = params.inputs ?? [];
     this.isAgentSkillsFormat = params.isAgentSkillsFormat ?? false;
     this.description = params.description ?? null;
+    this.mcpTools = params.mcpTools ?? null;
+    this.resources = params.resources ?? null;
 
     // Append missing variables prompt for task skills
     if (this.trigger?.type === 'task' && this.requiresUserInput()) {
@@ -149,6 +151,31 @@ export class Skill {
 
     const description = typeof metadata.description === 'string' ? metadata.description : null;
 
+    // For AgentSkills-format SKILL.md, load .mcp.json + discover resources (Python parity).
+    let mcpTools: McpConfig | null = null;
+    let resources: SkillResources | null = null;
+    if (isSkillMd) {
+      const skillRoot = dirname(filePath);
+      const mcpJsonPath = findMcpConfig(skillRoot);
+      if (mcpJsonPath) {
+        mcpTools = loadMcpConfig(mcpJsonPath, { skillRoot });
+      }
+
+      const discovered = discoverSkillResources(skillRoot);
+      if (hasSkillResources(discovered)) {
+        resources = discovered;
+      }
+    } else {
+      // Legacy skills only use mcp_tools from frontmatter (not .mcp.json) (Python parity).
+      const maybeMcpTools = metadata.mcp_tools;
+      if (maybeMcpTools !== undefined) {
+        if (typeof maybeMcpTools !== 'object' || maybeMcpTools === null || Array.isArray(maybeMcpTools)) {
+          throw new SkillValidationError('mcp_tools must be a dictionary or None');
+        }
+        mcpTools = validateMcpConfigObject(maybeMcpTools);
+      }
+    }
+
     // Validate and parse trigger keywords from metadata
     const triggerMetadata = metadata.triggers;
     if (triggerMetadata && !Array.isArray(triggerMetadata)) {
@@ -187,6 +214,8 @@ export class Skill {
         source: filePath,
         isAgentSkillsFormat: isSkillMd,
         description,
+        mcpTools,
+        resources,
         trigger: { type: 'task', triggers: keywords },
         inputs,
       });
@@ -197,6 +226,8 @@ export class Skill {
         source: filePath,
         isAgentSkillsFormat: isSkillMd,
         description,
+        mcpTools,
+        resources,
         trigger: { type: 'keyword', keywords },
       });
     } else {
@@ -207,6 +238,8 @@ export class Skill {
         source: filePath,
         isAgentSkillsFormat: isSkillMd,
         description,
+        mcpTools,
+        resources,
         trigger: null,
       });
     }

--- a/packages/agent-sdk-ts/src/sdk/context/skills/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/types.ts
@@ -49,7 +49,7 @@ export interface TaskTrigger extends BaseTrigger {
   triggers: string[];
 }
 
-export type McpServerConfig = {
+export interface McpServerConfig {
   type?: string;
   command?: string;
   args?: string[];
@@ -57,7 +57,7 @@ export type McpServerConfig = {
   cwd?: string;
   url?: string;
   headers?: Record<string, string>;
-};
+}
 
 export interface McpConfig {
   mcpServers: Record<string, McpServerConfig>;

--- a/packages/agent-sdk-ts/src/sdk/context/skills/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/types.ts
@@ -49,6 +49,27 @@ export interface TaskTrigger extends BaseTrigger {
   triggers: string[];
 }
 
+export type McpServerConfig = {
+  type?: string;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+  url?: string;
+  headers?: Record<string, string>;
+};
+
+export interface McpConfig {
+  mcpServers: Record<string, McpServerConfig>;
+}
+
+export interface SkillResources {
+  skillRoot: string;
+  scripts: string[];
+  references: string[];
+  assets: string[];
+}
+
 /**
  * Union type for all trigger types.
  */


### PR DESCRIPTION
Implements Python-parity Skill resource discovery + `.mcp.json` loading for AgentSkills-format `SKILL.md` directories.

- Discovers `scripts/`, `references/`, `assets/` under the skill root and stores sorted relative file lists.
- Loads `.mcp.json` from the skill root (AgentSkills only), supports `${VAR}` + `${VAR:-default}` and `${SKILL_ROOT}` expansion.
- Validates `.mcp.json` shape (requires `mcpServers` map; per-server config type checks).
- Adds unit tests covering resource discovery, variable expansion, invalid configs, and legacy frontmatter `mcp_tools`.

Closes #654.

Reviewer: OrangeCastle (no merge until explicit approval via Agent Mail).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP configuration support for skills with validation, safe variable expansion, and environment-driven values.
  * Skill resource discovery (scripts, references, assets) and new public properties on Skill for MCP tools and resources.
  * New typed error for skill validation and added public types for MCP and resources; index now re-exports these.

* **Bug Fixes**
  * Improved handling of symlinked resources and legacy frontmatter MCP handling.

* **Tests**
  * Comprehensive tests covering loading, validation, expansion, and resource discovery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->