### PR TITLE
agent-sdk-ts parity: ActionEvent reasoning metadata (#649)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1248,10 +1248,28 @@ export class Agent extends EventEmitter {
     securityRisk?: SecurityRisk,
   ): ActionEvent {
     const thought = message.content.filter(isTextContent);
+    const thinkingBlocks =
+      message.thinking_signature && typeof message.reasoning_content === 'string' && message.reasoning_content.trim().length
+        ? [
+            {
+              type: 'thinking' as const,
+              thinking: message.reasoning_content,
+              signature: message.thinking_signature,
+            },
+          ]
+        : [];
+    const responsesReasoningItem =
+      message.responses_reasoning_item
+        ? {
+            ...message.responses_reasoning_item,
+            encrypted_content: undefined,
+          }
+        : null;
     // Use reasoning_content if available (Anthropic/OpenAI Chat Completions),
     // otherwise fall back to responses_reasoning_item.summary (OpenAI Responses API / GPT-5)
-    const reasoningContent = message.reasoning_content
-      ?? (message.responses_reasoning_item?.summary?.length
+    const reasoningContent =
+      message.reasoning_content ??
+      (message.responses_reasoning_item?.summary?.length
         ? message.responses_reasoning_item.summary.join('\n\n')
         : undefined);
     return {
@@ -1259,6 +1277,8 @@ export class Agent extends EventEmitter {
       source: 'agent',
       thought,
       reasoning_content: reasoningContent,
+      thinking_blocks: thinkingBlocks,
+      responses_reasoning_item: responsesReasoningItem,
       action: args,
       tool_name: toolCall.function.name,
       tool_call_id: toolCall.id,

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.action-reasoning-metadata.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.action-reasoning-metadata.test.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import { isActionEvent } from '../../types';
+import type { ToolDefinition } from '../../types/tools';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class QueueLLM implements LLMClient {
+  callCount = 0;
+
+  constructor(private readonly runs: LLMStreamChunk[][]) {}
+
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    this.callCount += 1;
+    const chunks = this.runs[this.callCount - 1] ?? [{ type: 'finish' as const }];
+    for (const chunk of chunks) {
+      yield chunk;
+    }
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 2 },
+  confirmation: {},
+  secrets: {},
+};
+
+const createWorkspaceRoot = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'agent-action-reasoning-metadata-'));
+const cleanupWorkspaceRoot = (workspaceRoot: string) => {
+  fs.rmSync(workspaceRoot, { recursive: true, force: true });
+};
+
+describe('Agent ActionEvent reasoning metadata', () => {
+  it('includes thinking_blocks and redacts responses_reasoning_item.encrypted_content', async () => {
+    const log = new EventLog();
+    const tool: ToolDefinition<{ value: string }, { echoed: string }> = {
+      name: 'echo',
+      validate: (input) => ({ value: (input as { value: string }).value }),
+      execute: async (args) => ({ echoed: args.value }),
+    };
+
+    const llm = new QueueLLM([
+      [
+        { type: 'text', text: 'Call tools' },
+        {
+          type: 'responses_reasoning_item',
+          item: { id: 'rs_1', summary: ['short summary'], encrypted_content: 'encrypted' },
+        },
+        { type: 'reasoning', reasoning: 'Thinking...' },
+        { type: 'thinking_signature', signature: 'sig_1' },
+        { type: 'tool_call_delta', id: 'call_echo', name: 'echo', arguments: '{"value":"ok"}' },
+        { type: 'finish' },
+      ],
+      [
+        { type: 'text', text: 'Done' },
+        { type: 'finish' },
+      ],
+    ]);
+
+    const workspaceRoot = createWorkspaceRoot();
+    try {
+      const agent = new Agent({
+        settings: baseSettings,
+        events: log,
+        workspaceRoot,
+        llmClient: llm,
+        tools: [tool],
+      });
+
+      await agent.run('hi');
+
+      const actions = log.list().filter(isActionEvent);
+      expect(actions.length).toBeGreaterThan(0);
+      const action = actions.find((evt) => evt.tool_call_id === 'call_echo');
+      expect(action).toBeDefined();
+
+      expect(action?.thinking_blocks).toEqual([{ type: 'thinking', thinking: 'Thinking...', signature: 'sig_1' }]);
+
+      expect(action?.responses_reasoning_item).toMatchObject({ id: 'rs_1', summary: ['short summary'] });
+      expect(action?.responses_reasoning_item?.encrypted_content).toBeUndefined();
+    } finally {
+      cleanupWorkspaceRoot(workspaceRoot);
+    }
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -26,6 +26,19 @@ export interface ResponsesReasoningItem {
   status?: string;
 }
 
+export interface ThinkingBlock {
+  type: 'thinking';
+  thinking: string;
+  signature?: string | null;
+}
+
+export interface RedactedThinkingBlock {
+  type: 'redacted_thinking';
+  data: string;
+}
+
+export type ThinkingBlockEvent = ThinkingBlock | RedactedThinkingBlock;
+
 export interface Message {
   role: Role;
   content: Content[];
@@ -61,6 +74,8 @@ export interface ActionEvent extends EventBase {
   source: 'agent';
   thought: TextContent[];
   reasoning_content?: string | null;
+  thinking_blocks?: ThinkingBlockEvent[] | null;
+  responses_reasoning_item?: ResponsesReasoningItem | null;
   action: Record<string, unknown> | null; // Action schema serialized to JSON
   tool_name: string;
   tool_call_id: string;


### PR DESCRIPTION
Fixes #649.

Adds parity fields to ActionEvents:
- `thinking_blocks`: derived from `reasoning_content` + `thinking_signature` (only when signature present).
- `responses_reasoning_item`: copied from the LLM message, but with `encrypted_content` stripped to avoid leaking into event logs/visualizers.

Tests:
- Adds `Agent.action-reasoning-metadata.test.ts` covering thinking blocks + redaction.

Beads: `oh-tab-mgn0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent SDK now exposes thinking blocks and reasoning metadata in action events, providing visibility into agent reasoning during execution.
  * Sensitive encrypted content is automatically redacted from reasoning metadata.

* **Tests**
  * Added comprehensive tests for Agent action reasoning metadata collection and validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->