### PR TITLE
Move conversation persistence out of workspace (oh-tab-427)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import type { AgentState } from './ConversationState';
 import type { Event } from '../types';
@@ -122,7 +123,7 @@ export class FileStore implements ConversationPersistence {
   private readonly llmFile: string;
 
   constructor(options: FileStoreOptions) {
-    this.rootDir = options.rootDir ?? path.join(process.cwd(), '.openhands', 'conversations');
+    this.rootDir = options.rootDir ?? path.join(os.homedir(), '.openhands', 'conversations');
     this.conversationId = options.conversationId;
     this.conversationDir = path.join(this.rootDir, this.conversationId);
     this.eventsFile = path.join(this.conversationDir, 'events.jsonl');
@@ -188,7 +189,7 @@ export class FileStore implements ConversationPersistence {
   }
 
   static listConversations(rootDir?: string): string[] {
-    const dir = rootDir ?? path.join(process.cwd(), '.openhands', 'conversations');
+    const dir = rootDir ?? path.join(os.homedir(), '.openhands', 'conversations');
     if (!fs.existsSync(dir)) return [];
     return fs
       .readdirSync(dir, { withFileTypes: true })

--- a/src/extension/__tests__/conversationStoreMigration.test.ts
+++ b/src/extension/__tests__/conversationStoreMigration.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { migrateWorkspaceConversationStore } from '../conversationStoreMigration';
+
+async function makeTempDir(prefix: string): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), prefix));
+}
+
+describe('migrateWorkspaceConversationStore', () => {
+  it('moves legacy workspace conversation dirs into the target root', async () => {
+    const workspaceRoot = await makeTempDir('oh-tab-workspace-');
+    const targetRoot = await makeTempDir('oh-tab-target-');
+    const legacyDir = path.join(workspaceRoot, '.openhands', 'conversations');
+    const legacyConv = path.join(legacyDir, 'local-abc123');
+
+    await fs.mkdir(legacyConv, { recursive: true });
+    await fs.writeFile(path.join(legacyConv, 'state.json'), '{"ok":true}\n', 'utf8');
+    await fs.writeFile(path.join(legacyConv, 'events.jsonl'), '{"kind":"MessageEvent"}\n', 'utf8');
+
+    const result = await migrateWorkspaceConversationStore({ workspaceRoot, targetRoot });
+    expect(result.moved).toBe(1);
+    expect(await fs.readFile(path.join(targetRoot, 'local-abc123', 'state.json'), 'utf8')).toContain('"ok":true');
+
+    // Legacy dir should be removed when empty.
+    await expect(fs.stat(legacyDir)).rejects.toThrow();
+  });
+
+  it('avoids collisions by picking a unique destination name', async () => {
+    const workspaceRoot = await makeTempDir('oh-tab-workspace-');
+    const targetRoot = await makeTempDir('oh-tab-target-');
+    const legacyDir = path.join(workspaceRoot, '.openhands', 'conversations');
+
+    await fs.mkdir(path.join(legacyDir, 'local-dup'), { recursive: true });
+    await fs.writeFile(path.join(legacyDir, 'local-dup', 'state.json'), '{"from":"legacy"}\n', 'utf8');
+
+    await fs.mkdir(path.join(targetRoot, 'local-dup'), { recursive: true });
+    await fs.writeFile(path.join(targetRoot, 'local-dup', 'state.json'), '{"from":"target"}\n', 'utf8');
+
+    const result = await migrateWorkspaceConversationStore({ workspaceRoot, targetRoot });
+    expect(result.moved).toBe(1);
+
+    const entries = await fs.readdir(targetRoot, { withFileTypes: true });
+    const migrated = entries.filter((e) => e.isDirectory() && e.name.startsWith('local-dup-migrated-'));
+    expect(migrated.length).toBe(1);
+    expect(await fs.readFile(path.join(targetRoot, migrated[0]!.name, 'state.json'), 'utf8')).toContain('"legacy"');
+  });
+});
+

