### PR TITLE
Fix teleport summary on remote teleport (oh-tab-70c)

### DIFF
--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -171,24 +171,27 @@ Settings:
     - If no server is available (empty list): **abort the HAL flow** (exit overlay/audio), show "No server configured. Add one in Server Selection.", then proceed with the normal Reject path (including the usual reject-reason prompt).
   - **Connection-first approach** (critical for clean state management):
     1. Show "Connecting to (server name)…" status message.
-    2. Attempt to connect to the remote server **first**.
-    3. **Only if connection succeeds**:
-       - Cancel the local confirmation (reject the risky local action with reason "Teleported to remote runtime").
-       - Run a one-shot **local** LLM summarization.
-       - Start a new remote conversation and send the summary as the first user message.
-       - Show "Teleported to (server name)!" success message.
-    4. **If connection fails**:
-       - Do **NOT** cancel/reject the local confirmation (the local agent remains active with the pending action).
+	    2. Attempt to connect to the remote server **first**.
+	    3. **Only if connection succeeds**:
+	       - Cancel the local confirmation (reject the risky local action with reason "Teleported to remote runtime").
+	       - Run a one-shot **local** LLM summarization over recent local events (Action/Observation/Message only; capture events before switching to the remote conversation).
+	       - Start a new remote conversation and send the summary as the first user message.
+	       - Show "Teleported to (server name)!" success message.
+	    4. **If connection fails**:
+	       - Do **NOT** cancel/reject the local confirmation (the local agent remains active with the pending action).
        - Do **NOT** prepare or send any summary.
        - Show a short, user-friendly error message (e.g., "Server unreachable. Check if it is running.").
        - Return to the local conversation state (HAL flow resets to error phase).
-  - Summary message content (only prepared after successful connection):
-    - If summarization succeeds: intro + summary.
-    - If summarization fails: intro + note that summarization failed + last 10 events (Action/Observation/Message only; exclude system prompt/tools/skills).
-    - Intro includes: repo name, branch name, remote URL (if configured), and a note that uncommitted local changes may not be present in remote.
-    - Do **not** send the system prompt, tool list, or skills list (the remote agent/runtime has its own).
-    - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn't emit them today).
-  - Show the "Teleporting…" overlay and play the "Rhapsody in Blue…" snippet while waiting for the remote conversation to be ready.
+	  - Summary message content (only prepared after successful connection):
+	    - If summarization succeeds: intro + summary.
+	    - Summarization profile selection:
+	      - Prefer `gemini-flash-summarizer` (same as tool summaries).
+	      - If Gemini credentials are not configured, fall back to the main agent LLM profile so teleport still produces a summary.
+	    - If summarization fails **or returns empty text** (or if there are no teleportable events to summarize): intro + note + last 10 events (Action/Observation/Message only; exclude system prompt/tools/skills).
+	    - Intro includes: repo name, branch name, remote URL (if configured), and a note that uncommitted local changes may not be present in remote.
+	    - Do **not** send the system prompt, tool list, or skills list (the remote agent/runtime has its own).
+	    - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn't emit them today).
+	  - Show the "Teleporting…" overlay and play the "Rhapsody in Blue…" snippet while waiting for the remote conversation to be ready.
 
 ## Testing plan
 ### Unit tests (webview)

--- a/docs/hal/elevenlabs_prd.md
+++ b/docs/hal/elevenlabs_prd.md
@@ -171,27 +171,27 @@ Settings:
     - If no server is available (empty list): **abort the HAL flow** (exit overlay/audio), show "No server configured. Add one in Server Selection.", then proceed with the normal Reject path (including the usual reject-reason prompt).
   - **Connection-first approach** (critical for clean state management):
     1. Show "Connecting to (server name)…" status message.
