### PR TITLE
agent-sdk-ts parity: stable LLM error codes (#661)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/errorMapping.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/errorMapping.ts
@@ -1,0 +1,93 @@
+import type { LLMProvider } from './types';
+import { isContextLimitError } from './contextLimit';
+
+type ErrnoException = Error & { code?: string; syscall?: string; address?: string; port?: number };
+
+const normalizeErrorText = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+
+const getErrnoCode = (error: unknown): string | undefined => {
+  if (!error || typeof error !== 'object') return undefined;
+  const maybe = error as Partial<ErrnoException> & { cause?: unknown };
+  if (typeof maybe.code === 'string') return maybe.code;
+  if (maybe.cause && typeof maybe.cause === 'object') {
+    const causeCode = (maybe.cause as { code?: unknown }).code;
+    if (typeof causeCode === 'string') return causeCode;
+  }
+  return undefined;
+};
+
+const looksLikeAbort = (error: unknown): boolean => {
+  if (!error || typeof error !== 'object') return false;
+  const e = error as Error;
+  if (e.name === 'AbortError') return true;
+  const msg = normalizeErrorText(error).toLowerCase();
+  return msg.includes('aborted') || msg.includes('aborterror');
+};
+
+const parseHttpStatusFromMessage = (message: string): number | undefined => {
+  const text = message.trim();
+  if (!text) return undefined;
+
+  // Examples:
+  // - "LLM request failed (400): ..."
+  // - "LLM request failed (HTTP 400): ..."
+  // - "Anthropic request failed (401): ..."
+  const match = text.match(/\((?:HTTP )?(\d{3})\):/);
+  if (!match) return undefined;
+  const status = Number.parseInt(match[1], 10);
+  return Number.isFinite(status) ? status : undefined;
+};
+
+export const classifyLlmErrorCode = (params: {
+  provider?: LLMProvider | null;
+  error: unknown;
+}): string | undefined => {
+  const provider = params.provider ?? undefined;
+  const error = params.error;
+
+  if (isContextLimitError(provider, error)) return 'llm_context_limit';
+
+  const errno = getErrnoCode(error);
+  if (errno) {
+    // Network-ish failures. Note that Node's fetch typically throws TypeError('fetch failed')
+    // with a cause that includes these codes.
+    if ([
+      'ECONNREFUSED',
+      'ECONNRESET',
+      'EHOSTUNREACH',
+      'ENETUNREACH',
+      'ENOTFOUND',
+      'EAI_AGAIN',
+      'ETIMEDOUT',
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_SOCKET',
+    ].includes(errno)) {
+      return 'llm_network_error';
+    }
+  }
+
+  if (looksLikeAbort(error)) {
+    return 'llm_timeout';
+  }
+
+  const message = normalizeErrorText(error);
+  const status = parseHttpStatusFromMessage(message);
+  if (typeof status !== 'number') return undefined;
+
+  if (status === 401 || status === 403) return 'llm_auth';
+  if (status === 429) return 'llm_rate_limit';
+  if (status === 408 || status === 504) return 'llm_timeout';
+  if ([500, 502, 503].includes(status)) return 'llm_service_unavailable';
+
+  if (status >= 400 && status < 500) return 'llm_bad_request';
+
+  return undefined;
+};

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -667,7 +667,8 @@ export class Agent extends EventEmitter {
             if (condensed) continue;
           }
 
-          const classified = classifyError(error, { stage: 'llm_request' });
+          const provider = llmConfig.provider ?? detectProviderFromBaseUrl(llmConfig.baseUrl);
+          const classified = classifyError(error, { stage: 'llm_request', llmProvider: provider });
           await this.pushEventWithHooks(this.toConversationErrorEvent(error, { code: classified.code }));
           this.state.setStatus('IDLE');
           response = undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/errorPolicy.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/errorPolicy.test.ts
@@ -10,6 +10,56 @@ describe('classifyError', () => {
     expect(result.message).toContain('Missing API key');
   });
 
+  it('classifies OpenAI context-limit errors as conversation-level with stable codes', () => {
+    const err = new Error('LLM request failed (400): {"error":{"code":"context_length_exceeded"}}');
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'openai' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_context_limit');
+  });
+
+  it('classifies auth errors as conversation-level with stable codes', () => {
+    const err = new Error('LLM request failed (401): invalid_api_key');
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'openai' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_auth');
+  });
+
+  it('classifies rate-limit errors as conversation-level with stable codes', () => {
+    const err = new Error('LLM request failed (429): rate_limit_exceeded');
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'openai' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_rate_limit');
+  });
+
+  it('classifies service-unavailable errors as conversation-level with stable codes', () => {
+    const err = new Error('Anthropic request failed (503): overloaded_error');
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'anthropic' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_service_unavailable');
+  });
+
+  it('classifies abort errors as conversation-level timeouts', () => {
+    const err = Object.assign(new Error('The operation was aborted'), { name: 'AbortError' });
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'openai' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_timeout');
+  });
+
+  it('classifies fetch network errors as conversation-level network errors', () => {
+    const cause = Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:443'), { code: 'ECONNREFUSED' });
+    const err = Object.assign(new TypeError('fetch failed'), { cause });
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'openai' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_network_error');
+  });
+
+  it('classifies other 4xx errors as bad requests by default', () => {
+    const err = new Error('LLM request failed (400): invalid_request_error');
+    const result = classifyError(err, { stage: 'llm_request', llmProvider: 'openai' });
+    expect(result.classification).toBe('conversation');
+    expect(result.code).toBe('llm_bad_request');
+  });
+
   it('formats tool arg parse errors consistently', () => {
     const err = new Error('Unexpected end of JSON input');
     const result = classifyError(err, { stage: 'tool_args', toolName: 'task_tracker', rawArgs: '{"a":' });
@@ -32,4 +82,3 @@ describe('classifyError', () => {
     expect(result.code).toBe('terminal_shell_missing');
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/errorPolicy.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/errorPolicy.ts
@@ -1,9 +1,13 @@
+import type { LLMProvider } from '../llm/types';
+import { classifyLlmErrorCode } from '../llm/errorMapping';
+
 export type ErrorClassification = 'agent' | 'conversation';
 
 export type ErrorContext = {
   stage: 'tool_args' | 'tool_lookup' | 'tool_validation' | 'tool_execute' | 'llm_init' | 'llm_request';
   toolName?: string;
   rawArgs?: string;
+  llmProvider?: LLMProvider | null;
 };
 
 export type ClassifiedError = {
@@ -48,7 +52,10 @@ export const classifyError = (error: unknown, context: ErrorContext): Classified
   let message = baseMessage;
 
   if (context.stage === 'llm_init' || context.stage === 'llm_request') {
-    return { classification: 'conversation', message, code: classifyConversationErrorCode(message) };
+    const llmCode = context.stage === 'llm_request'
+      ? classifyLlmErrorCode({ provider: context.llmProvider, error })
+      : undefined;
+    return { classification: 'conversation', message, code: llmCode ?? classifyConversationErrorCode(message) };
   }
 
   // Default tool behavior: treat as agent-visible so the LLM can self-correct.


### PR DESCRIPTION
Refs #661 (parity): provider exception mapping.

What this does
- Adds stable ConversationErrorEvent codes for common LLM failures: context limit, auth, rate limit, timeout, service unavailable, network error, bad request.
- Threads LLM provider into runtime error classification for better accuracy.
- Adds unit tests covering the new mapping.

What this does NOT do (yet)
- Does not implement router/resolver abstractions or provider/model fallback routing (still needed for full #661 closure).

Notes
- No changes to LLM profile selection semantics; this is error classification only.