### PR TITLE
Teleport decision auto-rejects local pending tool call (oh-tab-23r)

### DIFF
--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -323,7 +323,7 @@ describe('registerHalCommands', () => {
       rejectAction: vi.fn().mockResolvedValue(undefined),
     };
     let connected = false;
-    mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation) as any);
+mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation));
 
     // Connection succeeds
     mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(async () => {

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -314,15 +314,21 @@ describe('registerHalCommands', () => {
     mockDeps.getChatView = vi.fn().mockReturnValue(mockChatView);
     mockDeps.getChatWebviewReady = vi.fn().mockReturnValue(true);
 
-    const mockConversation = {
+    const localConversation = {
       rejectAction: vi.fn().mockResolvedValue(undefined),
+    };
+    const remoteConversation = {
       startNewConversation: vi.fn().mockResolvedValue(undefined),
       sendUserMessage: vi.fn().mockResolvedValue(undefined),
+      rejectAction: vi.fn().mockResolvedValue(undefined),
     };
-    mockDeps.getConversation = vi.fn().mockReturnValue(mockConversation);
+    let connected = false;
+    mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation) as any);
 
     // Connection succeeds
-    mockDeps.ensureConversationAndConnection = vi.fn().mockResolvedValue(undefined);
+    mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(async () => {
+      connected = true;
+    });
 
     registerHalCommands(mockDeps);
 
@@ -337,7 +343,8 @@ describe('registerHalCommands', () => {
     });
 
     // The local action SHOULD be rejected because connection succeeded
-    expect(mockConversation.rejectAction).toHaveBeenCalledWith('Teleported to remote runtime');
+    expect(localConversation.rejectAction).toHaveBeenCalledWith('rejected because the user sent the conversation to the remote runtime');
+    expect(remoteConversation.rejectAction).not.toHaveBeenCalled();
   });
 
   it('rejects local action only after successful connection', async () => {
@@ -358,11 +365,13 @@ describe('registerHalCommands', () => {
 
     const callOrder: string[] = [];
 
-    const mockConversation = {
+    const localConversation = {
       rejectAction: vi.fn().mockImplementation(() => {
         callOrder.push('rejectAction');
         return Promise.resolve(undefined);
       }),
+    };
+    const remoteConversation = {
       startNewConversation: vi.fn().mockImplementation(() => {
         callOrder.push('startNewConversation');
         return Promise.resolve(undefined);
@@ -372,10 +381,12 @@ describe('registerHalCommands', () => {
         return Promise.resolve(undefined);
       }),
     };
-    mockDeps.getConversation = vi.fn().mockReturnValue(mockConversation);
+    let connected = false;
+    mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation) as any);
 
     mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(() => {
       callOrder.push('ensureConversationAndConnection');
+      connected = true;
       return Promise.resolve(undefined);
     });
 

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -382,7 +382,7 @@ describe('registerHalCommands', () => {
       }),
     };
     let connected = false;
-    mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation) as any);
+mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation));
 
     mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(() => {
       callOrder.push('ensureConversationAndConnection');

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -89,6 +89,8 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     return chatView.webview.postMessage(message);
   };
 
+  const TELEPORT_AUTO_REJECT_REASON = 'rejected because the user sent the conversation to the remote runtime';
+
   const isAbortError = (err: unknown): boolean => {
     if (err instanceof DOMException && err.name === 'AbortError') return true;
     if (err instanceof Error) {
@@ -135,6 +137,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     let targetServerUrl: string | undefined;
     let targetServerLabel: string | undefined;
     let connectionEstablished = false;
+    const localConversation = deps.getConversation();
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
 
     try {
@@ -196,7 +199,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       // STEP 2: Now that connection is established, reject the local action
       // This is safe because we know the remote server is available
       try {
-        await deps.getConversation()?.rejectAction('Teleported to remote runtime');
+        await localConversation?.rejectAction(TELEPORT_AUTO_REJECT_REASON);
       } catch (err) {
         deps.getOutputChannel()?.appendLine(`[hal.teleport] Failed to reject local confirmation: ${deps.renderError(err)}`);
       }


### PR DESCRIPTION
Implements clarified HAL semantics for the "Teleport to Remote" decision.

- Rejects the *original local* pending tool call after remote connection succeeds.
- Uses explicit reason: "rejected because the user sent the conversation to the remote runtime".
- Adds tests to ensure we reject the local conversation instance (not the remote one).

Checks: `npm test`, `npm run typecheck`, `npm run lint`.

Beads: oh-tab-23r


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for conversation teleportation and rejection handling, including scenarios for both local and remote conversation states.

* **Chores**
  * Standardized rejection message when conversations are teleported to remote runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->