### PR TITLE
TaskTrackerTool: clarify plan overwrites TASKS.json (oh-tab-inrb)

### DIFF
--- a/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TaskTrackerTool.ts
@@ -20,7 +20,7 @@ const TASK_TRACKER_DESCRIPTION = `Manage a structured task list for the current 
 Use this tool to create or update a lightweight plan when work has multiple steps.
 
 Commands:
-- plan: write the provided task_list to TASKS.json
+- plan: overwrite TASKS.json with the provided task_list
 - view: read TASKS.json and return the current task_list
 
 Task items:

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -514,6 +514,11 @@ startxref
 });
 
 describe('TaskTrackerTool', () => {
+  it('documents that plan overwrites TASKS.json', () => {
+    const tool = new TaskTrackerTool();
+    expect(tool.description).toMatch(/plan: overwrite TASKS\.json/i);
+  });
+
   it('plans and views tasks', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts
@@ -516,7 +516,7 @@ startxref
 describe('TaskTrackerTool', () => {
   it('documents that plan overwrites TASKS.json', () => {
     const tool = new TaskTrackerTool();
-    expect(tool.description).toMatch(/plan: overwrite TASKS\.json/i);
+    expect(tool.description).toMatch(/^- plan: overwrite TASKS\.json with the provided task_list$/im);
   });
 
   it('plans and views tasks', async () => {


### PR DESCRIPTION
Fixes Beads **oh-tab-inrb** / GH **#708**.

- TaskTrackerTool: clarify `plan` command overwrites/replaces `.openhands/TASKS.json`.
- Added a tiny unit assertion to prevent wording drift.

Local validation
- `npx vitest run packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the task plan command description to state it overwrites the task list file.

* **Tests**
  * Added a test to verify the task tool's description documents the overwrite behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->