### PR TITLE
Fix HAL overlay blocking header/history (oh-tab-0jh)

### DIFF
--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -686,97 +686,99 @@ export function App() {
         onSwitchToLocal={handleSwitchToLocal}
       />
 
-      <ConversationPane
-        events={events}
-        streamingContent={streamingContent}
-        skills={skills}
-        endRef={endRef}
-      />
-
-      {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}
-      {shouldShowHalOverlay && (
-        <HalOverlay
-          key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
-          userName={normalizeHalUserName(halSettings.userName)}
-          mode={halSettings.mode}
-          phase={halUiPhase}
-          eye={halEye}
-          line={halUiLine}
-          decision={halDecision}
-          lastError={halLastError}
-          isSubmitting={isSubmitting || halTeleporting}
-          startWithRejectInput={halForceRejectInput}
-          voiceConfirmFallbackToButtons={voiceConfirmFallbackToButtons}
-          onStartVoiceConfirm={handleStartVoiceConfirm}
-          onStopVoiceConfirm={handleStopVoiceConfirm}
-          onCancelVoiceConfirm={handleCancelVoiceConfirm}
-          onUseButtonsInstead={handleUseButtonsInstead}
-          onApprove={handleHalApprove}
-          onTeleport={handleHalTeleport}
-          onReject={handleHalReject}
-          onExit={handleHalExit}
+      <div className="relative flex flex-col flex-1 min-h-0">
+        <ConversationPane
+          events={events}
+          streamingContent={streamingContent}
+          skills={skills}
+          endRef={endRef}
         />
-      )}
 
-      {/* Confirmation prompt (modal overlay) */}
-      {hasPendingConfirmation && !shouldShowHalOverlay && (
-        <ConfirmationPrompt
-          pendingActions={pendingActions}
-          onApprove={handleApprove}
-          onReject={handleReject}
-          onOpenPath={handleOpenPath}
-          isSubmitting={isSubmitting}
+        {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}
+        {shouldShowHalOverlay && (
+          <HalOverlay
+            key={`hal:${halSessionKey ?? 'none'}:${halForceRejectInput ? 'reject' : 'normal'}`}
+            userName={normalizeHalUserName(halSettings.userName)}
+            mode={halSettings.mode}
+            phase={halUiPhase}
+            eye={halEye}
+            line={halUiLine}
+            decision={halDecision}
+            lastError={halLastError}
+            isSubmitting={isSubmitting || halTeleporting}
+            startWithRejectInput={halForceRejectInput}
+            voiceConfirmFallbackToButtons={voiceConfirmFallbackToButtons}
+            onStartVoiceConfirm={handleStartVoiceConfirm}
+            onStopVoiceConfirm={handleStopVoiceConfirm}
+            onCancelVoiceConfirm={handleCancelVoiceConfirm}
+            onUseButtonsInstead={handleUseButtonsInstead}
+            onApprove={handleHalApprove}
+            onTeleport={handleHalTeleport}
+            onReject={handleHalReject}
+            onExit={() => handleHalExit({ sessionKey: halSessionKey })}
+          />
+        )}
+
+        {/* Confirmation prompt (modal overlay) */}
+        {hasPendingConfirmation && !shouldShowHalOverlay && (
+          <ConfirmationPrompt
+            pendingActions={pendingActions}
+            onApprove={handleApprove}
+            onReject={handleReject}
+            onOpenPath={handleOpenPath}
+            isSubmitting={isSubmitting}
+          />
+        )}
+
+        {/* Input area */}
+        <ConversationInputDock
+          inputAreaProps={{
+            value: input,
+            onChange: handleInputChange,
+            onSubmit: handleSendMessage,
+            disabled: status === 'offline',
+            llmProfileId,
+            llmProfiles,
+            onSelectLlmProfileId: handleSelectLlmProfileId,
+            onOpenLlmProfilesCreate: handleOpenLlmProfilesCreate,
+            onOpenLlmProfilesEdit: handleOpenLlmProfilesEdit,
+            onOpenContext: handleOpenContext,
+            contextCount: selectedContextFiles.length,
+            showContextPicker,
+            contextPickerFiles: workspaceFiles,
+            contextPickerSelectedFiles: selectedContextFiles,
+            onToggleContextFile: handleToggleContextFile,
+            contextQuery,
+            onContextQueryChange: setContextQuery,
+            onCloseContextPicker: handleCloseContextPicker,
+            onOpenSkills: handleOpenSkills,
+            skillsCount: skills.length,
+            showSkillsPopover,
+            skillsPopoverSkills: skills,
+            onOpenSkill: handleOpenSkill,
+            onCloseSkillsPopover: () => setShowSkillsPopover(false),
+            onOpenTools: mode === 'local' ? handleOpenTools : undefined,
+            toolsCount: enabledToolIds.length,
+            showToolsPopover,
+            toolsPopoverTools: tools,
+            enabledToolIds,
+            onToggleTool: handleToggleTool,
+            onCloseToolsPopover: () => setShowToolsPopover(false),
+            onOpenAttachments: handleOpenAttachments,
+            attachments,
+            onOpenAttachment: handleOpenAttachment,
+            onRemoveAttachment: handleRemoveAttachment,
+            inlineImages,
+            onPasteImageFiles: (files) => { void handlePasteImageFiles(files); },
+            onRemoveInlineImage: handleRemoveInlineImage,
+            onSelectionChange: handleSelectionChange,
+          }}
+          statusBanner={statusBanner}
+          onDismissStatusBanner={() => setStatusBanner(null)}
+          agentStatus={agentStatus}
+          onStopAgent={handleStopAgent}
         />
-      )}
-
-      {/* Input area */}
-      <ConversationInputDock
-        inputAreaProps={{
-          value: input,
-          onChange: handleInputChange,
-          onSubmit: handleSendMessage,
-          disabled: status === 'offline',
-          llmProfileId,
-          llmProfiles,
-          onSelectLlmProfileId: handleSelectLlmProfileId,
-          onOpenLlmProfilesCreate: handleOpenLlmProfilesCreate,
-          onOpenLlmProfilesEdit: handleOpenLlmProfilesEdit,
-          onOpenContext: handleOpenContext,
-          contextCount: selectedContextFiles.length,
-          showContextPicker,
-          contextPickerFiles: workspaceFiles,
-          contextPickerSelectedFiles: selectedContextFiles,
-          onToggleContextFile: handleToggleContextFile,
-          contextQuery,
-          onContextQueryChange: setContextQuery,
-          onCloseContextPicker: handleCloseContextPicker,
-          onOpenSkills: handleOpenSkills,
-          skillsCount: skills.length,
-          showSkillsPopover,
-          skillsPopoverSkills: skills,
-          onOpenSkill: handleOpenSkill,
-          onCloseSkillsPopover: () => setShowSkillsPopover(false),
-          onOpenTools: mode === 'local' ? handleOpenTools : undefined,
-          toolsCount: enabledToolIds.length,
-          showToolsPopover,
-          toolsPopoverTools: tools,
-          enabledToolIds,
-          onToggleTool: handleToggleTool,
-          onCloseToolsPopover: () => setShowToolsPopover(false),
-          onOpenAttachments: handleOpenAttachments,
-          attachments,
-          onOpenAttachment: handleOpenAttachment,
-          onRemoveAttachment: handleRemoveAttachment,
-          inlineImages,
-          onPasteImageFiles: (files) => { void handlePasteImageFiles(files); },
-          onRemoveInlineImage: handleRemoveInlineImage,
-          onSelectionChange: handleSelectionChange,
-        }}
-        statusBanner={statusBanner}
-        onDismissStatusBanner={() => setStatusBanner(null)}
-        agentStatus={agentStatus}
-        onStopAgent={handleStopAgent}
-      />
+      </div>
 
       {/* LLM Profiles view (slide-over panel) */}
       <LlmProfilesView

--- a/src/webview-src/components/HalOverlay.tsx
+++ b/src/webview-src/components/HalOverlay.tsx
@@ -94,7 +94,7 @@ export function HalOverlay({
   const exitDisabled = isSubmitting && phase === 'error';
 
   return (
-    <div className="fixed inset-0 z-50 pointer-events-none">
+    <div className="absolute inset-0 z-50 pointer-events-none">
       <div className="absolute inset-0 bg-black/60 backdrop-blur-xs" aria-hidden="true" />
 
       <div className="absolute left-1/2 -translate-x-1/2 bottom-[124px] flex flex-col items-center gap-4 pointer-events-auto">

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -734,7 +734,7 @@ export function useHalFlow(deps: {
     deps.showStatusMessage('info', 'Switched to button decision for this conversation.');
   }, [cleanupHalVoiceConfirm, deps.showStatusMessage, getHalConversationKey, resetHalUiState]);
 
-  const handleHalExit = useCallback(() => {
+  const handleHalExit = useCallback((opts?: { sessionKey?: string | null }) => {
     if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
       deps.postMessage({ type: 'command', command: 'cancelTeleportAction' });
     }
@@ -742,7 +742,9 @@ export function useHalFlow(deps: {
     halTeleportInProgressRef.current = false;
     setHalTeleporting(false);
     setHalForceRejectInput(false);
-    const key = halActiveKeyRef.current;
+    const key = typeof opts?.sessionKey === 'string' && opts.sessionKey.length > 0
+      ? opts.sessionKey
+      : halActiveKeyRef.current;
     if (key) {
       setHalSuppressedKeySynced(key);
     }


### PR DESCRIPTION
Fixes a UX-severity regression where HAL overlay can get stuck after selecting an old conversation from HistoryView, blocking the entire UI.

Changes:
- Scope HAL overlay to the conversation + input dock (header stays clickable for History/Settings).
- Make HAL Exit suppression key use `conversationId:tool_call_id` consistently.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`

Beads: oh-tab-0jh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured main application layout with improved component organization and rendering order for better UI structure.

* **Bug Fixes**
  * Fixed HAL overlay positioning to display correctly relative to page content.
  * Enhanced HAL session exit handling with proper state cleanup to improve user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->