-	    2. Attempt to connect to the remote server **first**.
-	    3. **Only if connection succeeds**:
-	       - Cancel the local confirmation (reject the risky local action with reason "Teleported to remote runtime").
-	       - Run a one-shot **local** LLM summarization over recent local events (Action/Observation/Message only; capture events before switching to the remote conversation).
-	       - Start a new remote conversation and send the summary as the first user message.
-	       - Show "Teleported to (server name)!" success message.
-	    4. **If connection fails**:
-	       - Do **NOT** cancel/reject the local confirmation (the local agent remains active with the pending action).
-       - Do **NOT** prepare or send any summary.
-       - Show a short, user-friendly error message (e.g., "Server unreachable. Check if it is running.").
-       - Return to the local conversation state (HAL flow resets to error phase).
-	  - Summary message content (only prepared after successful connection):
-	    - If summarization succeeds: intro + summary.
-	    - Summarization profile selection:
-	      - Prefer `gemini-flash-summarizer` (same as tool summaries).
-	      - If Gemini credentials are not configured, fall back to the main agent LLM profile so teleport still produces a summary.
-	    - If summarization fails **or returns empty text** (or if there are no teleportable events to summarize): intro + note + last 10 events (Action/Observation/Message only; exclude system prompt/tools/skills).
-	    - Intro includes: repo name, branch name, remote URL (if configured), and a note that uncommitted local changes may not be present in remote.
-	    - Do **not** send the system prompt, tool list, or skills list (the remote agent/runtime has its own).
-	    - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn't emit them today).
-	  - Show the "Teleporting…" overlay and play the "Rhapsody in Blue…" snippet while waiting for the remote conversation to be ready.
+    2. Attempt to connect to the remote server **first**.
+    3. **Only if connection succeeds**:
+      - Cancel the local confirmation (reject the risky local action with reason "Teleported to remote runtime").
+      - Run a one-shot **local** LLM summarization over recent local events (Action/Observation/Message only; capture events before switching to the remote conversation).
+      - Start a new remote conversation and send the summary as the first user message.
+      - Show "Teleported to (server name)!" success message.
+    4. **If connection fails**:
+      - Do **NOT** cancel/reject the local confirmation (the local agent remains active with the pending action).
+      - Do **NOT** prepare or send any summary.
+      - Show a short, user-friendly error message (e.g., "Server unreachable. Check if it is running.").
+      - Return to the local conversation state (HAL flow resets to error phase).
+  - Summary message content (only prepared after successful connection):
+    - If summarization succeeds: intro + summary.
+    - Summarization profile selection:
+      - Prefer `gemini-flash-summarizer` (same as tool summaries).
+      - If Gemini credentials are not configured, fall back to the main agent LLM profile so teleport still produces a summary.
+    - If summarization fails **or returns empty text** (or if there are no teleportable events to summarize): intro + note + last 10 events (Action/Observation/Message only; exclude system prompt/tools/skills).
+    - Intro includes: repo name, branch name, remote URL (if configured), and a note that uncommitted local changes may not be present in remote.
+    - Do **not** send the system prompt, tool list, or skills list (the remote agent/runtime has its own).
+    - Do not rely on Condensation events for local mode (agent-sdk-ts defines the type but doesn't emit them today).
+  - Show the "Teleporting…" overlay and play the "Rhapsody in Blue…" snippet while waiting for the remote conversation to be ready.
 
 ## Testing plan
 ### Unit tests (webview)

--- a/src/extension/summarizeWithLocalLlm.ts
+++ b/src/extension/summarizeWithLocalLlm.ts
@@ -7,41 +7,53 @@ export async function summarizeWithLocalLlm(
   prompt: string,
   secrets: SecretRegistry,
 ): Promise<string> {
-  const profileId = normalizeNonEmptyString(settings.llm.profileId);
-  if (!profileId) {
-    throw new Error('LLM profileId is not configured');
+  const primaryProfileId = normalizeNonEmptyString(settings.llm.profileId);
+  if (!primaryProfileId) throw new Error('LLM profileId is not configured');
+
+  // Prefer the same "fast summarizer" profile used elsewhere, but fall back to the main
+  // agent profile when Gemini credentials (or the summarizer profile) are not configured.
+  const preferredSummarizerProfileId = 'gemini-flash-summarizer';
+  const profileIds: string[] = [];
+  for (const id of [preferredSummarizerProfileId, primaryProfileId]) {
+    if (!id) continue;
+    if (!profileIds.includes(id)) profileIds.push(id);
   }
 
   const model = normalizeNonEmptyString(settings.llm.model) ?? '';
-  const factory = new LLMFactory({
-    profileId,
-    // LLMFactory loads the effective provider/model/baseUrl/etc from the profile when profileId is set.
-    // Keep `model` set to satisfy the type and for error context if the profile load fails.
-    model,
-  }, {
-    secrets,
-    preferredApiKeys: [`openhands.llmProfileApiKey.${profileId}`],
-  });
+  let lastError: unknown;
+  for (const profileId of profileIds) {
+    try {
+      const factory = new LLMFactory({
+        profileId,
+        // LLMFactory loads the effective provider/model/baseUrl/etc from the profile when profileId is set.
+        // Keep `model` set to satisfy the type and for error context if the profile load fails.
+        model,
+      }, {
+        secrets,
+        preferredApiKeys: [`openhands.llmProfileApiKey.${profileId}`],
+      });
 
-  const client = await factory.createClient();
-  const request = {
-    systemPrompt: 'You are a very good summarizer.',
-    messages: [
-      {
-        role: 'user' as const,
-        content: [{ type: 'text' as const, text: prompt }],
-      },
-    ],
-  };
+      const client = await factory.createClient();
+      const request = {
+        systemPrompt: 'You are a very good summarizer.',
+        messages: [
+          {
+            role: 'user' as const,
+            content: [{ type: 'text' as const, text: prompt }],
+          },
+        ],
+      };
 
-  let text = '';
-  for await (const chunk of client.streamChat(request)) {
-    if (chunk.type === 'text') text += chunk.text;
+      let text = '';
+      for await (const chunk of client.streamChat(request)) {
+        if (chunk.type === 'text') text += chunk.text;
+      }
+      const trimmed = text.trim();
+      if (!trimmed) throw new Error('LLM returned an empty summary');
+      return trimmed;
+    } catch (err) {
+      lastError = err;
+    }
   }
-  const trimmed = text.trim();
-  if (!trimmed) {
-    throw new Error('LLM returned an empty summary');
-  }
-  return trimmed;
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
-

--- a/src/hal/__tests__/registerHalCommands.test.ts
+++ b/src/hal/__tests__/registerHalCommands.test.ts
@@ -403,4 +403,94 @@ mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteC
       'sendUserMessage',
     ]);
   });