--- a/src/extension/conversationStoreMigration.ts
+++ b/src/extension/conversationStoreMigration.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isFsError = (err: unknown): err is NodeJS.ErrnoException => isRecord(err) && typeof err.code === 'string';
+
+export async function migrateWorkspaceConversationStore(params: {
+  workspaceRoot: string;
+  targetRoot: string;
+  log?: (line: string) => void;
+}): Promise<{ moved: number; skipped: number; legacyDir: string }> {
+  const legacyDir = path.join(params.workspaceRoot, '.openhands', 'conversations');
+  const log = params.log;
+
+  try {
+    const stat = await fs.stat(legacyDir);
+    if (!stat.isDirectory()) return { moved: 0, skipped: 0, legacyDir };
+  } catch (err) {
+    if (isFsError(err) && err.code === 'ENOENT') return { moved: 0, skipped: 0, legacyDir };
+    throw err;
+  }
+
+  await fs.mkdir(params.targetRoot, { recursive: true });
+
+  const entries = await fs.readdir(legacyDir, { withFileTypes: true });
+  let moved = 0;
+  let skipped = 0;
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      skipped += 1;
+      continue;
+    }
+
+    const from = path.join(legacyDir, entry.name);
+    const baseTo = path.join(params.targetRoot, entry.name);
+    const chooseDestination = async (): Promise<string> => {
+      try {
+        await fs.stat(baseTo);
+        // Collision: keep both by choosing a unique destination.
+        for (let i = 1; i < 1000; i += 1) {
+          const candidate = `${baseTo}-migrated-${i}`;
+          try {
+            await fs.stat(candidate);
+          } catch (err) {
+            if (isFsError(err) && err.code === 'ENOENT') return candidate;
+            throw err;
+          }
+        }
+        return `${baseTo}-migrated-${Date.now()}`;
+      } catch (err) {
+        if (isFsError(err) && err.code === 'ENOENT') return baseTo;
+        throw err;
+      }
+    };
+
+    const to = await chooseDestination();
+    try {
+      await fs.rename(from, to);
+    } catch (err) {
+      if (isFsError(err) && err.code === 'EXDEV') {
+        await fs.cp(from, to, { recursive: true });
+        await fs.rm(from, { recursive: true, force: true });
+      } else {
+        throw err;
+      }
+    }
+    moved += 1;
+  }
+
+  try {
+    const remaining = await fs.readdir(legacyDir);
+    if (remaining.length === 0) {
+      await fs.rmdir(legacyDir);
+      log?.(`[storage] Migrated ${moved} conversation(s) from workspace legacy store to ${params.targetRoot}`);
+    } else if (moved > 0) {
+      log?.(`[storage] Migrated ${moved} conversation(s) from workspace legacy store to ${params.targetRoot} (legacy dir not empty)`);
+    }
+  } catch {
+    // Best-effort cleanup/logging; ignore.
+  }
+
+  return { moved, skipped, legacyDir };
+}

--- a/src/extension/conversationStoreRoot.ts
+++ b/src/extension/conversationStoreRoot.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { normalizeNonEmptyString } from '../shared/stringUtils';
+import { migrateWorkspaceConversationStore } from './conversationStoreMigration';
 
 function resolveConfiguredPath(p: string): string {
   const raw = p.trim();
@@ -54,6 +55,28 @@ export async function resolveConversationStoreRoot(params: {
   for (const candidate of candidates) {
     try {
       await ensureWritableDirectory(candidate.dir);
+
+      // One-time best-effort migration away from legacy workspace persistence.
+      // This keeps restore working for users who previously wrote to `./.openhands/conversations`.
+      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      if (workspaceRoot) {
+        const resolvedCandidate = path.resolve(candidate.dir);
+        const resolvedWorkspace = path.resolve(workspaceRoot);
+        const candidateIsWithinWorkspace =
+          resolvedCandidate === resolvedWorkspace || resolvedCandidate.startsWith(`${resolvedWorkspace}${path.sep}`);
+        if (!candidateIsWithinWorkspace) {
+          try {
+            await migrateWorkspaceConversationStore({
+              workspaceRoot,
+              targetRoot: candidate.dir,
+              log: (line) => params.getOutputChannel()?.appendLine(line),
+            });
+          } catch (err) {
+            params.getOutputChannel()?.appendLine(`[storage] Failed to migrate legacy workspace conversations: ${params.renderError(err)}`);
+          }
+        }
+      }
+
       if (candidate.dir !== candidates[0]?.dir) {
         params.getOutputChannel()?.appendLine(`[storage] Using conversation store root: ${candidate.dir} (${candidate.label})`);
       }


### PR DESCRIPTION
Fixes Beads: oh-tab-427

- Ensures we migrate legacy workspace persistence from `./.openhands/conversations` into the resolved conversation store root (default `~/.openhands/conversations-vscode`) before restore runs.
- Changes agent-sdk-ts `FileStore` default root away from `process.cwd()` to `~/.openhands/conversations` so missing `rootDir` can’t write into repos/workspaces.

Tests:
- `npx vitest run src/extension/__tests__/conversationStoreMigration.test.ts`
- `cd packages/agent-sdk-ts && npx vitest run src/sdk/__tests__/persistence.test.ts`
- `npm run build -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversations are now stored in the user's home directory instead of the workspace directory for improved accessibility across projects.
  * Added automatic migration of existing conversations from workspace locations to the new home directory location, with collision detection for duplicate directories.

* **Tests**
  * Added comprehensive test coverage for conversation store migration, including collision-handling scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->