### PR TITLE
Add tests for file_editor diff link clicks (oh-tab-j4e)

### DIFF
--- a/src/webview-src/__tests__/fileEditorDiffLink.test.tsx
+++ b/src/webview-src/__tests__/fileEditorDiffLink.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { FileEditorObservationSummary } from '../components/eventBlocks/shared';
+
+const mockApi = { postMessage: vi.fn() };
+
+describe('FileEditorObservationSummary diff link', () => {
+  beforeEach(() => {
+    mockApi.postMessage.mockClear();
+    // @ts-expect-error define VS Code API mock on window
+    window.acquireVsCodeApi = () => mockApi;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('create: clicking the filename posts openWorkspaceDiff (preferGitHead)', async () => {
+    render(
+      <FileEditorObservationSummary
+        observation={{
+          command: 'create',
+          path: 'src/foo.ts',
+          prev_exist: false,
+          old_content: null,
+          new_content: 'console.log(1);',
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'View diff for src/foo.ts' }));
+    expect(mockApi.postMessage).toHaveBeenCalledWith({
+      type: 'openWorkspaceDiff',
+      path: 'src/foo.ts',
+      oldContent: '',
+      newContent: 'console.log(1);',
+      preferGitHead: true,
+    });
+  });
+
+  it('insert: clicking the filename posts openWorkspaceDiff (preferGitHead)', async () => {
+    render(
+      <FileEditorObservationSummary
+        observation={{
+          command: 'insert',
+          path: 'README.md',
+          old_content: 'old',
+          new_content: 'new',
+        }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'View diff for README.md' }));
+    expect(mockApi.postMessage).toHaveBeenCalledWith({
+      type: 'openWorkspaceDiff',
+      path: 'README.md',
+      oldContent: 'old',
+      newContent: 'new',
+      preferGitHead: true,
+    });
+  });
+});
+

--- a/src/webview/host/__tests__/createWebviewMessageHandler.openWorkspaceDiff.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.openWorkspaceDiff.test.ts
@@ -66,5 +66,41 @@ describe('createWebviewMessageHandler(openWorkspaceDiff)', () => {
       }),
     );
   });
-});
 
+  it('uses provided content when preferGitHead is not enabled', async () => {
+    const handler = createWebviewMessageHandler({
+      context: { subscriptions: [] } as any,
+      host: { postMessage: vi.fn(async () => true) },
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp',
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    await handler({
+      type: 'openWorkspaceDiff',
+      path: 'README.md',
+      oldContent: 'OLD CONTENT',
+      newContent: 'NEW CONTENT',
+    });
+
+    expect(resolveGitHeadDiffContents).not.toHaveBeenCalled();
+    expect(showWorkspaceDiff).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: 'README.md',
+        oldContent: 'OLD CONTENT',
+        newContent: 'NEW CONTENT',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Fixes Beads: oh-tab-j4e

Adds webview unit tests verifying that `FileEditorObservationSummary` renders a clickable diff link for `create` and `insert` and that clicking posts `openWorkspaceDiff` with `preferGitHead: true`.

Test:
- `npx vitest run src/webview-src/__tests__/fileEditorDiffLink.test.tsx`
