### PR TITLE
Conversation webview Tools badge includes finish

### DIFF
--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -77,4 +77,27 @@ describe('Tools picker host messages', () => {
 
     expect(toolsListPayload.enabledToolIds).toEqual(['file_editor', 'finish']);
   });
+
+  it('does not duplicate finish when provided by the webview', async () => {
+    const state = { toolNames: ['terminal', 'file_editor', 'task_tracker'] as string[] };
+    const conversation = {
+      mode: 'local',
+      getToolNames: vi.fn(() => state.toolNames),
+      setTools: vi.fn((tools: Array<{ name: string }>) => {
+        state.toolNames = tools.map((t) => t.name);
+      }),
+    };
+
+    const { handler, postMessage } = createHandler(conversation);
+    await handler({ type: 'setEnabledTools', toolIds: ['finish', 'file_editor', 'finish'] } as any);
+
+    const arg = (conversation.setTools as any).mock.calls[0][0] as Array<{ name: string }>;
+    expect(arg.map((t) => t.name)).toEqual(['finish', 'file_editor']);
+
+    const toolsListPayload = postMessage.mock.calls
+      .map((call) => call[0])
+      .find((msg) => msg?.type === 'toolsList') as any;
+
+    expect(toolsListPayload.enabledToolIds).toEqual(['finish', 'file_editor']);
+  });
 });

--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -39,7 +39,7 @@ describe('Tools picker host messages', () => {
 
     expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({
       type: 'toolsList',
-      enabledToolIds: ['terminal', 'task_tracker'],
+      enabledToolIds: ['terminal', 'task_tracker', 'finish'],
     }));
 
     const payload = postMessage.mock.calls[0][0] as any;
@@ -50,7 +50,7 @@ describe('Tools picker host messages', () => {
       { id: 'glob', label: 'File Search (Glob)', description: 'Find files by name patterns (e.g., **/*.ts)', isDefault: false },
       { id: 'grep', label: 'Content Search (Grep)', description: 'Search file contents using regex patterns', isDefault: false },
       { id: 'browser', label: 'Web Fetch', description: 'Make HTTP GET/POST requests to fetch web content', isDefault: false },
-      { id: 'finish', label: 'Finish', description: 'Signal that the agent has completed its task', isDefault: false },
+      { id: 'finish', label: 'Finish', description: 'Signal that the agent has completed its task (always enabled)', isDefault: true },
     ]);
   });
 
@@ -69,13 +69,12 @@ describe('Tools picker host messages', () => {
 
     expect(conversation.setTools).toHaveBeenCalledTimes(1);
     const arg = (conversation.setTools as any).mock.calls[0][0] as Array<{ name: string }>;
-    expect(arg.map((t) => t.name)).toEqual(['file_editor']);
+    expect(arg.map((t) => t.name)).toEqual(['file_editor', 'finish']);
 
     const toolsListPayload = postMessage.mock.calls
       .map((call) => call[0])
       .find((msg) => msg?.type === 'toolsList') as any;
 
-    expect(toolsListPayload.enabledToolIds).toEqual(['file_editor']);
+    expect(toolsListPayload.enabledToolIds).toEqual(['file_editor', 'finish']);
   });
 });
-

--- a/src/shared/localTools.ts
+++ b/src/shared/localTools.ts
@@ -65,8 +65,8 @@ const LOCAL_TOOLS: LocalToolDescriptor[] = [
   {
     id: 'finish',
     label: 'Finish',
-    description: 'Signal that the agent has completed its task',
-    isDefault: false,
+    description: 'Signal that the agent has completed its task (always enabled)',
+    isDefault: true,
   },
 ];
 

