### PR TITLE
agent-sdk-ts: extract condensation helpers (oh-tab-wyrj)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.condensation-budget.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.condensation-budget.test.ts
@@ -21,24 +21,15 @@ describe('Agent condensation config', () => {
       },
     });
 
-    const { Agent, ConversationState, EventLog } = await import('../runtime');
-    const events = new EventLog();
-    const state = new ConversationState({ eventLog: events });
+    const { getEffectiveLlmConfigForCondensation } = await import('../llm');
 
-    const agent = new Agent({
-      settings: {
-        llm: { profileId: 'p1', maxInputTokens: 500, model: 'raw-model' },
-        agent: {},
-        conversation: {},
-        confirmation: { policy: 'never' },
-        secrets: {},
-      },
-      events,
-      state,
-      tools: [],
+    const config = getEffectiveLlmConfigForCondensation({
+      llm: { profileId: 'p1', maxInputTokens: 500, model: 'raw-model' },
+      agent: {},
+      conversation: {},
+      confirmation: { policy: 'never' },
+      secrets: {},
     });
-
-    const config = (agent as any).getEffectiveLlmConfigForCondensation();
     expect(config.maxInputTokens).toBe(100);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -5,7 +5,7 @@ import { LLMStreamer } from './LLMStreamer';
 import { AsyncLock } from './AsyncLock';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
-import type { LLMClient, LLMProfileStoreOptions, LLMProvider, LLMToolDefinition } from '../llm';
+import type { LLMClient, LLMProfileStoreOptions, LLMToolDefinition } from '../llm';
 import {
   DEFAULT_PROVIDER_BASE_URLS,
   detectProviderFromBaseUrl,
@@ -18,8 +18,6 @@ import type { ActionEvent, BashEvent, ConversationStateUpdateEvent, Event, Messa
 import {
   isActionEvent,
   isAgentErrorEvent,
-  isCondensation,
-  isMessageEvent,
   isObservationEvent,
   isPauseEvent,
   isSystemPromptEvent,
@@ -34,11 +32,9 @@ import { Workspace } from '../../workspace';
 import { FinishTool } from '../../tools/FinishTool';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
-import { LLMSummarizingCondenser } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
 import { SYSTEM_PROMPT } from './systemPrompt';
-import { sanitizeChatMessages } from './sanitizeChatMessages';
 import {
   redactAndTruncateArgs,
   sanitizeChatRequestForDebug,
@@ -50,6 +46,7 @@ import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } 
 import { deepTruncate, truncateToolMessage } from './toolResultTruncation';
 import { SecretMasker } from './secretMasker';
 import { ToolSummarizer } from './toolSummarizer';
+import { buildChatRequestWithCondensation, tryCondenseConversation as tryCondenseConversationWithDeps } from './condensation';
 import { buildLlmRequestParametersForDebug } from '../llm/debug';
 import { StuckDetector } from '../conversation/stuckDetector';
 import type { ConfirmationPolicy, SecurityAnalyzer } from '../security';
@@ -575,7 +572,7 @@ export class Agent extends EventEmitter {
         }
       }
 
-      const llmConfig = this.getEffectiveLlmConfigForCondensation();
+      const llmConfig = resolveCondensationLlmConfig(this.options.settings);
 
       // Debug logging for mid-run settings tracking (oh-tab-rw1k)
       const currentModel = this.options.settings?.llm?.model;
@@ -595,7 +592,11 @@ export class Agent extends EventEmitter {
       // Condensation is token-budget based: before calling the LLM (and again if we hit a context-limit
       // error), we may summarize the conversation to shrink the next request.
       for (let condensationAttempt = 0; condensationAttempt <= MAX_CONDENSATIONS_PER_STEP; condensationAttempt += 1) {
-        const request = this.buildChatRequest();
+        const request = buildChatRequestWithCondensation({
+          events: this.events.list(),
+          systemPrompt: this.buildSystemPrompt(),
+          tools: this.getToolDefinitions(),
+        });
 
         // Emit a lightweight debug/state event so hosts can log what tools are actually sent
         try {
@@ -650,7 +651,12 @@ export class Agent extends EventEmitter {
           typeof configuredMaxInputTokens === 'number' &&
           wouldExceedMaxInputTokens({ request, maxInputTokens: configuredMaxInputTokens })
         ) {
-          const condensed = await this.tryCondenseConversation({ maxInputTokens: configuredMaxInputTokens });
+          const condensed = await tryCondenseConversationWithDeps({
+            maxInputTokens: configuredMaxInputTokens,
+            listEvents: () => this.events.list(),
+            getPrimaryLlmClient: () => this.getPrimaryLlmClient(),
+            pushEvent: (event) => this.pushEventWithHooks(event),
+          });
           if (condensed) continue;
         }
 
@@ -686,7 +692,12 @@ export class Agent extends EventEmitter {
         } catch (error) {
           if (condensationAttempt < MAX_CONDENSATIONS_PER_STEP && isContextLimitError(llmConfig.provider, error)) {
             const budget = configuredMaxInputTokens ?? FALLBACK_CONDENSATION_MAX_INPUT_TOKENS;
-            const condensed = await this.tryCondenseConversation({ maxInputTokens: budget });
+            const condensed = await tryCondenseConversationWithDeps({
+              maxInputTokens: budget,
+              listEvents: () => this.events.list(),
+              getPrimaryLlmClient: () => this.getPrimaryLlmClient(),
+              pushEvent: (event) => this.pushEventWithHooks(event),
+            });
             if (condensed) continue;
           }
 
@@ -826,118 +837,6 @@ export class Agent extends EventEmitter {
     const raw = this.options.settings?.conversation?.maxIterations;
     const n = typeof raw === 'number' && Number.isFinite(raw) ? Math.trunc(raw) : 50;
     return Math.min(500, Math.max(1, n));
-  }
-
-  /**
-   * Build the next LLM request from the event log.
-   *
-   * Condensation is token-budget based: we inject the latest summary into the system prompt and
-   * omit message events whose ids were marked forgotten by `Condensation` events.
-   */
-  private buildChatRequest() {
-    const events = this.events.list();
-    const condensationState = this.getCondensationState(events);
-
-    let systemPrompt = this.buildSystemPrompt();
-    if (condensationState.summary) {
-      systemPrompt += `\n\n<CONVERSATION SUMMARY>\n${condensationState.summary}\n</CONVERSATION SUMMARY>`;
-    }
-
-    const rawMessages = events
-      .filter(isMessageEvent)
-      .filter((event) => !condensationState.forgottenEventIds.has(event.id ?? ''))
-      .map((event) => {
-        if (event.source === 'user' && event.extended_content?.length) {
-          return { ...event.llm_message, content: [...event.llm_message.content, ...event.extended_content] };
-        }
-        return event.llm_message;
-      });
-    const messages = sanitizeChatMessages(rawMessages);
-    const tools = this.getToolDefinitions();
-    return { systemPrompt, messages, tools };
-  }
-
-  /**
-   * Computes the current condensation state from the event log.
-   *
-   * Multiple condensations may occur over time; we keep the union of forgotten ids and the latest
-   * non-empty summary.
-   */
-  private getCondensationState(events: Event[]): { summary: string | null; forgottenEventIds: Set<string>; summaryOffset: number | null } {
-    const forgottenEventIds = new Set<string>();
-    let summary: string | null = null;
-    let summaryOffset: number | null = null;
-
-    for (const event of events) {
-      if (!isCondensation(event)) continue;
-      for (const id of event.forgotten_event_ids ?? []) {
-        if (typeof id === 'string' && id.trim()) forgottenEventIds.add(id);
-      }
-      if (typeof event.summary === 'string' && event.summary.trim()) {
-        summary = event.summary.trim();
-        const rawOffset = event.summary_offset;
-        summaryOffset =
-          typeof rawOffset === 'number' && Number.isFinite(rawOffset) ? Math.max(0, Math.trunc(rawOffset)) : null;
-      }
-    }
-
-    return { summary, forgottenEventIds, summaryOffset };
-  }
-
-  private getEffectiveLlmConfigForCondensation(): {
-    provider: LLMProvider | undefined;
-    baseUrl: string | undefined;
-    model: string;
-    openaiApiMode: unknown;
-    maxInputTokens: number | undefined;
-  } {
-    return resolveCondensationLlmConfig(this.options.settings);
-  }
-
-  /**
-   * Attempts to summarize the conversation so the next prompt fits within `maxInputTokens`.
-   *
-   * On success, emits a `Condensation` event containing a summary and the message event ids that
-   * should be omitted from future requests.
-   */
-  private async tryCondenseConversation(params: { maxInputTokens: number }): Promise<boolean> {
-    const maxInputTokens = Math.max(0, Math.trunc(params.maxInputTokens));
-    if (maxInputTokens <= 0) return false;
-
-    const events = this.events.list();
-    const condensationState = this.getCondensationState(events);
-    const condensableEvents = events
-      .filter(isMessageEvent)
-      .filter((event) => !condensationState.forgottenEventIds.has(event.id ?? ''));
-    const previousSummary = condensationState.summary ?? '';
-
-    let llm: LLMClient;
-    try {
-      llm = await this.getPrimaryLlmClient();
-    } catch {
-      return false;
-    }
-
-    const condenser = new LLMSummarizingCondenser(llm, { maxInputTokens });
-    let result;
-    try {
-      result = await condenser.condense({ events: condensableEvents, previousSummary });
-    } catch {
-      return false;
-    }
-
-    if (!result?.summary) return false;
-    if (!result.forgottenEventIds.length) return false;
-
-    await this.pushEventWithHooks({
-      kind: 'Condensation',
-      source: 'environment',
-      forgotten_event_ids: result.forgottenEventIds,
-      summary: result.summary,
-      summary_offset: result.summaryOffset,
-    } as Event);
-
-    return true;
   }
 
   private getToolDefinitions(): LLMToolDefinition[] {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Event } from '../../types';
+import type { LLMToolDefinition } from '../../llm';
+import { buildChatRequestWithCondensation, getCondensationState, tryCondenseConversation } from '../condensation';
+
+describe('condensation helpers', () => {
+  it('getCondensationState unions forgotten ids and keeps latest non-empty summary', () => {
+    const events: Event[] = [
+      {
+        kind: 'Condensation',
+        source: 'environment',
+        forgotten_event_ids: ['a', 'b', ' '],
+        summary: 'first',
+        summary_offset: 2,
+      },
+      { kind: 'Condensation', source: 'environment', forgotten_event_ids: ['c'], summary: '   ', summary_offset: 3 },
+      { kind: 'Condensation', source: 'environment', forgotten_event_ids: ['d'], summary: ' latest ', summary_offset: 5 },
+    ];
+
+    const state = getCondensationState(events);
+    expect(state.summary).toBe('latest');
+    expect(state.summaryOffset).toBe(5);
+    expect(Array.from(state.forgottenEventIds).sort()).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('buildChatRequestWithCondensation injects summary and filters forgotten messages', () => {
+    const message1 = {
+      kind: 'MessageEvent',
+      id: 'm1',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'Hello' }] },
+      extended_content: [{ type: 'text', text: 'Context' }],
+    } satisfies Extract<Event, { kind: 'MessageEvent' }>;
+
+    const message2 = {
+      kind: 'MessageEvent',
+      id: 'm2',
+      source: 'agent',
+      llm_message: { role: 'assistant', content: [{ type: 'text', text: 'Hi!' }] },
+    } satisfies Extract<Event, { kind: 'MessageEvent' }>;
+
+    const condense = {
+      kind: 'Condensation',
+      source: 'environment',
+      forgotten_event_ids: ['m2'],
+      summary: 'short summary',
+      summary_offset: 4,
+    } satisfies Extract<Event, { kind: 'Condensation' }>;
+
+    const tools: LLMToolDefinition[] = [];
+    const request = buildChatRequestWithCondensation({
+      events: [message1, message2, condense],
+      systemPrompt: 'SYS',
+      tools,
+    });
+
+    expect(request.systemPrompt).toContain('SYS');
+    expect(request.systemPrompt).toContain('<CONVERSATION SUMMARY>');
+    expect(request.systemPrompt).toContain('short summary');
+
+    expect(request.messages.map((m) => m.role)).toEqual(['user']);
+    const userMessage = request.messages[0]!;
+    expect(userMessage.content).toEqual([{ type: 'text', text: 'Hello' }, { type: 'text', text: 'Context' }]);
+  });
+
+  it('tryCondenseConversation emits a Condensation event using injected condense()', async () => {
+    const events: Event[] = [
+      { kind: 'MessageEvent', id: 'a', source: 'user', llm_message: { role: 'user', content: [{ type: 'text', text: 'a' }] } },
+      { kind: 'MessageEvent', id: 'b', source: 'user', llm_message: { role: 'user', content: [{ type: 'text', text: 'b' }] } },
+      { kind: 'MessageEvent', id: 'c', source: 'user', llm_message: { role: 'user', content: [{ type: 'text', text: 'c' }] } },
+    ];
+
+    const pushed: Event[] = [];
+    const condenseSpy = vi.fn(async () => ({ summary: 'S', forgottenEventIds: ['b'], summaryOffset: 4 }));
+    const getPrimaryLlmClient = vi.fn(async () => {
+      throw new Error('should not be called');
+    });
+
+    await expect(
+      tryCondenseConversation({
+        maxInputTokens: 123,
+        listEvents: () => events,
+        pushEvent: async (event) => {
+          pushed.push(event);
+        },
+        condense: condenseSpy,
+        getPrimaryLlmClient,
+      }),
+    ).resolves.toBe(true);
+
+    expect(getPrimaryLlmClient).not.toHaveBeenCalled();
+    expect(condenseSpy).toHaveBeenCalledWith({
+      events,
+      previousSummary: '',
+      maxInputTokens: 123,
+    });
+
+    expect(pushed).toHaveLength(1);
+    expect(pushed[0]).toMatchObject({
+      kind: 'Condensation',
+      source: 'environment',
+      forgotten_event_ids: ['b'],
+      summary: 'S',
+      summary_offset: 4,
+    });
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
@@ -1,0 +1,127 @@
+import type { LLMClient, LLMToolDefinition } from '../llm';
+import type { Event, Message } from '../types';
+import { isCondensation, isMessageEvent } from '../types';
+import { LLMSummarizingCondenser } from '../context';
+import { sanitizeChatMessages } from './sanitizeChatMessages';
+
+export type CondensationState = {
+  summary: string | null;
+  forgottenEventIds: Set<string>;
+  summaryOffset: number | null;
+};
+
+export const getCondensationState = (events: Event[]): CondensationState => {
+  const forgottenEventIds = new Set<string>();
+  let summary: string | null = null;
+  let summaryOffset: number | null = null;
+
+  for (const event of events) {
+    if (!isCondensation(event)) continue;
+    for (const id of event.forgotten_event_ids ?? []) {
+      if (typeof id === 'string' && id.trim()) forgottenEventIds.add(id);
+    }
+    if (typeof event.summary === 'string' && event.summary.trim()) {
+      summary = event.summary.trim();
+      const rawOffset = event.summary_offset;
+      summaryOffset = typeof rawOffset === 'number' && Number.isFinite(rawOffset) ? Math.max(0, Math.trunc(rawOffset)) : null;
+    }
+  }
+
+  return { summary, forgottenEventIds, summaryOffset };
+};
+
+export const buildChatRequestWithCondensation = (params: {
+  events: Event[];
+  systemPrompt: string;
+  tools: LLMToolDefinition[];
+}): { systemPrompt: string; messages: Message[]; tools: LLMToolDefinition[] } => {
+  const condensationState = getCondensationState(params.events);
+
+  let systemPrompt = params.systemPrompt;
+  if (condensationState.summary) {
+    systemPrompt += `\n\n<CONVERSATION SUMMARY>\n${condensationState.summary}\n</CONVERSATION SUMMARY>`;
+  }
+
+  const rawMessages = params.events
+    .filter(isMessageEvent)
+    .filter((event) => !condensationState.forgottenEventIds.has(event.id ?? ''))
+    .map((event) => {
+      if (event.source === 'user' && event.extended_content?.length) {
+        return { ...event.llm_message, content: [...event.llm_message.content, ...event.extended_content] };
+      }
+      return event.llm_message;
+    });
+  const messages = sanitizeChatMessages(rawMessages);
+
+  return { systemPrompt, messages, tools: params.tools };
+};
+
+export type CondensationResult = {
+  summary: string | null;
+  forgottenEventIds: string[];
+  summaryOffset: number | null;
+};
+
+export type CondensationDeps = {
+  maxInputTokens: number;
+  listEvents: () => Event[];
+  pushEvent: (event: Event) => Promise<void>;
+  /**
+   * Optional override used by unit tests. When provided, `getPrimaryLlmClient` is not called.
+   */
+  condense?: (params: { events: Event[]; previousSummary: string; maxInputTokens: number }) => Promise<CondensationResult | undefined>;
+  getPrimaryLlmClient?: () => Promise<LLMClient>;
+};
+
+export const tryCondenseConversation = async (deps: CondensationDeps): Promise<boolean> => {
+  const maxInputTokens = Math.max(0, Math.trunc(deps.maxInputTokens));
+  if (maxInputTokens <= 0) return false;
+
+  const events = deps.listEvents();
+  const condensationState = getCondensationState(events);
+  const condensableEvents = events
+    .filter(isMessageEvent)
+    .filter((event) => !condensationState.forgottenEventIds.has(event.id ?? ''));
+  const previousSummary = condensationState.summary ?? '';
+
+  let result: CondensationResult | undefined;
+  if (deps.condense) {
+    result = await deps.condense({ events: condensableEvents, previousSummary, maxInputTokens });
+  } else {
+    if (!deps.getPrimaryLlmClient) return false;
+    let llm: LLMClient;
+    try {
+      llm = await deps.getPrimaryLlmClient();
+    } catch {
+      return false;
+    }
+
+    const condenser = new LLMSummarizingCondenser(llm, { maxInputTokens });
+    try {
+      const condensed = await condenser.condense({ events: condensableEvents, previousSummary });
+      if (!condensed) return false;
+      result = {
+        summary: condensed.summary ?? null,
+        forgottenEventIds: condensed.forgottenEventIds,
+        summaryOffset: condensed.summaryOffset ?? null,
+      };
+    } catch {
+      return false;
+    }
+  }
+
+  if (!result?.summary) return false;
+  if (!result.forgottenEventIds.length) return false;
+
+  const condensationEvent: Extract<Event, { kind: 'Condensation' }> = {
+    kind: 'Condensation',
+    source: 'environment',
+    forgotten_event_ids: result.forgottenEventIds,
+    summary: result.summary,
+    summary_offset: result.summaryOffset,
+  };
+
+  await deps.pushEvent(condensationEvent);
+
+  return true;
+};

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
@@ -65,7 +65,7 @@ export type CondensationResult = {
 export type CondensationDeps = {
   maxInputTokens: number;
   listEvents: () => Event[];
-  pushEvent: (event: Event) => Promise<void>;
+  pushEvent: (event: Event) => Promise<unknown>;
   /**
    * Optional override used by unit tests. When provided, `getPrimaryLlmClient` is not called.
    */


### PR DESCRIPTION
Implements Beads **oh-tab-wyrj** (from GH #503).

Summary
- Extracted condensation helpers out of `Agent.ts` into `packages/agent-sdk-ts/src/sdk/runtime/condensation.ts`.
- Updated Agent to use the new helpers.
- Added unit tests for the new module.

Notes
- No behavior change intended; keeps LLM Profiles semantics unchanged.
- Ran `npm test -w @openhands/agent-sdk-ts` locally (green).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized conversation condensation and summarization flow into a standalone runtime module for more reliable and maintainable behavior without changing public interfaces.

* **Bug Fixes**
  * Improved handling of forgotten messages and empty summaries to prevent incorrect filtering and ensure consistent summary offsets.

* **Tests**
  * Expanded coverage for condensation state, summary injection, message filtering, and condensation execution paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->