### PR TITLE
agent-sdk-ts: remove console.log debug spam (oh-tab-65xd)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/agent-context.ts
@@ -224,7 +224,6 @@ export class AgentContext {
     for (const skill of this.skills) {
       const trigger = skill.matchTrigger(query);
       if (trigger && !skipSkillNames.includes(skill.name)) {
-        console.log(`Skill '${skill.name}' triggered by keyword '${trigger}'`);
         recalledKnowledge.push({
           name: skill.name,
           trigger,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -14,7 +14,7 @@ import {
   loadProfile,
   wouldExceedMaxInputTokens,
 } from '../llm';
-import type { ActionEvent, BashEvent, Event, Message, MessageEvent, ObservationEvent, ToolCall } from '../types';
+import type { ActionEvent, BashEvent, ConversationStateUpdateEvent, Event, Message, MessageEvent, ObservationEvent, ToolCall } from '../types';
 import {
   isActionEvent,
   isAgentErrorEvent,
@@ -322,22 +322,24 @@ export class Agent extends EventEmitter {
   }
 
   private emitRestorePendingConfirmationDiagnostic(reason: string, detail?: Record<string, unknown>): void {
-    void this.pushEventWithHooks({
+    const event: ConversationStateUpdateEvent = {
       kind: 'ConversationStateUpdateEvent',
       source: 'agent',
       key: 'restore_pending_confirmation',
       value: { restored: false, reason, ...detail },
-    } as Event);
+    };
+    void this.pushEventWithHooks(event);
   }
 
   private emitDebugStateUpdate(key: string, value: unknown): void {
     if (!this.debug) return;
-    void this.pushEventWithHooks({
+    const event: ConversationStateUpdateEvent = {
       kind: 'ConversationStateUpdateEvent',
       source: 'agent',
       key,
       value,
-    } as Event);
+    };
+    void this.pushEventWithHooks(event);
   }
 
   private clearWaitingForConfirmation(reason: string, detail?: Record<string, unknown>, emitError = false): void {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -291,7 +291,11 @@ export class Agent extends EventEmitter {
       // Debug logging for mid-run settings changes (oh-tab-rw1k)
       const newModel = settings?.llm?.model;
       const newProfileId = settings?.llm?.profileId;
-      console.log(`[Agent.setSettings] Settings updated. Profile: ${prevProfileId} -> ${newProfileId}, Model: ${prevModel} -> ${newModel}. Cleared streamerPromise.`);
+      this.emitDebugStateUpdate('agent_settings_updated', {
+        profile: { from: prevProfileId ?? null, to: newProfileId ?? null },
+        model: { from: prevModel ?? null, to: newModel ?? null },
+        cleared: { llmClientPromise: true, streamerPromise: true },
+      });
 
       return Promise.resolve();
     });
@@ -323,6 +327,16 @@ export class Agent extends EventEmitter {
       source: 'agent',
       key: 'restore_pending_confirmation',
       value: { restored: false, reason, ...detail },
+    } as Event);
+  }
+
+  private emitDebugStateUpdate(key: string, value: unknown): void {
+    if (!this.debug) return;
+    void this.pushEventWithHooks({
+      kind: 'ConversationStateUpdateEvent',
+      source: 'agent',
+      key,
+      value,
     } as Event);
   }
 
@@ -565,7 +579,14 @@ export class Agent extends EventEmitter {
       const currentModel = this.options.settings?.llm?.model;
       const currentProfileId = this.options.settings?.llm?.profileId;
       const hasStreamerPromise = !!this.streamerPromise;
-      console.log(`[Agent.runLoop] Iteration ${this.state.snapshot.iteration}. Settings: profile=${currentProfileId}, model=${currentModel}. streamerPromise cached=${hasStreamerPromise}`);
+      this.emitDebugStateUpdate('agent_run_loop_state', {
+        iteration: this.state.snapshot.iteration,
+        settings: {
+          profileId: currentProfileId ?? null,
+          model: currentModel ?? null,
+        },
+        cached: { streamerPromise: hasStreamerPromise },
+      });
 
       let response: Awaited<ReturnType<LLMStreamer['runChat']>> | undefined;
 
@@ -1048,13 +1069,17 @@ export class Agent extends EventEmitter {
     if (!this.streamerPromise) {
       const model = this.options.settings?.llm?.model;
       const profileId = this.options.settings?.llm?.profileId;
-      console.log(`[Agent.getStreamer] Creating new streamer. Profile: ${profileId}, Model: ${model}`);
+      this.emitDebugStateUpdate('agent_streamer_cache', {
+        action: 'create',
+        profileId: profileId ?? null,
+        model: model ?? null,
+      });
       this.streamerPromise = (async () => {
         const client = await this.getPrimaryLlmClient();
         return new LLMStreamer(client, { events: this.events, state: this.state });
       })();
     } else {
-      console.log(`[Agent.getStreamer] Reusing cached streamer.`);
+      this.emitDebugStateUpdate('agent_streamer_cache', { action: 'reuse' });
     }
 
     return this.streamerPromise;


### PR DESCRIPTION
Tech debt cleanup (no behavior change): remove console.log spam in agent-sdk-ts runtime hot paths.

- Replace Agent runtime console.log debug lines with debug-gated ConversationStateUpdateEvent emissions (agent_settings_updated, agent_run_loop_state, agent_streamer_cache).
- Remove skill trigger console.log in AgentContext.

Guardrails:
- Default remains silent (events only emitted when agent.debug is enabled).
- LLM Profiles semantics unchanged.

Refs: Beads oh-tab-65xd.