### PR TITLE
Release: v tags + bump to 0.5.0

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ develop ]
     tags:
-      - 'v*'
+      - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
 
 permissions:
@@ -26,7 +26,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
     steps:
@@ -66,9 +66,9 @@ jobs:
         run: npm ci
 
       - name: Verify tag matches package version
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          TAG_VERSION="${GITHUB_REF_NAME}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)." >&2

--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ develop ]
     tags:
-      - 'ext-v*'
+      - 'v*'
   workflow_dispatch:
 
 permissions:
@@ -26,7 +26,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build
-    if: startsWith(github.ref, 'refs/tags/ext-v')
+    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
     steps:
@@ -66,9 +66,9 @@ jobs:
         run: npm ci
 
       - name: Verify tag matches package version
-        if: startsWith(github.ref, 'refs/tags/ext-v')
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          TAG_VERSION="${GITHUB_REF_NAME#ext-v}"
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
           PKG_VERSION="$(node -p "require('./package.json').version")"
           if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
             echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)." >&2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhands-tab",
-  "version": "0.0.4",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhands-tab",
-      "version": "0.0.4",
+      "version": "0.5.0",
       "bundleDependencies": [
         "ws"
       ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenHands Tab",
   "publisher": "openhands",
   "icon": "media/icons/openhands-icon.png",
-  "version": "0.0.4",
+  "version": "0.5.0",
   "description": "A VS Code extension to interact with OpenHands agents in a dedicated sidebar chat view",
   "license": "MIT",
   "workspaces": [
@@ -35,7 +35,6 @@
     "onCommand:openhands.setSessionApiKey",
     "onCommand:openhands.setGithubToken",
     "onCommand:openhands.setHalTtsApiKey",
-
     "onCommand:openhands.setCustomSecret1",
     "onCommand:openhands.setCustomSecret2",
     "onCommand:openhands.setCustomSecret3",
@@ -98,7 +97,6 @@
         "command": "openhands.setHalTtsApiKey",
         "title": "OpenHands: Set HAL TTS API Key"
       },
-
       {
         "command": "openhands.setCustomSecret1",
         "title": "OpenHands: Set Custom Secret 1"


### PR DESCRIPTION
- Releases are now triggered by plain semver tags (no prefix), e.g. `0.5.0`.
- Workflow enforces tag name equals `package.json` version.

Changes:
- Bump extension version to `0.5.0`.
- Update `.github/workflows/build-vsix.yml` to trigger releases on semver tags and publish a draft GitHub Release with the VSIX attached.

After merge:
- `git tag 0.5.0 && git push origin 0.5.0`
