### PR TITLE
Remote mode: show Tools picker

### DIFF
--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebviewMessageHandler } from '../webview/host/createWebviewMessageHandler';
 
 describe('Tools picker host messages', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   const createHandler = (conversation?: any) => {
     const postMessage = vi.fn(async () => true);
     const handler = createWebviewMessageHandler({
@@ -9,6 +14,30 @@ describe('Tools picker host messages', () => {
       host: { postMessage },
       getConversation: () => conversation,
       getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp',
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    return { handler, postMessage };
+  };
+
+  const createRemoteHandler = (conversation?: any) => {
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context: {} as any,
+      host: { postMessage },
+      getConversation: () => conversation,
+      getConversationMode: () => 'remote',
       getConversationStoreRoot: () => undefined,
       resolveConversationStoreRoot: async () => '/tmp',
       setWebviewReadyState: () => {},
@@ -52,6 +81,43 @@ describe('Tools picker host messages', () => {
       { id: 'browser', label: 'Web Fetch', description: 'Make HTTP GET/POST requests to fetch web content', isDefault: false },
       { id: 'finish', label: 'Finish', description: 'Signal that the agent has completed its task (always enabled)', isDefault: true },
     ]);
+  });
+
+  it('responds to requestTools in remote mode with the agent-server tools list when available', async () => {
+    const fetchSpy = vi.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(['execute_bash', 'finish', 'file_edit']),
+      text: () => Promise.resolve(''),
+    } as unknown as Response));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = {
+      serverUrl: 'http://localhost:3000',
+      settings: { secrets: { sessionApiKey: 'test-key-123' } },
+    };
+
+    const { handler, postMessage } = createRemoteHandler(conversation);
+    await handler({ type: 'requestTools' } as any);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/\/api\/tools\/$/);
+    expect(fetchSpy.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        'X-Session-API-Key': 'test-key-123',
+      }),
+    }));
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'toolsList',
+      tools: [
+        { id: 'execute_bash', label: 'execute_bash' },
+        { id: 'finish', label: 'finish' },
+        { id: 'file_edit', label: 'file_edit' },
+      ],
+      enabledToolIds: ['execute_bash', 'finish', 'file_edit'],
+    });
   });
 
   it('applies setEnabledTools by calling conversation.setTools', async () => {

--- a/src/webview-src/__tests__/App.toolsPicker.test.tsx
+++ b/src/webview-src/__tests__/App.toolsPicker.test.tsx
@@ -114,4 +114,40 @@ describe('Tools picker', () => {
     expect(screen.getByTestId('status-row')).toHaveTextContent('To change Tools, please start a new conversation.');
     expect(screen.getByLabelText('Terminal')).toHaveAttribute('aria-selected', 'true');
   });
+
+  it('shows tools in remote mode as read-only', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'remote' }
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'toolsList',
+          tools: [
+            { id: 'execute_bash', label: 'execute_bash' },
+            { id: 'file_edit', label: 'file_edit' },
+            { id: 'finish', label: 'finish' },
+          ],
+          enabledToolIds: ['execute_bash', 'file_edit', 'finish'],
+        }
+      }));
+    });
+
+    const toolsButton = await screen.findByRole('button', { name: 'Tools' });
+    expect(toolsButton).toHaveTextContent('3');
+
+    mockApi.postMessage.mockClear();
+    await act(async () => {
+      fireEvent.click(toolsButton);
+    });
+    expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestTools' });
+
+    expect(await screen.findByText(/controlled by the agent-server/i)).toBeInTheDocument();
+
+    const bashRow = await screen.findByLabelText('execute_bash');
+    expect(bashRow).toBeDisabled();
+    expect(bashRow).toHaveAttribute('aria-selected', 'true');
+  });
 });

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -166,7 +166,7 @@ describe('Agent-SDK event rendering', () => {
       kind: 'SystemPromptEvent',
       source: 'agent' as const,
       system_prompt: { type: 'text' as const, text: 'You are a helpful AI assistant designed for testing' },
-      tools: [{ name: 'bash' }, { name: 'read' }, { name: 'write' }]
+      tools: [{ name: 'bash' }, { name: 'read' }, { name: 'write' }, { type: 'web_search_preview' }]
     } as any;
     postToWindow({ type: 'event', event: ev });
     const toggle = await screen.findByRole('button', { name: /Show system prompt/i });
@@ -174,7 +174,7 @@ describe('Agent-SDK event rendering', () => {
     expect(await screen.findByText(/You are a helpful AI assistant designed for testing/)).toBeInTheDocument();
 
     const skillsRow = await screen.findByRole('button', { name: /2 skills loaded/i });
-    const toolsRow = await screen.findByRole('button', { name: /3 tools available/i });
+    const toolsRow = await screen.findByRole('button', { name: /4 tools available/i });
 
     fireEvent.click(skillsRow);
     expect(await screen.findByText('react-skill')).toBeInTheDocument();
@@ -184,6 +184,7 @@ describe('Agent-SDK event rendering', () => {
     expect(await screen.findByText('bash')).toBeInTheDocument();
     expect(await screen.findByText('read')).toBeInTheDocument();
     expect(await screen.findByText('write')).toBeInTheDocument();
+    expect(await screen.findByText('web_search_preview')).toBeInTheDocument();
   });
 
   it('renders ActionEvent', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -76,7 +76,7 @@ export function App() {
   const [showSkillsPopover, setShowSkillsPopover] = useState(false);
   const [skills, setSkills] = useState<{ label: string; path: string }[]>([]);
 
-  // Tools state (local mode only)
+  // Tools state
   const [showToolsPopover, setShowToolsPopover] = useState(false);
   const [tools, setTools] = useState<{ id: string; label: string; description?: string; isDefault?: boolean }[]>([]);
   const [enabledToolIds, setEnabledToolIds] = useState<string[]>([]);
@@ -585,6 +585,11 @@ export function App() {
   }, [postMessage]);
 
   const handleToggleTool = useCallback((toolId: string) => {
+    if (mode !== 'local') {
+      showStatusMessage('info', 'Tools are controlled by the agent-server in remote mode.', { autoDismiss: true, autoDismissDelay: 4000 });
+      return;
+    }
+
     if (isToolSelectionLocked) {
       showStatusMessage('info', 'To change Tools, please start a new conversation.', { autoDismiss: true, autoDismissDelay: 4000 });
       return;
@@ -607,7 +612,7 @@ export function App() {
       postMessage({ type: 'setEnabledTools', toolIds: ordered });
       return ordered;
     });
-  }, [isToolSelectionLocked, postMessage, showStatusMessage, tools]);
+  }, [isToolSelectionLocked, mode, postMessage, showStatusMessage, tools]);
 
   // History handlers
   const handleSelectConversation = useCallback((id: string) => {
@@ -757,12 +762,13 @@ export function App() {
             skillsPopoverSkills: skills,
             onOpenSkill: handleOpenSkill,
             onCloseSkillsPopover: () => setShowSkillsPopover(false),
-            onOpenTools: mode === 'local' ? handleOpenTools : undefined,
-            toolsCount: enabledToolIds.length,
+            onOpenTools: handleOpenTools,
+            toolsCount: mode === 'local' ? enabledToolIds.length : tools.length,
             showToolsPopover,
             toolsPopoverTools: tools,
             enabledToolIds,
             onToggleTool: handleToggleTool,
+            toolsReadOnly: mode !== 'local',
             onCloseToolsPopover: () => setShowToolsPopover(false),
             onOpenAttachments: handleOpenAttachments,
             attachments,

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -35,13 +35,14 @@ interface InputAreaProps {
   skillsPopoverSkills?: Array<{ label: string; path: string }>;
   onOpenSkill?: (path: string) => void;
   onCloseSkillsPopover?: (reason: CloseReason) => void;
-  // Tools (local mode only)
+  // Tools
   onOpenTools?: () => void;
   toolsCount?: number;
   showToolsPopover?: boolean;
   toolsPopoverTools?: Array<{ id: string; label: string }>;
   enabledToolIds?: string[];
   onToggleTool?: (toolId: string) => void;
+  toolsReadOnly?: boolean;
   onCloseToolsPopover?: (reason: CloseReason) => void;
   // Attachments
   onOpenAttachments?: () => void;
@@ -93,6 +94,7 @@ export function InputArea({
   toolsPopoverTools = [],
   enabledToolIds = [],
   onToggleTool,
+  toolsReadOnly = false,
   onCloseToolsPopover,
   onOpenAttachments,
   attachments = [],
@@ -334,6 +336,7 @@ export function InputArea({
                   tools={toolsPopoverTools}
                   enabledToolIds={enabledToolIds}
                   onToggleTool={onToggleTool}
+                  readOnly={toolsReadOnly}
                 />
               )}
             </div>

--- a/src/webview-src/components/eventBlocks/SystemPromptEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/SystemPromptEventBlock.tsx
@@ -15,12 +15,25 @@ const getToolDisplayName = (tool: Record<string, unknown>, index: number): strin
   const direct = getNonEmptyString(tool.name);
   if (direct) return direct;
 
+  const type = getNonEmptyString(tool.type);
+
   const functionField = tool.function;
   if (functionField && typeof functionField === 'object') {
-    const name = getNonEmptyString((functionField as Record<string, unknown>).name);
+    const functionRecord = functionField as Record<string, unknown>;
+    const name = getNonEmptyString(functionRecord.name);
     if (name) return name;
+
+    const nestedFunction = functionRecord.function;
+    if (nestedFunction && typeof nestedFunction === 'object') {
+      const nestedName = getNonEmptyString((nestedFunction as Record<string, unknown>).name);
+      if (nestedName) return nestedName;
+    }
   }
 
+  const fallback = getNonEmptyString(tool.id) ?? getNonEmptyString(tool.tool_name);
+  if (fallback) return fallback;
+
+  if (type) return type;
   return `tool_${index + 1}`;
 };
 

--- a/src/webview-src/components/inputArea/ToolsPopover.tsx
+++ b/src/webview-src/components/inputArea/ToolsPopover.tsx
@@ -14,6 +14,7 @@ interface ToolsPopoverProps {
   tools: ToolDescriptor[];
   enabledToolIds: string[];
   onToggleTool: (toolId: string) => void;
+  readOnly?: boolean;
 }
 
 function ToolButton({
@@ -79,6 +80,7 @@ export function ToolsPopover({
   tools,
   enabledToolIds,
   onToggleTool,
+  readOnly = false,
 }: ToolsPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const listboxRef = useRef<HTMLDivElement>(null);
@@ -131,6 +133,7 @@ export function ToolsPopover({
       const tool = tools[safeActiveIndex < 0 ? 0 : safeActiveIndex];
       if (!tool) return;
       e.preventDefault();
+      if (readOnly) return;
       onToggleTool(tool.id);
     }
   };
@@ -157,7 +160,9 @@ export function ToolsPopover({
           <span className="codicon codicon-tools text-brand-400" />
           <h3 className="font-semibold text-sm text-stone-200">Tools</h3>
         </div>
-        <div className="mt-1 text-xs text-stone-500">Select which tools the agent can use</div>
+        <div className="mt-1 text-xs text-stone-500">
+          {readOnly ? 'Tools are controlled by the agent-server in remote mode' : 'Select which tools the agent can use'}
+        </div>
       </div>
 
       <div
@@ -184,14 +189,17 @@ export function ToolsPopover({
                     const globalIndex = allToolsFlat.findIndex((t) => t.id === tool.id);
                     const isEnabled = enabledToolIds.includes(tool.id);
                     const isActive = globalIndex === safeActiveIndex;
-                    const isLocked = tool.id === 'finish';
+                    const isLocked = tool.id === 'finish' || readOnly;
                     return (
                       <ToolButton
                         key={tool.id}
                         tool={tool}
                         isEnabled={isEnabled}
                         isActive={isActive}
-                        onToggle={() => onToggleTool(tool.id)}
+                        onToggle={() => {
+                          if (readOnly) return;
+                          onToggleTool(tool.id);
+                        }}
                         onMouseEnter={() => setActiveIndex(globalIndex)}
                         id={`tools-picker-option-${globalIndex}`}
                         disabled={isLocked}
@@ -213,14 +221,17 @@ export function ToolsPopover({
                     const globalIndex = allToolsFlat.findIndex((t) => t.id === tool.id);
                     const isEnabled = enabledToolIds.includes(tool.id);
                     const isActive = globalIndex === safeActiveIndex;
-                    const isLocked = tool.id === 'finish';
+                    const isLocked = tool.id === 'finish' || readOnly;
                     return (
                       <ToolButton
                         key={tool.id}
                         tool={tool}
                         isEnabled={isEnabled}
                         isActive={isActive}
-                        onToggle={() => onToggleTool(tool.id)}
+                        onToggle={() => {
+                          if (readOnly) return;
+                          onToggleTool(tool.id);
+                        }}
                         onMouseEnter={() => setActiveIndex(globalIndex)}
                         id={`tools-picker-option-${globalIndex}`}
                         disabled={isLocked}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -71,6 +71,54 @@ const ensureRequiredLocalToolIds = (toolIds: LocalToolId[]): LocalToolId[] => {
   return [...toolIds, 'finish'];
 };
 
+type RemoteToolListDeps = {
+  serverUrl: string;
+  sessionApiKey?: string;
+};
+
+const getRemoteToolListDeps = (conversation: unknown): RemoteToolListDeps | null => {
+  if (!conversation || typeof conversation !== 'object') return null;
+  const candidate = conversation as { [k: string]: unknown };
+  const serverUrl = candidate.serverUrl;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) return null;
+
+  const rawSessionKey =
+    (candidate.settings as { secrets?: { sessionApiKey?: unknown } } | undefined)?.secrets?.sessionApiKey;
+  const sessionApiKey = typeof rawSessionKey === 'string' && rawSessionKey.trim().length > 0 ? rawSessionKey : undefined;
+  return { serverUrl: serverUrl.trim(), sessionApiKey };
+};
+
+async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[] | null> {
+  const normalized = normalizeServerUrl(params.serverUrl);
+  if (!normalized.ok) return null;
+  const url = `${normalized.url}/api/tools/`;
+  const headers: Record<string, string> = {};
+  if (params.sessionApiKey) {
+    headers['X-Session-API-Key'] = params.sessionApiKey;
+  }
+
+  const fetchFn = globalThis.fetch;
+  if (typeof fetchFn !== 'function') return null;
+
+  try {
+    const res = await fetchFn(url, { method: 'GET', headers });
+    if (!res.ok) return null;
+    const payload = await res.json();
+    if (!Array.isArray(payload)) return null;
+
+    const out: string[] = [];
+    for (const tool of payload) {
+      if (typeof tool !== 'string') continue;
+      const trimmed = tool.trim();
+      if (!trimmed) continue;
+      out.push(trimmed);
+    }
+    return out;
+  } catch {
+    return null;
+  }
+}
+
 export type CreateWebviewMessageHandlerDeps = {
   context: vscode.ExtensionContext;
   host: WebviewHost;
@@ -142,10 +190,14 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
   let elevenlabsTtsGate: TtsConversationGate | null = null;
 
-  const postToolsList = (): void => {
+  const postToolsList = async (): Promise<void> => {
     const mode = deps.getConversationMode();
     if (mode !== 'local') {
-      void host.postMessage({ type: 'toolsList', tools: [], enabledToolIds: [] });
+      const conversation = deps.getConversation();
+      const remoteDeps = getRemoteToolListDeps(conversation);
+      const toolNames = remoteDeps ? await fetchRemoteToolNames(remoteDeps) : null;
+      const tools = (toolNames ?? []).map((name) => ({ id: name, label: name }));
+      void host.postMessage({ type: 'toolsList', tools, enabledToolIds: toolNames ?? [] });
       return;
     }
 
@@ -302,7 +354,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           activeProfileId: initSettings.llm.profileId ?? null,
         });
 
-        postToolsList();
+        await postToolsList();
 
         void host.postMessage({
           type: 'serverListUpdated',
@@ -339,7 +391,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'requestTools': {
-        postToolsList();
+        await postToolsList();
         break;
       }
       case 'setEnabledTools': {
@@ -367,7 +419,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           void host.postMessage({ type: 'statusMessage', level: 'info', message: reason, autoDismiss: true, autoDismissDelay: 4000 });
         }
 
-        postToolsList();
+        await postToolsList();
         break;
       }
       case 'openSkill': {
@@ -1189,7 +1241,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
                 const reason = err instanceof Error ? err.message : String(err);
                 outputChannel?.appendLine(`[tools] Failed to reset tools: ${reason}`);
               }
-              postToolsList();
+              await postToolsList();
             }
             break;
           }

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -100,8 +100,12 @@ async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[
   const fetchFn = globalThis.fetch;
   if (typeof fetchFn !== 'function') return null;
 
+  const abortController = new AbortController();
+  const timeoutMs = 4000;
+  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+
   try {
-    const res = await fetchFn(url, { method: 'GET', headers });
+    const res = await fetchFn(url, { method: 'GET', headers, signal: abortController.signal });
     if (!res.ok) return null;
     const payload = await res.json();
     if (!Array.isArray(payload)) return null;
@@ -116,6 +120,8 @@ async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[
     return out;
   } catch {
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 
@@ -354,7 +360,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           activeProfileId: initSettings.llm.profileId ?? null,
         });
 
-        await postToolsList();
+        void postToolsList();
 
         void host.postMessage({
           type: 'serverListUpdated',


### PR DESCRIPTION
Fixes oh-tab-b0x.

- Show Tools button in remote mode (read-only).
- Host fetches /api/tools/ from the connected agent-server to populate the list.
- System Prompt tools list displays a better fallback name (type/id) instead of tool_1 style placeholders.
- Adds/updates unit tests for host + webview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added remote mode support for tools selection—tools are now fetched from a remote server and displayed as read-only in remote mode.

* **Tests**
  * Added comprehensive test coverage for remote mode tools picker functionality, including remote API endpoint validation and authentication header verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->