### PR TITLE
CI: harden VSIX release workflow

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -17,7 +17,7 @@ permissions:
   issues: write
 
 concurrency:
-  group: build-vsix-${{ github.event.pull_request.number || github.run_id }}
+  group: build-vsix-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 
@@ -63,24 +63,31 @@ jobs:
           check-latest: true
 
       - name: Install dependencies
-        run: npm ci || npm install
+        run: npm ci
 
-      - name: Compile extension
-        run: npm run compile
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/ext-v')
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#ext-v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)." >&2
+            exit 1
+          fi
 
-      - name: Type check only (no build)
+      - name: Build everything (SDK + extension + webview)
+        run: npm run build
+
+      - name: Type check (webview + extension)
         run: npm run typecheck
 
       - name: Run unit tests
-        run: npm run test
-
-      - name: Build webview bundle
-        run: npm run build:webview
+        run: npm test
 
       - name: Package VSIX
         id: package
         run: |
-          npx vsce package --no-yarn --allow-missing-repository --allow-star-activation --follow-symlinks
+          npm run package -- --no-yarn --allow-missing-repository --allow-star-activation
           VSIX_FILE=$(ls -1 *.vsix | head -n1)
           echo "vsix_file=$VSIX_FILE" >> $GITHUB_OUTPUT
           echo "vsix_name=$(basename "$VSIX_FILE")" >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Align build steps with `npm run build` + `npm run package` (ensures SDK dist + follow-symlinks + os.cpus patch).
- Remove `npm ci || npm install` fallback for reproducible releases.
- Add guard that `ext-v*` tag version matches `package.json` version.
- Improve concurrency grouping for pushes/PRs/tags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the build workflow with improved dependency installation, streamlined build steps, and enhanced tag version verification for releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->