### PR TITLE
Tool result tooltip no longer covers tool name

### DIFF
--- a/src/webview-src/components/Tooltip.tsx
+++ b/src/webview-src/components/Tooltip.tsx
@@ -41,17 +41,21 @@ export function Tooltip({
     const trigger = triggerRef.current.getBoundingClientRect();
     const padding = 8;
 
-    let nextPosition = position;
+    const fits: Record<TooltipPosition, boolean> = {
+      top: trigger.top - tooltip.height - padding >= 0,
+      bottom: trigger.bottom + tooltip.height + padding <= window.innerHeight,
+      left: trigger.left - tooltip.width - padding >= 0,
+      right: trigger.right + tooltip.width + padding <= window.innerWidth,
+    };
 
-    if (position === 'top' && trigger.top - tooltip.height - padding < 0) {
-      nextPosition = 'bottom';
-    } else if (position === 'bottom' && trigger.bottom + tooltip.height + padding > window.innerHeight) {
-      nextPosition = 'top';
-    } else if (position === 'left' && trigger.left - tooltip.width - padding < 0) {
-      nextPosition = 'right';
-    } else if (position === 'right' && trigger.right + tooltip.width + padding > window.innerWidth) {
-      nextPosition = 'left';
-    }
+    const fallbackOrder: Record<TooltipPosition, TooltipPosition[]> = {
+      top: ['top', 'bottom', 'right', 'left'],
+      bottom: ['bottom', 'top', 'right', 'left'],
+      left: ['left', 'top', 'bottom', 'right'],
+      right: ['right', 'top', 'bottom', 'left'],
+    };
+
+    const nextPosition = fallbackOrder[position].find((candidate) => fits[candidate]) ?? position;
 
     setActualPosition((prev) => (prev === nextPosition ? prev : nextPosition));
     setIsVisible(true);

--- a/src/webview-src/components/Tooltip.tsx
+++ b/src/webview-src/components/Tooltip.tsx
@@ -10,6 +10,13 @@ interface TooltipProps {
   className?: string;
 }
 
+const TOOLTIP_FALLBACK_ORDER: Record<TooltipPosition, TooltipPosition[]> = {
+  top: ['top', 'bottom', 'right', 'left'],
+  bottom: ['bottom', 'top', 'right', 'left'],
+  left: ['left', 'top', 'bottom', 'right'],
+  right: ['right', 'top', 'bottom', 'left'],
+};
+
 /**
  * Styled tooltip component matching OpenHands "Warm Technical Refinement" design.
  * Features glass morphism, warm amber accents, and smooth animations.
@@ -48,14 +55,7 @@ export function Tooltip({
       right: trigger.right + tooltip.width + padding <= window.innerWidth,
     };
 
-    const fallbackOrder: Record<TooltipPosition, TooltipPosition[]> = {
-      top: ['top', 'bottom', 'right', 'left'],
-      bottom: ['bottom', 'top', 'right', 'left'],
-      left: ['left', 'top', 'bottom', 'right'],
-      right: ['right', 'top', 'bottom', 'left'],
-    };
-
-    const nextPosition = fallbackOrder[position].find((candidate) => fits[candidate]) ?? position;
+    const nextPosition = TOOLTIP_FALLBACK_ORDER[position].find((candidate) => fits[candidate]) ?? position;
 
     setActualPosition((prev) => (prev === nextPosition ? prev : nextPosition));
     setIsVisible(true);

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -95,7 +95,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
         <div className="font-semibold text-sm text-stone-200">Tool Result</div>
         <span className="font-mono text-xs text-amber-400/80 bg-amber-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
         {showHeaderToggle && (
-          <Tooltip content={headerToggleLabel} position="left">
+          <Tooltip content={headerToggleLabel} position="right">
             <button
               onClick={() => setIsExpanded(!isExpanded)}
               className="ml-auto text-xs text-stone-400 hover:text-stone-300 transition-colors flex items-center gap-1 px-2 py-1 rounded-md hover:bg-white/[0.05]"


### PR DESCRIPTION
Fixes #718

- Tooltip positioning tries multiple fallbacks to avoid covering adjacent UI.
- Tool Result header toggle tooltip now prefers opening to the right.

Beads: oh-tab-cem

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip positioning with smarter, viewport-aware fallback placement to reduce off-screen clipping and unstable placement.
  * Adjusted header tool toggle tooltip to display on the right for more consistent alignment.
  * No changes to public component APIs or exports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->