### PR TITLE
agent-sdk-ts: dedupe includeDefaultTools resolution (oh-tab-tpom)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -26,6 +26,7 @@ import path from 'path';
 import type { ConversationPersistence } from '../runtime';
 import { AgentContext } from '../context';
 import type { AgentHook } from '../runtime/hooks';
+import { resolveToolsWithDefaultTools } from './includeDefaultTools';
 
 const toOptionalNonEmptyString = (value: unknown): string | undefined => {
   const trimmed = typeof value === 'string' ? value.trim() : '';
@@ -290,50 +291,13 @@ export class LocalConversation extends EventEmitter {
       new FileEditorTool(),
       new TaskTrackerTool(),
     ];
-    const defaultNames = new Set(defaultTools.map((tool) => tool.name));
 
-    const includeDefaultTools = this.includeDefaultTools;
-    if (includeDefaultTools === false) {
-      return provided ?? [];
-    }
-
-    if (includeDefaultTools === undefined) {
-      return provided ?? defaultTools;
-    }
-
-    const selectedDefaults = Array.isArray(includeDefaultTools)
-      ? (() => {
-        const uniqueNames = new Set<string>();
-        for (const raw of includeDefaultTools) {
-          const name = typeof raw === 'string' ? raw.trim() : '';
-          if (!name) continue;
-          if (!defaultNames.has(name)) {
-            throw new Error(`includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(defaultNames).sort().join(', ')}`);
-          }
-          uniqueNames.add(name);
-        }
-        return defaultTools.filter((tool) => uniqueNames.has(tool.name));
-      })()
-      : defaultTools;
-
-    const mergedByName = new Map<string, ToolDefinition<unknown, unknown>>(selectedDefaults.map((tool) => [tool.name, tool]));
-    for (const tool of provided ?? []) mergedByName.set(tool.name, tool);
-
-    const result: ToolDefinition<unknown, unknown>[] = [];
-    const included = new Set<string>();
-
-    for (const tool of selectedDefaults) {
-      result.push(mergedByName.get(tool.name)!);
-      included.add(tool.name);
-    }
-
-    for (const tool of provided ?? []) {
-      if (included.has(tool.name)) continue;
-      result.push(tool);
-      included.add(tool.name);
-    }
-
-    return result;
+    return resolveToolsWithDefaultTools({
+      includeDefaultTools: this.includeDefaultTools,
+      hasToolsOption: this.hasToolsOption,
+      defaultTools,
+      providedTools: provided,
+    });
   }
 
   private createAgent(): Agent {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -12,6 +12,7 @@ import { RemoteState } from './RemoteState';
 import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
 import type { BaseWorkspace } from '../../workspace/BaseWorkspace';
 import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from '../../workspace/types';
+import { resolveToolsWithDefaultTools } from './includeDefaultTools';
 
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
@@ -369,61 +370,12 @@ export class RemoteConversation extends EventEmitter {
       ];
       const workspace = this.workspace ?? { kind: 'LocalWorkspace', working_dir: this.workspaceRoot };
 
-      const mergeTools = (defaults: RemoteConversationTool[], provided: RemoteConversationTool[]): RemoteConversationTool[] => {
-        const byName = new Map<string, RemoteConversationTool>(defaults.map((tool) => [tool.name, tool]));
-        for (const tool of provided) byName.set(tool.name, tool);
-
-        const result: RemoteConversationTool[] = [];
-        const included = new Set<string>();
-
-        for (const tool of defaults) {
-          result.push(byName.get(tool.name)!);
-          included.add(tool.name);
-        }
-
-        for (const tool of provided) {
-          if (!included.has(tool.name)) {
-            result.push(tool);
-            included.add(tool.name);
-          }
-        }
-
-        return result;
-      };
-
-      const resolveDefaultToolSubset = (selection: readonly string[]): RemoteConversationTool[] => {
-        const allowed = new Set(defaultTools.map((tool) => tool.name));
-        const uniqueNames = new Set<string>();
-        for (const raw of selection) {
-          const name = typeof raw === 'string' ? raw.trim() : '';
-          if (!name) continue;
-          if (!allowed.has(name)) {
-            throw new Error(`includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(allowed).sort().join(', ')}`);
-          }
-          uniqueNames.add(name);
-        }
-        return defaultTools.filter((tool) => uniqueNames.has(tool.name));
-      };
-
-      const tools = (() => {
-        const provided = this.tools ?? [];
-        const includeDefaultTools = this.includeDefaultTools;
-
-        if (includeDefaultTools === undefined) {
-          if (this.hasToolsOption) return provided;
-          return defaultTools;
-        }
-
-        if (includeDefaultTools === false) {
-          return provided;
-        }
-
-        const selectedDefaults = Array.isArray(includeDefaultTools)
-          ? resolveDefaultToolSubset(includeDefaultTools)
-          : defaultTools;
-
-        return mergeTools(selectedDefaults, provided);
-      })();
+      const tools = resolveToolsWithDefaultTools({
+        includeDefaultTools: this.includeDefaultTools,
+        hasToolsOption: this.hasToolsOption,
+        defaultTools,
+        providedTools: this.tools,
+      });
       const req = {
         agent: {
           llm,

--- a/packages/agent-sdk-ts/src/sdk/conversation/__tests__/includeDefaultTools.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/__tests__/includeDefaultTools.test.ts
@@ -1,28 +1,32 @@
 import { describe, expect, it } from 'vitest';
 import { resolveToolsWithDefaultTools } from '../includeDefaultTools';
 
+type TestTool = { name: string; custom?: boolean };
+
 describe('resolveToolsWithDefaultTools', () => {
   it('throws on unknown default tool name', () => {
     expect(() =>
       resolveToolsWithDefaultTools({
         includeDefaultTools: ['nope'],
         hasToolsOption: false,
-        defaultTools: [{ name: 'terminal' }, { name: 'file_editor' }],
+        defaultTools: [{ name: 'terminal' }, { name: 'file_editor' }] satisfies TestTool[],
         providedTools: undefined,
       }),
     ).toThrow(/unknown default tool 'nope'/i);
   });
 
   it('merges selected defaults with provided tools, preserving default ordering', () => {
+    const defaultTools: TestTool[] = [{ name: 'terminal' }, { name: 'file_editor' }];
+    const providedTools: TestTool[] = [{ name: 'terminal', custom: true }, { name: 'glob' }];
+
     const tools = resolveToolsWithDefaultTools({
       includeDefaultTools: ['terminal'],
       hasToolsOption: false,
-      defaultTools: [{ name: 'terminal' }, { name: 'file_editor' }],
-      providedTools: [{ name: 'terminal', custom: true } as any, { name: 'glob' } as any],
+      defaultTools,
+      providedTools,
     });
 
     expect(tools.map((t) => t.name)).toEqual(['terminal', 'glob']);
-    expect((tools[0] as any).custom).toBe(true);
+    expect(tools[0].custom).toBe(true);
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/conversation/__tests__/includeDefaultTools.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/__tests__/includeDefaultTools.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { resolveToolsWithDefaultTools } from '../includeDefaultTools';
+
+describe('resolveToolsWithDefaultTools', () => {
+  it('throws on unknown default tool name', () => {
+    expect(() =>
+      resolveToolsWithDefaultTools({
+        includeDefaultTools: ['nope'],
+        hasToolsOption: false,
+        defaultTools: [{ name: 'terminal' }, { name: 'file_editor' }],
+        providedTools: undefined,
+      }),
+    ).toThrow(/unknown default tool 'nope'/i);
+  });
+
+  it('merges selected defaults with provided tools, preserving default ordering', () => {
+    const tools = resolveToolsWithDefaultTools({
+      includeDefaultTools: ['terminal'],
+      hasToolsOption: false,
+      defaultTools: [{ name: 'terminal' }, { name: 'file_editor' }],
+      providedTools: [{ name: 'terminal', custom: true } as any, { name: 'glob' } as any],
+    });
+
+    expect(tools.map((t) => t.name)).toEqual(['terminal', 'glob']);
+    expect((tools[0] as any).custom).toBe(true);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/conversation/__tests__/includeDefaultTools.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/__tests__/includeDefaultTools.test.ts
@@ -29,4 +29,59 @@ describe('resolveToolsWithDefaultTools', () => {
     expect(tools.map((t) => t.name)).toEqual(['terminal', 'glob']);
     expect(tools[0].custom).toBe(true);
   });
+
+  it('defaults to default tools when includeDefaultTools is undefined and tools option is omitted', () => {
+    const defaultTools: TestTool[] = [{ name: 'terminal' }, { name: 'file_editor' }];
+
+    const tools = resolveToolsWithDefaultTools({
+      includeDefaultTools: undefined,
+      hasToolsOption: false,
+      defaultTools,
+      providedTools: undefined,
+    });
+
+    expect(tools.map((t) => t.name)).toEqual(['terminal', 'file_editor']);
+  });
+
+  it('preserves provided tools when includeDefaultTools is undefined and tools option is explicitly passed', () => {
+    const defaultTools: TestTool[] = [{ name: 'terminal' }, { name: 'file_editor' }];
+    const providedTools: TestTool[] = [{ name: 'glob' }];
+
+    const tools = resolveToolsWithDefaultTools({
+      includeDefaultTools: undefined,
+      hasToolsOption: true,
+      defaultTools,
+      providedTools,
+    });
+
+    expect(tools.map((t) => t.name)).toEqual(['glob']);
+  });
+
+  it('excludes defaults when includeDefaultTools is false', () => {
+    const defaultTools: TestTool[] = [{ name: 'terminal' }, { name: 'file_editor' }];
+    const providedTools: TestTool[] = [{ name: 'glob' }];
+
+    const tools = resolveToolsWithDefaultTools({
+      includeDefaultTools: false,
+      hasToolsOption: false,
+      defaultTools,
+      providedTools,
+    });
+
+    expect(tools.map((t) => t.name)).toEqual(['glob']);
+  });
+
+  it('includes all defaults when includeDefaultTools is true', () => {
+    const defaultTools: TestTool[] = [{ name: 'terminal' }, { name: 'file_editor' }];
+    const providedTools: TestTool[] = [{ name: 'glob' }];
+
+    const tools = resolveToolsWithDefaultTools({
+      includeDefaultTools: true,
+      hasToolsOption: false,
+      defaultTools,
+      providedTools,
+    });
+
+    expect(tools.map((t) => t.name)).toEqual(['terminal', 'file_editor', 'glob']);
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/conversation/includeDefaultTools.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/includeDefaultTools.ts
@@ -1,0 +1,73 @@
+export type IncludeDefaultToolsOption = boolean | string[] | undefined;
+
+const toToolName = (value: unknown): string => (typeof value === 'string' ? value.trim() : '');
+
+const resolveDefaultToolSubset = <T extends { name: string }>(
+  selection: readonly string[],
+  defaults: readonly T[],
+): T[] => {
+  const allowed = new Set(defaults.map((tool) => tool.name));
+  const uniqueNames = new Set<string>();
+  for (const raw of selection) {
+    const name = toToolName(raw);
+    if (!name) continue;
+    if (!allowed.has(name)) {
+      throw new Error(
+        `includeDefaultTools: unknown default tool '${name}'. Allowed: ${Array.from(allowed).sort().join(', ')}`,
+      );
+    }
+    uniqueNames.add(name);
+  }
+  return defaults.filter((tool) => uniqueNames.has(tool.name));
+};
+
+const mergeTools = <T extends { name: string }>(defaults: readonly T[], provided: readonly T[]): T[] => {
+  const byName = new Map<string, T>(defaults.map((tool) => [tool.name, tool]));
+  for (const tool of provided) byName.set(tool.name, tool);
+
+  const result: T[] = [];
+  const included = new Set<string>();
+
+  for (const tool of defaults) {
+    result.push(byName.get(tool.name)!);
+    included.add(tool.name);
+  }
+
+  for (const tool of provided) {
+    if (included.has(tool.name)) continue;
+    result.push(tool);
+    included.add(tool.name);
+  }
+
+  return result;
+};
+
+export const resolveToolsWithDefaultTools = <T extends { name: string }>(params: {
+  includeDefaultTools: IncludeDefaultToolsOption;
+  /**
+   * True if the caller explicitly passed a tools option (even if empty).
+   * When true and includeDefaultTools is undefined, we preserve provided tools as-is.
+   */
+  hasToolsOption: boolean;
+  defaultTools: readonly T[];
+  providedTools: readonly T[] | undefined;
+}): T[] => {
+  const includeDefaultTools = params.includeDefaultTools;
+  const provided = params.providedTools ?? [];
+  const defaults = params.defaultTools;
+
+  if (includeDefaultTools === undefined) {
+    return params.hasToolsOption ? [...provided] : [...defaults];
+  }
+
+  if (includeDefaultTools === false) {
+    return [...provided];
+  }
+
+  const selectedDefaults = Array.isArray(includeDefaultTools)
+    ? resolveDefaultToolSubset(includeDefaultTools, defaults)
+    : [...defaults];
+
+  return mergeTools(selectedDefaults, provided);
+};
+


### PR DESCRIPTION
Tech debt refactor: LocalConversation and RemoteConversation had near-duplicate includeDefaultTools merge/validation logic.

- Add shared resolver: packages/agent-sdk-ts/src/sdk/conversation/includeDefaultTools.ts
- Use it from LocalConversation + RemoteConversation
- Add unit coverage for resolver

No behavior change intended; existing Local/Remote tests still pass.

Refs: Beads oh-tab-tpom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized tool-selection and merging into a single shared utility to simplify behavior and reduce duplication.

* **Tests**
  * Added comprehensive tests covering merging behavior, selection subsets, default inclusion/exclusion, and error handling for unknown default tool names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->