### PR TITLE
Add ThinkTool builtin (oh-tab-72c)

### DIFF
--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -626,6 +626,8 @@ In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (se
   5. Wrapping the returned result in an `ObservationEvent` where `observation` is a plain JSON object.
 - Event interfaces in `src/sdk/types/index.ts` mirror the Python wire format: `ActionEvent` and `ObservationEvent` are present, but they carry raw records (`Record<string, unknown>`) instead of strongly-typed `Action`/`Observation` models.
 
+**Built-in tools parity note:** Python includes built-in `finish` and `think` tools by default. TypeScript now includes both as built-ins in `src/sdk/runtime/Agent.ts` (unless `includeDefaultTools === false`), matching the Python tool surface for “log a thought without side effects” workflows.
+
 ### Gaps and intended direction
 
 - The TS runtime currently has **ActionEvent/ObservationEvent types but no first-class Action/Observation classes**. The Python stack uses Pydantic models for validation, kind resolution, and serialization; TS simply forwards validated args/results as plain JSON.

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -31,6 +31,7 @@ import type { ToolDefinition } from '../types/tools';
 import type { BaseWorkspace } from '../../workspace';
 import { Workspace } from '../../workspace';
 import { FinishTool } from '../../tools/FinishTool';
+import { ThinkTool } from '../../tools/ThinkTool';
 import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
@@ -162,12 +163,14 @@ export class Agent extends EventEmitter {
       injectedClient: options.toolSummarizerClient,
     });
     const providedTools = options.tools ?? [];
