### PR TITLE
agent-sdk-ts parity: observations module for tool messages (#664)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/observations/__tests__/observations.format.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/observations/__tests__/observations.format.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import type { ToolCall } from '../../types';
+import { toolResultToLLMText } from '..';
+
+const toolCall = (name: string, args: Record<string, unknown> | string): ToolCall => ({
+  id: 'call_1',
+  type: 'function',
+  function: {
+    name,
+    arguments: typeof args === 'string' ? args : JSON.stringify(args),
+  },
+});
+
+describe('observations formatting', () => {
+  it('formats terminal tool output like the legacy runtime formatter', () => {
+    const call = toolCall('terminal', { command: 'echo hi' });
+    const text = toolResultToLLMText(call, { stdout: 'hi\n', stderr: '', exit_code: 0 });
+    expect(text).toBe('$ echo hi\nhi\n[Command finished with exit code 0]');
+  });
+
+  it('formats terminal tool output with timeout marker', () => {
+    const call = toolCall('terminal', { command: 'sleep 10' });
+    const text = toolResultToLLMText(call, { stdout: '', stderr: '', timeout: true });
+    expect(text).toBe('$ sleep 10\n[Command finished]\n[Command timed out]');
+  });
+
+  it('formats file_editor tool output like the legacy runtime formatter', () => {
+    const call = toolCall('file_editor', { command: 'view', path: '/tmp/a.txt' });
+    const text = toolResultToLLMText(call, { command: 'view', path: '/tmp/a.txt', new_content: 'hello' });
+    expect(text).toBe('file_editor view /tmp/a.txt\nhello');
+  });
+
+  it('formats generic objects via stable JSON stringification', () => {
+    const call = toolCall('some_tool', '{}');
+    const text = toolResultToLLMText(call, { ok: true });
+    expect(text).toBe('{\n  "ok": true\n}');
+  });
+
+  it('returns generic string results as-is', () => {
+    const call = toolCall('some_tool', '{}');
+    const text = toolResultToLLMText(call, 'hello');
+    expect(text).toBe('hello');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/observations/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/observations/index.ts
@@ -1,0 +1,120 @@
+import type { ToolCall } from '../types';
+
+export type Observation = TerminalObservation | FileEditorObservation | GenericObservation;
+
+export interface TerminalObservation {
+  kind: 'terminal';
+  command?: string;
+  stdout?: string;
+  stderr?: string;
+  exit_code?: number;
+  timeout?: boolean;
+}
+
+export interface FileEditorObservation {
+  kind: 'file_editor';
+  command?: string;
+  path?: string;
+  new_content?: string | null;
+}
+
+export interface GenericObservation {
+  kind: 'generic';
+  value: unknown;
+}
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+
+const toOptionalNonEmptyString = (value: unknown): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed : undefined;
+};
+
+const parseTerminalCommandFromToolCall = (toolCall: ToolCall): string | undefined => {
+  const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
+  if (!rawArgs) return undefined;
+  try {
+    const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
+    return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
+  } catch {
+    return rawArgs;
+  }
+};
+
+export function toObservation(toolCall: ToolCall, result: unknown): Observation {
+  const toolName = toolCall.function.name;
+
+  if (toolName === 'terminal') {
+    const record = asRecord(result) ?? {};
+    const command = toOptionalNonEmptyString(record.command) ?? parseTerminalCommandFromToolCall(toolCall);
+    const stdout = typeof record.stdout === 'string' ? record.stdout : undefined;
+    const stderr = typeof record.stderr === 'string' ? record.stderr : undefined;
+    const exit_code = typeof record.exit_code === 'number' ? record.exit_code : undefined;
+    const timeout = record.timeout === true;
+    return { kind: 'terminal', command, stdout, stderr, exit_code, timeout };
+  }
+
+  if (toolName === 'file_editor') {
+    const record = asRecord(result) ?? {};
+    const command = toOptionalNonEmptyString(record.command);
+    const path = toOptionalNonEmptyString(record.path);
+    const new_content =
+      typeof record.new_content === 'string'
+        ? record.new_content
+        : record.new_content === null
+          ? null
+          : undefined;
+    return { kind: 'file_editor', command, path, new_content };
+  }
+
+  return { kind: 'generic', value: result };
+}
+
+export function observationToLLMText(observation: Observation): string {
+  if (observation.kind === 'terminal') {
+    const stdout = typeof observation.stdout === 'string' ? observation.stdout.trimEnd() : '';
+    const stderr = typeof observation.stderr === 'string' ? observation.stderr.trimEnd() : '';
+    const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
+
+    const parts: string[] = [];
+    if (observation.command) {
+      parts.push(observation.command.startsWith('$') ? observation.command : `$ ${observation.command}`);
+    }
+    if (output) parts.push(output);
+    if (typeof observation.exit_code === 'number') {
+      parts.push(`[Command finished with exit code ${observation.exit_code}]`);
+    } else {
+      parts.push('[Command finished]');
+    }
+    if (observation.timeout) parts.push('[Command timed out]');
+    return parts.join('\n');
+  }
+
+  if (observation.kind === 'file_editor') {
+    const headerParts = ['file_editor'];
+    if (observation.command) headerParts.push(observation.command);
+    if (observation.path) headerParts.push(observation.path);
+    const header = headerParts.join(' ');
+    const content =
+      typeof observation.new_content === 'string'
+        ? observation.new_content
+        : observation.new_content === null
+          ? '<file removed>'
+          : '';
+    return content ? `${header}\n${content}` : header;
+  }
+
+  const result = observation.value;
+  if (typeof result === 'string') return result;
+  if (result === null || result === undefined) return String(result);
+  try {
+    return JSON.stringify(result, null, 2);
+  } catch {
+    return Object.prototype.toString.call(result);
+  }
+}
+
+export function toolResultToLLMText(toolCall: ToolCall, result: unknown): string {
+  return observationToLLMText(toObservation(toolCall, result));
+}

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolMessageFormatting.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolMessageFormatting.ts
@@ -1,62 +1,6 @@
 import type { ToolCall } from '../types';
-import { toOptionalNonEmptyString } from './settingsUtils';
+import { toolResultToLLMText } from '../observations';
 
 export function formatToolMessageText(toolCall: ToolCall, result: unknown): string {
-  const toolName = toolCall.function.name;
-  const asRecord = (value: unknown): Record<string, unknown> | undefined =>
-    value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
-
-  if (toolName === 'terminal') {
-    const record = asRecord(result) ?? {};
-    const commandFromArgs = (() => {
-      const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
-      if (!rawArgs) return undefined;
-      try {
-        const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
-        return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
-      } catch {
-        return rawArgs;
-      }
-    })();
-    const command = toOptionalNonEmptyString(record.command) ?? commandFromArgs;
-    const stdout = typeof record.stdout === 'string' ? record.stdout.trimEnd() : '';
-    const stderr = typeof record.stderr === 'string' ? record.stderr.trimEnd() : '';
-    const exitCode = typeof record.exit_code === 'number' ? record.exit_code : undefined;
-    const timedOut = record.timeout === true;
-
-    const parts: string[] = [];
-    if (command) {
-      parts.push(command.startsWith('$') ? command : `$ ${command}`);
-    }
-    const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
-    if (output) parts.push(output);
-    if (typeof exitCode === 'number') {
-      parts.push(`[Command finished with exit code ${exitCode}]`);
-    } else {
-      parts.push('[Command finished]');
-    }
-    if (timedOut) parts.push('[Command timed out]');
-    return parts.join('\n');
-  }
-
-  if (toolName === 'file_editor') {
-    const record = asRecord(result) ?? {};
-    const command = toOptionalNonEmptyString(record.command);
-    const targetPath = toOptionalNonEmptyString(record.path);
-    const headerParts = ['file_editor'];
-    if (command) headerParts.push(command);
-    if (targetPath) headerParts.push(targetPath);
-    const header = headerParts.join(' ');
-    const content = typeof record.new_content === 'string' ? record.new_content : record.new_content === null ? '<file removed>' : '';
-    return content ? `${header}\n${content}` : header;
-  }
-
-  if (typeof result === 'string') return result;
-  if (result === null || result === undefined) return String(result);
-  try {
-    return JSON.stringify(result, null, 2);
-  } catch {
-    return Object.prototype.toString.call(result);
-  }
+  return toolResultToLLMText(toolCall, result);
 }
-


### PR DESCRIPTION
Implements an observations-layer formatter (terminal/file_editor/generic) and routes the runtime tool-message formatter through it.

Closes #664.

Tests:
- 
> @openhands/agent-sdk-ts@0.1.0 lint
> eslint ./src
- 
> @openhands/agent-sdk-ts@0.1.0 test
> vitest run


 RUN  v3.2.4 /Users/enyst/repos/oh-tab/packages/agent-sdk-ts

 ✓ src/sdk/__tests__/agent.condensation-budget.test.ts (1 test) 280ms
 ✓ src/sdk/__tests__/remoteConversation.test.ts (31 tests) 160ms
 ✓ src/tools/__tests__/glob-grep.test.ts (17 tests) 139ms
 ✓ src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts (3 tests) 334ms
 ✓ src/workspace/__tests__/local.workspace.test.ts (17 tests) 59ms
 ✓ src/tools/__tests__/new-tools.test.ts (13 tests) 45ms
stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits system prompt and stops when no tool calls
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits system prompt and stops when no tool calls
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > honors confirmation policy and executes tool on approval
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > honors confirmation policy and executes tool on approval
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > replays persisted history when restored
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > replays persisted history when restored
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a tool message when the user rejects a tool call (avoids stale tool_call_id)
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a tool message when the user rejects a tool call (avoids stale tool_call_id)
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > replays persisted history when restored
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a tool message when the user rejects a tool call (avoids stale tool_call_id)
[Agent.getStreamer] Reusing cached streamer.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a tool message when the user rejects a tool call (avoids stale tool_call_id)
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores persisted LLM config on conversation restore
[Agent.getStreamer] Creating new streamer. Profile: sonnet-45, Model: undefined

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > prompts for confirmation before accessing files outside the workspace
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores persisted LLM config on conversation restore
[Agent.runLoop] Iteration 0. Settings: profile=sonnet-45, model=undefined. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > prompts for confirmation before accessing files outside the workspace
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores persisted LLM config on conversation restore
[Agent.setSettings] Settings updated. Profile: undefined -> sonnet-45, Model: restored-model -> undefined. Cleared streamerPromise.

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > does not persist or restore raw LLM fields when a profileId is present
[Agent.getStreamer] Creating new streamer. Profile: sonnet-45, Model: undefined

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > does not persist or restore raw LLM fields when a profileId is present
[Agent.runLoop] Iteration 0. Settings: profile=sonnet-45, model=undefined. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > does not persist or restore raw LLM fields when a profileId is present
[Agent.setSettings] Settings updated. Profile: undefined -> sonnet-45, Model: restored-model -> undefined. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows creating an external file after approval
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows creating an external file after approval
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > ignores corrupted persisted LLM config
[Agent.getStreamer] Creating new streamer. Profile: sonnet-45, Model: undefined

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > ignores corrupted persisted LLM config
[Agent.runLoop] Iteration 0. Settings: profile=sonnet-45, model=undefined. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > continues conversation after restoration
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > continues conversation after restoration
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > does not grant directory access when creating an external file
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > does not grant directory access when creating an external file
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > continues conversation after restoration
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > does not grant directory access when creating an external file
[Agent.getStreamer] Reusing cached streamer.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > does not grant directory access when creating an external file
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores pending confirmations so approveAction works after restore
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores pending confirmations so approveAction works after restore
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > records agent error when tool arguments are not objects
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > records agent error when tool arguments are not objects
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > handles JSON primitives in tool arguments by emitting agent error
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > handles JSON primitives in tool arguments by emitting agent error
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores pending confirmations so approveAction works after restore
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > runs condensation after a context-limit error and retries the LLM request
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > runs condensation after a context-limit error and retries the LLM request
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits ConversationErrorEvent and sets status to IDLE when maxIterations is reached
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits ConversationErrorEvent and sets status to IDLE when maxIterations is reached
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits ConversationErrorEvent and sets status to IDLE when maxIterations is reached
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > does not emit maxIterations error when loop exits for other reasons
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > does not emit maxIterations error when loop exits for other reasons
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows continuation after maxIterations is increased
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows continuation after maxIterations is increased
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows continuation after maxIterations is increased
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows continuation after maxIterations is increased
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > allows continuation after maxIterations is increased
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores pending workspace access confirmations so approveAction allows file_editor paths after restore
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a ConversationErrorEvent when stuck detection triggers
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores pending workspace access confirmations so approveAction allows file_editor paths after restore
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a ConversationErrorEvent when stuck detection triggers
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.loop.test.ts > Agent loop control > emits a ConversationErrorEvent when stuck detection triggers
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/persistence.test.ts > LocalConversation persistence > restores pending workspace access confirmations so approveAction allows file_editor paths after restore
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

 ✓ src/sdk/__tests__/agent.loop.test.ts (13 tests) 58ms
 ✓ src/sdk/__tests__/persistence.test.ts (20 tests) 55ms
 ✓ src/tools/__tests__/ApplyPatchTool.test.ts (6 tests) 21ms
 ✓ src/sdk/llm/__tests__/factory.gemini-profile-generation-config.test.ts (2 tests) 6ms
 ✓ src/sdk/context/skills/__tests__/skill.test.ts (39 tests) 26ms
 ✓ src/sdk/__tests__/llm.profiles.test.ts (9 tests) 15ms
stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > emits assistant messages when LLM responds without tools
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > emits assistant messages when LLM responds without tools
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > executes tool calls and emits observations
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > executes tool calls and emits observations
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > executes tool calls and emits observations
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > records AgentErrorEvents when tool args JSON is invalid
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > records AgentErrorEvents when tool args JSON is invalid
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > records AgentErrorEvents when tool args JSON is invalid
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > emits AgentErrorEvent for unknown tools
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > emits AgentErrorEvent for unknown tools
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > emits AgentErrorEvent for unknown tools
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > captures tool validation failures as AgentErrorEvents
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > captures tool validation failures as AgentErrorEvents
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > captures tool validation failures as AgentErrorEvents
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > emits ConversationErrorEvent when no LLM API key is available
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > includes skill extended_content in LLM requests when agentContext is configured
Skill 'e2e-skill' triggered by keyword 'banana'
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > includes skill extended_content in LLM requests when agentContext is configured
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > supports tool introspection and updates tools only before user messages
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/LocalConversation.test.ts > LocalConversation > supports tool introspection and updates tools only before user messages
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/conversation/LocalConversation.test.ts (12 tests) 24ms
stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > llm_request debug event emission > silently ignores emission failures when debug is disabled (default)
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > llm_request debug event emission > silently ignores emission failures when debug is disabled (default)
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > llm_request debug event emission > logs warnings and emits error events when debug is enabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > llm_request debug event emission > logs warnings and emits error events when debug is enabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > tool_call_raw debug event emission > silently ignores emission failures when debug is disabled (default)
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > tool_call_raw debug event emission > silently ignores emission failures when debug is disabled (default)
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > tool_call_raw debug event emission > logs warnings and emits error events when debug is enabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > tool_call_raw debug event emission > logs warnings and emits error events when debug is enabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > normal operation without failures > emits debug events successfully when debug is disabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > normal operation without failures > emits debug events successfully when debug is disabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > normal operation without failures > emits debug events successfully when debug is enabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.debug-mode.test.ts > Agent debug mode > normal operation without failures > emits debug events successfully when debug is enabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.debug-mode.test.ts (6 tests) 13ms
 ✓ src/tools/__tests__/tools.test.ts (27 tests) 818ms
   ✓ FileEditorTool > prunes undo_edit history by byte cap without losing the latest edit  360ms
stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > formats terminal tool output as plain text and masks configured secrets
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > formats terminal tool output as plain text and masks configured secrets
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks secrets in BashEvents emitted from the terminal tool
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks secrets in BashEvents emitted from the terminal tool
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > serializes non-plain tool results in ObservationEvent payloads
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > serializes non-plain tool results in ObservationEvent payloads
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks secrets inside class-instance tool results in ObservationEvent payloads
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks secrets inside class-instance tool results in ObservationEvent payloads
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > handles circular arrays in ObservationEvent payloads
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > handles circular arrays in ObservationEvent payloads
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks uppercase secrets even when they resemble env var names
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks uppercase secrets even when they resemble env var names
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks uppercase secrets when an env var of the same name exists with a different value
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks uppercase secrets when an env var of the same name exists with a different value
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > truncates long terminal tool outputs using <response clipped>
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > truncates long terminal tool outputs using <response clipped>
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks secrets registered in SecretRegistry
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > masks secrets registered in SecretRegistry
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > parses terminal command from tool call args when tool result omits it
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > parses terminal command from tool call args when tool result omits it
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > formats file_editor tool output as plain text
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-messages.test.ts > Agent tool message formatting > formats file_editor tool output as plain text
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.tool-messages.test.ts (11 tests) 22ms
 ✓ src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts (2 tests) 9ms
stdout | src/sdk/conversation/Conversation.factory.test.ts > Conversation factory > supports local hello-world tool flow via Conversation()
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/conversation/Conversation.factory.test.ts > Conversation factory > supports local hello-world tool flow via Conversation()
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/conversation/Conversation.factory.test.ts > Conversation factory > supports local hello-world tool flow via Conversation()
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/conversation/Conversation.factory.test.ts (3 tests) 25ms
stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > emits tool messages when parsing tool arguments fails
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > emits tool messages when parsing tool arguments fails
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > emits tool messages when an unknown tool is requested
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > emits tool messages when an unknown tool is requested
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > propagates validation failures while emitting tool messages
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > propagates validation failures while emitting tool messages
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > propagates execution failures while emitting tool messages
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > propagates execution failures while emitting tool messages
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > emits ConversationErrorEvent (and no tool message) for conversation-level tool execution failures
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > emits ConversationErrorEvent (and no tool message) for conversation-level tool execution failures
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > sanitizes orphan tool_calls from future requests after conversation-level tool failures
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > sanitizes orphan tool_calls from future requests after conversation-level tool failures
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > sanitizes orphan tool_calls from future requests after conversation-level tool failures
[Agent.getStreamer] Reusing cached streamer.

stdout | src/sdk/runtime/__tests__/Agent.tool-errors.test.ts > Agent tool call error handling > sanitizes orphan tool_calls from future requests after conversation-level tool failures
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.tool-errors.test.ts (6 tests) 13ms
stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > requires security_risk when enableSecurityAnalyzer is true
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > requires security_risk when enableSecurityAnalyzer is true
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > uses security_risk for ConfirmRisky decisions when analyzer is enabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > uses security_risk for ConfirmRisky decisions when analyzer is enabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > preserves runtime confirmation policy overrides across setSettings()
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > preserves runtime confirmation policy overrides across setSettings()
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > preserves runtime confirmation policy overrides across setSettings()
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > preserves runtime security analyzer overrides across setSettings()
[Agent.setSettings] Settings updated. Profile: undefined -> undefined, Model: test-model -> test-model. Cleared streamerPromise.

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > preserves runtime security analyzer overrides across setSettings()
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > preserves runtime security analyzer overrides across setSettings()
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > defaults analyzer errors to HIGH risk (confirmation required)
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > defaults analyzer errors to HIGH risk (confirmation required)
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > uses ActionEvent.security_risk when analyzer is disabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/__tests__/agent.security.test.ts > Security analyzer + confirmation policy parity > uses ActionEvent.security_risk when analyzer is disabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/__tests__/agent.security.test.ts (7 tests) 12ms
 ✓ src/sdk/llm/__tests__/thinkingBlocks.test.ts (9 tests) 9ms
stdout | src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts > Agent truncates tool logs and observations > truncates llm_tool_call_raw arguments value
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts > Agent truncates tool logs and observations > truncates llm_tool_call_raw arguments value
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts > Agent truncates tool logs and observations > deep truncates ObservationEvent payload and tool message content
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts > Agent truncates tool logs and observations > deep truncates ObservationEvent payload and tool message content
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts > Agent truncates tool logs and observations > truncates large stdout results in ObservationEvent and tool message
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts > Agent truncates tool logs and observations > truncates large stdout results in ObservationEvent and tool message
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts (3 tests) 8ms
stdout | src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts > Agent mixed tool call outcomes > executes later tool calls even if an earlier tool is missing
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts > Agent mixed tool call outcomes > executes later tool calls even if an earlier tool is missing
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts > Agent mixed tool call outcomes > executes later tool calls even if an earlier tool is missing
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts > Agent mixed tool call outcomes > executes later tool calls even if an earlier tool call has invalid JSON args
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts > Agent mixed tool call outcomes > executes later tool calls even if an earlier tool call has invalid JSON args
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts > Agent mixed tool call outcomes > executes later tool calls even if an earlier tool call has invalid JSON args
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts (2 tests) 10ms
stdout | src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts > Agent terminal ObservationEvent summaries (UI) > attaches observation.summary when tool summaries are enabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts > Agent terminal ObservationEvent summaries (UI) > attaches observation.summary when tool summaries are enabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts > Agent terminal ObservationEvent summaries (UI) > does not attach observation.summary when disabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts > Agent terminal ObservationEvent summaries (UI) > does not attach observation.summary when disabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts (2 tests) 8ms
stdout | src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts > Agent tool-call summaries > attaches summary to observation event for UI display but does NOT send to LLM
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts > Agent tool-call summaries > attaches summary to observation event for UI display but does NOT send to LLM
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts > Agent tool-call summaries > attaches summary to observation event for UI display but does NOT send to LLM
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts > Agent tool-call summaries > does not summarize tools when disabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts > Agent tool-call summaries > does not summarize tools when disabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts > Agent tool-call summaries > does not summarize tools when disabled
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts (2 tests) 12ms
 ✓ src/sdk/llm/__tests__/debug.test.ts (7 tests) 2ms
stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > prompt and tool schema includes security_risk when 'risky confirmations'
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > prompt and tool schema includes security_risk when 'risky confirmations'
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > prompt and tool schema includes security_risk when 'always confirmations'
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > prompt and tool schema includes security_risk when 'always confirmations'
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > prompt and tool schema includes security_risk when 'confirmations disabled'
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > prompt and tool schema includes security_risk when 'confirmations disabled'
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > defaults unknown tool-provided security_risk to UNKNOWN
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.security-risk.test.ts > Agent security risk handling > defaults unknown tool-provided security_risk to UNKNOWN
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.security-risk.test.ts (4 tests) 8ms
 ✓ src/sdk/runtime/__tests__/SecretRegistry.test.ts (5 tests) 3ms
 ✓ src/sdk/context/condenser/__tests__/llmSummarizingCondenser.test.ts (2 tests) 3ms
stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > emits and uses the full OpenHands system prompt text
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > emits and uses the full OpenHands system prompt text
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > includes the latest AgentContext systemMessageSuffix on each LLM request
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > includes the latest AgentContext systemMessageSuffix on each LLM request
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > includes the latest AgentContext systemMessageSuffix on each LLM request
[Agent.getStreamer] Reusing cached streamer.

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > includes the latest AgentContext systemMessageSuffix on each LLM request
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > includes the latest AgentContext systemMessageSuffix on each LLM request
[Agent.getStreamer] Reusing cached streamer.

stdout | src/sdk/runtime/__tests__/Agent.system-prompt.test.ts > Agent system prompt > includes the latest AgentContext systemMessageSuffix on each LLM request
[Agent.runLoop] Iteration 2. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.system-prompt.test.ts (2 tests) 7ms
stdout | src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts > Agent file diff summaries (optional) > attaches a summary to file_editor edit observations when enabled
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts > Agent file diff summaries (optional) > attaches a summary to file_editor edit observations when enabled
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts > Agent file diff summaries (optional) > attaches a summary to file_editor edit observations when enabled
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts (1 test) 6ms
stdout | src/sdk/runtime/__tests__/Agent.finish-tool.test.ts > FinishTool > stops the run and skips subsequent tool calls in the same batch
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.finish-tool.test.ts > FinishTool > stops the run and skips subsequent tool calls in the same batch
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.finish-tool.test.ts > FinishTool > never requires confirmation even when policy=always
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.finish-tool.test.ts > FinishTool > never requires confirmation even when policy=always
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.finish-tool.test.ts (2 tests) 8ms
stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers keyword skills
Skill 'react-skill' triggered by keyword 'react'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > triggers multiple skills
Skill 'react-skill' triggered by keyword 'react'
Skill 'typescript-skill' triggered by keyword 'typescript'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > appends custom user message suffix to triggered skills
Skill 'test-skill' triggered by keyword 'test'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles multiple text content blocks
Skill 'test-skill' triggered by keyword 'keyword'

stdout | src/sdk/context/__tests__/agent-context.test.ts > AgentContext > getUserMessageSuffix > handles task triggers
Skill 'refactor' triggered by keyword '/refactor'

 ✓ src/sdk/context/__tests__/agent-context.test.ts (30 tests) 6ms
stdout | src/sdk/runtime/__tests__/Agent.redaction.test.ts > Agent redacts sensitive tool-call arguments in llm_tool_call_raw > masks common secret keys and bearer tokens, preserving truncation
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.redaction.test.ts > Agent redacts sensitive tool-call arguments in llm_tool_call_raw > masks common secret keys and bearer tokens, preserving truncation
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.redaction.test.ts > Agent redacts sensitive tool-call arguments in llm_tool_call_raw > masks nested secrets and token-like strings without requiring key names
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.redaction.test.ts > Agent redacts sensitive tool-call arguments in llm_tool_call_raw > masks nested secrets and token-like strings without requiring key names
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.redaction.test.ts (2 tests) 7ms
 ✓ src/sdk/__tests__/llm.streamer.test.ts (20 tests | 1 skipped) 1525ms
   ✓ OpenAICompatibleClient streaming > propagates failure after retries  755ms
   ✓ GeminiClient streaming > propagates failure after retries  754ms
 ✓ src/sdk/runtime/__tests__/gitChangeSummarizer.test.ts (4 tests) 4ms
 ✓ src/workspace/__tests__/remote.workspace.test.ts (6 tests) 6ms
 ✓ src/tools/__tests__/TerminalTool.session.test.ts (9 tests) 1866ms
   ✓ TerminalTool session behavior > executes a new command even if the previous one completed between calls  492ms
   ✓ TerminalTool session behavior > returns previous metadata when a timed-out command finishes before the next command  490ms
 ✓ src/sdk/__tests__/llm.profile-selection.test.ts (4 tests) 9ms
stdout | src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts > Agent debug LLM payload events > emits sanitized request/response payloads (no system prompt, redacted tool args, truncated tool text)
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts > Agent debug LLM payload events > emits sanitized request/response payloads (no system prompt, redacted tool args, truncated tool text)
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

stdout | src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts > Agent debug LLM payload events > emits sanitized request/response payloads (no system prompt, redacted tool args, truncated tool text)
[Agent.runLoop] Iteration 1. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts (1 test) 7ms
stdout | src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts > Agent tool call logging redaction > redacts nested sensitive values when logging tool calls
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts > Agent tool call logging redaction > redacts nested sensitive values when logging tool calls
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts (1 test) 6ms
stdout | src/sdk/runtime/__tests__/Agent.workspace.test.ts > Agent workspace option > passes the provided workspace instance to tools
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: test-model

stdout | src/sdk/runtime/__tests__/Agent.workspace.test.ts > Agent workspace option > passes the provided workspace instance to tools
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=test-model. streamerPromise cached=true

 ✓ src/sdk/runtime/__tests__/Agent.workspace.test.ts (1 test) 8ms
stdout | src/sdk/__tests__/agent.error-detail.test.ts > ConversationErrorEvent details > does not include internal LLM context in the error detail by default
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: gpt-5-mini

stdout | src/sdk/__tests__/agent.error-detail.test.ts > ConversationErrorEvent details > includes internal LLM context in the error detail when agent.debug=true
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: gpt-5-mini

 ✓ src/sdk/__tests__/agent.error-detail.test.ts (2 tests) 6ms
 ✓ src/sdk/runtime/__tests__/textSanitizers.test.ts (7 tests) 4ms
 ✓ src/sdk/llm/__tests__/factory.api-key-precedence.test.ts (3 tests) 7ms
 ✓ src/sdk/__tests__/metrics.test.ts (11 tests) 4ms
 ✓ src/sdk/llm/__tests__/providerQuirks.test.ts (27 tests) 3ms
 ✓ src/sdk/conversation/RemoteConversation.test.ts (7 tests) 7ms
 ✓ src/sdk/__tests__/composeCallbacks.test.ts (2 tests) 3ms
stdout | src/sdk/conversation/LocalConversation.secretStorage.test.ts > LocalConversation SecretStorage wiring > passes secretStorage into the default SecretRegistry when secrets is omitted
[Agent.getStreamer] Creating new streamer. Profile: undefined, Model: gpt-5-mini

stdout | src/sdk/conversation/LocalConversation.secretStorage.test.ts > LocalConversation SecretStorage wiring > passes secretStorage into the default SecretRegistry when secrets is omitted
[Agent.runLoop] Iteration 0. Settings: profile=undefined, model=gpt-5-mini. streamerPromise cached=true

 ✓ src/sdk/conversation/LocalConversation.secretStorage.test.ts (1 test) 8ms
 ✓ src/sdk/__tests__/runtime.test.ts (4 tests) 5ms
 ✓ src/sdk/context/skills/__tests__/prompt.test.ts (4 tests) 2ms
 ✓ src/sdk/__tests__/registry.test.ts (5 tests) 5ms
 ✓ src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts (9 tests) 4ms
 ✓ src/sdk/llm/__tests__/contextLimit.test.ts (6 tests) 2ms
 ✓ src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts (9 tests) 8ms
 ✓ src/sdk/llm/__tests__/gemini.stripUnsupportedSchemaProps.test.ts (7 tests) 5ms
 ✓ src/sdk/runtime/__tests__/sanitizeChatMessages.test.ts (4 tests) 3ms
 ✓ src/sdk/__tests__/conversation-stats.test.ts (5 tests) 3ms
 ✓ src/sdk/observations/__tests__/observations.format.test.ts (5 tests) 3ms
 ✓ src/sdk/runtime/__tests__/truncateError.unit.test.ts (5 tests) 2ms
 ✓ src/sdk/runtime/__tests__/errorPolicy.test.ts (4 tests) 2ms
 ✓ src/sdk/conversation/__tests__/ConversationVisualizer.test.ts (1 test) 3ms
 ✓ src/sdk/__tests__/llmSettingsHelpers.test.ts (2 tests) 1ms
 ✓ src/sdk/__tests__/agent-sdk.guards.test.ts (5 tests) 2ms
 ✓ src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts (3 tests) 1ms
 ✓ src/workspace/__tests__/workspace.factory.test.ts (2 tests) 2ms
 ✓ src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts (2 tests) 1ms
 ✓ src/sdk/llm/__tests__/timeoutDefaults.test.ts (1 test) 1ms

 Test Files  69 passed (69)
      Tests  506 passed | 1 skipped (507)
   Start at  02:52:41
   Duration  3.14s (transform 969ms, setup 0ms, collect 5.45s, tests 5.76s, environment 7ms, prepare 3.02s)
- 
> @openhands/agent-sdk-ts@0.1.0 build
> npm run build:bundle && npm run build:types


> @openhands/agent-sdk-ts@0.1.0 build:bundle
> tsup --config tsup.config.ts

CLI Building entry: src/browser.ts, src/index.ts
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /Users/enyst/repos/oh-tab/packages/agent-sdk-ts/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
CJS Build start
CJS dist/browser.cjs     5.40 KB
CJS dist/index.cjs       408.99 KB
CJS dist/browser.cjs.map 16.92 KB
CJS dist/index.cjs.map   913.75 KB
CJS ⚡️ Build success in 435ms
ESM dist/browser.mjs            563.00 B
ESM dist/chunk-R72JAUNP.mjs     5.16 KB
ESM dist/index.mjs              396.82 KB
ESM dist/browser.mjs.map        72.00 B
ESM dist/chunk-R72JAUNP.mjs.map 16.93 KB
ESM dist/index.mjs.map          896.42 KB
ESM ⚡️ Build success in 440ms

> @openhands/agent-sdk-ts@0.1.0 build:types
> tsc -p tsconfig.json