### PR TITLE
Parity: ThinkTool matches Python (oh-tab-o6i)

### DIFF
--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -628,6 +628,13 @@ In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (se
 
 **Built-in tools parity note:** Python includes built-in `finish` and `think` tools by default. TypeScript now includes both as built-ins in `src/sdk/runtime/Agent.ts` (unless `includeDefaultTools === false`), matching the Python tool surface for “log a thought without side effects” workflows.
 
+#### ThinkTool details
+
+- **Tool name:** Python `think`; TypeScript `think`.
+- **Input schema:** Python `{ thought: string }`; TypeScript `{ thought: string }` (required).
+- **Behavior:** no side effects; returns a simple confirmation message which is emitted as a tool message and included in subsequent LLM requests.
+- **Description text:** Python’s built-in tool description is long and includes usage examples. TypeScript intentionally keeps this description short to avoid inflating every tool-list/system-prompt payload; the guidance is deliberately equivalent (“log a thought without side effects”).
+
 ### Gaps and intended direction
 
 - The TS runtime currently has **ActionEvent/ObservationEvent types but no first-class Action/Observation classes**. The Python stack uses Pydantic models for validation, kind resolution, and serialization; TS simply forwards validated args/results as plain JSON.

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.think-tool-parity.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.think-tool-parity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import type { ChatCompletionRequest, LLMClient, LLMStreamChunk } from '../../llm';
+import { Agent, EventLog } from '..';
+import type { OpenHandsSettings } from '../../types/settings';
+
+class ThinkThenFinishLLM implements LLMClient {
+  readonly requests: ChatCompletionRequest[] = [];
+
+  async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
+    this.requests.push(request);
+
+    if (this.requests.length === 1) {
+      yield { type: 'tool_call_delta', id: 'tool_think', name: 'think', arguments: '{"thought":"hello"}' };
+      yield { type: 'finish' };
+      return;
+    }
+
+    yield { type: 'text', text: 'done' };
+    yield { type: 'finish' };
+  }
+}
+
+const baseSettings: OpenHandsSettings = {
+  llm: { model: 'test-model' },
+  agent: {},
+  conversation: { maxIterations: 2 },
+  confirmation: { policy: 'never' },
+  secrets: {},
+};
+
+describe('ThinkTool parity', () => {
+  it('includes think observation output in the next LLM request context', async () => {
+    const llm = new ThinkThenFinishLLM();
+    const log = new EventLog();
+    const agent = new Agent({ settings: baseSettings, events: log, llmClient: llm });
+
+    await agent.run('hi');
+
+    expect(llm.requests).toHaveLength(2);
+
+    const second = llm.requests[1];
+    const thinkToolMessage = second.messages.find((m) => m.role === 'tool' && m.name === 'think');
+    expect(thinkToolMessage).toBeDefined();
+    const toolText = thinkToolMessage?.content?.[0]?.type === 'text' ? thinkToolMessage.content[0].text : '';
+    expect(toolText).toContain('Your thought has been logged.');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/tools/ThinkTool.ts
+++ b/packages/agent-sdk-ts/src/tools/ThinkTool.ts
@@ -12,7 +12,7 @@ export type ThinkToolResult = {
   message: string;
 };
 
-const THINK_DESCRIPTION = 'Log a thought without making changes. Use for planning, brainstorming, or organizing hypotheses.';
+const THINK_DESCRIPTION = 'Log a thought without side effects. This tool does not execute code or modify the workspace.';
 
 export class ThinkTool extends ZodTool<ThinkToolArgs, ThinkToolResult> {
   readonly name = 'think';


### PR DESCRIPTION
Fixes oh-tab-o6i.

- Keep `think` tool description short but explicit about no side effects.
- Add runtime unit test asserting the `think` tool message is included in the next LLM request.
- Document Python vs TS ThinkTool parity in `packages/agent-sdk-ts/docs/python-parity.md`.