-    const toolsWithFinish = (() => {
+    const toolsWithBuiltins = (() => {
       if (options.includeDefaultTools === false) return providedTools;
-      if (providedTools.some((tool) => tool.name === 'finish')) return providedTools;
-      return [...providedTools, new FinishTool()];
+      const byName = new Map<string, ToolDefinition<unknown, unknown>>(providedTools.map((tool) => [tool.name, tool]));
+      if (!byName.has('finish')) byName.set('finish', new FinishTool());
+      if (!byName.has('think')) byName.set('think', new ThinkTool());
+      return Array.from(byName.values());
     })();
-    this.tools = new Map(toolsWithFinish.map((tool) => [tool.name, tool]));
+    this.tools = new Map(toolsWithBuiltins.map((tool) => [tool.name, tool]));
     this.registry = options.registry;
     this.conversationStats = options.conversationStats;
     this.agentContext = options.agentContext;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -165,10 +165,11 @@ export class Agent extends EventEmitter {
     const providedTools = options.tools ?? [];
     const toolsWithBuiltins = (() => {
       if (options.includeDefaultTools === false) return providedTools;
-      const byName = new Map<string, ToolDefinition<unknown, unknown>>(providedTools.map((tool) => [tool.name, tool]));
-      if (!byName.has('finish')) byName.set('finish', new FinishTool());
-      if (!byName.has('think')) byName.set('think', new ThinkTool());
-      return Array.from(byName.values());
+      const names = new Set(providedTools.map((tool) => tool.name));
+      const result = [...providedTools];
+      if (!names.has('finish')) result.push(new FinishTool());
+      if (!names.has('think')) result.push(new ThinkTool());
+      return result;
     })();
     this.tools = new Map(toolsWithBuiltins.map((tool) => [tool.name, tool]));
     this.registry = options.registry;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.builtin-tools.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.builtin-tools.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class RecordingLLM implements LLMClient {
+  readonly requests: ChatCompletionRequest[] = [];
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
+    yield { type: 'text', text: 'ok' };
+    yield { type: 'finish' };
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 1 },
+  confirmation: { policy: 'never' },
+  secrets: {},
+};
+
+describe('Agent builtin tools', () => {
+  it('includes finish and think when includeDefaultTools is not false', async () => {
+    const llm = new RecordingLLM();
+    const log = new EventLog();
+    const agent = new Agent({ settings: baseSettings, events: log, llmClient: llm });
+
+    await agent.run('hi');
+
+    const tools = llm.requests[0]?.tools ?? [];
+    const names = tools.map((t) => t.function?.name).filter((v): v is string => typeof v === 'string');
+    expect(names).toContain('finish');
+    expect(names).toContain('think');
+  });
+
+  it('omits builtin tools when includeDefaultTools is false', async () => {
+    const llm = new RecordingLLM();
+    const log = new EventLog();
+    const agent = new Agent({ settings: baseSettings, events: log, llmClient: llm, includeDefaultTools: false });
+
+    await agent.run('hi');
+
+    expect(llm.requests[0]?.tools ?? []).toHaveLength(0);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/tools/ThinkTool.ts
+++ b/packages/agent-sdk-ts/src/tools/ThinkTool.ts
@@ -12,16 +12,7 @@ export type ThinkToolResult = {
   message: string;
 };
 
-const THINK_DESCRIPTION = `Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed.
-
-Common use cases:
-1. When exploring a repository and discovering the source of a bug, call this tool to brainstorm several unique ways of fixing the bug, and assess which change(s) are likely to be simplest and most effective.
-2. After receiving test results, use this tool to brainstorm ways to fix failing tests.
-3. When planning a complex refactoring, use this tool to outline different approaches and their tradeoffs.
-4. When designing a new feature, use this tool to think through architecture decisions and implementation details.
-5. When debugging a complex issue, use this tool to organize your thoughts and hypotheses.
-
-The tool simply logs your thought process for better transparency and does not execute any code or make changes.`;
+const THINK_DESCRIPTION = 'Log a thought without making changes. Use for planning, brainstorming, or organizing hypotheses.';
 
 export class ThinkTool extends ZodTool<ThinkToolArgs, ThinkToolResult> {
   readonly name = 'think';
@@ -33,4 +24,3 @@ export class ThinkTool extends ZodTool<ThinkToolArgs, ThinkToolResult> {
     return { message: 'Your thought has been logged.' };
   }
 }
-

--- a/packages/agent-sdk-ts/src/tools/ThinkTool.ts
+++ b/packages/agent-sdk-ts/src/tools/ThinkTool.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import type { ToolContext } from './types';
+import { ZodTool } from './zod-tool';
+
+const thinkSchema = z.object({
+  thought: z.string().min(1).describe('The thought to log.'),
+});
+
+export type ThinkToolArgs = z.infer<typeof thinkSchema>;
+
+export type ThinkToolResult = {
+  message: string;
+};
+
+const THINK_DESCRIPTION = `Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed.
+
+Common use cases:
+1. When exploring a repository and discovering the source of a bug, call this tool to brainstorm several unique ways of fixing the bug, and assess which change(s) are likely to be simplest and most effective.
+2. After receiving test results, use this tool to brainstorm ways to fix failing tests.
+3. When planning a complex refactoring, use this tool to outline different approaches and their tradeoffs.
+4. When designing a new feature, use this tool to think through architecture decisions and implementation details.
+5. When debugging a complex issue, use this tool to organize your thoughts and hypotheses.
+
+The tool simply logs your thought process for better transparency and does not execute any code or make changes.`;
+
+export class ThinkTool extends ZodTool<ThinkToolArgs, ThinkToolResult> {
+  readonly name = 'think';
+  readonly description = THINK_DESCRIPTION;
+  readonly schema = thinkSchema;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async execute(_args: ThinkToolArgs, _context: ToolContext): Promise<ThinkToolResult> {
+    return { message: 'Your thought has been logged.' };
+  }
+}
+

--- a/packages/agent-sdk-ts/src/tools/__tests__/ThinkTool.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/ThinkTool.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { ThinkTool } from '../ThinkTool';
+import { LocalWorkspace } from '../../workspace';
+
+describe('ThinkTool', () => {
+  it('validates thought and returns a logged message', async () => {
+    const tool = new ThinkTool();
+    expect(() => tool.validate({})).toThrow();
+
+    const args = tool.validate({ thought: 'Consider edge cases' });
+    const result = await tool.execute(args, { workspace: new LocalWorkspace(process.cwd()) });
+    expect(result.message).toBe('Your thought has been logged.');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/tools/index.ts
+++ b/packages/agent-sdk-ts/src/tools/index.ts
@@ -3,6 +3,7 @@ export * from './TerminalTool';
 export * from './FileEditorTool';
 export * from './TaskTrackerTool';
 export * from './FinishTool';
+export * from './ThinkTool';
 export * from './BrowserTool';
 export * from './BrowserUseTool';
 export * from './DelegateTool';


### PR DESCRIPTION
Fixes oh-tab-72c.

- Add ThinkTool (name: think) with schema { thought: string }.
- Auto-include think + finish as built-in tools in Agent unless includeDefaultTools is false.
- Add unit tests and update python-parity doc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the "think" tool as a built-in default tool, enabling agents to log and reflect on thoughts during execution.

* **Documentation**
  * Updated the parity guide to document that built-in tools (finish and think) are included by default in the TypeScript runtime, aligning with the Python SDK.

* **Tests**
  * Added tests validating think tool functionality and built-in tools behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->