### PR TITLE
fix(agent-sdk-ts): type-safe terminal tool args parsing (#694)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/observations/__tests__/observations.format.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/observations/__tests__/observations.format.test.ts
@@ -24,6 +24,12 @@ describe('observations formatting', () => {
     expect(text).toBe('$ sleep 10\n[Command finished]\n[Command timed out]');
   });
 
+  it('does not throw when terminal tool args are JSON null', () => {
+    const call = toolCall('terminal', 'null');
+    const text = toolResultToLLMText(call, { stdout: '', stderr: '', exit_code: 0 });
+    expect(text).toBe('$ null\n[Command finished with exit code 0]');
+  });
+
   it('formats file_editor tool output like the legacy runtime formatter', () => {
     const call = toolCall('file_editor', { command: 'view', path: '/tmp/a.txt' });
     const text = toolResultToLLMText(call, { command: 'view', path: '/tmp/a.txt', new_content: 'hello' });

--- a/packages/agent-sdk-ts/src/sdk/observations/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/observations/index.ts
@@ -35,8 +35,8 @@ const parseTerminalCommandFromToolCall = (toolCall: ToolCall): string | undefine
   const rawArgs = toOptionalNonEmptyString(toolCall.function.arguments);
   if (!rawArgs) return undefined;
   try {
-    const parsed = JSON.parse(rawArgs) as Record<string, unknown>;
-    return toOptionalNonEmptyString(parsed.command) ?? rawArgs;
+    const parsed = asRecord(JSON.parse(rawArgs));
+    return toOptionalNonEmptyString(parsed?.command) ?? rawArgs;
   } catch {
     return rawArgs;
   }


### PR DESCRIPTION
Fixes #694.

- Avoids `JSON.parse(...) as Record<string, unknown>` in `parseTerminalCommandFromToolCall()`.
- Uses `asRecord(JSON.parse(...))` + optional chaining, so JSON `null` does not rely on exception control-flow.
- Adds a unit test for `toolCall.function.arguments = "null"`.

Beads: `oh-tab-a3ca`.