### PR TITLE
Docs: align ThinkTool parity note

### DIFF
--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -637,7 +637,7 @@ If any future optimization is desired (e.g., shorter descriptions to reduce prom
 - **Tool name:** Python `think`; TypeScript `think`.
 - **Input schema:** Python `{ thought: string }`; TypeScript `{ thought: string }` (required).
 - **Behavior:** no side effects; returns a simple confirmation message which is emitted as a tool message and included in subsequent LLM requests.
-- **Description text:** Python’s built-in tool description is long and includes usage examples. TypeScript intentionally keeps this description short to avoid inflating every tool-list/system-prompt payload; the guidance is deliberately equivalent (“log a thought without side effects”).
+- **Description text:** TypeScript matches Python’s built-in tool description verbatim (including usage examples) for parity, per HUMAN OVERSEER guidance. This is longer but ensures identical tool guidance across SDKs.
 
 ### Gaps and intended direction
 


### PR DESCRIPTION
Follow-up to #738: packages/agent-sdk-ts/docs/python-parity.md still claimed TS keeps the think tool description short. Update to reflect the HUMAN OVERSEER decision that TS matches Python’s ThinkTool description verbatim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Think tool description to reflect parity between TypeScript and Python SDKs. Tool descriptions now match verbatim across implementations to ensure consistent guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->