### PR TITLE
agent-sdk-ts parity: Skills third-party files truncation/gating (#656)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
@@ -183,16 +183,23 @@ describe('AgentContext', () => {
 
       const context = new AgentContext({ skills: [style, claude, gemini] });
 
+      const unknown = context.getSystemMessageSuffix();
+      expect(unknown).toContain('[BEGIN context from [style]]');
+      expect(unknown).toContain('[BEGIN context from [claude]]');
+      expect(unknown).toContain('[BEGIN context from [gemini]]');
+
       const openAi = context.getSystemMessageSuffix({ llmModel: 'gpt-4', llmProvider: 'openai' });
       expect(openAi).toContain('[BEGIN context from [style]]');
       expect(openAi).not.toContain('[BEGIN context from [claude]]');
       expect(openAi).not.toContain('[BEGIN context from [gemini]]');
 
       const anthropic = context.getSystemMessageSuffix({ llmModel: 'claude-3-5-sonnet', llmProvider: 'anthropic' });
+      expect(anthropic).toContain('[BEGIN context from [style]]');
       expect(anthropic).toContain('[BEGIN context from [claude]]');
       expect(anthropic).not.toContain('[BEGIN context from [gemini]]');
 
       const google = context.getSystemMessageSuffix({ llmModel: 'gemini-2.0-flash', llmProvider: 'gemini' });
+      expect(google).toContain('[BEGIN context from [style]]');
       expect(google).toContain('[BEGIN context from [gemini]]');
       expect(google).not.toContain('[BEGIN context from [claude]]');
     });

--- a/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/__tests__/agent-context.test.ts
@@ -176,6 +176,27 @@ describe('AgentContext', () => {
       );
     });
 