+
+  it('uses local backlog events captured before switching to remote', async () => {
+    mockSettings = {
+      serverUrl: '',
+      servers: [{ url: 'https://example.com', label: 'My Server' }],
+      llm: {},
+    };
+
+    const mockWebview = {
+      postMessage: vi.fn().mockResolvedValue(true),
+    };
+    const mockChatView = {
+      webview: mockWebview,
+    };
+    mockDeps.getChatView = vi.fn().mockReturnValue(mockChatView);
+    mockDeps.getChatWebviewReady = vi.fn().mockReturnValue(true);
+
+    const localConversation = {
+      rejectAction: vi.fn().mockResolvedValue(undefined),
+    };
+    const remoteConversation = {
+      startNewConversation: vi.fn().mockResolvedValue(undefined),
+      sendUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    let connected = false;
+    mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation));
+
+    let backlog: any[] = [{ event: { kind: 'ActionEvent', id: 'local-evt-1', action: 'terminal' } }];
+    mockDeps.iterConversationEventBacklog = vi.fn().mockImplementation(() => backlog as any);
+
+    mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(async () => {
+      connected = true;
+      backlog = [];
+    });
+
+    const seenPrompts: string[] = [];
+    mockDeps.summarizeWithLocalLlm = vi.fn().mockImplementation(async (_settings: any, prompt: string) => {
+      seenPrompts.push(prompt);
+      return 'Test summary';
+    });
+
+    registerHalCommands(mockDeps);
+
+    const teleportCommand = registeredCommands.get('openhands._teleportToRemoteRuntime');
+    await teleportCommand!();
+
+    expect(seenPrompts).toHaveLength(1);
+    expect(seenPrompts[0]).toContain('local-evt-1');
+  });
+
+  it('skips summarization and falls back when there are no teleportable events', async () => {
+    mockSettings = {
+      serverUrl: '',
+      servers: [{ url: 'https://example.com' }],
+      llm: {},
+    };
+
+    const mockWebview = {
+      postMessage: vi.fn().mockResolvedValue(true),
+    };
+    const mockChatView = {
+      webview: mockWebview,
+    };
+    mockDeps.getChatView = vi.fn().mockReturnValue(mockChatView);
+    mockDeps.getChatWebviewReady = vi.fn().mockReturnValue(true);
+
+    const localConversation = {
+      rejectAction: vi.fn().mockResolvedValue(undefined),
+    };
+    const remoteConversation = {
+      startNewConversation: vi.fn().mockResolvedValue(undefined),
+      sendUserMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    let connected = false;
+    mockDeps.getConversation = vi.fn().mockImplementation(() => (connected ? remoteConversation : localConversation));
+    mockDeps.ensureConversationAndConnection = vi.fn().mockImplementation(async () => {
+      connected = true;
+    });
+
+    mockDeps.iterConversationEventBacklog = vi.fn().mockReturnValue([{ event: { kind: 'ConversationStateUpdateEvent', state: {} } }] as any);
+
+    registerHalCommands(mockDeps);
+
+    const teleportCommand = registeredCommands.get('openhands._teleportToRemoteRuntime');
+    await teleportCommand!();
+
+    expect(mockDeps.summarizeWithLocalLlm).not.toHaveBeenCalled();
+    expect(remoteConversation.sendUserMessage).toHaveBeenCalledWith(expect.stringContaining('Teleport summary unavailable'));
+    expect(remoteConversation.sendUserMessage).toHaveBeenCalledWith(expect.stringContaining('Last 10 events'));
+  });
 });

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -139,6 +139,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
     let connectionEstablished = false;
     const localConversation = deps.getConversation();
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+    const localBacklogEvents = Array.from(deps.iterConversationEventBacklog(), (item) => item.event);
 
     try {
       if (activeTeleport) {
@@ -218,22 +219,28 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       introLines.push('Note: uncommitted local changes may not be present remotely.');
       const intro = introLines.join('\n');
 
-      const backlogEvents = Array.from(deps.iterConversationEventBacklog(), (item) => item.event);
-      const summaryEvents = takeLastTeleportableEvents(backlogEvents, TELEPORT_SUMMARY_EVENT_LIMIT);
-      const prompt = renderCondensationSummarizingPrompt({
-        previousSummary: '',
-        eventStrings: summaryEvents.map((e) => safeStringify(e)),
-      });
-
       let firstRemoteMessage: string;
-      try {
-        const summary = await deps.summarizeWithLocalLlm(settings, prompt, deps.secretRegistry);
-        firstRemoteMessage = `${intro}\n\n---\n\n${summary}`;
-      } catch (err) {
-        const last10 = takeLastTeleportableEvents(backlogEvents, TELEPORT_FALLBACK_EVENT_LIMIT).map((e) => safeStringify(e));
-        const reason = deps.renderError(err);
-        const block = last10.map((e) => `<EVENT>\n${e}\n</EVENT>`).join('\n\n');
-        firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary failed: ${reason}\n\nLast 10 events (Action/Observation/Message only):\n\n${block}`;
+      const summaryEvents = takeLastTeleportableEvents(localBacklogEvents, TELEPORT_SUMMARY_EVENT_LIMIT);
+      const fallbackEvents = takeLastTeleportableEvents(localBacklogEvents, TELEPORT_FALLBACK_EVENT_LIMIT).map((e) => safeStringify(e));
+      const fallbackBlock = fallbackEvents.length
+        ? fallbackEvents.map((e) => `<EVENT>\n${e}\n</EVENT>`).join('\n\n')
+        : '(none)';
+
+      if (!summaryEvents.length) {
+        firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary unavailable: no recent events to summarize.\n\nLast 10 events (Action/Observation/Message only):\n\n${fallbackBlock}`;
+      } else {
+        const prompt = renderCondensationSummarizingPrompt({
+          previousSummary: '',
+          eventStrings: summaryEvents.map((e) => safeStringify(e)),
+        });
+
+        try {
+          const summary = await deps.summarizeWithLocalLlm(settings, prompt, deps.secretRegistry);
+          firstRemoteMessage = `${intro}\n\n---\n\n${summary}`;
+        } catch (err) {
+          const reason = deps.renderError(err);
+          firstRemoteMessage = `${intro}\n\n---\n\nTeleport summary failed: ${reason}\n\nLast 10 events (Action/Observation/Message only):\n\n${fallbackBlock}`;
+        }
       }
 
       // STEP 4: Start new conversation and send the summary


### PR DESCRIPTION
Fixes Beads: oh-tab-70c\n\n- Capture local backlog before switching to remote to avoid empty-summary prompts\n- Prefer gemini-flash-summarizer for teleport summaries; fall back to main profile when Gemini credentials aren’t configured\n- Guarantee non-empty first remote message with last-10-events fallback on summarization failure/empty\n- Adds unit tests for backlog capture + fallback behavior\n\nTests: npx vitest run src/hal/__tests__/registerHalCommands.test.ts && npm run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced "Teleport to remote server" with intelligent summarization: prioritizes specific summarization profile and falls back to primary agent profile if unavailable.
  * Added fallback display of last 10 events when summarization fails or no events available.

* **Bug Fixes**
  * Improved error messaging for failed remote connections with graceful degradation.

* **Documentation**
  * Updated feature specification for teleport flow and summarization behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->