--- a/src/webview-src/__tests__/App.toolsPicker.test.tsx
+++ b/src/webview-src/__tests__/App.toolsPicker.test.tsx
@@ -30,14 +30,15 @@ describe('Tools picker', () => {
             { id: 'terminal', label: 'Terminal' },
             { id: 'file_editor', label: 'File Editor' },
             { id: 'task_tracker', label: 'Task Tracker' },
+            { id: 'finish', label: 'Finish' },
           ],
-          enabledToolIds: ['terminal', 'file_editor', 'task_tracker'],
+          enabledToolIds: ['terminal', 'file_editor', 'task_tracker', 'finish'],
         }
       }));
     });
 
     const toolsButton = await screen.findByRole('button', { name: 'Tools' });
-    expect(toolsButton).toHaveTextContent('3');
+    expect(toolsButton).toHaveTextContent('4');
 
     mockApi.postMessage.mockClear();
     await act(async () => {
@@ -55,12 +56,12 @@ describe('Tools picker', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Tools' })).toHaveTextContent('2');
+      expect(screen.getByRole('button', { name: 'Tools' })).toHaveTextContent('3');
     });
 
     expect(mockApi.postMessage).toHaveBeenCalledWith({
       type: 'setEnabledTools',
-      toolIds: ['file_editor', 'task_tracker'],
+      toolIds: ['file_editor', 'task_tracker', 'finish'],
     });
     expect(screen.getByLabelText('Terminal')).toHaveAttribute('aria-selected', 'false');
   });
@@ -79,8 +80,9 @@ describe('Tools picker', () => {
             { id: 'terminal', label: 'Terminal' },
             { id: 'file_editor', label: 'File Editor' },
             { id: 'task_tracker', label: 'Task Tracker' },
+            { id: 'finish', label: 'Finish' },
           ],
-          enabledToolIds: ['terminal', 'file_editor', 'task_tracker'],
+          enabledToolIds: ['terminal', 'file_editor', 'task_tracker', 'finish'],
         }
       }));
     });

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -590,6 +590,11 @@ export function App() {
       return;
     }
 
