### PR TITLE
agent-sdk-ts parity: hooks pipeline (#646)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -25,6 +25,7 @@ import type { SecretStorage } from 'vscode';
 import path from 'path';
 import type { ConversationPersistence } from '../runtime';
 import { AgentContext } from '../context';
+import type { AgentHook } from '../runtime/hooks';
 
 const toOptionalNonEmptyString = (value: unknown): string | undefined => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
@@ -46,6 +47,7 @@ export interface LocalConversationOptions {
   persistenceDir?: string;
   persistence?: ConversationPersistence;
   agentContext?: AgentContext;
+  hooks?: AgentHook | AgentHook[];
 }
 
 export class LocalConversation extends EventEmitter {
@@ -64,6 +66,7 @@ export class LocalConversation extends EventEmitter {
   private readonly persistenceDir?: string;
   private persistence?: ConversationPersistence;
   private readonly agentContext?: AgentContext;
+  private readonly hooks?: AgentHook | AgentHook[];
   private agent: Agent;
   private readonly llmRegistry: LLMRegistry;
   private readonly stats: ConversationStats;
@@ -84,6 +87,7 @@ export class LocalConversation extends EventEmitter {
     this.tools = this.resolveTools(this.hasToolsOption ? (options.tools ?? []) : undefined);
     this.secrets = options.secrets ?? new SecretRegistry(options.secretStorage);
     this.agentContext = options.agentContext;
+    this.hooks = options.hooks;
     this.llmRegistry = new LLMRegistry();
     this.stats = new ConversationStats();
     // connect registry to stats
@@ -343,6 +347,7 @@ export class LocalConversation extends EventEmitter {
       state: this.state,
       secrets: this.secrets,
       agentContext: this.agentContext,
+      hooks: this.hooks,
       onTerminalEvent: (event) => this.emit('terminal', event),
       registry: this.llmRegistry,
       conversationStats: this.stats,

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -2,6 +2,7 @@ import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
 import type { AgentContext } from '../context';
 import type { SecretRegistry } from '../runtime';
+import type { AgentHook } from '../runtime/hooks';
 import type { SecretStorage } from 'vscode';
 import type { BaseWorkspace } from '../../workspace';
 import { LocalConversation } from './LocalConversation';
@@ -23,6 +24,7 @@ export interface ConversationFactoryOptions {
   secretStorage?: SecretStorage;
   persistenceDir?: string;
   agentContext?: AgentContext;
+  hooks?: AgentHook | AgentHook[];
 }
 
 export function Conversation(options: ConversationFactoryOptions): ConversationInstance {
@@ -46,6 +48,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     secretStorage: options.secretStorage,
     persistenceDir: options.persistenceDir,
     agentContext: options.agentContext,
+    hooks: options.hooks,
   }) as ConversationInstance;
 }
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -112,6 +112,13 @@ function stringifyErrorWithCause(error: unknown, maxDepth = 4): string {
   }
 }
 
+function requireToolArgsObject(value: unknown, context: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${context} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
 
 export class Agent extends EventEmitter {
   private readonly workspace: BaseWorkspace;
@@ -1271,9 +1278,9 @@ export class Agent extends EventEmitter {
       throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
     }
 
-    let validated;
+    let validated: Record<string, unknown>;
     try {
-      validated = tool.validate(args);
+      validated = requireToolArgsObject(tool.validate(args), `Validated args for tool '${tool.name}'`);
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_validation', toolName: tool.name, rawArgs: toolCall.function.arguments });
       await this.emitToolError(toolCall, classified.message);
@@ -1285,7 +1292,7 @@ export class Agent extends EventEmitter {
         const hookResult = await this.runBeforeToolCallHooks({ toolCall, actionEvent, args: validated });
         if (hookResult && hookResult.args) {
           try {
-            validated = tool.validate(hookResult.args);
+            validated = requireToolArgsObject(tool.validate(hookResult.args), `Validated args for tool '${tool.name}'`);
           } catch (e) {
             const classified = classifyError(e, { stage: 'tool_validation', toolName: tool.name, rawArgs: toolCall.function.arguments });
             await this.emitToolError(toolCall, classified.message);

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -14,7 +14,7 @@ import {
   loadProfile,
   wouldExceedMaxInputTokens,
 } from '../llm';
-import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ToolCall } from '../types';
+import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ObservationEvent, ToolCall } from '../types';
 import {
   isActionEvent,
   isAgentErrorEvent,
@@ -54,6 +54,7 @@ import { buildLlmRequestParametersForDebug } from '../llm/debug';
 import { StuckDetector } from '../conversation/stuckDetector';
 import type { ConfirmationPolicy, SecurityAnalyzer } from '../security';
 import { createConfirmationPolicyFromSettings, LLMSecurityAnalyzer } from '../security';
+import type { AgentHook, AfterToolCallHookParams, BeforeToolCallHookParams, BeforeToolCallHookResult, ShouldStopHookParams } from './hooks';
 
 
 export type AgentRunInput = string | Message;
@@ -85,6 +86,7 @@ export interface AgentOptions {
   conversationStats?: import('./ConversationStats').ConversationStats;
   confirmationPolicy?: ConfirmationPolicy;
   securityAnalyzer?: SecurityAnalyzer | null;
+  hooks?: AgentHook | AgentHook[];
 }
 
 // Condensation is token-budget based (maxInputTokens). When the next request would exceed that
@@ -136,6 +138,7 @@ export class Agent extends EventEmitter {
   private readonly conversationStats?: import('./ConversationStats').ConversationStats;
   private debug: boolean;
   private readonly toolSummarizer: ToolSummarizer;
+  private readonly hooks: AgentHook[];
 
   constructor(private readonly options: AgentOptions) {
     super();
@@ -164,6 +167,7 @@ export class Agent extends EventEmitter {
     this.conversationStats = options.conversationStats;
     this.agentContext = options.agentContext;
     this.debug = false;
+    this.hooks = Array.isArray(options.hooks) ? options.hooks : options.hooks ? [options.hooks] : [];
 
     if (options.confirmationPolicy) {
       this.confirmationPolicyOverride = options.confirmationPolicy;
@@ -175,6 +179,67 @@ export class Agent extends EventEmitter {
     this.updateDerivedSettings(options.settings);
 
     this.events.on((event) => this.emit('event', event));
+  }
+
+  private async shouldStopByHooks(params: ShouldStopHookParams): Promise<boolean> {
+    for (const hook of this.hooks) {
+      if (!hook.shouldStop) continue;
+      try {
+        if (await hook.shouldStop(params)) {
+          return true;
+        }
+      } catch {
+        // Ignore hook failures to match Python SDK "hook results" semantics.
+      }
+    }
+    return false;
+  }
+
+  private async runAfterEventHooks(event: Event): Promise<void> {
+    for (const hook of this.hooks) {
+      if (!hook.afterEvent) continue;
+      try {
+        await hook.afterEvent({ event });
+      } catch {
+        // Ignore hook failures to match Python SDK "hook results" semantics.
+      }
+    }
+  }
+
+  private async pushEventWithHooks<T extends Event>(event: T): Promise<T> {
+    const recorded = this.events.push(event) as T;
+    await this.runAfterEventHooks(recorded);
+    return recorded;
+  }
+
+  private async runBeforeToolCallHooks(params: BeforeToolCallHookParams): Promise<BeforeToolCallHookResult> {
+    let currentArgs = params.args;
+    for (const hook of this.hooks) {
+      if (!hook.beforeToolCall) continue;
+      try {
+        const result = await hook.beforeToolCall({ ...params, args: currentArgs });
+        if (result && result.args) {
+          currentArgs = result.args;
+        }
+      } catch {
+        // Ignore hook failures to match Python SDK "hook results" semantics.
+      }
+    }
+    if (currentArgs !== params.args) {
+      return { args: currentArgs };
+    }
+    return undefined;
+  }
+
+  private async runAfterToolCallHooks(params: AfterToolCallHookParams): Promise<void> {
+    for (const hook of this.hooks) {
+      if (!hook.afterToolCall) continue;
+      try {
+        await hook.afterToolCall(params);
+      } catch {
+        // Ignore hook failures to match Python SDK "hook results" semantics.
+      }
+    }
   }
 
   private updateDerivedSettings(settings: OpenHandsSettings): void {
@@ -245,7 +310,7 @@ export class Agent extends EventEmitter {
   }
 
   private emitRestorePendingConfirmationDiagnostic(reason: string, detail?: Record<string, unknown>): void {
-    this.events.push({
+    void this.pushEventWithHooks({
       kind: 'ConversationStateUpdateEvent',
       source: 'agent',
       key: 'restore_pending_confirmation',
@@ -261,7 +326,7 @@ export class Agent extends EventEmitter {
         `Reason: ${reason}`,
         detail ? `Context: ${JSON.stringify(detail)}` : undefined,
       ].filter(Boolean) as string[];
-      this.events.push({
+      void this.pushEventWithHooks({
         kind: 'ConversationErrorEvent',
         source: 'agent',
         code: 'restore_pending_confirmation_failed',
@@ -339,7 +404,7 @@ export class Agent extends EventEmitter {
   pause(): void {
     if (this.paused) return;
     this.paused = true;
-    this.events.push({ kind: 'PauseEvent', source: 'user' });
+    void this.pushEventWithHooks({ kind: 'PauseEvent', source: 'user' } as Event);
     this.state.setStatus('PAUSED');
   }
 
@@ -374,7 +439,7 @@ export class Agent extends EventEmitter {
         await this.executeTool(pending.toolCall, pending.actionEvent, pending.args);
       } catch (error) {
         if (error instanceof ClassifiedToolExecutionError && error.classification === 'conversation') {
-          this.events.push(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
+          await this.pushEventWithHooks(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
         }
         this.state.setStatus('IDLE');
         throw error;
@@ -389,7 +454,7 @@ export class Agent extends EventEmitter {
     const rejectionReason = reason ?? 'User rejected the action';
     this.pendingAction = undefined;
     this.pendingWorkspaceAccess = undefined;
-    this.events.push({
+    void this.pushEventWithHooks({
       kind: 'UserRejectObservation',
       source: 'environment',
       rejection_reason: rejectionReason,
@@ -401,7 +466,7 @@ export class Agent extends EventEmitter {
     // OpenAI-compatible providers require that assistant tool_calls are followed by tool messages for each tool_call_id.
     // If the user rejects a tool call, emit a synthetic tool response so subsequent LLM calls remain valid.
     const rejectionText = truncateToolMessage(this.secretMasker.maskText(`User rejected tool call: ${rejectionReason}`));
-    this.events.push({
+    void this.pushEventWithHooks({
       kind: 'MessageEvent',
       source: 'environment',
       llm_message: {
@@ -422,7 +487,7 @@ export class Agent extends EventEmitter {
     this.pendingAction = pendingAction;
     this.pendingWorkspaceAccess = pendingWorkspaceAccess;
     this.state.setStatus('WAITING_FOR_CONFIRMATION');
-    this.events.push({ kind: 'PauseEvent', source: 'agent' });
+    void this.pushEventWithHooks({ kind: 'PauseEvent', source: 'agent' } as Event);
   }
 
   private async runLoop(): Promise<Message | undefined> {
@@ -434,7 +499,7 @@ export class Agent extends EventEmitter {
 
     // Check if we've already reached maxIterations
     if (this.state.snapshot.iteration >= maxIterations) {
-      this.events.push({
+      await this.pushEventWithHooks({
         kind: 'ConversationErrorEvent',
         source: 'agent',
         code: 'max_iterations_exceeded',
@@ -449,7 +514,7 @@ export class Agent extends EventEmitter {
       streamer = await this.getStreamer();
     } catch (error) {
       const classified = classifyError(error, { stage: 'llm_init' });
-      this.events.push(this.toConversationErrorEvent(error, { code: classified.code }));
+      await this.pushEventWithHooks(this.toConversationErrorEvent(error, { code: classified.code }));
       this.state.setStatus('IDLE');
       // Allow a future retry after settings/secrets are updated.
       this.llmClientPromise = undefined;
@@ -466,11 +531,16 @@ export class Agent extends EventEmitter {
     while (!this.paused && !this.pendingAction && !this.cancelled && !this.finished && this.state.snapshot.iteration < maxIterations) {
       this.state.setStatus('RUNNING');
 
+      if (await this.shouldStopByHooks({ state: this.state, events: this.events })) {
+        this.state.setStatus('IDLE');
+        break;
+      }
+
 
       if (stuckDetector) {
         const stuck = stuckDetector.detect(this.events.list());
         if (stuck.stuck) {
-          this.events.push({
+          await this.pushEventWithHooks({
             kind: 'ConversationErrorEvent',
             source: 'agent',
             code: 'stuck_detected',
@@ -499,7 +569,7 @@ export class Agent extends EventEmitter {
         // Emit a lightweight debug/state event so hosts can log what tools are actually sent
         try {
           const toolNames = (request.tools ?? []).map((t) => t.function?.name).filter(Boolean);
-          this.events.push({
+          await this.pushEventWithHooks({
             kind: 'ConversationStateUpdateEvent',
             source: 'agent',
             key: 'llm_request',
@@ -508,7 +578,7 @@ export class Agent extends EventEmitter {
         } catch (error) {
           if (this.debug) {
             console.warn('[Agent] Failed to emit llm_request debug event:', error);
-            this.events.push({
+            await this.pushEventWithHooks({
               kind: 'ConversationErrorEvent',
               source: 'agent',
               detail: `Debug event emission failed: ${error instanceof Error ? error.message : String(error)}`,
@@ -524,7 +594,7 @@ export class Agent extends EventEmitter {
               llmSettings: this.options.settings.llm,
               model: llmConfig.model,
             });
-            this.events.push({
+            await this.pushEventWithHooks({
               kind: 'ConversationStateUpdateEvent',
               source: 'agent',
               key: 'llm_request_payload',
@@ -560,7 +630,7 @@ export class Agent extends EventEmitter {
             try {
               const provider = llmConfig.provider ?? detectProviderFromBaseUrl(llmConfig.baseUrl);
               const baseUrl = llmConfig.baseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider];
-              this.events.push({
+              await this.pushEventWithHooks({
                 kind: 'ConversationStateUpdateEvent',
                 source: 'agent',
                 key: 'llm_response_payload',
@@ -590,7 +660,7 @@ export class Agent extends EventEmitter {
           }
 
           const classified = classifyError(error, { stage: 'llm_request' });
-          this.events.push(this.toConversationErrorEvent(error, { code: classified.code }));
+          await this.pushEventWithHooks(this.toConversationErrorEvent(error, { code: classified.code }));
           this.state.setStatus('IDLE');
           response = undefined;
           break;
@@ -604,7 +674,7 @@ export class Agent extends EventEmitter {
         source: 'agent',
         llm_message: response.message,
       };
-      this.events.push(assistantEvent);
+      await this.pushEventWithHooks(assistantEvent);
       if (response.usage) {
         this.state.setValue('llm_usage', response.usage);
       }
@@ -629,7 +699,7 @@ export class Agent extends EventEmitter {
         try {
           const rawArgs = toolCall.function?.arguments ?? '';
           const safeArgs = typeof rawArgs === 'string' ? redactAndTruncateArgs(rawArgs) : rawArgs;
-          this.events.push({
+          await this.pushEventWithHooks({
             kind: 'ConversationStateUpdateEvent',
             source: 'agent',
             key: 'llm_tool_call_raw',
@@ -642,7 +712,7 @@ export class Agent extends EventEmitter {
         } catch (error) {
           if (this.debug) {
             console.warn('[Agent] Failed to emit tool_call_raw debug event:', error);
-            this.events.push({
+            await this.pushEventWithHooks({
               kind: 'ConversationErrorEvent',
               source: 'agent',
               detail: `Debug event emission failed for tool call: ${error instanceof Error ? error.message : String(error)}`,
@@ -659,10 +729,10 @@ export class Agent extends EventEmitter {
         const actionArgs = args ?? {};
 
         const actionEvent = this.createActionEvent(response.message, toolCall, args, securityRisk);
-        const recordedAction = this.events.push(actionEvent) as ActionEvent;
+        const recordedAction = await this.pushEventWithHooks(actionEvent);
 
         if (finishedThisTurn) {
-          this.emitSkippedToolCall(toolCall, recordedAction, 'Skipped: finish tool already called in this run.');
+          await this.emitSkippedToolCall(toolCall, recordedAction, 'Skipped: finish tool already called in this run.');
           continue;
         }
 
@@ -685,7 +755,7 @@ export class Agent extends EventEmitter {
           }
         } catch (error) {
           if (error instanceof ClassifiedToolExecutionError && error.classification === 'conversation') {
-            this.events.push(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
+            await this.pushEventWithHooks(this.toConversationErrorEvent(error, { code: error.code, message: error.message }));
             this.state.setStatus('IDLE');
             return lastAssistantMessage;
           }
@@ -706,7 +776,7 @@ export class Agent extends EventEmitter {
 
       // Check if we've reached maxIterations
       if (this.state.snapshot.iteration >= maxIterations) {
-        this.events.push({
+        await this.pushEventWithHooks({
           kind: 'ConversationErrorEvent',
           source: 'agent',
           code: 'max_iterations_exceeded',
@@ -827,7 +897,7 @@ export class Agent extends EventEmitter {
     if (!result?.summary) return false;
     if (!result.forgottenEventIds.length) return false;
 
-    this.events.push({
+    await this.pushEventWithHooks({
       kind: 'Condensation',
       source: 'environment',
       forgotten_event_ids: result.forgottenEventIds,
@@ -1022,7 +1092,7 @@ export class Agent extends EventEmitter {
     if (existing) return;
 
     const systemPrompt = this.buildSystemPrompt();
-    this.events.push({
+    void this.pushEventWithHooks({
       kind: 'SystemPromptEvent',
       source: 'agent',
       system_prompt: { type: 'text', text: systemPrompt },
@@ -1056,13 +1126,13 @@ export class Agent extends EventEmitter {
       ...(activatedSkillNames.length > 0 && { activated_skills: activatedSkillNames }),
       ...(extendedContent.length > 0 && { extended_content: extendedContent }),
     };
-    this.events.push(event);
+    void this.pushEventWithHooks(event);
   }
 
-  private emitToolError(toolCall: ToolCall, error: string): void {
+  private async emitToolError(toolCall: ToolCall, error: string): Promise<void> {
     const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, error);
-    this.events.push(agentErrorEvent);
-    this.events.push(toolMessageEvent);
+    await this.pushEventWithHooks(agentErrorEvent);
+    await this.pushEventWithHooks(toolMessageEvent);
   }
 
   private parseToolArgs(toolCall: ToolCall): { args: Record<string, unknown>; securityRisk?: SecurityRisk } | undefined {
@@ -1099,7 +1169,7 @@ export class Agent extends EventEmitter {
       throw new Error('Tool arguments must be a JSON object.');
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_args', toolName: toolCall.function.name, rawArgs: raw });
-      this.emitToolError(toolCall, classified.message);
+      void this.emitToolError(toolCall, classified.message);
       return undefined;
     }
   }
@@ -1130,10 +1200,10 @@ export class Agent extends EventEmitter {
     return this.confirmationPolicy.shouldConfirm(risk);
   }
 
-  private emitSkippedToolCall(toolCall: ToolCall, actionEvent: ActionEvent, reason: string): void {
+  private async emitSkippedToolCall(toolCall: ToolCall, actionEvent: ActionEvent, reason: string): Promise<void> {
     const maskedReason = this.secretMasker.maskText(reason);
     const clipped = truncateToolMessage(maskedReason);
-    this.events.push({
+    await this.pushEventWithHooks({
       kind: 'ObservationEvent',
       source: 'environment',
       observation: { skipped: true, reason: maskedReason },
@@ -1141,7 +1211,7 @@ export class Agent extends EventEmitter {
       tool_call_id: toolCall.id,
       action_id: actionEvent.id ?? randomUUID(),
     } as Event);
-    this.events.push({
+    await this.pushEventWithHooks({
       kind: 'MessageEvent',
       source: 'environment',
       llm_message: {
@@ -1197,7 +1267,7 @@ export class Agent extends EventEmitter {
       const available = Array.from(this.tools.keys());
       const errText = `Tool '${toolCall.function.name}' not found. Available: ${JSON.stringify(available)}`;
       const classified = classifyError(errText, { stage: 'tool_lookup', toolName: toolCall.function.name });
-      this.emitToolError(toolCall, classified.message);
+      await this.emitToolError(toolCall, classified.message);
       throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
     }
 
@@ -1206,11 +1276,25 @@ export class Agent extends EventEmitter {
       validated = tool.validate(args);
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_validation', toolName: tool.name, rawArgs: toolCall.function.arguments });
-      this.emitToolError(toolCall, classified.message);
+      await this.emitToolError(toolCall, classified.message);
       throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
     }
 
     try {
+      if (this.hooks.length) {
+        const hookResult = await this.runBeforeToolCallHooks({ toolCall, actionEvent, args: validated });
+        if (hookResult && hookResult.args) {
+          try {
+            validated = tool.validate(hookResult.args);
+          } catch (e) {
+            const classified = classifyError(e, { stage: 'tool_validation', toolName: tool.name, rawArgs: toolCall.function.arguments });
+            await this.emitToolError(toolCall, classified.message);
+            await this.runAfterToolCallHooks({ toolCall, actionEvent, args: validated, error: classified.message });
+            throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
+          }
+        }
+      }
+
       const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
       const result = await tool.execute(validated, context);
       // Attach specialized summaries first (file diff, terminal), then general tool call summary as fallback
@@ -1222,15 +1306,15 @@ export class Agent extends EventEmitter {
         this.emitTerminalEvents(toolCall, enrichedResult);
       }
 
-      const observation = {
+      const observation: ObservationEvent = {
         kind: 'ObservationEvent',
         source: 'environment',
         observation: deepTruncate(this.secretMasker.maskUnknown(enrichedResult)) as Record<string, unknown>,
         tool_name: toolCall.function.name,
         tool_call_id: toolCall.id,
         action_id: actionEvent.id ?? randomUUID(),
-      } as Event;
-      this.events.push(observation);
+      } as ObservationEvent;
+      const recordedObservation = await this.pushEventWithHooks(observation);
 
       // Remove summary from result before formatting for LLM - summaries are for UI display only
       const resultForLlm = (() => {
@@ -1257,14 +1341,23 @@ export class Agent extends EventEmitter {
           content: [{ type: 'text', text: clipped }],
         },
       };
-      this.events.push(toolMessage);
+      await this.pushEventWithHooks(toolMessage);
+
+      await this.runAfterToolCallHooks({
+        toolCall,
+        actionEvent,
+        args: validated,
+        observationEvent: recordedObservation,
+      });
     } catch (e) {
       const classified = classifyError(e, { stage: 'tool_execute', toolName: tool.name });
       if (classified.classification === 'agent') {
         // Treat execution failures as agent-visible errors so the LLM can self-correct.
-        this.emitToolError(toolCall, classified.message);
+        await this.emitToolError(toolCall, classified.message);
+        await this.runAfterToolCallHooks({ toolCall, actionEvent, args: validated, error: classified.message });
         throw new ClassifiedToolExecutionError({ classification: 'agent', message: classified.message });
       }
+      await this.runAfterToolCallHooks({ toolCall, actionEvent, args: validated, error: classified.message });
       throw new ClassifiedToolExecutionError({
         classification: 'conversation',
         message: classified.message,

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts
@@ -1,0 +1,173 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { Agent, EventLog } from '../';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+import { isMessageEvent, isObservationEvent } from '../../types';
+import type { AgentHook } from '../hooks';
+
+class MockLLM implements LLMClient {
+  constructor(private readonly chunks: LLMStreamChunk[]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    for (const chunk of this.chunks) {
+      yield chunk;
+    }
+  }
+}
+
+class CountingLLM implements LLMClient {
+  calls = 0;
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    this.calls += 1;
+    yield { type: 'text', text: 'Hello' };
+    yield { type: 'finish' };
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: {},
+  secrets: {},
+};
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-hooks-'));
+
+describe('Agent hooks', () => {
+  it('runs hooks around tool execution (beforeToolCall can rewrite args; afterEvent ordering; afterToolCall receives observation)', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => {
+        const value = (input as { value?: unknown }).value;
+        if (typeof value !== 'string') throw new Error('value must be a string');
+        return { value };
+      },
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'echo', arguments: '{"value":"original"}' },
+      { type: 'finish' },
+    ]);
+
+    const timeline: string[] = [];
+    let afterToolCallError: unknown;
+    let afterToolCallArgs: Record<string, unknown> | undefined;
+    let afterToolCallObservation: Record<string, unknown> | undefined;
+
+    const hook: AgentHook = {
+      beforeToolCall: ({ args }) => {
+        timeline.push('beforeToolCall');
+        return { args: { ...args, value: 'modified' } };
+      },
+      afterEvent: ({ event }) => {
+        if (isObservationEvent(event) && event.tool_call_id === 'call_1') {
+          timeline.push('afterEvent:ObservationEvent');
+        }
+        if (isMessageEvent(event) && event.llm_message.role === 'tool' && event.llm_message.tool_call_id === 'call_1') {
+          timeline.push('afterEvent:ToolMessage');
+        }
+      },
+      afterToolCall: ({ toolCall, args, observationEvent, error }) => {
+        if (toolCall.id !== 'call_1') return;
+        timeline.push('afterToolCall');
+        afterToolCallError = error;
+        afterToolCallArgs = args;
+        afterToolCallObservation = observationEvent?.observation as Record<string, unknown> | undefined;
+      },
+    };
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+      hooks: hook,
+    });
+
+    await agent.run('run tool');
+
+    expect(afterToolCallError).toBeUndefined();
+    expect(afterToolCallArgs).toEqual({ value: 'modified' });
+    expect(afterToolCallObservation).toEqual({ echoed: 'modified' });
+
+    const afterEventObservationIdx = timeline.indexOf('afterEvent:ObservationEvent');
+    const afterEventToolMessageIdx = timeline.indexOf('afterEvent:ToolMessage');
+    const afterToolCallIdx = timeline.indexOf('afterToolCall');
+    expect(afterEventObservationIdx).toBeGreaterThanOrEqual(0);
+    expect(afterEventToolMessageIdx).toBeGreaterThan(afterEventObservationIdx);
+    expect(afterToolCallIdx).toBeGreaterThan(afterEventToolMessageIdx);
+  });
+
+  it('shouldStop hook can stop the run loop before any LLM call', async () => {
+    const log = new EventLog();
+    const llm = new CountingLLM();
+
+    const agent = new Agent({
+      settings: { ...baseSettings, conversation: { maxIterations: 3 } },
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      hooks: {
+        shouldStop: () => true,
+      },
+    });
+
+    await agent.run('hi');
+
+    expect(llm.calls).toBe(0);
+  });
+
+  it('afterToolCall hook receives error when tool execution fails', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<Record<string, never>, Record<string, never>> = {
+      name: 'fail',
+      validate: () => ({}),
+      execute: async () => {
+        throw new Error('boom');
+      },
+    };
+
+    const llm = new MockLLM([
+      { type: 'text', text: 'Using tool' },
+      { type: 'tool_call_delta', id: 'call_1', name: 'fail', arguments: '{}' },
+      { type: 'finish' },
+    ]);
+
+    let called = false;
+    let errorValue: unknown;
+
+    const agent = new Agent({
+      settings: baseSettings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      tools: [tool],
+      hooks: {
+        afterToolCall: ({ toolCall, observationEvent, error }) => {
+          if (toolCall.id !== 'call_1') return;
+          called = true;
+          errorValue = error;
+          expect(observationEvent).toBeUndefined();
+        },
+      },
+    });
+
+    await agent.run('run tool');
+
+    expect(called).toBe(true);
+    expect(errorValue).toBeTruthy();
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/hooks.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/hooks.ts
@@ -1,0 +1,40 @@
+import type { ActionEvent, Event, ObservationEvent, ToolCall } from '../types';
+import type { ConversationState } from './ConversationState';
+import type { EventLog } from './EventLog';
+
+export type BeforeToolCallHookResult =
+  | void
+  | {
+      args?: Record<string, unknown>;
+    };
+
+export interface BeforeToolCallHookParams {
+  toolCall: ToolCall;
+  actionEvent: ActionEvent;
+  args: Record<string, unknown>;
+}
+
+export interface AfterToolCallHookParams {
+  toolCall: ToolCall;
+  actionEvent: ActionEvent;
+  args: Record<string, unknown>;
+  observationEvent?: ObservationEvent;
+  error?: unknown;
+}
+
+export interface AfterEventHookParams {
+  event: Event;
+}
+
+export interface ShouldStopHookParams {
+  state: ConversationState;
+  events: EventLog;
+}
+
+export interface AgentHook {
+  beforeToolCall?: (params: BeforeToolCallHookParams) => BeforeToolCallHookResult | Promise<BeforeToolCallHookResult>;
+  afterToolCall?: (params: AfterToolCallHookParams) => void | Promise<void>;
+  afterEvent?: (params: AfterEventHookParams) => void | Promise<void>;
+  shouldStop?: (params: ShouldStopHookParams) => boolean | Promise<boolean>;
+}
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/index.ts
@@ -3,6 +3,7 @@ export * from './ConversationState';
 export * from './SecretRegistry';
 export * from './AsyncLock';
 export * from './Agent';
+export * from './hooks';
 export * from './LLMStreamer';
 export * from './persistence';
 export * from './ConversationStats';


### PR DESCRIPTION
Implements a minimal hooks pipeline in agent-sdk-ts runtime for parity with Python SDK (pre/post tool use, afterEvent, shouldStop).

Closes #646.

Tests:
- 
 RUN  v3.2.4 /Users/enyst/repos/oh-tab

stdout | packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts > Agent hooks > runs hooks around tool execution (beforeToolCall can rewrite args; afterEvent ordering; afterToolCall receives observation)
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts > Agent hooks > runs hooks around tool execution (beforeToolCall can rewrite args; afterEvent ordering; afterToolCall receives observation)
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts > Agent hooks > shouldStop hook can stop the run loop before any LLM call
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts > Agent hooks > afterToolCall hook receives error when tool execution fails
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts > Agent hooks > afterToolCall hook receives error when tool execution fails
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.hooks.test.ts (3 tests) 7ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  02:35:48
   Duration  548ms (transform 142ms, setup 23ms, collect 194ms, tests 7ms, environment 174ms, prepare 28ms)
- 
> @openhands/agent-sdk-ts@0.1.0 lint
> eslint ./src
- 
> openhands-tab@0.0.4 typecheck
> tsc -p . && tsc -p tsconfig.webview.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added extensible hook system for agents with four lifecycle hooks: beforeToolCall to modify tool arguments, afterToolCall for post-execution logic, afterEvent to observe events, and shouldStop to control execution flow.
* Hooks can be passed through conversation and agent configuration options for enhanced runtime customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->