### PR TITLE
Fix GPT-5 reasoning summary request (oh-tab-onk)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.streamer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.streamer.test.ts
@@ -376,6 +376,29 @@ describe('OpenAIResponsesClient (non-stream)', () => {
     expect(body?.reasoning).toEqual({ effort: 'medium', summary: 'detailed' });
   });
 
+  it('includes reasoning summary in Responses request body when effort is unset', async () => {
+    const payload = {
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Hello' }],
+        },
+      ],
+      usage: { input_tokens: 5, output_tokens: 2 },
+    };
+
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue(new Response(JSON.stringify(payload), { status: 200 }));
+    const client = new OpenAIResponsesClient({ ...baseConfig, reasoningSummary: 'detailed' }, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    await streamer.runChat(buildRequest());
+
+    const init = fetchMock.mock.calls[0]?.[1] as { body?: unknown } | undefined;
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null;
+    expect(body?.reasoning).toEqual({ summary: 'detailed' });
+  });
+
   it('ignores reasoningSummary when reasoningEffort is none', async () => {
     const payload = {
       output: [

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -216,12 +216,16 @@ const toRequestBody = (config: LLMConfiguration, request: ChatCompletionRequest)
   store: false,
   temperature: config.temperature ?? undefined,
   max_output_tokens: config.maxOutputTokens ?? undefined,
-  reasoning: config.reasoningEffort && config.reasoningEffort !== 'none'
-    ? {
-      effort: config.reasoningEffort,
-      ...(config.reasoningSummary ? { summary: config.reasoningSummary } : {}),
-    }
-    : undefined,
+  reasoning: (() => {
+    const effort = config.reasoningEffort && config.reasoningEffort !== 'none' ? config.reasoningEffort : undefined;
+    const summary = config.reasoningSummary ?? undefined;
+    if (config.reasoningEffort === 'none') return undefined;
+    if (!effort && !summary) return undefined;
+    return {
+      ...(effort ? { effort } : {}),
+      ...(summary ? { summary } : {}),
+    };
+  })(),
 });
 
 const parseResponsesOutput = (output: unknown): { text?: string; toolCalls: ToolCall[]; responsesReasoningItem?: ResponsesReasoningItem } => {


### PR DESCRIPTION
Fixes Beads: oh-tab-onk

Problem: setting `reasoningSummary=detailed` didn’t affect Responses requests unless `reasoningEffort` was also set, so GPT-5 returned an empty/absent reasoning summary.

Change:
- `OpenAIResponsesClient` now includes `reasoning: { summary: ... }` even when `reasoningEffort` is unset.
- Still omits `reasoning` when `reasoningEffort` is explicitly `none` (existing behavior).

Tests:
- Added coverage in `llm.streamer.test.ts` for summary-without-effort.
- `cd packages/agent-sdk-ts && npx vitest run src/sdk/__tests__/llm.streamer.test.ts`
- `npm run build -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced reasoning configuration to support summary-only settings independent of effort levels, allowing more flexible LLM reasoning control.

* **Tests**
  * Added test coverage for reasoning summary configuration scenarios, including verification of correct request formatting when reasoning effort is not explicitly set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->