+    if (toolId === 'finish') {
+      showStatusMessage('info', 'Finish is always enabled.', { autoDismiss: true, autoDismissDelay: 2500 });
+      return;
+    }
+
     setEnabledToolIds((prev) => {
       const known = new Set(tools.map((tool) => tool.id));
       if (!known.has(toolId)) return prev;

--- a/src/webview-src/components/inputArea/ToolsPopover.tsx
+++ b/src/webview-src/components/inputArea/ToolsPopover.tsx
@@ -23,6 +23,7 @@ function ToolButton({
   onToggle,
   onMouseEnter,
   id,
+  disabled = false,
 }: {
   tool: ToolDescriptor;
   isEnabled: boolean;
@@ -30,22 +31,26 @@ function ToolButton({
   onToggle: () => void;
   onMouseEnter: () => void;
   id: string;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onToggle}
       onMouseEnter={onMouseEnter}
+      disabled={disabled}
       role="option"
       id={id}
       aria-label={tool.label}
       aria-selected={isEnabled ? 'true' : 'false'}
+      aria-disabled={disabled ? 'true' : 'false'}
       className={`
         w-full text-left px-3 py-2.5 rounded-lg
         text-sm
         transition-all duration-150
         flex items-start gap-2.5
         group
+        ${disabled ? 'opacity-70 cursor-not-allowed' : ''}
         ${isEnabled ? 'bg-brand-500/10 text-stone-200 oh-outline-soft' : 'text-stone-400 hover:bg-white/[0.04] hover:text-stone-300'}
         ${isActive && !isEnabled ? 'bg-white/[0.04] text-stone-200 oh-outline-soft' : ''}
         ${isActive && isEnabled ? 'bg-brand-500/15' : ''}
@@ -56,6 +61,7 @@ function ToolButton({
         <div className="flex items-center gap-2">
           <span className="font-medium">{tool.label}</span>
           {isEnabled && <span className="codicon codicon-check text-brand-400 text-xs" />}
+          {disabled && <span className="codicon codicon-lock text-stone-500 text-xs" />}
         </div>
         {tool.description && (
           <div className="text-xs text-stone-500 mt-0.5 leading-snug">
@@ -178,6 +184,7 @@ export function ToolsPopover({
                     const globalIndex = allToolsFlat.findIndex((t) => t.id === tool.id);
                     const isEnabled = enabledToolIds.includes(tool.id);
                     const isActive = globalIndex === safeActiveIndex;
+                    const isLocked = tool.id === 'finish';
                     return (
                       <ToolButton
                         key={tool.id}
@@ -187,6 +194,7 @@ export function ToolsPopover({
                         onToggle={() => onToggleTool(tool.id)}
                         onMouseEnter={() => setActiveIndex(globalIndex)}
                         id={`tools-picker-option-${globalIndex}`}
+                        disabled={isLocked}
                       />
                     );
                   })}
@@ -205,6 +213,7 @@ export function ToolsPopover({
                     const globalIndex = allToolsFlat.findIndex((t) => t.id === tool.id);
                     const isEnabled = enabledToolIds.includes(tool.id);
                     const isActive = globalIndex === safeActiveIndex;
+                    const isLocked = tool.id === 'finish';
                     return (
                       <ToolButton
                         key={tool.id}
@@ -214,6 +223,7 @@ export function ToolsPopover({
                         onToggle={() => onToggleTool(tool.id)}
                         onMouseEnter={() => setActiveIndex(globalIndex)}
                         id={`tools-picker-option-${globalIndex}`}
+                        disabled={isLocked}
                       />
                     );
                   })}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -24,7 +24,7 @@ import * as llmProfilesStore from './llmProfilesStore';
 import { listSkillFiles } from './skills';
 import { listWorkspaceFiles } from './workspaceFiles';
 import { resolveWorkspaceFilePath } from './workspacePaths';
-import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools } from '../../shared/localTools';
+import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools, type LocalToolId } from '../../shared/localTools';
 
 export type WebviewHost = {
   postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
@@ -62,6 +62,13 @@ async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, bytes);
 }
+
+const ensureRequiredLocalToolIds = (toolIds: LocalToolId[]): LocalToolId[] => {
+  // `finish` is always enabled by the runtime agent (for safe termination).
+  // Keep the UI/tool-selection source of truth consistent with what is actually sent to the LLM.
+  if (toolIds.includes('finish')) return toolIds;
+  return [...toolIds, 'finish'];
+};
 
 export type CreateWebviewMessageHandlerDeps = {
   context: vscode.ExtensionContext;
@@ -151,7 +158,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       return getDefaultLocalToolIds();
     })();
 
-    void host.postMessage({ type: 'toolsList', tools, enabledToolIds });
+    void host.postMessage({ type: 'toolsList', tools, enabledToolIds: ensureRequiredLocalToolIds(enabledToolIds) });
   };
 
   const postStatusError = (message: string): void => {
@@ -350,8 +357,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           break;
         }
 
+        const toolIds = ensureRequiredLocalToolIds(normalized);
         try {
-          conversation.setTools(resolveLocalTools(normalized));
+          conversation.setTools(resolveLocalTools(toolIds));
         } catch (err) {
           const reason = err instanceof Error ? err.message : String(err);
           outputChannel?.appendLine(`[tools] Failed to update tools: ${reason}`);


### PR DESCRIPTION
Fixes #716

- Make `finish` tool always-enabled/locked in the Tools picker so the UI count matches what the runtime sends.
- Ensure host tool list always includes `finish`.
- Update relevant unit tests.

Beads: oh-tab-a7p

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "finish" tool as a permanently enabled tool across the app.

* **UI Improvements**
  * Finish tool shows a lock icon and is non-interactive.
  * Attempting to toggle it displays an informational message that it is always enabled.

* **Bug Fixes**
  * Prevented duplicate "finish" entries in tool lists and payloads.

* **Tests**
  * Updated and added tests to cover the finish tool behavior and deduplication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->