### PR TITLE
webview: reduce LLM profile switch log spam (oh-tab-beum)

### DIFF
--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -529,52 +529,74 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
         const currentSettings = await settingsMgr.get();
         const previousProfileId = currentSettings.llm.profileId || '(none)';
+        const debugProfiles = currentSettings.agent?.debug === true;
         const convMode = deps.getConversationMode();
         const convStatus = conversation?.getStatus() ?? 'offline';
         const convId = conversation?.getConversationId?.() || '(no conversation)';
 
-        outputChannel?.appendLine('[LLM Profile] ========== SWITCH REQUESTED ==========');
-        outputChannel?.appendLine('[LLM Profile] From: ' + previousProfileId + ' -> To: ' + (profileId || '(none)'));
-        outputChannel?.appendLine('[LLM Profile] Conversation: mode=' + convMode + ', status=' + convStatus + ', id=' + convId);
-        outputChannel?.appendLine('[LLM Profile] Current settings.llm: ' + JSON.stringify(currentSettings.llm));
+        if (debugProfiles) {
+          outputChannel?.appendLine('[LLM Profile] ========== SWITCH REQUESTED ==========');
+          outputChannel?.appendLine(
+            `[LLM Profile] Switch requested: ${previousProfileId} -> ${profileId || '(none)'} (mode=${convMode}, status=${convStatus}, id=${convId})`,
+          );
+          outputChannel?.appendLine('[LLM Profile] Current settings.llm: ' + JSON.stringify(currentSettings.llm));
+        }
 
         try {
-          outputChannel?.appendLine('[LLM Profile] Calling settingsMgr.update({ llm: { profileId: "' + profileId + '" } }, "global")...');
+          if (debugProfiles) {
+            outputChannel?.appendLine(
+              '[LLM Profile] Calling settingsMgr.update({ llm: { profileId: "' + profileId + '" } }, "global")...',
+            );
+          }
           await settingsMgr.update({ llm: { profileId } }, 'global');
-          outputChannel?.appendLine('[LLM Profile] Settings persisted successfully');
+          if (debugProfiles) {
+            outputChannel?.appendLine('[LLM Profile] Settings persisted successfully');
+          }
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine('[LLM Profile] FAILED to persist: ' + reason);
+          outputChannel?.appendLine('[LLM Profile] Failed to persist selection: ' + reason);
           postStatusError(`Failed to save profile selection: ${reason}`);
           break;
         }
 
         const updated = await settingsMgr.get();
-        outputChannel?.appendLine('[LLM Profile] Updated settings.llm: ' + JSON.stringify(updated.llm));
+        if (debugProfiles) {
+          outputChannel?.appendLine('[LLM Profile] Updated settings.llm: ' + JSON.stringify(updated.llm));
 
-        outputChannel?.appendLine('[LLM Profile] Applying to conversation...');
-        outputChannel?.appendLine('[LLM Profile] conversation exists: ' + (conversation ? 'yes' : 'no'));
-        if (conversation) {
-          outputChannel?.appendLine('[LLM Profile] conversation.setSettings exists: ' + (typeof conversation.setSettings === 'function' ? 'yes' : 'no'));
+          outputChannel?.appendLine('[LLM Profile] Applying to conversation...');
+          outputChannel?.appendLine('[LLM Profile] conversation exists: ' + (conversation ? 'yes' : 'no'));
+          if (conversation) {
+            outputChannel?.appendLine(
+              '[LLM Profile] conversation.setSettings exists: ' + (typeof conversation.setSettings === 'function' ? 'yes' : 'no'),
+            );
+          }
         }
 
         try {
           conversation?.setSettings(updated);
-          outputChannel?.appendLine('[LLM Profile] Applied to conversation successfully');
+          if (debugProfiles) {
+            outputChannel?.appendLine('[LLM Profile] Applied to conversation successfully');
+          }
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine('[LLM Profile] FAILED to apply to conversation: ' + reason);
+          outputChannel?.appendLine('[LLM Profile] Failed to apply to conversation: ' + reason);
         }
 
         const newLabel = resolveConfiguredLlmLabel(updated);
         const oldLabel = deps.getLastKnownLlmLabel();
-        outputChannel?.appendLine('[LLM Profile] Label: ' + (oldLabel || '(null)') + ' -> ' + (newLabel || '(null)'));
+        if (debugProfiles) {
+          outputChannel?.appendLine('[LLM Profile] Label: ' + (oldLabel || '(null)') + ' -> ' + (newLabel || '(null)'));
+        }
         deps.setLastKnownLlmLabel(newLabel);
 
         const finalStatus = conversation?.getStatus() ?? 'offline';
         const finalMode = deps.getConversationMode();
         const finalLabel = deps.getLastKnownLlmLabel();
-        outputChannel?.appendLine('[LLM Profile] Posting status message: status=' + finalStatus + ', mode=' + finalMode + ', label=' + (finalLabel || '(null)'));
+        if (debugProfiles) {
+          outputChannel?.appendLine(
+            '[LLM Profile] Posting status message: status=' + finalStatus + ', mode=' + finalMode + ', label=' + (finalLabel || '(null)'),
+          );
+        }
 
         void host.postMessage({
           type: 'status',
@@ -585,7 +607,11 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         const profiles = listAvailableLlmProfiles();
         const activeProfileId = updated.llm.profileId ?? null;
-        outputChannel?.appendLine('[LLM Profile] Posting llmProfilesUpdated: profiles=[' + profiles.join(', ') + '], activeProfileId=' + (activeProfileId || '(null)'));
+        if (debugProfiles) {
+          outputChannel?.appendLine(
+            '[LLM Profile] Posting llmProfilesUpdated: profiles=[' + profiles.join(', ') + '], activeProfileId=' + (activeProfileId || '(null)'),
+          );
+        }
 
         void host.postMessage({
           type: 'llmProfilesUpdated',
@@ -593,7 +619,12 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           activeProfileId,
         });
 
-        outputChannel?.appendLine('[LLM Profile] ========== SWITCH COMPLETE ==========');
+        outputChannel?.appendLine(
+          `[LLM Profile] Switched: ${previousProfileId} -> ${activeProfileId || '(none)'} (mode=${finalMode}, status=${finalStatus}, label=${finalLabel || '(null)'})`,
+        );
+        if (debugProfiles) {
+          outputChannel?.appendLine('[LLM Profile] ========== SWITCH COMPLETE ==========');
+        }
         break;
       }
       case 'llmProfilesListRequest': {


### PR DESCRIPTION
Tech debt cleanup: reduce Output channel spam when switching LLM profiles.

- Default: single-line summary log on successful switch.
- Debug (openhands.agent.debug=true): keep detailed multi-line tracing.

No behavior change to profile selection/remote/local semantics.

Refs: Beads oh-tab-beum.