### PR TITLE
Fix server selector after teleport (oh-tab-z0h)

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -509,6 +509,33 @@ describe('App - Advanced Test Coverage', () => {
         expect(screen.queryByText('Local Mode')).not.toBeInTheDocument();
       });
     });
+
+    it('shows active server label after HAL teleport success', async () => {
+      render(<App />);
+
+      postToWindow({ type: 'configUpdated', serverUrl: null, mode: 'local' });
+
+      await waitFor(() => {
+        expect(screen.getByText('Local Mode')).toBeInTheDocument();
+      });
+
+      postToWindow({
+        type: 'serverListUpdated',
+        servers: [{ url: 'http://localhost:3000', label: 'local-remote' }],
+      });
+      postToWindow({ type: 'status', status: 'online', mode: 'remote' });
+
+      await waitFor(() => {
+        expect(screen.getByText('No Server')).toBeInTheDocument();
+      });
+
+      postToWindow({ type: 'halTeleportSuccess', serverUrl: 'http://localhost:3000', serverLabel: 'local-remote' });
+
+      await waitFor(() => {
+        expect(screen.getByText('local-remote')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('No Server')).not.toBeInTheDocument();
+    });
   });
 
   describe('Conversation lifecycle', () => {

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -536,6 +536,27 @@ describe('App - Advanced Test Coverage', () => {
       });
       expect(screen.queryByText('No Server')).not.toBeInTheDocument();
     });
+
+    it('handles HAL teleport success before serverListUpdated', async () => {
+      render(<App />);
+
+      postToWindow({ type: 'status', status: 'online', mode: 'remote' });
+      postToWindow({ type: 'halTeleportSuccess', serverUrl: 'http://localhost:3000', serverLabel: 'local-remote' });
+
+      await waitFor(() => {
+        expect(screen.getByText('localhost:3000')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('No Server')).not.toBeInTheDocument();
+
+      postToWindow({
+        type: 'serverListUpdated',
+        servers: [{ url: 'http://localhost:3000', label: 'local-remote' }],
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('local-remote')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('Conversation lifecycle', () => {

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -487,6 +487,8 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
         }
         case 'halTeleportSuccess': {
           if (typeof payload.serverUrl === 'string') {
+            currentServerUrlRef.current = payload.serverUrl;
+            setCurrentServerUrl(payload.serverUrl);
             handleHalTeleportSuccess(payload.serverUrl, payload.serverLabel);
           }
           break;


### PR DESCRIPTION
Fixes oh-tab-z0h.

- Webview: on halTeleportSuccess, set currentServerUrl so the Header server selector shows the active server label instead of "No Server".
- Tests: add a webview regression test covering local→remote status + serverListUpdated + halTeleportSuccess.
