### PR TITLE
agent-sdk-ts: allow retry after LLM init rejection (oh-tab-l1d9)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/LlmClientCache.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/LlmClientCache.ts
@@ -30,7 +30,15 @@ export class LlmClientCache<TStreamer> {
     if (injected) return injected;
 
     if (!this.llmClientPromise) {
-      this.llmClientPromise = this.deps.createClient();
+      const pending = Promise.resolve(this.deps.createClient());
+      const wrapped = pending.catch((error) => {
+        // Only clear if this is still the cached promise (avoid clobbering a newer one).
+        if (this.llmClientPromise === wrapped) {
+          this.llmClientPromise = undefined;
+        }
+        throw error;
+      });
+      this.llmClientPromise = wrapped;
     }
     return this.llmClientPromise;
   }
@@ -44,10 +52,16 @@ export class LlmClientCache<TStreamer> {
         model: ctx.model,
       });
 
-      this.streamerPromise = (async () => {
+      const wrapped = (async () => {
         const client = await this.getPrimaryClient();
         return this.deps.createStreamer(client);
-      })();
+      })().catch((error) => {
+        if (this.streamerPromise === wrapped) {
+          this.streamerPromise = undefined;
+        }
+        throw error;
+      });
+      this.streamerPromise = wrapped;
     } else {
       this.deps.emitDebugStateUpdate?.('agent_streamer_cache', { action: 'reuse' });
     }
@@ -55,4 +69,3 @@ export class LlmClientCache<TStreamer> {
     return this.streamerPromise;
   }
 }
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/LlmClientCache.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/LlmClientCache.test.ts
@@ -64,4 +64,42 @@ describe('LlmClientCache', () => {
     expect(createStreamer).toHaveBeenCalledTimes(2);
     expect(createClient).toHaveBeenCalledTimes(2);
   });
+
+  it('clears cached client promise when createClient rejects', async () => {
+    const createClient = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce(new MockClient());
+    const createStreamer = vi.fn(() => ({ kind: 'streamer' }));
+
+    const cache = new LlmClientCache({
+      createClient,
+      createStreamer,
+    });
+
+    await expect(cache.getPrimaryClient()).rejects.toThrowError(/boom/);
+    await expect(cache.getPrimaryClient()).resolves.toBeInstanceOf(MockClient);
+    expect(createClient).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears cached streamer promise when createStreamer rejects', async () => {
+    const createClient = vi.fn(async () => new MockClient());
+    const createStreamer = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('streamer boom');
+      })
+      .mockImplementationOnce(() => ({ kind: 'streamer' }));
+
+    const cache = new LlmClientCache({
+      createClient,
+      createStreamer,
+    });
+
+    await expect(cache.getStreamer()).rejects.toThrowError(/streamer boom/);
+    await expect(cache.getStreamer()).resolves.toEqual({ kind: 'streamer' });
+    expect(createStreamer).toHaveBeenCalledTimes(2);
+    // Client is cached; streamer retries should reuse it.
+    expect(createClient).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Fix: don’t cache rejected LLM init promises.

If `createClient()` or streamer construction rejects once, the cached promise used to stay rejected and keep failing until an external `clear()`.

Changes
- `packages/agent-sdk-ts/src/sdk/runtime/LlmClientCache.ts`: clear cached promise on rejection (guarded so we don’t clobber a newer promise); wrap `createClient()` in `Promise.resolve(...)` to support sync mocks.
- `packages/agent-sdk-ts/src/sdk/runtime/__tests__/LlmClientCache.test.ts`: cover “first fail then succeed” for both client + streamer paths.

Refs
- GH #712
- Beads oh-tab-l1d9

Tests
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in client and streamer creation to prevent stale cached promises from persisting after failures, ensuring proper retry behavior on subsequent attempts.

* **Tests**
  * Added tests for error scenarios when client and streamer creation fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->