### PR TITLE
Webview: rename Tool Result to Environment Result

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -215,7 +215,7 @@ describe('Agent-SDK event rendering', () => {
       action_id: 'action_obs_1'
     } as any;
     postToWindow({ type: 'event', event: ev });
-    const toggle = await screen.findByRole('button', { name: /Show tool result/i });
+    const toggle = await screen.findByRole('button', { name: /Show environment result/i });
     fireEvent.click(toggle);
     expect(await screen.findByText(/Directory listing output from bash execution/)).toBeInTheDocument();
   });
@@ -344,7 +344,7 @@ describe('Agent-SDK event rendering', () => {
     } as any;
     postToWindow({ type: 'event', event: observationEvent });
     await screen.findByText(/Agent read/);
-    const toggle = await screen.findByRole('button', { name: /Show tool result/i });
+    const toggle = await screen.findByRole('button', { name: /Show environment result/i });
     expect(screen.queryByText(/SECRET FILE CONTENT/)).toBeNull();
     fireEvent.click(toggle);
     expect(await screen.findByText(/SECRET FILE CONTENT/)).toBeInTheDocument();
@@ -371,7 +371,7 @@ describe('Agent-SDK event rendering', () => {
     postToWindow({ type: 'event', event: observationEvent });
     expect(await screen.findByText(/Replaced the greeting line/i)).toBeInTheDocument();
     expect(await screen.findByRole('button', { name: 'View diff for /tmp/README.md' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Show tool result/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Show environment result/i })).toBeNull();
     expect(screen.queryByText(/SECRET FILE CONTENT/)).toBeNull();
   });
 
@@ -409,7 +409,7 @@ describe('Agent-SDK event rendering', () => {
     expect(screen.queryByText(/Done\./i)).toBeNull();
     expect(screen.getAllByText(/ls -la/)).toHaveLength(1);
 
-    const toggle = await screen.findByRole('button', { name: /Show tool result/i });
+    const toggle = await screen.findByRole('button', { name: /Show environment result/i });
     fireEvent.click(toggle);
     expect(await screen.findByText(/"stdout": "README\.md"/)).toBeInTheDocument();
   });
@@ -432,7 +432,7 @@ describe('Agent-SDK event rendering', () => {
     postToWindow({ type: 'event', event: observationEvent });
     expect(await screen.findByText(/Done\./i)).toBeInTheDocument();
 
-    const toggle = await screen.findByRole('button', { name: /Show tool result/i });
+    const toggle = await screen.findByRole('button', { name: /Show environment result/i });
     fireEvent.click(toggle);
     expect(await screen.findByText(/hello/)).toBeInTheDocument();
   });

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -33,7 +33,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
           >
             <span className="codicon codicon-eye text-sm" style={{ color: OBSERVATION_ACCENT_COLOR }} />
           </div>
-          <div className="font-semibold text-sm text-stone-200">Tool Result</div>
+          <div className="font-semibold text-sm text-stone-200">Environment Result</div>
           <span className="font-mono text-xs text-amber-400/80 bg-amber-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
           <div className="ml-auto flex items-center gap-1.5">
             <span className="codicon codicon-check text-green-700" />
@@ -92,7 +92,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
         >
           <span className="codicon codicon-eye text-sm" style={{ color: OBSERVATION_ACCENT_COLOR }} />
         </div>
-        <div className="font-semibold text-sm text-stone-200">Tool Result</div>
+        <div className="font-semibold text-sm text-stone-200">Environment Result</div>
         <span className="font-mono text-xs text-amber-400/80 bg-amber-500/10 px-2 py-0.5 rounded">{event.tool_name}</span>
         {showHeaderToggle && (
           <Tooltip content={headerToggleLabel} position="right">

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -14,7 +14,7 @@ import {
 import { Tooltip } from '../Tooltip';
 
 /**
- * Renders tool result - shows observation with summary and expandable raw data.
+ * Renders environment result - shows observation with summary and expandable raw data.
  */
 export function ObservationEventBlock({ event, index }: { event: ObservationEvent; index?: number }) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -80,7 +80,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
   const isTruncated = shouldShowRaw && observationString.length > 2000;
   const showHeaderToggle = hasSummary && event.tool_name !== 'terminal' && !isFileEditObservation;
   const showFooterToggle = !hasSummary && isTruncated;
-  const headerToggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';
+  const headerToggleLabel = isExpanded ? 'Hide environment result' : 'Show environment result';
   const footerToggleLabel = isExpanded ? 'Show less' : 'Show more';
 
   return (

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -423,7 +423,7 @@ export function TerminalObservationSummary({
   const geminiSummary = getString(observation.summary) ?? metadataSummary;
   const trimmedGeminiSummary = geminiSummary?.trim() ? geminiSummary.trim() : undefined;
   const summaryText = trimmedGeminiSummary ?? (exitCodeText === '0' ? 'Done.' : `Done (exit code ${exitCodeText}).`);
-  const toggleLabel = isExpanded ? 'Hide tool result' : 'Show tool result';
+  const toggleLabel = isExpanded ? 'Hide environment result' : 'Show environment result';
   return (
     <div className="text-sm leading-relaxed">
       <Tooltip content={toggleLabel} position="top">


### PR DESCRIPTION
Fixes oh-tab-nzu.

Webview-only copy tweak: ObservationEventBlock now displays 'Environment Result' instead of 'Tool Result'.