### PR TITLE
agent-sdk-ts: trim fallback error codes + fix router test (oh-tab-2371)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts
@@ -66,6 +66,42 @@ describe('LLM router helpers', () => {
     expect(out.join('')).toBe('ok');
   });
 
+  it('treats configured fallback codes as trimmed tokens', async () => {
+    const primary: LLMClient = {
+      async *streamChat(request) {
+        if (request.messages.length < 0) {
+          yield { type: 'finish' };
+        }
+        throw new Error('LLM request failed (503): overloaded');
+      },
+    };
+    const fallback: LLMClient = {
+      async *streamChat() {
+        yield { type: 'text', text: 'ok' };
+        yield { type: 'finish' };
+      },
+    };
+
+    const client = createFallbackLlmClient({
+      primary,
+      fallback,
+      shouldFallback: shouldFallbackOnLlmErrorCodes({
+        provider: 'anthropic',
+        codes: [' llm_service_unavailable '],
+      }),
+    });
+
+    const out: string[] = [];
+    for await (const chunk of client.streamChat({
+      systemPrompt: '',
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hi' }] }],
+    })) {
+      if (chunk.type === 'text') out.push(chunk.text);
+    }
+
+    expect(out.join('')).toBe('ok');
+  });
+
   it('does not fall back after yielding any chunks', async () => {
     const primary: LLMClient = {
       async *streamChat() {
@@ -105,9 +141,10 @@ describe('LLM router helpers', () => {
 
   it('rethrows when shouldFallback returns false', async () => {
     const primary: LLMClient = {
-      async *streamChat() {
-        // Yield once to satisfy lint rules, then throw to test rethrow behavior.
-        yield { type: 'finish' };
+      async *streamChat(request) {
+        if (request.messages.length < 0) {
+          yield { type: 'finish' };
+        }
         throw new Error('LLM request failed (401): invalid_api_key');
       },
     };

--- a/packages/agent-sdk-ts/src/sdk/llm/router.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/router.ts
@@ -73,7 +73,7 @@ export const shouldFallbackOnLlmErrorCodes = (params: {
   provider?: LLMProvider | null;
   codes: string[];
 }): ((error: unknown) => boolean) => {
-  const allow = new Set(params.codes.filter((c) => typeof c === 'string' && c.trim()));
+  const allow = new Set(params.codes.map((c) => c.trim()).filter(Boolean));
   return (error: unknown): boolean => {
     const code = classifyLlmErrorCode({ provider: params.provider ?? undefined, error });
     return typeof code === 'string' && allow.has(code);


### PR DESCRIPTION
Fixes Beads **oh-tab-2371** / GH **#707**.

- `shouldFallbackOnLlmErrorCodes`: trim configured codes before Set membership.
- Tests: add whitespace coverage; fix `shouldFallback=false` test so it throws before yielding any chunks.

Local validation
- `npx vitest run packages/agent-sdk-ts/src/sdk/llm/__tests__/router.test.ts`
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Enhanced error code handling in LLM fallback logic to properly normalize codes by trimming whitespace, improving reliability of fallback behavior when configured error codes contain extra spaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->