### PR TITLE
agent-sdk-ts: extract LLM client caching from Agent.ts (oh-tab-r2cs)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'crypto';
 import path from 'path';
 import { LLMStreamer } from './LLMStreamer';
 import { AsyncLock } from './AsyncLock';
+import { LlmClientCache } from './LlmClientCache';
 import { ConversationState } from './ConversationState';
 import { EventLog } from './EventLog';
 import type { LLMClient, LLMProfileStoreOptions, LLMToolDefinition } from '../llm';
@@ -130,8 +131,7 @@ export class Agent extends EventEmitter {
   private securityAnalyzerOverride?: SecurityAnalyzer | null;
   private securityAnalyzer: SecurityAnalyzer | null = null;
   private readonly lock = new AsyncLock();
-  private llmClientPromise?: Promise<LLMClient>;
-  private streamerPromise?: Promise<LLMStreamer>;
+  private readonly llmClientCache: LlmClientCache<LLMStreamer>;
   private paused = false;
   private cancelled = false;
   private finished = false;
@@ -173,6 +173,16 @@ export class Agent extends EventEmitter {
     this.agentContext = options.agentContext;
     this.debug = false;
     this.hooks = Array.isArray(options.hooks) ? options.hooks : options.hooks ? [options.hooks] : [];
+    this.llmClientCache = new LlmClientCache<LLMStreamer>({
+      getInjectedClient: () => this.options.llmClient,
+      createClient: () => this.createLlmClientFromSettings(),
+      createStreamer: (client) => new LLMStreamer(client, { events: this.events, state: this.state }),
+      emitDebugStateUpdate: (key, value) => this.emitDebugStateUpdate(key, value),
+      getDebugContext: () => ({
+        model: this.options.settings?.llm?.model ?? null,
+        profileId: this.options.settings?.llm?.profileId ?? null,
+      }),
+    });
 
     if (options.confirmationPolicy) {
       this.confirmationPolicyOverride = options.confirmationPolicy;
@@ -282,8 +292,7 @@ export class Agent extends EventEmitter {
       this.updateDerivedSettings(settings);
 
       // Force the next run to rebuild the LLM client from updated settings.
-      this.llmClientPromise = undefined;
-      this.streamerPromise = undefined;
+      this.llmClientCache.clear();
 
       // Debug logging for mid-run settings changes (oh-tab-rw1k)
       const newModel = settings?.llm?.model;
@@ -538,8 +547,7 @@ export class Agent extends EventEmitter {
       await this.pushEventWithHooks(this.toConversationErrorEvent(error, { code: classified.code }));
       this.state.setStatus('IDLE');
       // Allow a future retry after settings/secrets are updated.
-      this.llmClientPromise = undefined;
-      this.streamerPromise = undefined;
+      this.llmClientCache.clear();
       return undefined;
     }
     let lastAssistantMessage: Message | undefined;
@@ -577,7 +585,7 @@ export class Agent extends EventEmitter {
       // Debug logging for mid-run settings tracking (oh-tab-rw1k)
       const currentModel = this.options.settings?.llm?.model;
       const currentProfileId = this.options.settings?.llm?.profileId;
-      const hasStreamerPromise = !!this.streamerPromise;
+      const hasStreamerPromise = this.llmClientCache.hasStreamerPromise();
       this.emitDebugStateUpdate('agent_run_loop_state', {
         iteration: this.state.snapshot.iteration,
         settings: {
@@ -959,31 +967,11 @@ export class Agent extends EventEmitter {
   }
 
   private async getPrimaryLlmClient(): Promise<LLMClient> {
-    if (this.options.llmClient) return this.options.llmClient;
-    if (!this.llmClientPromise) {
-      this.llmClientPromise = this.createLlmClientFromSettings();
-    }
-    return this.llmClientPromise;
+    return this.llmClientCache.getPrimaryClient();
   }
 
   private async getStreamer(): Promise<LLMStreamer> {
-    if (!this.streamerPromise) {
-      const model = this.options.settings?.llm?.model;
-      const profileId = this.options.settings?.llm?.profileId;
-      this.emitDebugStateUpdate('agent_streamer_cache', {
-        action: 'create',
-        profileId: profileId ?? null,
-        model: model ?? null,
-      });
-      this.streamerPromise = (async () => {
-        const client = await this.getPrimaryLlmClient();
-        return new LLMStreamer(client, { events: this.events, state: this.state });
-      })();
-    } else {
-      this.emitDebugStateUpdate('agent_streamer_cache', { action: 'reuse' });
-    }
-
-    return this.streamerPromise;
+    return this.llmClientCache.getStreamer();
   }
 
   private createLlmClientFromSettings(): Promise<LLMClient> {

--- a/packages/agent-sdk-ts/src/sdk/runtime/LlmClientCache.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/LlmClientCache.ts
@@ -1,0 +1,58 @@
+import type { LLMClient } from '../llm';
+
+type DebugContext = { model: string | null; profileId: string | null };
+
+export class LlmClientCache<TStreamer> {
+  private llmClientPromise?: Promise<LLMClient>;
+  private streamerPromise?: Promise<TStreamer>;
+
+  constructor(
+    private readonly deps: {
+      getInjectedClient?: () => LLMClient | undefined;
+      createClient: () => Promise<LLMClient>;
+      createStreamer: (client: LLMClient) => TStreamer;
+      emitDebugStateUpdate?: (key: string, value: unknown) => void;
+      getDebugContext?: () => DebugContext;
+    },
+  ) {}
+
+  clear(): void {
+    this.llmClientPromise = undefined;
+    this.streamerPromise = undefined;
+  }
+
+  hasStreamerPromise(): boolean {
+    return Boolean(this.streamerPromise);
+  }
+
+  async getPrimaryClient(): Promise<LLMClient> {
+    const injected = this.deps.getInjectedClient?.();
+    if (injected) return injected;
+
+    if (!this.llmClientPromise) {
+      this.llmClientPromise = this.deps.createClient();
+    }
+    return this.llmClientPromise;
+  }
+
+  async getStreamer(): Promise<TStreamer> {
+    if (!this.streamerPromise) {
+      const ctx = this.deps.getDebugContext?.() ?? { model: null, profileId: null };
+      this.deps.emitDebugStateUpdate?.('agent_streamer_cache', {
+        action: 'create',
+        profileId: ctx.profileId,
+        model: ctx.model,
+      });
+
+      this.streamerPromise = (async () => {
+        const client = await this.getPrimaryClient();
+        return this.deps.createStreamer(client);
+      })();
+    } else {
+      this.deps.emitDebugStateUpdate?.('agent_streamer_cache', { action: 'reuse' });
+    }
+
+    return this.streamerPromise;
+  }
+}
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-client-cache-reset.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.llm-client-cache-reset.test.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import type { OpenHandsSettings } from '../../types/settings';
+
+vi.mock('../createLlmClientFromSettings', async () => {
+  const actual = await vi.importActual<any>('../createLlmClientFromSettings');
+  return {
+    ...actual,
+    createLlmClientFromSettings: vi.fn(),
+  };
+});
+
+class MockLLM implements LLMClient {
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    yield { type: 'finish' };
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 10 },
+  confirmation: { policy: 'never' },
+  secrets: {},
+};
+
+const createdRoots: string[] = [];
+
+const createWorkspaceRoot = (): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-llm-cache-'));
+  createdRoots.push(root);
+  return root;
+};
+
+beforeEach(async () => {
+  const { createLlmClientFromSettings } = await import('../createLlmClientFromSettings');
+  (createLlmClientFromSettings as any).mockReset();
+});
+
+afterEach(() => {
+  for (const root of createdRoots) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  }
+  createdRoots.length = 0;
+});
+
+describe('Agent LLM cache reset', () => {
+  it('clears LLM caches on setSettings() so the next run re-creates the client', async () => {
+    const { createLlmClientFromSettings } = await import('../createLlmClientFromSettings');
+    (createLlmClientFromSettings as any)
+      .mockResolvedValueOnce(new MockLLM())
+      .mockResolvedValueOnce(new MockLLM());
+
+    const { Agent, EventLog } = await import('..');
+    const workspaceRoot = createWorkspaceRoot();
+    const log = new EventLog();
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot });
+
+    await agent.run('hi');
+    expect(createLlmClientFromSettings).toHaveBeenCalledTimes(1);
+
+    agent.setSettings({ ...baseSettings, llm: { ...baseSettings.llm, model: 'test-model-2' } });
+    await (agent as any).lock.acquire(async () => undefined);
+    await agent.run('hi again');
+    expect(createLlmClientFromSettings).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears LLM caches after llm_init failure so the next run retries client creation', async () => {
+    const { createLlmClientFromSettings } = await import('../createLlmClientFromSettings');
+    (createLlmClientFromSettings as any)
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(new MockLLM());
+
+    const { Agent, EventLog } = await import('..');
+    const workspaceRoot = createWorkspaceRoot();
+    const log = new EventLog();
+    const agent = new Agent({ settings: baseSettings, events: log, workspaceRoot });
+
+    await expect(agent.run('hi')).resolves.toBeUndefined();
+    expect(createLlmClientFromSettings).toHaveBeenCalledTimes(1);
+
+    await expect(agent.run('retry')).resolves.toEqual({ role: 'assistant', content: [] });
+    expect(createLlmClientFromSettings).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/LlmClientCache.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/LlmClientCache.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest';
+import { randomUUID } from 'crypto';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { LlmClientCache } from '../LlmClientCache';
+
+class MockClient implements LLMClient {
+  async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    void _request;
+    yield { type: 'finish' };
+  }
+}
+
+describe('LlmClientCache', () => {
+  it('returns injected client without creating a new one', async () => {
+    const injected = new MockClient();
+    const createClient = vi.fn(async () => new MockClient());
+    const createStreamer = vi.fn(() => ({ kind: 'streamer' }));
+
+    const cache = new LlmClientCache({
+      getInjectedClient: () => injected,
+      createClient,
+      createStreamer,
+    });
+
+    await expect(cache.getPrimaryClient()).resolves.toBe(injected);
+    await expect(cache.getStreamer()).resolves.toEqual({ kind: 'streamer' });
+    expect(createClient).not.toHaveBeenCalled();
+    expect(createStreamer).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches client creation across calls', async () => {
+    const createClient = vi.fn(async () => new MockClient());
+    const createStreamer = vi.fn(() => ({ kind: 'streamer' }));
+
+    const cache = new LlmClientCache({
+      createClient,
+      createStreamer,
+    });
+
+    const [a, b] = await Promise.all([cache.getPrimaryClient(), cache.getPrimaryClient()]);
+    expect(a).toBe(b);
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches streamer creation and resets on clear()', async () => {
+    const createClient = vi.fn(async () => new MockClient());
+    const createStreamer = vi.fn(() => ({ id: randomUUID() }));
+
+    const cache = new LlmClientCache({
+      createClient,
+      createStreamer,
+    });
+
+    const first = await cache.getStreamer();
+    const again = await cache.getStreamer();
+    expect(first).toBe(again);
+    expect(createStreamer).toHaveBeenCalledTimes(1);
+    expect(createClient).toHaveBeenCalledTimes(1);
+
+    cache.clear();
+
+    const second = await cache.getStreamer();
+    expect(second).not.toBe(first);
+    expect(createStreamer).toHaveBeenCalledTimes(2);
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Refactor-only extraction of LLM client/streamer caching from `Agent.ts` into a small helper.

- Adds `packages/agent-sdk-ts/src/sdk/runtime/LlmClientCache.ts` and unit tests.
- Keeps behavior identical (including injected `llmClient` precedence and cache clears on `setSettings()` / init failures).
- Profiles-safe: no changes to `openhands.llm.profileId` selection or provider/baseUrl resolution.

Tests
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized LLM client and streamer caching to improve reuse, simplify lifecycle, and reduce redundant initializations.

* **Bug Fixes**
  * Cache is properly cleared on settings changes and initialization errors, enabling reliable retries and avoiding stale clients/streams.

* **Tests**
  * Added end-to-end and unit tests covering injection, concurrency, cache reuse, invalidation, and recovery after failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->