### PR TITLE
HAL: cancel teleport, friendly errors, and audio retry

### DIFF
--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -119,6 +119,7 @@ describe('registerHalCommands', () => {
   let mockSecretRegistry: SecretRegistry;
   let mockDeps: RegisterHalCommandsDeps;
   let registeredCommands: Map<string, (...args: unknown[]) => unknown>;
+  let originalFetch: any;
 
   beforeEach(() => {
     mockSettings = structuredClone(defaultMockSettings);
@@ -132,6 +133,9 @@ describe('registerHalCommands', () => {
     mockContext = createMockContext();
 
     mockSecretRegistry = new SecretRegistry(mockContext.secrets);
+
+    originalFetch = (globalThis as any).fetch;
+    (globalThis as any).fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
 
     mockDeps = {
       context: mockContext,
@@ -153,19 +157,21 @@ describe('registerHalCommands', () => {
   afterEach(() => {
     vi.clearAllMocks();
     registeredCommands.clear();
+    (globalThis as any).fetch = originalFetch;
   });
 
   it('registers the teleportToRemoteRuntime command', () => {
     const disposables = registerHalCommands(mockDeps);
 
-    expect(disposables).toHaveLength(1);
+    expect(disposables).toHaveLength(2);
     expect(registeredCommands.has('openhands._teleportToRemoteRuntime')).toBe(true);
+    expect(registeredCommands.has('openhands._cancelTeleportToRemoteRuntime')).toBe(true);
   });
 
   it('returns disposables for all registered commands', () => {
     const disposables = registerHalCommands(mockDeps);
 
-    expect(disposables).toHaveLength(1);
+    expect(disposables).toHaveLength(2);
     disposables.forEach((d) => {
       expect(d).toHaveProperty('dispose');
     });

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -247,7 +247,14 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         serverLabel: targetServerLabel,
       });
     } catch (err) {
-      if (activeTeleport?.didCancel || activeTeleport?.abort.signal.aborted || isAbortError(err)) {
+      if (activeTeleport?.didCancel) {
+        // Cancellation is UX-only: the cancel command already notified the webview to return to the confirmation UI.
+        // Avoid double-posting halTeleportCanceled when the abort surfaces here.
+        deps.getOutputChannel()?.appendLine('[hal.teleport] Teleport canceled by user');
+        return;
+      }
+
+      if (activeTeleport?.abort.signal.aborted || isAbortError(err)) {
         // Cancellation is UX-only: we return to the confirmation UI and stop HAL waiting/music.
         // We intentionally avoid trying to revert settings or unwind any in-flight connection logic.
         deps.getOutputChannel()?.appendLine('[hal.teleport] Teleport canceled by user');

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -91,9 +91,10 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
 
   const isAbortError = (err: unknown): boolean => {
     if (err instanceof DOMException && err.name === 'AbortError') return true;
-    if (err instanceof Error && err.name === 'AbortError') return true;
-    const text = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
-    return /aborterror/i.test(text) || /aborted/i.test(text);
+    if (err instanceof Error) {
+      return err.name === 'AbortError' || /\bAbortError\b/.test(err.message);
+    }
+    return /\bAbortError\b/i.test(String(err));
   };
 
   const HEALTHCHECK_TIMEOUT_MS = 2500;

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -121,7 +121,6 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     try {
       activeTeleport.abort.abort();
     } catch {}
-    activeTeleport = null;
   });
 
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
@@ -130,6 +129,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     let connectionEstablished = false;
     let didUpdateServerUrl = false;
     let previousServerUrl: string | undefined;
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
 
     try {
       if (activeTeleport) {
@@ -139,7 +139,6 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       const abort = new AbortController();
       activeTeleport = { abort };
 
-      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
       const settings = await settingsMgr.get();
       previousServerUrl = typeof settings.serverUrl === 'string' && settings.serverUrl.trim() ? settings.serverUrl.trim() : undefined;
 
@@ -248,9 +247,13 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         // User canceled from the webview. Avoid re-opening the HAL overlay with an error toast.
         if (didUpdateServerUrl && !connectionEstablished) {
           try {
-            await new SettingsManager(new VscodeSettingsAdapter(deps.context)).update({ serverUrl: previousServerUrl });
+            await settingsMgr.update({ serverUrl: previousServerUrl });
             await deps.ensureConversationAndConnection();
-          } catch {}
+          } catch (revertErr) {
+            deps.getOutputChannel()?.appendLine(
+              `[hal.teleport] Failed to revert server settings after cancellation: ${deps.renderError(revertErr)}`
+            );
+          }
         }
         return;
       }

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -38,6 +38,11 @@ export type RegisterHalCommandsDeps = {
 export function formatTeleportError(rawError: string): string {
   const lower = rawError.toLowerCase();
 
+  // Node fetch failures (common for localhost when server isn't running)
+  if (lower.includes('fetch failed') || lower.includes('failed to fetch')) {
+    return 'Server unreachable. Check if it is running.';
+  }
+
   // Connection refused / unreachable
   if (lower.includes('econnrefused') || lower.includes('connection refused')) {
     return 'Server unreachable. Check if it is running.';

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -84,14 +84,59 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     return chatView.webview.postMessage(message);
   };
 
+  const isAbortError = (err: unknown): boolean => {
+    if (err instanceof DOMException && err.name === 'AbortError') return true;
+    if (err instanceof Error && err.name === 'AbortError') return true;
+    const text = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+    return /aborterror/i.test(text) || /aborted/i.test(text);
+  };
+
+  const checkServerHealth = async (serverUrl: string, signal: AbortSignal): Promise<void> => {
+    const normalized = serverUrl.replace(/\/+$/, '');
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 2500);
+    const onAbort = () => controller.abort();
+    signal.addEventListener('abort', onAbort, { once: true });
+
+    try {
+      const res = await fetch(`${normalized}/health`, { method: 'GET', signal: controller.signal });
+      if (!res.ok) {
+        throw new Error(`Health check failed (${res.status})`);
+      }
+    } finally {
+      clearTimeout(timeout);
+      signal.removeEventListener('abort', onAbort);
+    }
+  };
+
+  let activeTeleport: { abort: AbortController } | null = null;
+
+  const cancelTeleportToRemoteRuntime = vscode.commands.registerCommand('openhands._cancelTeleportToRemoteRuntime', () => {
+    if (!activeTeleport) return;
+    try {
+      activeTeleport.abort.abort();
+    } catch {}
+    activeTeleport = null;
+  });
+
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
     let targetServerUrl: string | undefined;
     let targetServerLabel: string | undefined;
     let connectionEstablished = false;
+    let didUpdateServerUrl = false;
+    let previousServerUrl: string | undefined;
 
     try {
+      if (activeTeleport) {
+        deps.getOutputChannel()?.appendLine('[hal.teleport] Teleport already in progress');
+        return;
+      }
+      const abort = new AbortController();
+      activeTeleport = { abort };
+
       const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
       const settings = await settingsMgr.get();
+      previousServerUrl = typeof settings.serverUrl === 'string' && settings.serverUrl.trim() ? settings.serverUrl.trim() : undefined;
 
       const firstServer = settings.servers?.[0];
       const firstServerUrl = typeof firstServer?.url === 'string' ? firstServer.url.trim() : '';
@@ -116,6 +161,15 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         serverLabel: targetServerLabel,
       });
 
+      // Fast liveness check to avoid long reconnect loops when the server is down.
+      // (RemoteConversation retries can keep the HAL waiting screen/music going for a long time.)
+      try {
+        await checkServerHealth(targetServerUrl, abort.signal);
+      } catch (err) {
+        if (isAbortError(err)) return;
+        throw err;
+      }
+
       // STEP 1: Try to connect to the remote server FIRST
       // This must succeed before we do anything else (reject local action, prepare summary, etc.)
       deps.getOutputChannel()?.appendLine(`[hal.teleport] Attempting connection to ${serverDisplayName}...`);
@@ -124,6 +178,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       await deps.context.workspaceState.update('openhands.conversationId.remote', undefined);
 
       await settingsMgr.update({ serverUrl: firstServerUrl });
+      didUpdateServerUrl = true;
       await deps.ensureConversationAndConnection({ uiJustCreated: true });
 
       // Connection succeeded - mark it so we know we can proceed
@@ -184,6 +239,17 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         serverLabel: targetServerLabel,
       });
     } catch (err) {
+      if (activeTeleport?.abort.signal.aborted || isAbortError(err)) {
+        // User canceled from the webview. Avoid re-opening the HAL overlay with an error toast.
+        if (didUpdateServerUrl && !connectionEstablished) {
+          try {
+            await new SettingsManager(new VscodeSettingsAdapter(deps.context)).update({ serverUrl: previousServerUrl });
+            await deps.ensureConversationAndConnection();
+          } catch {}
+        }
+        return;
+      }
+
       const reason = formatTeleportError(deps.renderError(err));
       deps.getOutputChannel()?.appendLine(`[hal.teleport] Teleport failed: ${reason}`);
 
@@ -197,10 +263,13 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       if (!posted) {
         void vscode.window.showErrorMessage(`Teleport failed: ${reason}`);
       }
+    } finally {
+      activeTeleport = null;
     }
   });
 
   return [
+    cancelTeleportToRemoteRuntime,
     teleportToRemoteRuntime,
   ];
 }

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -96,10 +96,12 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     return /aborterror/i.test(text) || /aborted/i.test(text);
   };
 
+  const HEALTHCHECK_TIMEOUT_MS = 2500;
+
   const checkServerHealth = async (serverUrl: string, signal: AbortSignal): Promise<void> => {
     const normalized = serverUrl.replace(/\/+$/, '');
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 2500);
+    const timeout = setTimeout(() => controller.abort(), HEALTHCHECK_TIMEOUT_MS);
     const onAbort = () => controller.abort();
     signal.addEventListener('abort', onAbort, { once: true });
 
@@ -114,21 +116,24 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     }
   };
 
