### PR TITLE
Truncate encrypted_content in debug LLM request logs (oh-tab-c8i)

### DIFF
--- a/src/extension/__tests__/debugJsonOutputChannel.test.ts
+++ b/src/extension/__tests__/debugJsonOutputChannel.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const appendLines: string[] = [];
+  const createOutputChannel = vi.fn(() => ({
+    appendLine: (line: string) => appendLines.push(line),
+    show: vi.fn(),
+    dispose: vi.fn(),
+  }));
+
+  return { appendLines, createOutputChannel };
+});
+
+vi.mock('vscode', () => ({
+  ExtensionMode: {
+    Development: 1,
+    Test: 2,
+    Production: 3,
+  },
+  workspace: {
+    getConfiguration: () => ({
+      get: () => false,
+    }),
+  },
+  window: {
+    createOutputChannel: mocks.createOutputChannel,
+  },
+}));
+
+import * as vscode from 'vscode';
+import { createDebugJsonOutputChannel } from '../debugJsonOutputChannel';
+
+describe('createDebugJsonOutputChannel', () => {
+  beforeEach(() => {
+    mocks.appendLines.length = 0;
+    mocks.createOutputChannel.mockClear();
+  });
+
+  it('truncates responses_reasoning_item.encrypted_content for display only', () => {
+    const context = { extensionMode: vscode.ExtensionMode.Development, subscriptions: [] } as any;
+    const channel = createDebugJsonOutputChannel({ context });
+    expect(channel.isEnabled()).toBe(true);
+
+    const encrypted = 'abcd0123456789wxyz';
+    const payload = { responses_reasoning_item: { encrypted_content: encrypted } };
+    channel.logJson('LLM_REQUEST', payload);
+
+    expect(payload.responses_reasoning_item.encrypted_content).toBe(encrypted);
+    const printed = mocks.appendLines.join('\n');
+    expect(printed).toContain('"encrypted_content": "abcd…wxyz"');
+  });
+});

--- a/src/extension/debugJsonOutputChannel.ts
+++ b/src/extension/debugJsonOutputChannel.ts
@@ -2,6 +2,12 @@ import * as vscode from 'vscode';
 import { maskSecretsInText } from '../shared/maskSecrets';
 import type { SecretRegistry } from '@openhands/agent-sdk-ts';
 
+function truncateEncryptedContentForDisplay(value: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= 12) return value;
+  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
+}
+
 export interface DebugJsonOutputChannel {
   /** Log JSON data with a category badge and pretty formatting */
   logJson(category: string, data: unknown): void;
@@ -77,7 +83,12 @@ export function createDebugJsonOutputChannel(
 
   const formatJsonPretty = (data: unknown): string => {
     try {
-      const jsonString = JSON.stringify(data, null, 2);
+      const jsonString = JSON.stringify(data, (key: string, value: unknown) => {
+        if (key === 'encrypted_content' && typeof value === 'string') {
+          return truncateEncryptedContentForDisplay(value);
+        }
+        return value;
+      }, 2);
       return maskSecrets(jsonString);
     } catch (e) {
       return `<failed to stringify: ${String(e)}>`;


### PR DESCRIPTION
Fixes Beads: oh-tab-c8i

In OpenHands-DEBUG output, truncate `responses_reasoning_item.encrypted_content` for display only (first 4 + … + last 4) to keep logs readable.

Test:
- `npx vitest run src/extension/__tests__/debugJsonOutputChannel.test.ts`
