### PR TITLE
Shorten risk tooltip text (oh-tab-mv8)

### DIFF
--- a/src/webview-src/components/SecurityRiskBadge.tsx
+++ b/src/webview-src/components/SecurityRiskBadge.tsx
@@ -17,7 +17,7 @@ const RISK_ICONS: Record<SecurityRiskLevel, string> = {
 };
 
 export function SecurityRiskBadge({ risk, labelSuffix = '' }: { risk: SecurityRiskLevel; labelSuffix?: string }) {
-  const tooltip = `The model assessed ${risk.toLowerCase()} risk for this action.`;
+  const tooltip = `The agent assessed ${risk.toLowerCase()} risk.`;
   const label = `${risk.toLowerCase()}${labelSuffix}`;
 
   return (
@@ -31,4 +31,3 @@ export function SecurityRiskBadge({ risk, labelSuffix = '' }: { risk: SecurityRi
     </Tooltip>
   );
 }
-


### PR DESCRIPTION
Fixes Beads: oh-tab-mv8

Text-only change to prevent the tooltip from forcing a horizontal scrollbar.

Tooltip now reads: `The agent assessed <low|medium|high> risk.`
