### PR TITLE
docs: update AgentSkills resources/.mcp.json docs (oh-tab-43es)

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -279,7 +279,13 @@ class AgentContext {
   });
 
   // Get system message suffix with repo skill content
-  getSystemMessageSuffix(): string | null;
+  getSystemMessageSuffix(options?: {
+    secretNames?: string[];
+    llmModel?: string | null;
+    llmModelCanonical?: string | null;
+    llmProvider?: string | null;
+    llmBaseUrl?: string | null;
+  }): string | null;
 
   // Augment user message with triggered skills
   getUserMessageSuffix(
@@ -307,7 +313,7 @@ const context = new AgentContext({
 });
 
 // Get system suffix (includes repo skills)
-const systemSuffix = context.getSystemMessageSuffix();
+const systemSuffix = context.getSystemMessageSuffix({ llmModel: 'gpt-4', llmProvider: 'openai' });
 // Returns: "## repo-guidelines\n\nUse TypeScript strict mode.\n\nCurrent date: 2025-01-15"
 
 // Augment user message
@@ -327,7 +333,7 @@ const augmented = context.getUserMessageSuffix(userMessage);
 
 **Key Responsibilities**:
 - Load skills from markdown files with frontmatter metadata
-- Support third-party files (.cursorrules, agents.md, AGENTS.md)
+- Support third-party files (.cursorrules, agents.md/AGENTS.md, CLAUDE.md, GEMINI.md) with truncation and vendor gating
 - Match triggers against user messages
 - Extract variables from skill content (${variable_name} format)
 - Load user skills from ~/.openhands/skills/
@@ -452,14 +458,20 @@ inputs:
 Refactor ${target_file} using ${pattern} pattern.
 ```
 
+**AgentSkills format (SKILL.md directories)**:
+
+In addition to legacy single-file markdown skills, skills can also be represented as directories containing a `SKILL.md` file (with strict naming). Skill directories may include resource folders (`scripts/`, `references/`, `assets/`) and an optional `.mcp.json` for MCP server configuration with variable expansion.
+
 **User Skills Loading**:
 
 Skills are automatically loaded from:
 1. `~/.openhands/skills/` - Primary skills directory
 
-Third-party files supported:
+Third-party files supported (loaded as repo skills; oversized files are truncated with a notice):
 - `.cursorrules` → skill name: "cursorrules"
 - `agents.md` or `AGENTS.md` → skill name: "agents"
+- `CLAUDE.md` → skill name: "claude" (vendor-gated)
+- `GEMINI.md` → skill name: "gemini" (vendor-gated)
 
 ## Layer 2: Runtime (Orchestration)
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -65,13 +65,11 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
     - TypeScript: not implemented.
     - Note (2026-01-12): TypeScript now supports AgentSkills (SKILL.md directories) with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` loading with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
 
-11. **Agent tool selection** - `include_default_tools` option to include/disable built-in tools
+11. **Plugins + custom tool loading** - plugin data model, directory loading, and remote custom tools support
 
-12. **Plugins + custom tool loading** - plugin data model, directory loading, and remote custom tools support
+12. **Tools** - `TomConsultTool`, `ApplyPatchTool`, extended `BrowserUseTool` with Windows impl
 
-13. **Tools** - `TomConsultTool`, `ApplyPatchTool`, extended `BrowserUseTool` with Windows impl
-
-14. **Conversation Features** - `ConversationVisualizer`, `ConversationStats`, `StuckDetector`, `TitleUtils`
+13. **Conversation Features** - `ConversationVisualizer`, `ConversationStats`, `StuckDetector`, `TitleUtils`
 
 ### Features in TypeScript but NOT in Python
 
@@ -119,11 +117,10 @@ This section summarizes concrete behavior alignment between Python agent-sdk and
 
 - ActionEvent summary + reasoning metadata
   - Python: ActionEvent includes `summary`, `thinking_blocks`, and `responses_reasoning_item` (for Responses API), and uses these in UI/visualization. See openhands/sdk/event/llm_convertible/action.py.
-  - TypeScript: ActionEvent only includes `thought`, `reasoning_content`, and tool call metadata; no `summary` / `thinking_blocks` / Responses-API reasoning metadata fields. See packages/agent-sdk-ts/src/sdk/types/index.ts ActionEvent.
+  - TypeScript: ActionEvent includes `thought`, `reasoning_content`, `thinking_blocks`, and `responses_reasoning_item`; `summary` is not represented in the TypeScript ActionEvent model. See packages/agent-sdk-ts/src/sdk/types/index.ts ActionEvent.
   - Status:
-    - **Summary** (`summary`): not a TS parity gap for OpenHands-Tab, because we don’t rely on server-provided action summaries (Gemini Flash generates summaries on the fly).
-    - **Anthropic thinking blocks** (`thinking_blocks`): structured “thinking” content emitted by Anthropic models (often multiple segments), useful for richer reasoning trace/debugging and UI rendering.
-    - **OpenAI Responses reasoning item** (`responses_reasoning_item`): structured reasoning metadata returned by the OpenAI Responses API, useful for parity/debuggability and (optionally) exposing reasoning traces.
+    - `summary`: not a TS parity gap for OpenHands-Tab, because we don’t rely on server-provided action summaries (Gemini Flash generates summaries on the fly).
+    - `thinking_blocks` and `responses_reasoning_item`: aligned for parity/debuggability.
 
 - ConversationErrorEvent visualization
   - Python: ConversationErrorEvent now defines `visualize()` for UI output. See openhands/sdk/event/conversation_error.py.
@@ -137,8 +134,8 @@ This section summarizes concrete behavior alignment between Python agent-sdk and
 
 - include_default_tools option
   - Python: Agent supports `include_default_tools` to selectively include built-in tools or disable all defaults. See openhands/sdk/agent/base.py and tests/sdk/agent/test_agent_tool_init.py.
-  - TypeScript: no equivalent option; default tool set is fixed in runtime initialization.
-  - Status: Missing feature.
+  - TypeScript: supports `includeDefaultTools?: boolean | string[]` to disable defaults or select a subset when tools are omitted. See packages/agent-sdk-ts/src/sdk/conversation/index.ts and tests: packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts.
+  - Status: Aligned (API naming differs).
 
 - AgentSkills (SKILL.md) + repo skill files
   - Python: SKILL.md directories with strict naming, progressive disclosure (`to_prompt()` XML), resources, `.mcp.json` support, and optional public skills loading. See openhands/sdk/context/skills/*.py and openhands/sdk/context/agent_context.py.
@@ -464,7 +461,6 @@ Python's RemoteConversation has significantly more features than TypeScript's im
 - Support persisted `ConversationState` restoration and pending-action replay (implemented in PR #246 / `oh-tab-wc7`).
 - Implement responses-API parity and richer confirmation policies akin to Python analyzers
 - Add hook execution pipeline (pre/post tool use, post event, stop hook)
-- Add `include_default_tools` option for default tool selection parity
 
 ```mermaid
 classDiagram
@@ -545,11 +541,11 @@ classDiagram
   - AgentSkills (SKILL.md directories) with strict naming validation
   - Resource discovery (`scripts/`, `references/`, `assets/`) and optional `.mcp.json` parsing/validation with variable expansion
   - Third-party files: `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` (truncates oversized files; vendor-gated where applicable)
-  - No regex/weighted triggers and no template-driven prompt rendering (tracked separately)
+  - Trigger matching is substring-based (same as Python); template-driven prompt rendering and richer trigger semantics are optional enhancements (not parity)
 
 ### Gaps to close
 - Add public skills repo loading (`load_public_skills`)
-- Expand trigger matching (regex/weighted keywords) and template-driven prompt rendering
+- Optional enhancements (not python parity): template-driven prompt rendering and richer trigger semantics (regex/weights, scoring)
 
 ```mermaid
 classDiagram
@@ -717,8 +713,9 @@ Rather than fully re-implementing Pydantic-style action/observation classes in T
   - Metadata fields are narrower (e.g., no stuck-detection or condenser fields)
   - Missing ActionEvent additions from Python:
     - `summary`: **not required for OpenHands-Tab**, since Gemini Flash generates summaries on the fly
-    - `thinking_blocks`: Anthropic “thinking” blocks (structured reasoning trace content) — important if we want richer reasoning/debuggability parity
-    - `responses_reasoning_item`: OpenAI Responses API reasoning metadata item — important for Responses-API parity/debuggability
+  - Implemented ActionEvent reasoning metadata:
+    - `thinking_blocks`: Anthropic “thinking” blocks (structured reasoning trace content)
+    - `responses_reasoning_item`: OpenAI Responses API reasoning metadata item
 
 ```mermaid
 classDiagram

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -63,7 +63,7 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 
 10. **Public skills repo loading** (`load_public_skills`)
     - TypeScript: not implemented.
-    - Parity note (2026-01-12): TypeScript now supports AgentSkills (SKILL.md directories) with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` loading with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
+    - Note (2026-01-12): TypeScript now supports AgentSkills (SKILL.md directories) with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` loading with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
 
 11. **Agent tool selection** - `include_default_tools` option to include/disable built-in tools
 
@@ -140,10 +140,10 @@ This section summarizes concrete behavior alignment between Python agent-sdk and
   - TypeScript: no equivalent option; default tool set is fixed in runtime initialization.
   - Status: Missing feature.
 
-- AgentSkills (SKILL.md) + public skills
+- AgentSkills (SKILL.md) + repo skill files
   - Python: SKILL.md directories with strict naming, progressive disclosure (`to_prompt()` XML), resources, `.mcp.json` support, and optional public skills loading. See openhands/sdk/context/skills/*.py and openhands/sdk/context/agent_context.py.
-  - TypeScript: legacy .md skills only; no SKILL.md handling, no resources, no public skills, no MCP config ingestion, no `<available_skills>` prompt block.
-  - Status: Large gap in skills parity.
+  - TypeScript: supports SKILL.md directories with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` parsing/validation with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
+  - Status: Parity largely aligned; remaining gap is public skills repo loading.
 
 - tool_call_id propagation
   - Python: tool_call_id is preserved across ActionEvent, ObservationEvent, AgentErrorEvent, and tool MessageEvent. See tests/sdk/event/test_events_to_messages.py and cross tests.
@@ -518,15 +518,11 @@ classDiagram
 
 ### TypeScript AgentContext
 
-- Lightweight class that concatenates always-on skills into Markdown
-  - Appends optional suffix
-  - Matches triggers via substring search
-  - Logs warnings for duplicates
-- Skill activation tracking is minimal
-- Formatting is plain strings (no templating)
-  - No `<available_skills>` progressive disclosure
-  - No public skills loading or microagents compatibility
-  - No model-family gating for vendor-specific repo instructions
+- Lightweight class that concatenates repo skills into a system suffix and triggered skills into a user suffix
+  - Matches triggers (keyword/task) and logs warnings for duplicates
+- Supports AgentSkills progressive disclosure via `<available_skills>` (lists triggered skills without injecting full content)
+- Supports model-family gating for vendor-specific repo instructions (`CLAUDE.md`/`GEMINI.md`) and handles profiles-first settings (when `llm.profileId` is selected)
+- No public skills repo loading
 
 ### Skill models
 
@@ -546,17 +542,13 @@ classDiagram
 - **TypeScript `Skill`**
   - Mirrors keyword/task/always-on triggers
   - Aliasing and missing-variable prompts
-  - Lacks MCP tool metadata
-  - No schema validation
-  - No regex triggers
-  - No SKILL.md or resource discovery support
-  - Third-party files limited to `.cursorrules` and `agents.md`
+  - AgentSkills (SKILL.md directories) with strict naming validation
+  - Resource discovery (`scripts/`, `references/`, `assets/`) and optional `.mcp.json` parsing/validation with variable expansion
+  - Third-party files: `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` (truncates oversized files; vendor-gated where applicable)
+  - No regex/weighted triggers and no template-driven prompt rendering (tracked separately)
 
 ### Gaps to close
-- Add SKILL.md directory support, name validation, and AgentSkills fields
-- Add resource discovery and `.mcp.json` parsing + validation
-- Add `<available_skills>` prompt generation (progressive disclosure)
-- Align third-party files and truncation behavior (AGENTS, CLAUDE, GEMINI)
+- Add public skills repo loading (`load_public_skills`)
 - Expand trigger matching (regex/weighted keywords) and template-driven prompt rendering
 
 ```mermaid

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -69,7 +69,7 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 
 11. **Plugins + custom tool loading** - plugin data model, directory loading, and remote custom tools support
 
-12. **Tools** - `TomConsultTool`, `ApplyPatchTool`, extended `BrowserUseTool` with Windows impl
+12. **Tools** - `TomConsultTool`, extended `BrowserUseTool` with Windows impl
 
 13. **Conversation Features** - `ConversationVisualizer`, `ConversationStats`, `StuckDetector`, `TitleUtils`
 
@@ -86,6 +86,8 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 5. **Tool Validation** - `ZodTool` wrapper for zod schema-based validation
 
 6. **IntegratedTerminalRunner** - Direct VS Code terminal integration
+
+7. **ApplyPatchTool** - TypeScript-only builtin tool (not present in the Python fork at `~/repos/agent-sdk`)
 
 ### Cross-cutting differences
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -61,13 +61,9 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 
 9. **Hooks System** - `HookManager`, `HookExecutor`, event interception (pre/post tool use, post event, stop hook)
 
-10. **AgentSkills (SKILL.md) + progressive disclosure**
-    - SKILL.md directory convention (case-insensitive) and strict name validation
-    - `<available_skills>` XML prompt via `to_prompt()` and progressive disclosure
-    - Skill resources discovery (`scripts/`, `references/`, `assets/`)
-    - `.mcp.json` loading with variable expansion for AgentSkills
-    - Public skills repo loading (`load_public_skills`)
-    - Third-party skill files include `CLAUDE.md`/`GEMINI.md` with truncation limits
+10. **Public skills repo loading** (`load_public_skills`)
+    - TypeScript: not implemented.
+    - Parity note (2026-01-12): TypeScript now supports AgentSkills (SKILL.md directories) with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` loading with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
 
 11. **Agent tool selection** - `include_default_tools` option to include/disable built-in tools
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -57,7 +57,9 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 
 7. **MCP** - `MCPClient` for external tool integration (not planned)
 
-8. **LLM Features** - Registry with resolver pattern, Router LLM, provider-specific exception mapping, `Metrics`/`Telemetry` classes
+8. **LLM routing + provider error normalization**
+   - Python: LiteLLM-based routing strategies and provider exception mapping into typed SDK exceptions.
+   - TypeScript: native provider clients + LLM Profiles + an `LLMRegistry` + `Metrics` exist, but there is no router/fallback layer and provider-specific exception normalization is tracked as parity work (GH #661).
 
 9. **Hooks System** - `HookManager`, `HookExecutor`, event interception (pre/post tool use, post event, stop hook)
 
@@ -129,8 +131,8 @@ This section summarizes concrete behavior alignment between Python agent-sdk and
 
 - Default LLM timeout
   - Python: LLM default timeout raised to 300s (`timeout` default in LLM config). See openhands/sdk/llm config defaults.
-  - TypeScript: DEFAULT_TIMEOUT_MS is 60s unless overridden. See packages/agent-sdk-ts/src/sdk/llm/types.ts.
-  - Status: Divergence in long-running tool/LLM calls.
+  - TypeScript: DEFAULT_TIMEOUT_MS is 300s (300_000ms) unless overridden. See packages/agent-sdk-ts/src/sdk/llm/types.ts.
+  - Status: Aligned.
 
 - include_default_tools option
   - Python: Agent supports `include_default_tools` to selectively include built-in tools or disable all defaults. See openhands/sdk/agent/base.py and tests/sdk/agent/test_agent_tool_init.py.
@@ -503,7 +505,7 @@ classDiagram
   - Uses `system_message_suffix.j2` templates
   - Triggered knowledge rendering
   - Duplicate detection
-  - Auto-loading of user skills with warnings (skills). Note: “microagents” is the old name of “skills” and we don’t need it
+  - Auto-loading of user skills with warnings (skills). Note: Python also supports legacy “microagents”; TypeScript does not load legacy microagents today.
   - Optional public skills loading from OpenHands/skills
   - Structured metadata
 - Produces both system and user suffixes
@@ -516,7 +518,7 @@ classDiagram
 
 - Lightweight class that concatenates repo skills into a system suffix and triggered skills into a user suffix
   - Matches triggers (keyword/task) and logs warnings for duplicates
-- Supports AgentSkills progressive disclosure via `<available_skills>` (lists triggered skills without injecting full content)
+- Supports AgentSkills progressive disclosure via `<available_skills>` (lists available skills by name/description/location; full content is injected only when triggered)
 - Supports model-family gating for vendor-specific repo instructions (`CLAUDE.md`/`GEMINI.md`) and handles profiles-first settings (when `llm.profileId` is selected)
 - No public skills repo loading
 


### PR DESCRIPTION
Docs-only update for recent AgentSkills parity work.

- Update `docs/agent-sdk-architecture.md` to reflect AgentSkills (SKILL.md directories), resource discovery, optional `.mcp.json`, and expanded third-party repo skill files (AGENTS/CLAUDE/GEMINI) with truncation + vendor gating.
- Update `packages/agent-sdk-ts/docs/python-parity.md` to note AgentSkills parity is now implemented in TypeScript; remaining Python-only piece is public skills repo loading (`load_public_skills`).

No runtime/SDK code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded skill-loading docs to include vendor-gated skill files (CLAUDE.md, GEMINI.md) and a directory-based skill format (SKILL.md directories).
  * Updated TypeScript–Python parity notes covering tool loading, event structures, timeout defaults, and agent skills coverage.

* **API Changes**
  * Updated system-suffix API to accept optional LLM configuration parameters (model, provider, base URL, secrets).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->