### PR TITLE
Remote mode: clarify LLM profile switching timing (oh-tab-d9k9)

### DIFF
--- a/docs/llm_profiles.md
+++ b/docs/llm_profiles.md
@@ -87,8 +87,8 @@ Current selection heuristic (best-effort):
 ### Runtime switching semantics
 
 - Switching profiles mid-conversation:
-  - Applies to the **next** LLM request (no interruption of in-flight streaming).
-  - Uses the newly selected profile for subsequent requests (until changed again).
+  - Local mode: applies to the **next** LLM request (no interruption of in-flight streaming).
+  - Remote mode: applies when you start a **new conversation** (the agent-server does not currently support mid-conversation LLM switching).
 
 ### Consistency requirement (critical)
 
@@ -145,4 +145,3 @@ User-facing errors should **not** include internal diagnostic fields like:
 
 Internal diagnostics (full request payload, effective resolution details) belong in:
 - Debug logs / Output channel gated behind a debug setting, not in normal UI error blocks.
-

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -79,6 +79,7 @@ Purpose: consolidate the real settings an OpenHands-Tab VS Code extension needs,
   - Therefore, treat `openhands.llm.profileId` as a **local alias only** for now.
   - In remote mode, the extension/SDK must load the profile locally and expand it into the existing `agent.llm` payload (only server-supported fields).
   - Do **not** send `profile_id` to the server until the agent-server supports it.
+  - Remote mode limitation: changing `openhands.llm.profileId` does **not** reconfigure the agent-server mid-conversation; it applies on the next new conversation.
 - Merge rules
   - Profile config is canonical for provider/model/baseUrl/openaiApiMode and generation parameters.
   - The only remaining VS Code LLM setting is `openhands.llm.profileId`.

--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -21,7 +21,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
     }
   });
 
-  const createHandler = (options?: { conversation?: any }) => {
+  const createHandler = (options?: { conversation?: any; mode?: 'local' | 'remote' }) => {
     const postMessage = vi.fn(async () => true);
     const secretValues = new Map<string, string>();
     const secrets = {
@@ -39,7 +39,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       host: { postMessage },
       secretRegistry,
       getConversation: () => options?.conversation,
-      getConversationMode: () => 'local',
+      getConversationMode: () => options?.mode ?? 'local',
       getConversationStoreRoot: () => undefined,
       resolveConversationStoreRoot: async () => tmpDir,
       getLlmProfilesStoreRoot: () => tmpDir,
@@ -172,5 +172,20 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
 
     expect(conversation.setSettings).toHaveBeenCalledTimes(1);
     expect(conversation.setSettings.mock.calls[0]?.[0]?.llm?.profileId).toBe('test-gpt-4');
+  });
+
+  it('warns that remote mode profile switching applies on the next new conversation', async () => {
+    const conversation = { getStatus: () => 'online', setSettings: vi.fn() };
+    const { handler, postMessage } = createHandler({ conversation, mode: 'remote' });
+
+    await handler({ type: 'setLlmProfileId', profileId: 'test-gpt-4' });
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'statusMessage',
+      level: 'warn',
+      message: expect.stringContaining('Remote mode'),
+      autoDismiss: true,
+      autoDismissDelay: 8000,
+    });
   });
 });

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -619,6 +619,16 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           activeProfileId,
         });
 
+        if (finalMode === 'remote' && finalStatus === 'online') {
+          void host.postMessage({
+            type: 'statusMessage',
+            level: 'warn',
+            message: 'Remote mode: LLM profile changes apply when you start a new conversation. The current remote conversation will continue using its existing model.',
+            autoDismiss: true,
+            autoDismissDelay: 8000,
+          });
+        }
+
         outputChannel?.appendLine(
           `[LLM Profile] Switched: ${previousProfileId} -> ${activeProfileId || '(none)'} (mode=${finalMode}, status=${finalStatus}, label=${finalLabel || '(null)'})`,
         );


### PR DESCRIPTION
Implements Beads **oh-tab-d9k9**.

- Remote mode: show a webview warning toast when changing `openhands.llm.profileId` while connected (applies on next new conversation).
- Docs: clarify remote-mode switching semantics.
- Tests: add unit coverage for the warning path.

Notes
- Must not regress LLM Profiles; this is UX clarification only (no behavior change to profile resolution).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM profile switching now operates differently based on mode: Local mode applies changes on the next request; Remote mode applies changes on the next conversation.
  * Added warning notification when switching profiles in remote mode, clarifying that profile changes take effect only when starting a new conversation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->