### PR TITLE
agent-sdk-ts parity: add router/fallback helpers (#661)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts
@@ -32,9 +32,10 @@ describe('LLM router helpers', () => {
 
   it('falls back when shouldFallback returns true', async () => {
     const primary: LLMClient = {
-      async *streamChat() {
-        // Yield once to satisfy lint rules, then throw to test fallback behavior.
-        yield { type: 'finish' };
+      async *streamChat(request) {
+        if (request.messages.length < 0) {
+          yield { type: 'finish' };
+        }
         throw new Error('LLM request failed (503): overloaded');
       },
     };
@@ -63,6 +64,43 @@ describe('LLM router helpers', () => {
     }
 
     expect(out.join('')).toBe('ok');
+  });
+
+  it('does not fall back after yielding any chunks', async () => {
+    const primary: LLMClient = {
+      async *streamChat() {
+        yield { type: 'text', text: 'partial' };
+        throw new Error('LLM request failed (503): overloaded');
+      },
+    };
+    const fallback: LLMClient = {
+      async *streamChat() {
+        yield { type: 'text', text: 'ok' };
+        yield { type: 'finish' };
+      },
+    };
+
+    const client = createFallbackLlmClient({
+      primary,
+      fallback,
+      shouldFallback: shouldFallbackOnLlmErrorCodes({
+        provider: 'anthropic',
+        codes: ['llm_service_unavailable'],
+      }),
+    });
+
+    const out: string[] = [];
+    const iterate = async (): Promise<void> => {
+      for await (const chunk of client.streamChat({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      })) {
+        if (chunk.type === 'text') out.push(chunk.text);
+      }
+    };
+
+    await expect(iterate()).rejects.toThrow(/503/);
+    expect(out.join('')).toBe('partial');
   });
 
   it('rethrows when shouldFallback returns false', async () => {

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { LLMClient } from '../types';
+import { createFallbackLlmClient, createRouterLlmClient, shouldFallbackOnLlmErrorCodes } from '../router';
+
+describe('LLM router helpers', () => {
+  it('routes based on the selected key', async () => {
+    const events: string[] = [];
+    const mkClient = (key: string): LLMClient => ({
+      async *streamChat() {
+        events.push(key);
+        yield { type: 'text', text: key };
+        yield { type: 'finish' };
+      },
+    });
+
+    const client = createRouterLlmClient({
+      clients: { a: mkClient('a'), b: mkClient('b') },
+      router: { select: ({ hasImages }) => (hasImages ? 'b' : 'a') },
+    });
+
+    const out: string[] = [];
+    for await (const chunk of client.streamChat({
+      systemPrompt: '',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    })) {
+      if (chunk.type === 'text') out.push(chunk.text);
+    }
+
+    expect(events).toEqual(['a']);
+    expect(out.join('')).toBe('a');
+  });
+
+  it('falls back when shouldFallback returns true', async () => {
+    const primary: LLMClient = {
+      async *streamChat() {
+        // Yield once to satisfy lint rules, then throw to test fallback behavior.
+        yield { type: 'finish' };
+        throw new Error('LLM request failed (503): overloaded');
+      },
+    };
+    const fallback: LLMClient = {
+      async *streamChat() {
+        yield { type: 'text', text: 'ok' };
+        yield { type: 'finish' };
+      },
+    };
+
+    const client = createFallbackLlmClient({
+      primary,
+      fallback,
+      shouldFallback: shouldFallbackOnLlmErrorCodes({
+        provider: 'anthropic',
+        codes: ['llm_service_unavailable'],
+      }),
+    });
+
+    const out: string[] = [];
+    for await (const chunk of client.streamChat({
+      systemPrompt: '',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    })) {
+      if (chunk.type === 'text') out.push(chunk.text);
+    }
+
+    expect(out.join('')).toBe('ok');
+  });
+
+  it('rethrows when shouldFallback returns false', async () => {
+    const primary: LLMClient = {
+      async *streamChat() {
+        // Yield once to satisfy lint rules, then throw to test rethrow behavior.
+        yield { type: 'finish' };
+        throw new Error('LLM request failed (401): invalid_api_key');
+      },
+    };
+    const fallback: LLMClient = {
+      async *streamChat() {
+        yield { type: 'text', text: 'ok' };
+        yield { type: 'finish' };
+      },
+    };
+
+    const client = createFallbackLlmClient({
+      primary,
+      fallback,
+      shouldFallback: shouldFallbackOnLlmErrorCodes({
+        provider: 'openai',
+        codes: ['llm_rate_limit'],
+      }),
+    });
+
+    const iterate = async (): Promise<void> => {
+      for await (const chunk of client.streamChat({
+        systemPrompt: '',
+        messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+      })) {
+        void chunk;
+      }
+    };
+
+    await expect(iterate()).rejects.toThrow(/401/);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/index.ts
@@ -13,3 +13,5 @@ export * from './contextLimit';
 export * from './condensationLlmConfig';
 export * from './debug';
 export * from './providerQuirks';
+export * from './errorMapping';
+export * from './router';

--- a/packages/agent-sdk-ts/src/sdk/llm/router.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/router.ts
@@ -1,0 +1,75 @@
+import type { Message } from '../types';
+import { isImageContent } from '../types';
+import type { ChatCompletionRequest, LLMClient, LLMProvider } from './types';
+import { classifyLlmErrorCode } from './errorMapping';
+
+export type RouterSelectContext = {
+  request: ChatCompletionRequest;
+  /** Full concatenated user+assistant+tool message history for the request. */
+  messages: Message[];
+  /** Convenience: whether the request contains any image content. */
+  hasImages: boolean;
+};
+
+export type LlmRouter = {
+  /** Return the key for the client to use. */
+  select: (context: RouterSelectContext) => string;
+};
+
+export type RouterLlmClientOptions = {
+  clients: Record<string, LLMClient>;
+  router: LlmRouter;
+};
+
+export function createRouterLlmClient(options: RouterLlmClientOptions): LLMClient {
+  const keys = Object.keys(options.clients);
+  if (keys.length === 0) {
+    throw new Error('Router LLM requires at least one client');
+  }
+
+  return {
+    async *streamChat(request: ChatCompletionRequest) {
+      const messages = request.messages;
+      const hasImages = messages.some((m) => m.content.some(isImageContent));
+      const key = options.router.select({ request, messages, hasImages });
+      const client = options.clients[key];
+      if (!client) {
+        throw new Error(`Router selected missing LLM key '${key}'. Available: ${keys.join(', ')}`);
+      }
+      yield* client.streamChat(request);
+    },
+  };
+}
+
+export type FallbackLlmClientOptions = {
+  primary: LLMClient;
+  fallback: LLMClient;
+  shouldFallback: (error: unknown) => boolean;
+};
+
+export function createFallbackLlmClient(options: FallbackLlmClientOptions): LLMClient {
+  return {
+    async *streamChat(request: ChatCompletionRequest) {
+      try {
+        yield* options.primary.streamChat(request);
+      } catch (error) {
+        if (!options.shouldFallback(error)) {
+          throw error;
+        }
+        yield* options.fallback.streamChat(request);
+      }
+    },
+  };
+}
+
+export const shouldFallbackOnLlmErrorCodes = (params: {
+  provider?: LLMProvider | null;
+  codes: string[];
+}): ((error: unknown) => boolean) => {
+  const allow = new Set(params.codes.filter((c) => typeof c === 'string' && c.trim()));
+  return (error: unknown): boolean => {
+    const code = classifyLlmErrorCode({ provider: params.provider ?? undefined, error });
+    return typeof code === 'string' && allow.has(code);
+  };
+};
+

--- a/packages/agent-sdk-ts/src/sdk/llm/router.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/router.ts
@@ -50,9 +50,16 @@ export type FallbackLlmClientOptions = {
 export function createFallbackLlmClient(options: FallbackLlmClientOptions): LLMClient {
   return {
     async *streamChat(request: ChatCompletionRequest) {
+      let yielded = false;
       try {
-        yield* options.primary.streamChat(request);
+        for await (const chunk of options.primary.streamChat(request)) {
+          yielded = true;
+          yield chunk;
+        }
       } catch (error) {
+        if (yielded) {
+          throw error;
+        }
         if (!options.shouldFallback(error)) {
           throw error;
         }
@@ -72,4 +79,3 @@ export const shouldFallbackOnLlmErrorCodes = (params: {
     return typeof code === 'string' && allow.has(code);
   };
 };
-


### PR DESCRIPTION
Refs #661 (parity): router/resolver capability.

What this does
- Adds `createRouterLlmClient()` + `createFallbackLlmClient()` helpers in `packages/agent-sdk-ts/src/sdk/llm/router.ts`.
- Adds `shouldFallbackOnLlmErrorCodes()` helper powered by `classifyLlmErrorCode`.
- Exports `errorMapping` + `router` from `packages/agent-sdk-ts/src/sdk/llm/index.ts`.
- Adds unit tests: `packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts`.

Notes
- Opt-in only (not wired into extension settings); should not affect LLM Profiles behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent LLM routing capabilities to select between multiple language model clients based on request context.
  * Added automatic fallback support to switch to a secondary LLM client when errors occur, with customizable error classification and fallback conditions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->