+    it('gates vendor-specific repo skills (claude/gemini) based on model family', () => {
+      const style = new Skill({ name: 'style', content: 'Style guide', trigger: null });
+      const claude = new Skill({ name: 'claude', content: 'Claude-only rules', trigger: null });
+      const gemini = new Skill({ name: 'gemini', content: 'Gemini-only rules', trigger: null });
+
+      const context = new AgentContext({ skills: [style, claude, gemini] });
+
+      const openAi = context.getSystemMessageSuffix({ llmModel: 'gpt-4', llmProvider: 'openai' });
+      expect(openAi).toContain('[BEGIN context from [style]]');
+      expect(openAi).not.toContain('[BEGIN context from [claude]]');
+      expect(openAi).not.toContain('[BEGIN context from [gemini]]');
+
+      const anthropic = context.getSystemMessageSuffix({ llmModel: 'claude-3-5-sonnet', llmProvider: 'anthropic' });
+      expect(anthropic).toContain('[BEGIN context from [claude]]');
+      expect(anthropic).not.toContain('[BEGIN context from [gemini]]');
+
+      const google = context.getSystemMessageSuffix({ llmModel: 'gemini-2.0-flash', llmProvider: 'gemini' });
+      expect(google).toContain('[BEGIN context from [gemini]]');
+      expect(google).not.toContain('[BEGIN context from [claude]]');
+    });
+
     it('lists triggered skills in <available_skills> without injecting full content', () => {
       const repoSkill = new Skill({ name: 'repo', content: 'Repo', trigger: null });
       const knowledgeSkill = new Skill({

--- a/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
@@ -86,11 +86,39 @@ export class AgentContext {
    * - Conversation instructions (e.g., user preferences, task details)
    * - Repository-specific instructions (collected from repo skills)
    */
-  getSystemMessageSuffix(options?: { secretNames?: string[] }): string | null {
-    const repoSkills = this.skills.filter((s) => s.trigger === null && !s.isAgentSkillsFormat);
+  getSystemMessageSuffix(options?: {
+    secretNames?: string[];
+    llmModel?: string | null;
+    llmModelCanonical?: string | null;
+    llmProvider?: string | null;
+    llmBaseUrl?: string | null;
+  }): string | null {
+    const llmModel = typeof options?.llmModel === 'string' ? options.llmModel : null;
+    const llmModelCanonical = typeof options?.llmModelCanonical === 'string' ? options.llmModelCanonical : null;
+    const llmProvider = typeof options?.llmProvider === 'string' ? options.llmProvider : null;
+    const llmBaseUrl = typeof options?.llmBaseUrl === 'string' ? options.llmBaseUrl : null;
+
+    let repoSkills = this.skills.filter((s) => s.trigger === null && !s.isAgentSkillsFormat);
     const availableSkills = this.skills.filter((s) => s.isAgentSkillsFormat || s.trigger !== null);
 
     const parts: string[] = [];
+
+    // Gate vendor-specific repo skills based on model family (Python parity).
+    if (llmModel || llmModelCanonical) {
+      const family = [llmProvider, llmModel, llmModelCanonical, llmBaseUrl].filter(Boolean).join(' ').toLowerCase();
+      if (family) {
+        repoSkills = repoSkills.filter((s) => {
+          const n = (s.name ?? '').toLowerCase();
+          if (n === 'claude' && !(family.includes('anthropic') || family.includes('claude'))) {
+            return false;
+          }
+          if (n === 'gemini' && !(family.includes('gemini') || family.includes('google_gemini'))) {
+            return false;
+          }
+          return true;
+        });
+      }
+    }
 
     if (repoSkills.length) {
       const repoSkillContent = repoSkills

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -576,6 +576,20 @@ Knowledge content`);
       expect(repoSkills.has('gemini')).toBe(true);
     });
 
+    it('skips symlinked third-party files in repo root', () => {
+      const repoRoot = join(tempDir, 'repo');
+      const external = join(tempDir, 'external.md');
+      writeFileSync(external, 'External rules');
+
+      writeFileSync(join(repoRoot, 'AGENTS.md'), 'Agent guidelines');
+      symlinkSync(external, join(repoRoot, 'CLAUDE.md'));
+
+      const { repoSkills } = loadSkillsFromDir(skillDir);
+
+      expect(repoSkills.has('agents')).toBe(true);
+      expect(repoSkills.has('claude')).toBe(false);
+    });
+
     it('truncates oversized third-party files', () => {
       const repoRoot = join(tempDir, 'repo');
       const head = 'HEAD\n';

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -564,12 +564,32 @@ Knowledge content`);
     it('loads third-party files from repo root', () => {
       const repoRoot = join(tempDir, 'repo');
       writeFileSync(join(repoRoot, '.cursorrules'), 'Cursor rules');
-      writeFileSync(join(repoRoot, 'agents.md'), 'Agent guidelines');
+      writeFileSync(join(repoRoot, 'AGENTS.md'), 'Agent guidelines');
+      writeFileSync(join(repoRoot, 'CLAUDE.md'), 'Claude guidelines');
+      writeFileSync(join(repoRoot, 'GEMINI.md'), 'Gemini guidelines');
 
       const { repoSkills } = loadSkillsFromDir(skillDir);
 
       expect(repoSkills.has('cursorrules')).toBe(true);
       expect(repoSkills.has('agents')).toBe(true);
+      expect(repoSkills.has('claude')).toBe(true);
+      expect(repoSkills.has('gemini')).toBe(true);
+    });
+
+    it('truncates oversized third-party files', () => {
+      const repoRoot = join(tempDir, 'repo');
+      const head = 'HEAD\n';
+      const tail = '\nTAIL';
+      const huge = head + 'x'.repeat(20_000) + tail;
+      writeFileSync(join(repoRoot, 'AGENTS.md'), huge);
+
+      const { repoSkills } = loadSkillsFromDir(skillDir);
+      const agents = repoSkills.get('agents');
+      expect(agents).toBeDefined();
+      expect(agents?.content).toContain('<TRUNCATED><NOTE>');
+      expect(agents?.content.startsWith('HEAD')).toBe(true);
+      expect(agents?.content.endsWith('TAIL')).toBe(true);
+      expect((agents?.content ?? '').length).toBeLessThanOrEqual(10_000);
     });
 
     it('recursively loads skills from subdirectories', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -3,7 +3,7 @@
  * Transpiled from Python SDK: openhands/sdk/context/skills/skill.py
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
+import { existsSync, lstatSync, readFileSync, readdirSync, statSync } from 'fs';
 import { basename, dirname, join, relative } from 'path';
 import { homedir } from 'os';
 import frontmatter from 'front-matter';
@@ -53,7 +53,9 @@ function findThirdPartyFiles(repoRoot: string): string[] {
   for (const entry of readdirSync(repoRoot)) {
     const fullPath = join(repoRoot, entry);
     if (!existsSync(fullPath)) continue;
-    if (!statSync(fullPath).isFile()) continue;
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) continue;
+    if (!stat.isFile()) continue;
 
     const nameLower = entry.toLowerCase();
     if (!targetNames.has(nameLower)) continue;

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -20,7 +20,55 @@ import { findMcpConfig, loadMcpConfig, validateMcpConfigObject } from './mcp';
 // - must not contain consecutive hyphens (--)
 const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
+// Maximum characters for third-party skill files (e.g., AGENTS.md, CLAUDE.md, GEMINI.md).
+// These files are always active, so we want to keep them reasonably sized.
+const THIRD_PARTY_SKILL_MAX_CHARS = 10_000;
+
 export { SkillValidationError } from './exceptions';
+
+function maybeTruncate(content: string, truncateAfter: number, truncateNotice: string): string {
+  if (!truncateAfter || truncateAfter < 0 || content.length <= truncateAfter) return content;
+
+  if (truncateNotice.length >= truncateAfter) {
+    return truncateNotice.slice(0, truncateAfter);
+  }
+
+  const availableChars = truncateAfter - truncateNotice.length;
+  const proposedHead = Math.floor(availableChars / 2) + (availableChars % 2);
+
+  const remaining = truncateAfter - truncateNotice.length;
+  const headChars = Math.min(proposedHead, remaining);
+  const tailChars = remaining - headChars;
+
+  return content.slice(0, headChars) + truncateNotice + (tailChars > 0 ? content.slice(-tailChars) : '');
+}
+
+function findThirdPartyFiles(repoRoot: string): string[] {
+  if (!existsSync(repoRoot)) return [];
+
+  const targetNames = new Set(Object.keys(Skill.PATH_TO_THIRD_PARTY_SKILL_NAME).map((name) => name.toLowerCase()));
+  const files: string[] = [];
+  const seenNames = new Set<string>();
+
+  for (const entry of readdirSync(repoRoot)) {
+    const fullPath = join(repoRoot, entry);
+    if (!existsSync(fullPath)) continue;
+    if (!statSync(fullPath).isFile()) continue;
+
+    const nameLower = entry.toLowerCase();
+    if (!targetNames.has(nameLower)) continue;
+
+    if (seenNames.has(nameLower)) {
+      console.warn(`Duplicate third-party skill file ignored: ${fullPath} (already found a file with name '${nameLower}')`);
+      continue;
+    }
+
+    files.push(fullPath);
+    seenNames.add(nameLower);
+  }
+
+  return files;
+}
 
 /**
  * A skill provides specialized knowledge or functionality.
@@ -46,6 +94,8 @@ export class Skill {
     '.cursorrules': 'cursorrules',
     'agents.md': 'agents',
     'agent.md': 'agents',
+    'claude.md': 'claude',
+    'gemini.md': 'gemini',
   };
 
   constructor(params: {
@@ -88,9 +138,20 @@ export class Skill {
     const skillName = this.PATH_TO_THIRD_PARTY_SKILL_NAME[baseName];
 
     if (skillName) {
+      const truncateNotice =
+        `\n\n<TRUNCATED><NOTE>The file ${path} exceeded the maximum length (${THIRD_PARTY_SKILL_MAX_CHARS} characters) and has been truncated. ` +
+        'Only the beginning and end are shown. You can read the full file if needed.</NOTE>\n\n';
+      const truncatedContent = maybeTruncate(fileContent, THIRD_PARTY_SKILL_MAX_CHARS, truncateNotice);
+
+      if (fileContent.length > THIRD_PARTY_SKILL_MAX_CHARS) {
+        console.warn(
+          `Third-party skill file ${path} (${fileContent.length} chars) exceeded limit (${THIRD_PARTY_SKILL_MAX_CHARS} chars), truncating`,
+        );
+      }
+
       return new Skill({
         name: skillName,
-        content: fileContent,
+        content: truncatedContent,
         source: path,
         trigger: null,
       });
@@ -315,17 +376,8 @@ export function loadSkillsFromDir(skillDir: string): {
   // Get repo root (two levels up from skillDir)
   const repoRoot = join(skillDir, '..', '..');
 
-  // Check for third-party rules: .cursorrules, AGENTS.md, etc
-  const specialFiles: string[] = [];
-  for (const filename of Object.keys(Skill.PATH_TO_THIRD_PARTY_SKILL_NAME)) {
-    for (const variant of [filename, filename.toLowerCase(), filename.toUpperCase()]) {
-      const filePath = join(repoRoot, variant);
-      if (existsSync(filePath)) {
-        specialFiles.push(filePath);
-        break; // Only add the first one found to avoid duplicates
-      }
-    }
-  }
+  // Check for third-party rules: .cursorrules, AGENTS.md, CLAUDE.md, GEMINI.md, etc.
+  const specialFiles = findThirdPartyFiles(repoRoot);
 
   const agentSkillMdFiles = findSkillMdDirectories(skillDir);
   const excludedDirs = new Set(agentSkillMdFiles.map((p) => dirname(p)));

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -140,9 +140,7 @@ export class Skill {
     const skillName = this.PATH_TO_THIRD_PARTY_SKILL_NAME[baseName];
 
     if (skillName) {
-      const truncateNotice =
-        `\n\n<TRUNCATED><NOTE>The file ${path} exceeded the maximum length (${THIRD_PARTY_SKILL_MAX_CHARS} characters) and has been truncated. ` +
-        'Only the beginning and end are shown. You can read the full file if needed.</NOTE>\n\n';
+      const truncateNotice = `\n\n<TRUNCATED><NOTE>The file ${path} exceeded the maximum length (${THIRD_PARTY_SKILL_MAX_CHARS} characters) and has been truncated. Only the beginning and end are shown. You can read the full file if needed.</NOTE>\n\n`;
       const truncatedContent = maybeTruncate(fileContent, THIRD_PARTY_SKILL_MAX_CHARS, truncateNotice);
 
       if (fileContent.length > THIRD_PARTY_SKILL_MAX_CHARS) {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -5,7 +5,7 @@ import { LLMStreamer } from './LLMStreamer';
 import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
-import type { LLMClient, LLMProvider, LLMToolDefinition } from '../llm';
+import type { LLMClient, LLMProfileStoreOptions, LLMProvider, LLMToolDefinition } from '../llm';
 import {
   DEFAULT_PROVIDER_BASE_URLS,
   detectProviderFromBaseUrl,
@@ -81,6 +81,7 @@ export interface AgentOptions {
   state?: ConversationState;
   secrets?: SecretRegistry;
   agentContext?: AgentContext;
+  profileStoreOptions?: LLMProfileStoreOptions;
   onTerminalEvent?: (event: BashEvent) => void;
   registry?: import('../llm').LLMRegistry;
   conversationStats?: import('./ConversationStats').ConversationStats;
@@ -984,9 +985,26 @@ export class Agent extends EventEmitter {
       systemPrompt = systemPrompt.replace(SECURITY_RISK_ASSESSMENT_SECTION, '');
     }
     if (this.agentContext) {
-      const llmModel = this.options.settings?.llm?.model;
-      const llmProvider = this.options.settings?.llm?.provider ?? detectProviderFromBaseUrl(this.options.settings?.llm?.baseUrl);
-      const llmBaseUrl = this.options.settings?.llm?.baseUrl;
+      const settings = this.options.settings?.llm;
+      const profileId = toOptionalNonEmptyString(settings?.profileId);
+      let llmModel = toOptionalNonEmptyString(settings?.model) ?? null;
+      let llmProvider = toOptionalNonEmptyString(settings?.provider) ?? null;
+      let llmBaseUrl = toOptionalNonEmptyString(settings?.baseUrl) ?? null;
+
+      // When profileId is set, raw model/provider/baseUrl can be intentionally cleared (profiles-first).
+      // Load the profile config (when safe) so vendor-specific repo skills are gated correctly.
+      if (profileId && isSafeProfileId(profileId)) {
+        try {
+          const profile = loadProfile(profileId, this.options.profileStoreOptions);
+          llmModel = toOptionalNonEmptyString(profile.config.model) ?? llmModel;
+          llmProvider = toOptionalNonEmptyString(profile.config.provider) ?? llmProvider;
+          llmBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl) ?? llmBaseUrl;
+        } catch {
+          // Best-effort: profile loading failures will surface elsewhere when creating the LLM client.
+        }
+      }
+
+      llmProvider = llmProvider ?? detectProviderFromBaseUrl(llmBaseUrl ?? undefined);
       const suffix = this.agentContext.getSystemMessageSuffix({
         secretNames: this.secrets.getRegisteredNames(),
         llmModel,
@@ -1045,6 +1063,7 @@ export class Agent extends EventEmitter {
     return createLlmClientFromSettingsFromConfig({
       settings: this.options.settings,
       secrets: this.secrets,
+      profileStoreOptions: this.options.profileStoreOptions,
       registry: this.registry,
       conversationStats: this.conversationStats,
       state: this.state,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -984,7 +984,15 @@ export class Agent extends EventEmitter {
       systemPrompt = systemPrompt.replace(SECURITY_RISK_ASSESSMENT_SECTION, '');
     }
     if (this.agentContext) {
-      const suffix = this.agentContext.getSystemMessageSuffix({ secretNames: this.secrets.getRegisteredNames() });
+      const llmModel = this.options.settings?.llm?.model;
+      const llmProvider = this.options.settings?.llm?.provider ?? detectProviderFromBaseUrl(this.options.settings?.llm?.baseUrl);
+      const llmBaseUrl = this.options.settings?.llm?.baseUrl;
+      const suffix = this.agentContext.getSystemMessageSuffix({
+        secretNames: this.secrets.getRegisteredNames(),
+        llmModel,
+        llmProvider,
+        llmBaseUrl,
+      });
       if (suffix) {
         systemPrompt += '\n\n' + suffix;
       }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts
@@ -2,9 +2,9 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
-import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { saveProfile, type ChatCompletionRequest, type LLMClient, type LLMStreamChunk } from '../../llm';
 import { Agent, EventLog } from '..';
-import { AgentContext } from '../..';
+import { AgentContext, Skill } from '../..';
 import { isSystemPromptEvent } from '../../types';
 import type { OpenHandsSettings } from '../../types/settings';
 
@@ -19,6 +19,7 @@ class RecordingLLM implements LLMClient {
 }
 
 const workspaceRoots: string[] = [];
+const profileRoots: string[] = [];
 const createWorkspaceRoot = (): string => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-system-prompt-'));
   workspaceRoots.push(root);
@@ -27,6 +28,9 @@ const createWorkspaceRoot = (): string => {
 
 afterEach(() => {
   for (const root of workspaceRoots.splice(0)) {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+  for (const root of profileRoots.splice(0)) {
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
@@ -96,5 +100,46 @@ describe('Agent system prompt', () => {
     agentContext.systemMessageSuffix = undefined;
     await agent.run('hi again (cleared)');
     expect(llm.requests[2]?.systemPrompt).not.toContain('Currently opened in the editor:');
+  });
+
+  it('gates vendor-specific repo skills using LLM profile config', async () => {
+    const profilesRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-system-prompt-profiles-'));
+    profileRoots.push(profilesRoot);
+    saveProfile('p1', { provider: 'openai', model: 'gpt-4' }, { rootDir: profilesRoot });
+
+    const settings: OpenHandsSettings = {
+      llm: { profileId: 'p1' },
+      agent: {},
+      conversation: { maxIterations: 1 },
+      confirmation: { policy: 'never' },
+      secrets: {},
+    };
+
+    const log = new EventLog();
+    const llm = new RecordingLLM();
+    const agentContext = new AgentContext({
+      skills: [
+        new Skill({ name: 'style', content: 'Style guide', trigger: null }),
+        new Skill({ name: 'claude', content: 'Claude-only rules', trigger: null }),
+        new Skill({ name: 'gemini', content: 'Gemini-only rules', trigger: null }),
+      ],
+    });
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      agentContext,
+      profileStoreOptions: { rootDir: profilesRoot },
+    });
+
+    await agent.run('hi');
+    expect(llm.requests).toHaveLength(1);
+    const { systemPrompt } = llm.requests[0];
+
+    expect(systemPrompt).toContain('Style guide');
+    expect(systemPrompt).not.toContain('Claude-only rules');
+    expect(systemPrompt).not.toContain('Gemini-only rules');
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
@@ -1,4 +1,4 @@
-import type { LLMClient } from '../llm';
+import type { LLMClient, LLMProfileStoreOptions } from '../llm';
 import { LLMFactory } from '../llm';
 import type { LLMRegistry } from '../llm/registry';
 import type { OpenHandsSettings } from '../types/settings';
@@ -10,6 +10,7 @@ import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 export function createLlmClientFromSettings(params: {
   settings: OpenHandsSettings;
   secrets: SecretRegistry;
+  profileStoreOptions?: LLMProfileStoreOptions;
   registry?: LLMRegistry;
   conversationStats?: ConversationStats;
   state: ConversationState;
@@ -63,6 +64,7 @@ export function createLlmClientFromSettings(params: {
   const factory = new LLMFactory(config, {
     secrets,
     preferredApiKeys,
+    profileStoreOptions: params.profileStoreOptions,
     registry,
     onMetricsUpdate: (usageId, metrics) => {
       if (!conversationStats) return;


### PR DESCRIPTION
Fixes #656.

Implements parity with Python skill third-party files handling:
- Detect `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` (and `.cursorrules`) as third-party skill context inputs.
- Truncate these files to 10k chars with a `<TRUNCATED>...` marker (Python parity).
- Gate `CLAUDE.md` / `GEMINI.md` repo-skill inclusion by model family (avoid irrelevant noise).

Tests:
- `npm test -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run build -w @openhands/agent-sdk-ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vendor-specific skill gating now automatically selects appropriate skills based on the LLM provider and model.
  * Extended support for third-party skill files, including Claude and Gemini-specific configurations.
  * Profile-driven LLM configuration enables dynamic model and provider selection.

* **Tests**
  * Added comprehensive tests validating skill gating and profile-based LLM configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->