-  let activeTeleport: { abort: AbortController } | null = null;
+  let activeTeleport: { abort: AbortController; didCancel: boolean } | null = null;
 
   const cancelTeleportToRemoteRuntime = vscode.commands.registerCommand('openhands._cancelTeleportToRemoteRuntime', () => {
     if (!activeTeleport) return;
+    activeTeleport.didCancel = true;
     try {
       activeTeleport.abort.abort();
     } catch {}
+
+    // Keep behavior simple: cancel only affects the HAL UI/UX.
+    // We do NOT try to unwind in-flight connection/retry loops here.
+    void postToWebview({ type: 'halTeleportCanceled' });
   });
 
   const teleportToRemoteRuntime = vscode.commands.registerCommand('openhands._teleportToRemoteRuntime', async () => {
     let targetServerUrl: string | undefined;
     let targetServerLabel: string | undefined;
     let connectionEstablished = false;
-    let didUpdateServerUrl = false;
-    let previousServerUrl: string | undefined;
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
 
     try {
@@ -137,10 +142,9 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         return;
       }
       const abort = new AbortController();
-      activeTeleport = { abort };
+      activeTeleport = { abort, didCancel: false };
 
       const settings = await settingsMgr.get();
-      previousServerUrl = typeof settings.serverUrl === 'string' && settings.serverUrl.trim() ? settings.serverUrl.trim() : undefined;
 
       const firstServer = settings.servers?.[0];
       const firstServerUrl = typeof firstServer?.url === 'string' ? firstServer.url.trim() : '';
@@ -181,8 +185,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       // Ensure we always start a new remote conversation instead of restoring a prior one.
       await deps.context.workspaceState.update('openhands.conversationId.remote', undefined);
 
-      await settingsMgr.update({ serverUrl: firstServerUrl });
-      didUpdateServerUrl = true;
+      await settingsMgr.update({ serverUrl: targetServerUrl });
       await deps.ensureConversationAndConnection({ uiJustCreated: true });
 
       // Connection succeeded - mark it so we know we can proceed
@@ -243,18 +246,11 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
         serverLabel: targetServerLabel,
       });
     } catch (err) {
-      if (activeTeleport?.abort.signal.aborted || isAbortError(err)) {
-        // User canceled from the webview. Avoid re-opening the HAL overlay with an error toast.
-        if (didUpdateServerUrl && !connectionEstablished) {
-          try {
-            await settingsMgr.update({ serverUrl: previousServerUrl });
-            await deps.ensureConversationAndConnection();
-          } catch (revertErr) {
-            deps.getOutputChannel()?.appendLine(
-              `[hal.teleport] Failed to revert server settings after cancellation: ${deps.renderError(revertErr)}`
-            );
-          }
-        }
+      if (activeTeleport?.didCancel || activeTeleport?.abort.signal.aborted || isAbortError(err)) {
+        // Cancellation is UX-only: we return to the confirmation UI and stop HAL waiting/music.
+        // We intentionally avoid trying to revert settings or unwind any in-flight connection logic.
+        deps.getOutputChannel()?.appendLine('[hal.teleport] Teleport canceled by user');
+        void postToWebview({ type: 'halTeleportCanceled' });
         return;
       }
 

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -66,6 +66,7 @@ export type HostToWebviewMessage =
   | { type: 'halTeleportUnavailable'; error: string }
   | { type: 'halTeleportFailed'; error: string; serverUrl?: string }
   | { type: 'halTeleportStarting'; serverUrl: string; serverLabel?: string }
+  | { type: 'halTeleportCanceled' }
   | { type: 'halTeleportSuccess'; serverUrl: string; serverLabel?: string }
   | { type: 'halTtsResponse'; requestId: string; ok: true; audioBase64: string; volume: number; mimeType?: string }
   | { type: 'halTtsResponse'; requestId: string; ok: false; error: string; shouldNotify?: boolean; disabled?: boolean }

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -90,6 +90,23 @@ describe('HAL voice_confirm', () => {
     expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'cancelTeleportAction' });
   });
 
