### PR TITLE
HUMAN OVERSEER COMMENT - Parity: ThinkTool description matches Python SDK

### DIFF
--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -626,7 +626,11 @@ In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (se
   5. Wrapping the returned result in an `ObservationEvent` where `observation` is a plain JSON object.
 - Event interfaces in `src/sdk/types/index.ts` mirror the Python wire format: `ActionEvent` and `ObservationEvent` are present, but they carry raw records (`Record<string, unknown>`) instead of strongly-typed `Action`/`Observation` models.
 
-**Built-in tools parity note:** Python includes built-in `finish` and `think` tools by default. TypeScript now includes both as built-ins in `src/sdk/runtime/Agent.ts` (unless `includeDefaultTools === false`), matching the Python tool surface for “log a thought without side effects” workflows.
+**Built-in tools parity note (product decision / source of truth):** Python includes built-in `finish` and `think` tools by default. TypeScript includes both as built-ins in `src/sdk/runtime/Agent.ts` (unless `includeDefaultTools === false`).
+
+For `think`, **the TypeScript SDK MUST keep the tool description text identical to the Python SDK** (i.e., copy the Python `THINK_DESCRIPTION` verbatim). Even though the TS implementation is simpler, the tool description is part of the LLM-facing contract and directly affects agent behavior. We prioritize **cross-SDK behavioral parity** over minimizing prompt size for this specific tool.
+
+If any future optimization is desired (e.g., shorter descriptions to reduce prompt tokens), it must be treated as an explicit product decision and applied consistently across Python and TS (not a TS-only divergence).
 
 ### Gaps and intended direction
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -630,7 +630,7 @@ In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (se
 
 For `think`, **the TypeScript SDK MUST keep the tool description text identical to the Python SDK** (i.e., copy the Python `THINK_DESCRIPTION` verbatim). Even though the TS implementation is simpler, the tool description is part of the LLM-facing contract and directly affects agent behavior. We prioritize **cross-SDK behavioral parity** over minimizing prompt size for all common tools.
 
-If any future optimization is desired (e.g., shorter descriptions to reduce prompt tokens), it must be treated as an explicit product decision and applied consistently across Python and TS (not a TS-only divergence).
+If any future optimization is desired (e.g., shorter descriptions to reduce prompt tokens), it must be treated as an explicit product decision, applied consistently across Python and TS (not a TS-only divergence) and approved by Mail by the Human Overseer.
 
 ### Gaps and intended direction
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -628,7 +628,7 @@ In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (se
 
 **Built-in tools parity note (product decision / source of truth):** Python includes built-in `finish` and `think` tools by default. TypeScript includes both as built-ins in `src/sdk/runtime/Agent.ts` (unless `includeDefaultTools === false`).
 
-For `think`, **the TypeScript SDK MUST keep the tool description text identical to the Python SDK** (i.e., copy the Python `THINK_DESCRIPTION` verbatim). Even though the TS implementation is simpler, the tool description is part of the LLM-facing contract and directly affects agent behavior. We prioritize **cross-SDK behavioral parity** over minimizing prompt size for this specific tool.
+For `think`, **the TypeScript SDK MUST keep the tool description text identical to the Python SDK** (i.e., copy the Python `THINK_DESCRIPTION` verbatim). Even though the TS implementation is simpler, the tool description is part of the LLM-facing contract and directly affects agent behavior. We prioritize **cross-SDK behavioral parity** over minimizing prompt size for all common tools.
 
 If any future optimization is desired (e.g., shorter descriptions to reduce prompt tokens), it must be treated as an explicit product decision and applied consistently across Python and TS (not a TS-only divergence).
 

--- a/packages/agent-sdk-ts/src/tools/ThinkTool.ts
+++ b/packages/agent-sdk-ts/src/tools/ThinkTool.ts
@@ -12,7 +12,16 @@ export type ThinkToolResult = {
   message: string;
 };
 
-const THINK_DESCRIPTION = 'Log a thought without making changes. Use for planning, brainstorming, or organizing hypotheses.';
+const THINK_DESCRIPTION = `Use the tool to think about something. It will not obtain new information or make any changes to the repository, but just log the thought. Use it when complex reasoning or brainstorming is needed.
+
+Common use cases:
+1. When exploring a repository and discovering the source of a bug, call this tool to brainstorm several unique ways of fixing the bug, and assess which change(s) are likely to be simplest and most effective.
+2. After receiving test results, use this tool to brainstorm ways to fix failing tests.
+3. When planning a complex refactoring, use this tool to outline different approaches and their tradeoffs.
+4. When designing a new feature, use this tool to think through architecture decisions and implementation details.
+5. When debugging a complex issue, use this tool to organize your thoughts and hypotheses.
+
+The tool simply logs your thought process for better transparency and does not execute any code or make changes.`;
 
 export class ThinkTool extends ZodTool<ThinkToolArgs, ThinkToolResult> {
   readonly name = 'think';


### PR DESCRIPTION
Restores the ThinkTool tool description in `@openhands/agent-sdk-ts` to match the Python SDK (enyst/agent-sdk) exactly.

Rationale: agent-sdk-ts is intended to be a transpilation of the Python SDK, and the tool description must remain identical so the LLM receives the same tool context whether calls come from Python or TS.

Changes:
- Update `packages/agent-sdk-ts/src/tools/ThinkTool.ts` to use the original Python `THINK_DESCRIPTION` text.

Tests:
- `npm test -w @openhands/agent-sdk-ts`

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7f5699301d6b41ee964b62464671760d)