### PR TITLE
Docs: add PR template sections for Beads + reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,8 +161,8 @@ Before opening or updating a PR:
 Reviews (do not merge without review):
 - Do **not** request OpenHands review via GitHub comments anymore (e.g. `@openhands /codereview-roasted`).
 - Request review via **Agent Mail** (mandatory):
-  - Requester (e.g., `BlackDog`): send an Agent Mail message to a reviewer with the PR link/number and context; set `ack_required=true`.
-  - Reviewer (e.g., `OrangeCastle`): run the OpenHands roasted review locally (via tmux) and reply in-thread with the full output.
+  - Requester: send an Agent Mail message to the designated reviewer with the PR link/number and context; set `ack_required=true`.
+  - Reviewer: run the OpenHands roasted review locally (via tmux) and reply in-thread with the full output.
 - Ensure the GitHub AI reviewers are done (or clearly unavailable):
   - **Gemini-code-assist**: starts automatically upon PR creation; treat it as "one review done" once it has posted two top-level comments and you've checked/resolved its inline threads. Re-trigger with `/gemini review` if needed.
   - **CodeRabbitAI**: only wait if its ETA is <=10 minutes (pending or rate-limited). If it would block longer than that, proceed without it.
@@ -172,7 +172,7 @@ Reviews (do not merge without review):
   - "Conversation" tab: scan top-level comments (including bots).
   - "Files changed" tab: scan/resolve inline review threads.
   - Checks: confirm OpenHands/Gemini/CodeRabbit aren't still pending (or explicitly waived per the policy above).
-- When merging: edit the PR description to append a `### Review` section summarizing **OrangeCastle**'s roasted review(s) and any back-and-forth/resolution notes, then merge.
+- When merging: edit the PR description to append a `### Review` section summarizing the roasted review(s) from the designated reviewer and any back-and-forth/resolution notes, then merge.
 - If OpenHands feedback is "truly minor" (e.g., wording/typos/formatting only), you can address it without re-requesting review.
 - Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,7 @@ Before opening or updating a PR:
 - If you changed extension/webview/runtime behavior: `npm run e2e`
 - If you changed build tooling or packaging: `npm run build`
 - Ensure GitHub CI checks are green on the PR
+- For Beads-tracked work: include a PR description section `### Bead` containing the **full contents** of the Beads issue the PR fixes (copy/paste for traceability).
 
 Reviews (do not merge without review):
 - Do **not** request OpenHands review via GitHub comments anymore (e.g. `@openhands /codereview-roasted`).
@@ -171,6 +172,7 @@ Reviews (do not merge without review):
   - "Conversation" tab: scan top-level comments (including bots).
   - "Files changed" tab: scan/resolve inline review threads.
   - Checks: confirm OpenHands/Gemini/CodeRabbit aren't still pending (or explicitly waived per the policy above).
+- When merging: edit the PR description to append a `### Review` section summarizing **OrangeCastle**'s roasted review(s) and any back-and-forth/resolution notes, then merge.
 - If OpenHands feedback is "truly minor" (e.g., wording/typos/formatting only), you can address it without re-requesting review.
 - Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -212,8 +212,81 @@ src/
 ## 11. Packaging & Distribution
 - Engine: VS Code >= 1.104.0
 - Node: >= 22
-- Publish as VSIX; Marketplace later
 - Extension ID: openhands.openhands-tab
+
+### 11.1 What ships in the VSIX (and what doesn’t)
+- The extension vendors the SDK code under `src/sdk`, `src/tools`, `src/workspace` and compiles it into `dist/`.
+- There is no runtime dependency on `@openhands/agent-sdk-ts` via npm in the extension. Users do not need the npm package to use the VS Code extension.
+- The separate `@openhands/agent-sdk-ts` publish is only for developers who want to import the SDK in their own projects.
+
+Implication: You can publish a GitHub release with just the `.vsix` and it will work for users, even if the npm package has not been published.
+
+### 11.2 Build and package the extension
+```bash
+# From repo root
+npm ci
+npm run compile                # build extension + webview
+npm run package                # produces a .vsix under the repo root
+```
+Notes:
+- `npm run package` wraps `vsce package` via `scripts/run-vsce-package.cjs` (adds a small CPU patch and follows symlinks).
+- If you want a clean build: `git clean -fdx && npm ci && npm run compile`.
+
+### 11.3 Validate the VSIX locally
+```bash
+# Install the built VSIX in your VS Code
+code --install-extension openhands.openhands-tab-*.vsix
+# Or via UI: Extensions panel → … menu → Install from VSIX…
+```
+
+### 11.4 GitHub Release (recommended)
+1) Bump version in `package.json` and commit
+```bash
+npm version patch    # or minor/major
+```
+2) Build and package
+```bash
+npm run compile && npm run package
+```
+3) Create a Git tag and GitHub release, attach the `.vsix` file
+- Tag suggestion: `v<version>` (e.g., `v0.5.1`)
+- Release notes: include highlights and compatibility notes
+
+Users can download the `.vsix` from the release and install directly (no Marketplace required).
+
+### 11.5 VS Code Marketplace (optional)
+Requirements:
+- Publisher set to `openhands` (already in `package.json`).
+- Logged in with `vsce` (PAT):
+```bash
+npx vsce login openhands
+```
+Publish:
+```bash
+npx vsce publish               # publishes the current version
+# or
+npx vsce publish patch         # bump + publish (minor/major also supported)
+```
+
+### 11.6 Releasing the SDK package (optional)
+Only needed if you want others to `npm i @openhands/agent-sdk-ts` in their projects. It is NOT required for the VSIX to work.
+```bash
+# Preflight
+npm ci
+npm test -w @openhands/agent-sdk-ts
+npm run lint -w @openhands/agent-sdk-ts
+npm run build -w @openhands/agent-sdk-ts
+# Optional: see tarball contents
+npm pack -w @openhands/agent-sdk-ts --dry-run
+# Version bump and publish
+npm version patch -w @openhands/agent-sdk-ts
+npm publish -w @openhands/agent-sdk-ts --access public
+```
+
+### 11.7 Troubleshooting
+- If users install from GitHub release and see missing module errors for `@openhands/agent-sdk-ts`, it means the extension started depending on the npm package. Revert to vendoring under `src/sdk` or publish the package and add it to `dependencies`.
+- Engine mismatch: ensure VS Code version >= `engines.vscode` and Node >= `engines.node`.
+- To exclude source maps from the VSIX, add an `.npmignore` entry like `*.map` or adjust bundler settings.
 
 ## 12. Implementation Phases
 


### PR DESCRIPTION
- Require PR descriptions to include `### Bead` with the full Beads issue contents for traceability.
- Require PR descriptions to be updated at merge time with `### Review` summarizing the designated reviewer’s roasted review(s) and any back-and-forth.
- Expand `docs/PRD.md` packaging/release guidance for VSIX shipping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PR workflow checklist: require a "Bead" section in PR descriptions containing the full Beads issue, use role-based reviewer wording, and send an Agent Mail with context and ack_required=true.
  * New merge step: append a "Review" section summarizing review notes and resolutions before merging.
  * Expanded release/packaging guidance for VSIX shipping, build, validation, and marketplace publishing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Designated reviewer ran `/codereview-roasted` and requested two follow-ups: make reviewer wording in `AGENTS.md` reviewer-agnostic, and ensure CI is fully green.
- Follow-ups implemented and pushed; CI green; reviewer replied "Approved ✅ / OK to merge PR #726." (Agent Mail thread `pr-726`).