+  it('shows a friendly teleport failure message with server url', async () => {
+    await renderAppAndWaitReady();
+
+    vi.useFakeTimers();
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-teleport-fail-1') });
+
+    await advanceBundledDialogueToAwaitingUser();
+    fireEvent.click(screen.getByRole('button', { name: /teleport to remote/i }));
+
+    postToWindow({ type: 'halTeleportFailed', error: 'TypeError: fetch failed', serverUrl: 'http://localhost:3000' });
+
+    expect(screen.getByText(/Remote server is not available at this time\./)).toBeInTheDocument();
+    expect(screen.getAllByText(/http:\/\/localhost:3000/).length).toBeGreaterThan(0);
+  });
+
   it('falls back to buttons when microphone is unavailable', async () => {
     await renderAppAndWaitReady();
 

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -111,6 +111,25 @@ describe('HAL voice_confirm', () => {
     expect(screen.getAllByText(/http:\/\/localhost:3000/).length).toBeGreaterThan(0);
   });
 
+  it('returns to confirmation UI when host cancels teleport', async () => {
+    await renderAppAndWaitReady();
+
+    vi.useFakeTimers();
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-teleport-cancel-1') });
+
+    await advanceBundledDialogueToAwaitingUser();
+    fireEvent.click(screen.getByRole('button', { name: /teleport to remote/i }));
+
+    // While waiting_remote, we get a cancel event from the host.
+    postToWindow({ type: 'halTeleportCanceled' });
+
+    expect(screen.getByText(/Please choose an action\./)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /teleport to remote/i })).toBeInTheDocument();
+  });
+
+
   it('retries bundled HAL audio playback after a user click when autoplay blocks the first attempt', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const meta = document.createElement('meta');

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -70,6 +70,26 @@ describe('HAL voice_confirm', () => {
     cleanup();
   });
 
+  it('allows exiting while teleport is in progress and sends cancel', async () => {
+    await renderAppAndWaitReady();
+
+    vi.useFakeTimers();
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-teleport-exit-1') });
+
+    await advanceBundledDialogueToAwaitingUser();
+
+    const teleportBtn = screen.getByRole('button', { name: /teleport to remote/i });
+    fireEvent.click(teleportBtn);
+
+    const exitBtn = screen.getByRole('button', { name: /exit/i });
+    expect(exitBtn).not.toBeDisabled();
+
+    fireEvent.click(exitBtn);
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'command', command: 'cancelTeleportAction' });
+  });
+
   it('falls back to buttons when microphone is unavailable', async () => {
     await renderAppAndWaitReady();
 

--- a/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
+++ b/src/webview-src/__tests__/Hal.voiceConfirm.test.tsx
@@ -7,6 +7,7 @@ import { postToWindow } from './testUtils';
 
 describe('HAL voice_confirm', () => {
   const mockApi = { postMessage: vi.fn() } as any;
+  let originalAudio: any;
 
   const mkHighRiskAction = (toolCallId: string): ActionEvent => ({
     kind: 'ActionEvent',
@@ -63,11 +64,14 @@ describe('HAL voice_confirm', () => {
     try {
       Object.defineProperty(window.navigator, 'mediaDevices', { value: undefined, configurable: true });
     } catch {}
+    originalAudio = (globalThis as any).Audio;
   });
 
   afterEach(() => {
     vi.useRealTimers();
     cleanup();
+    (globalThis as any).Audio = originalAudio;
+    document.querySelector('meta[name="openhands-media-base"]')?.remove();
   });
 
   it('allows exiting while teleport is in progress and sends cancel', async () => {
@@ -105,6 +109,64 @@ describe('HAL voice_confirm', () => {
 
     expect(screen.getByText(/Remote server is not available at this time\./)).toBeInTheDocument();
     expect(screen.getAllByText(/http:\/\/localhost:3000/).length).toBeGreaterThan(0);
+  });
+
+  it('retries bundled HAL audio playback after a user click when autoplay blocks the first attempt', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const meta = document.createElement('meta');
+    meta.setAttribute('name', 'openhands-media-base');
+    meta.setAttribute('content', 'vscode-webview://test/media/');
+    document.head.appendChild(meta);
+
+    let playAttempts = 0;
+    class MockAudio {
+      public src = '';
+      public volume = 1;
+      public loop = false;
+      public onended: (() => void) | null = null;
+      public onerror: (() => void) | null = null;
+      public error: any = null;
+
+      constructor(url: string) {
+        this.src = url;
+      }
+
+      play() {
+        playAttempts += 1;
+        if (playAttempts === 1) {
+          return Promise.reject(new DOMException('Playback blocked', 'NotAllowedError'));
+        }
+        this.onended?.();
+        return Promise.resolve();
+      }
+
+      pause() {}
+    }
+
+    (globalThis as any).Audio = MockAudio;
+
+    await renderAppAndWaitReady();
+    vi.useFakeTimers();
+    postToWindow({ type: 'halSettings', hal: { enabled: true, mode: 'bundled', userName: 'Engel', volume: 1 } });
+    setWaitingForConfirmation();
+    postToWindow({ type: 'event', event: mkHighRiskAction('call-hal-audio-retry-1') });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/HAL audio was blocked by autoplay policy/i)).toBeInTheDocument();
+    expect(playAttempts).toBe(1);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    window.dispatchEvent(new Event('pointerdown'));
+    expect(playAttempts).toBe(2);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByText(/HAL audio was blocked by autoplay policy/i)).not.toBeInTheDocument();
+    warnSpy.mockRestore();
   });
 
   it('falls back to buttons when microphone is unavailable', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -210,6 +210,7 @@ export function App() {
     handleHalTeleportUnavailable,
     handleHalTeleportFailed,
     handleHalTeleportStarting,
+    handleHalTeleportCanceled,
     handleHalTeleportSuccess,
     handleConversationStarted,
   } = useHalFlow({
@@ -273,6 +274,7 @@ export function App() {
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTeleportStarting,
+    handleHalTeleportCanceled,
     handleHalTeleportSuccess,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -134,7 +134,7 @@ export function HalOverlay({
 
           <div className="px-5 py-4">
             {lastError && (
-              <div className="mb-3 text-xs text-red-300 bg-red-500/10 border border-red-400/20 rounded-lg p-3">
+              <div className="mb-3 text-xs text-red-300 bg-red-500/10 border border-red-400/20 rounded-lg p-3 whitespace-pre-wrap break-words">
                 {lastError}
               </div>
             )}

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -91,6 +91,7 @@ export function HalOverlay({
   };
 
   const isPulsating = eye === 'pulsating';
+  const exitDisabled = isSubmitting && phase !== 'waiting_remote';
 
   return (
     <div className="fixed inset-0 z-50 pointer-events-none">
@@ -124,7 +125,7 @@ export function HalOverlay({
             <button
               type="button"
               onClick={onExit}
-              disabled={isSubmitting}
+              disabled={exitDisabled}
               className="shrink-0 px-3 py-1.5 rounded-lg bg-white/[0.04] border border-white/[0.06] text-stone-300 hover:bg-white/[0.08] hover:text-stone-200 text-xs font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed"
             >
               Exit

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -91,7 +91,7 @@ export function HalOverlay({
   };
 
   const isPulsating = eye === 'pulsating';
-  const exitDisabled = isSubmitting && phase !== 'waiting_remote';
+  const exitDisabled = isSubmitting && phase === 'error';
 
   return (
     <div className="fixed inset-0 z-50 pointer-events-none">

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -55,7 +55,7 @@ function describeHalAudioPlaybackFailure(error: unknown): { message: string; deb
   if (error instanceof DOMException) {
     if (error.name === 'NotAllowedError') {
       return {
-        message: 'HAL audio was blocked by autoplay policy. Click inside the chat webview to enable audio playback, then trigger HAL again.',
+        message: 'HAL audio was blocked by autoplay policy. Click anywhere in this dialog (or any button) to play the audio.',
         debug: `${error.name}: ${error.message || '(no message)'}`,
       };
     }
@@ -70,7 +70,7 @@ function describeHalAudioPlaybackFailure(error: unknown): { message: string; deb
     const message = error.message || '(no message)';
     if (name === 'NotAllowedError' || /notallowederror/i.test(`${name}: ${message}`)) {
       return {
-        message: 'HAL audio was blocked by autoplay policy. Click inside the chat webview to enable audio playback, then trigger HAL again.',
+        message: 'HAL audio was blocked by autoplay policy. Click anywhere in this dialog (or any button) to play the audio.',
         debug: `${name}: ${message}`,
       };
     }
@@ -82,6 +82,13 @@ function describeHalAudioPlaybackFailure(error: unknown): { message: string; deb
   }
 
   return { message: 'HAL audio failed to play (bundled clip).', debug: String(error) };
+}
+
+function isAutoplayBlockedError(error: unknown): boolean {
+  if (error instanceof DOMException) return error.name === 'NotAllowedError';
+  if (error instanceof Error) return error.name === 'NotAllowedError' || /notallowederror/i.test(`${error.name}: ${error.message}`);
+  if (typeof error === 'string') return /notallowederror/i.test(error) || /autoplay/i.test(error);
+  return false;
 }
 
 function blobToBase64(blob: Blob): Promise<string> {
@@ -140,6 +147,7 @@ export function useHalFlow(deps: {
   const halBundledMusicKeyRef = useRef<string | null>(null);
   const halBundledAudioErrorKeyRef = useRef<string | null>(null);
   const halBundledMusicErrorKeyRef = useRef<string | null>(null);
+  const halBundledSceneAutoplayRetryKeyRef = useRef<string | null>(null);
   const halTtsRequestSeqRef = useRef(0);
   const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
   const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
@@ -362,6 +370,14 @@ export function useHalFlow(deps: {
     const fallBackToAwaiting = (error?: unknown) => {
       if (halAudioPlayTokenRef.current !== token) return;
       const errorKey = `${sessionKey}:scene`;
+      if (error && isAutoplayBlockedError(error)) {
+        halBundledSceneAutoplayRetryKeyRef.current = errorKey;
+        const info = describeHalAudioPlaybackFailure(error);
+        console.warn(`[HAL] Bundled scene audio failed: ${info.debug}`);
+        stopHalAudio();
+        resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', stepIndex: 0, lastError: info.message });
+        return;
+      }
       if (error && halBundledAudioErrorKeyRef.current !== errorKey) {
         halBundledAudioErrorKeyRef.current = errorKey;
         const info = describeHalAudioPlaybackFailure(error);
@@ -381,6 +397,61 @@ export function useHalFlow(deps: {
       stopHalAudio();
     };
   }, [clearHalTimer, halPhase, halStepIndex, resetHalUiState, stopHalAudio]);
+
+  useEffect(() => {
+    const sessionKey = halActiveKeyRef.current ?? 'unknown';
+    const retryKey = `${sessionKey}:scene`;
+    if (halBundledSceneAutoplayRetryKeyRef.current !== retryKey) return;
+    if (halSettingsRef.current.mode !== 'bundled') return;
+    if (halPhase !== 'dialogue' && halPhase !== 'awaiting_user') return;
+
+    const clipUrl = getBundledHalSceneUrl();
+    if (!clipUrl || typeof Audio !== 'function') return;
+
+    const retry = () => {
+      if (halBundledSceneAutoplayRetryKeyRef.current !== retryKey) return;
+      halBundledSceneAutoplayRetryKeyRef.current = null;
+      setHalLastError(null);
+
+      const volume = halSettingsRef.current.volume;
+      stopHalAudio();
+      const token = halAudioPlayTokenRef.current;
+      const audio = new Audio(clipUrl);
+      halAudioRef.current = audio;
+      audio.volume = Math.min(1, Math.max(0, Number.isFinite(volume) ? volume : 1));
+      audio.onended = () => {
+        if (halAudioPlayTokenRef.current !== token) return;
+        stopHalAudio();
+        resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', stepIndex: 0 });
+      };
+
+      const onFail = (error: unknown) => {
+        if (halAudioPlayTokenRef.current !== token) return;
+        if (isAutoplayBlockedError(error)) {
+          halBundledSceneAutoplayRetryKeyRef.current = retryKey;
+          const info = describeHalAudioPlaybackFailure(error);
+          console.warn(`[HAL] Bundled scene audio failed: ${info.debug}`);
+          stopHalAudio();
+          setHalLastError(info.message);
+          return;
+        }
+        stopHalAudio();
+      };
+
+      audio.onerror = () => onFail(audio.error ?? 'Bundled scene audio error');
+      void audio.play().catch(onFail);
+    };
+
+    const onPointerDown = () => retry();
+    const onKeyDown = () => retry();
+
+    window.addEventListener('pointerdown', onPointerDown, { capture: true, once: true });
+    window.addEventListener('keydown', onKeyDown, { capture: true, once: true });
+    return () => {
+      window.removeEventListener('pointerdown', onPointerDown, true);
+      window.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [halPhase, resetHalUiState, stopHalAudio]);
 
   useEffect(() => {
     if (halPhase !== 'waiting_remote') {

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -615,6 +615,9 @@ export function useHalFlow(deps: {
   }, [cleanupHalVoiceConfirm, deps.showStatusMessage, getHalConversationKey, resetHalUiState]);
 
   const handleHalExit = useCallback(() => {
+    if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
+      deps.postMessage({ type: 'command', command: 'cancelTeleportAction' });
+    }
     cleanupHalFlow();
     halTeleportInProgressRef.current = false;
     setHalTeleporting(false);
@@ -624,7 +627,7 @@ export function useHalFlow(deps: {
       setHalSuppressedKeySynced(key);
     }
     resetHalUiState();
-  }, [cleanupHalFlow, resetHalUiState, setHalSuppressedKeySynced]);
+  }, [cleanupHalFlow, deps.postMessage, resetHalUiState, setHalSuppressedKeySynced]);
 
   const handleHalApprove = useCallback(() => {
     setHalDecision('approve_local');
@@ -759,6 +762,9 @@ export function useHalFlow(deps: {
     }, [applyHalVoiceConfirmDecision, disableVoiceConfirmForConversation]);
 
   const handleHalTeleportUnavailable = useCallback((error: unknown) => {
+    if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {
+      return;
+    }
     const message = typeof error === 'string' && error.trim() ? error.trim() : 'No server available';
     halTeleportInProgressRef.current = false;
     setHalTeleporting(false);
@@ -768,6 +774,9 @@ export function useHalFlow(deps: {
   }, [deps.showStatusMessage, resetHalUiState]);
 
   const handleHalTeleportFailed = useCallback((error: unknown, serverUrl?: string) => {
+    if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {
+      return;
+    }
     const message = typeof error === 'string' && error.trim() ? error.trim() : 'Teleport failed';
     const serverInfo = serverUrl ? ` (${serverUrl})` : '';
     halTeleportInProgressRef.current = false;
@@ -778,11 +787,17 @@ export function useHalFlow(deps: {
   }, [deps.showStatusMessage, resetHalUiState]);
 
   const handleHalTeleportStarting = useCallback((serverUrl: string, serverLabel?: string) => {
+    if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {
+      return;
+    }
     const displayName = serverLabel || serverUrl;
     deps.showStatusMessage('info', `Connecting to ${displayName}…`);
   }, [deps.showStatusMessage]);
 
   const handleHalTeleportSuccess = useCallback((serverUrl: string, serverLabel?: string) => {
+    if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {
+      return;
+    }
     const displayName = serverLabel || serverUrl;
     deps.showStatusMessage('info', `Teleported to ${displayName}!`);
     // Note: The HAL UI state will be reset by handleConversationStarted when the new conversation starts

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -917,6 +917,14 @@ export function useHalFlow(deps: {
     deps.showStatusMessage('info', `Connecting to ${displayName}…`);
   }, [deps.showStatusMessage]);
 
+  const handleHalTeleportCanceled = useCallback(() => {
+    halTeleportInProgressRef.current = false;
+    setHalTeleporting(false);
+    setHalForceRejectInput(false);
+    stopHalAudio();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', decision: null });
+  }, [resetHalUiState, stopHalAudio]);
+
   const handleHalTeleportSuccess = useCallback((serverUrl: string, serverLabel?: string) => {
     if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {
       return;
@@ -985,6 +993,7 @@ export function useHalFlow(deps: {
     handleHalTeleportUnavailable,
     handleHalTeleportFailed,
     handleHalTeleportStarting,
+    handleHalTeleportCanceled,
     handleHalTeleportSuccess,
     handleConversationStarted,
   };

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -51,6 +51,39 @@ function getBundledHalMusicStingUrl(): string | null {
   return buildMediaUrl(`hal/bundled/music_sting.${DEFAULT_BUNDLED_AUDIO_EXTENSION}`);
 }
 
+function describeHalAudioPlaybackFailure(error: unknown): { message: string; debug: string } {
+  if (error instanceof DOMException) {
+    if (error.name === 'NotAllowedError') {
+      return {
+        message: 'HAL audio was blocked by autoplay policy. Click inside the chat webview to enable audio playback, then trigger HAL again.',
+        debug: `${error.name}: ${error.message || '(no message)'}`,
+      };
+    }
+    return {
+      message: `HAL audio failed to play (${error.name}).`,
+      debug: `${error.name}: ${error.message || '(no message)'}`,
+    };
+  }
+
+  if (error instanceof Error) {
+    const name = error.name || 'Error';
+    const message = error.message || '(no message)';
+    if (name === 'NotAllowedError' || /notallowederror/i.test(`${name}: ${message}`)) {
+      return {
+        message: 'HAL audio was blocked by autoplay policy. Click inside the chat webview to enable audio playback, then trigger HAL again.',
+        debug: `${name}: ${message}`,
+      };
+    }
+    return { message: 'HAL audio failed to play (bundled clip).', debug: `${name}: ${message}` };
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return { message: 'HAL audio failed to play (bundled clip).', debug: error.trim() };
+  }
+
+  return { message: 'HAL audio failed to play (bundled clip).', debug: String(error) };
+}
+
 function blobToBase64(blob: Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -105,6 +138,8 @@ export function useHalFlow(deps: {
   const halAudioPlayTokenRef = useRef(0);
   const halBundledAudioKeyRef = useRef<string | null>(null);
   const halBundledMusicKeyRef = useRef<string | null>(null);
+  const halBundledAudioErrorKeyRef = useRef<string | null>(null);
+  const halBundledMusicErrorKeyRef = useRef<string | null>(null);
   const halTtsRequestSeqRef = useRef(0);
   const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
   const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
@@ -324,19 +359,28 @@ export function useHalFlow(deps: {
       stopHalAudio();
       resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', stepIndex: 0 });
     };
-    const fallBackToAwaiting = () => {
+    const fallBackToAwaiting = (error?: unknown) => {
       if (halAudioPlayTokenRef.current !== token) return;
+      const errorKey = `${sessionKey}:scene`;
+      if (error && halBundledAudioErrorKeyRef.current !== errorKey) {
+        halBundledAudioErrorKeyRef.current = errorKey;
+        const info = describeHalAudioPlaybackFailure(error);
+        console.warn(`[HAL] Bundled scene audio failed: ${info.debug}`);
+        stopHalAudio();
+        resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', stepIndex: 0, lastError: info.message });
+        return;
+      }
       stopHalAudio();
       resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', stepIndex: 0 });
     };
-    audio.onerror = fallBackToAwaiting;
+    audio.onerror = () => fallBackToAwaiting(audio.error ?? 'Bundled scene audio error');
     void audio.play().catch(fallBackToAwaiting);
 
     return () => {
       clearHalTimer();
       stopHalAudio();
     };
-  }, [clearHalTimer, halPhase, halStepIndex, stopHalAudio]);
+  }, [clearHalTimer, halPhase, halStepIndex, resetHalUiState, stopHalAudio]);
 
   useEffect(() => {
     if (halPhase !== 'waiting_remote') {
@@ -358,19 +402,24 @@ export function useHalFlow(deps: {
     halAudioRef.current = audio;
     audio.loop = true;
     audio.volume = Math.min(1, Math.max(0, Number.isFinite(volume) ? volume : 1));
-    audio.onerror = () => {
+    const stopWithError = (error: unknown) => {
       if (halAudioPlayTokenRef.current !== token) return;
+      const errorKey = `${sessionKey}:music`;
+      if (halBundledMusicErrorKeyRef.current !== errorKey) {
+        halBundledMusicErrorKeyRef.current = errorKey;
+        const info = describeHalAudioPlaybackFailure(error);
+        console.warn(`[HAL] Bundled music audio failed: ${info.debug}`);
+        resetHalUiState({ phase: 'waiting_remote', eye: 'pulsating', decision: 'teleport_remote', lastError: info.message });
+      }
       stopHalAudio();
     };
-    void audio.play().catch(() => {
-      if (halAudioPlayTokenRef.current !== token) return;
-      stopHalAudio();
-    });
+    audio.onerror = () => stopWithError(audio.error ?? 'Bundled music audio error');
+    void audio.play().catch(stopWithError);
 
     return () => {
       stopHalAudio();
     };
-  }, [halPhase, stopHalAudio]);
+  }, [halPhase, resetHalUiState, stopHalAudio]);
 
   const playHalAudioBytes = useCallback(
     (bytes: Uint8Array, volume: number, opts: { mimeType?: string } = {}) => {

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -777,13 +777,16 @@ export function useHalFlow(deps: {
     if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {
       return;
     }
-    const message = typeof error === 'string' && error.trim() ? error.trim() : 'Teleport failed';
+    const rawMessage = typeof error === 'string' && error.trim() ? error.trim() : 'Teleport failed';
+    const message = serverUrl
+      ? `Remote server is not available at this time.\n${serverUrl}`
+      : 'Remote server is not available at this time.';
     const serverInfo = serverUrl ? ` (${serverUrl})` : '';
     halTeleportInProgressRef.current = false;
     setHalTeleporting(false);
     setHalForceRejectInput(false);
     resetHalUiState({ phase: 'error', eye: 'dim', lastError: message });
-    deps.showStatusMessage('error', `${message}${serverInfo}`);
+    deps.showStatusMessage('error', `${rawMessage}${serverInfo}`);
   }, [deps.showStatusMessage, resetHalUiState]);
 
   const handleHalTeleportStarting = useCallback((serverUrl: string, serverLabel?: string) => {

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -59,6 +59,7 @@ export type HostMessageHandlerOptions = {
   handleHalTeleportFailed: (error: unknown, serverUrl?: string) => void;
   handleHalTeleportUnavailable: (error: unknown) => void;
   handleHalTeleportStarting: (serverUrl: string, serverLabel?: string) => void;
+  handleHalTeleportCanceled: () => void;
   handleHalTeleportSuccess: (serverUrl: string, serverLabel?: string) => void;
   handleHalTtsResponse: (payload: Record<string, unknown>) => void;
   handleHalVoiceConfirmResponse: (payload: Record<string, unknown>) => void;
@@ -119,6 +120,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTeleportStarting,
+    handleHalTeleportCanceled,
     handleHalTeleportSuccess,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,
@@ -479,6 +481,10 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
           }
           break;
         }
+        case 'halTeleportCanceled': {
+          handleHalTeleportCanceled();
+          break;
+        }
         case 'halTeleportSuccess': {
           if (typeof payload.serverUrl === 'string') {
             handleHalTeleportSuccess(payload.serverUrl, payload.serverLabel);
@@ -717,6 +723,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     handleHalTeleportFailed,
     handleHalTeleportUnavailable,
     handleHalTeleportStarting,
+    handleHalTeleportCanceled,
     handleHalTeleportSuccess,
     handleHalTtsResponse,
     handleHalVoiceConfirmResponse,

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -1186,6 +1186,14 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
               outputChannel?.appendLine(`[teleportAction] ${reason}`);
             }
             break;
+          case 'cancelTeleportAction':
+            try {
+              await vscode.commands.executeCommand('openhands._cancelTeleportToRemoteRuntime');
+            } catch (err) {
+              const reason = err instanceof Error ? err.message : String(err);
+              outputChannel?.appendLine(`[cancelTeleportAction] ${reason}`);
+            }
+            break;
           default:
             console.warn(`Unknown command received from webview: ${message.command}`);
             break;


### PR DESCRIPTION
Fixes HAL UX regressions around high-risk confirmations.

Changes:
- Keep HAL "Exit" clickable during teleport; cancels teleport + stops looping audio and returns to the confirmation UI.
- Add fast remote liveness check (GET /health) so teleport fails quickly when the first configured server is down.
- Replace raw teleport errors in the HAL overlay with a user-friendly message and the attempted server URL.
- If bundled HAL audio is blocked by autoplay policy, show a clear hint and automatically retry playback on the next user gesture (click/key).

Tests:
- npm run typecheck
- npm test

Beads:
- oh-tab-cvy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel in-progress teleport from UI; host emits a cancellation event.

* **Bug Fixes**
  * Improved teleport failure and connectivity messages (includes server URL when relevant).
  * Exit button and teleport flow now respect ongoing operations and properly revert state on cancellation.
  * Cleanup ensures in-progress teleport state is reset on completion/cancel.

* **Tests**
  * Expanded tests for teleport cancellation and audio playback with better setup/cleanup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->