### PR TITLE
Output channel: quiet by default in production

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -165,4 +165,4 @@ For the bead **oh-tab-odqs** (P4: Status bar errors), we should replace raw/trun
 - Status bar shows **short, actionable summary** (max ~60 chars)
 - Full error details remain in:
   - Chat timeline (EventBlocks)
-  - Output channel logs
+  - Output channel logs (warnings/errors always; enable verbose output for extra diagnostics via `openhands.logging.verbosity` or the “OpenHands: Toggle Verbose Output” command)

--- a/docs/llm_profiles.md
+++ b/docs/llm_profiles.md
@@ -144,4 +144,4 @@ User-facing errors should **not** include internal diagnostic fields like:
 - mode=local / profileId echoing unless it helps the user (prefer a simple “Selected profile: <id>” if needed)
 
 Internal diagnostics (full request payload, effective resolution details) belong in:
-- Debug logs / Output channel gated behind a debug setting, not in normal UI error blocks.
+- Debug logs / Output channel gated behind debug/verbosity settings (e.g. `openhands.agent.debug`, `openhands.devBridge.enabled`, `openhands.logging.verbosity`), not in normal UI error blocks.

--- a/docs/vscode_local_setup.md
+++ b/docs/vscode_local_setup.md
@@ -95,6 +95,7 @@ Note on Webview DevTools from CLI
 - Open Output panel (to view logs)
   - Visual: View → Output, then pick the "OpenHands" channel
   - CLI: code --command workbench.action.output.toggleOutput (opens/toggles Output; channel selection is manual)
+  - Note: in Production mode, OpenHands is quiet by default; use “OpenHands: Toggle Verbose Output” (or `openhands.logging.verbosity`) to see routine logs.
 
 - Open Logs Folder
   - Visual: Command Palette → Developer: Open Logs Folder

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "onCommand:openhands.reconnect",
     "onCommand:openhands.pauseCurrentRun",
     "onCommand:openhands.resumeCurrentRun",
+    "onCommand:openhands.toggleVerboseOutput",
     "onView:openhands.agent"
   ],
   "contributes": {
@@ -60,6 +61,10 @@
       {
         "command": "openhands.configure",
         "title": "OpenHands: Configure"
+      },
+      {
+        "command": "openhands.toggleVerboseOutput",
+        "title": "OpenHands: Toggle Verbose Output"
       },
       {
         "command": "openhands.setApiKey",
@@ -191,6 +196,24 @@
             "default": false,
             "order": 4,
             "markdownDescription": "Enable webview→extension debug logging bridge (Output channel + file in extension log path)."
+          }
+        }
+      },
+      {
+        "type": "object",
+        "title": "OpenHands: Logging",
+        "order": 2.5,
+        "properties": {
+          "openhands.logging.verbosity": {
+            "type": "string",
+            "enum": [
+              "minimal",
+              "verbose"
+            ],
+            "default": "minimal",
+            "scope": "machine",
+            "order": 0,
+            "markdownDescription": "Controls OpenHands Output channel verbosity.\n\n- `minimal` (default): suppress routine informational lines in Production.\n- `verbose`: print more logs and auto-show the Output channel.\n\nNote: enabling `openhands.agent.debug` or `openhands.devBridge.enabled` also turns on verbose-style logging."
           }
         }
       },

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -181,6 +181,7 @@ describe('Extension Activation', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     (vscode as any).__resetMocks();
+    delete (vscode as any).ExtensionMode;
     mockSettings = structuredClone(defaultMockSettings);
     mockContext = createMockContext();
     extension = await import('../extension');
@@ -200,6 +201,61 @@ describe('Extension Activation', () => {
     await extension.activate(mockContext);
     expect(__getLastConversation()).toBeNull();
   });
+
+  it('does not auto-show the Output channel in production with minimal verbosity', async () => {
+    (vscode as any).ExtensionMode = { Production: 1, Development: 2, Test: 3 };
+    mockContext.extensionMode = (vscode as any).ExtensionMode.Production;
+
+    const cfgValues = (vscode as any).__getMockConfigValues();
+    cfgValues.set('openhands.logging.verbosity', 'minimal');
+    cfgValues.set('openhands.agent.debug', false);
+    cfgValues.set('openhands.devBridge.enabled', false);
+
+    await extension.activate(mockContext);
+
+    const created = (vscode.window.createOutputChannel as Mock).mock.results[0]?.value;
+    expect(created?.show).not.toHaveBeenCalled();
+  });
+
+  it('auto-shows the Output channel in production when verbose output is enabled', async () => {
+    (vscode as any).ExtensionMode = { Production: 1, Development: 2, Test: 3 };
+    mockContext.extensionMode = (vscode as any).ExtensionMode.Production;
+
+    const cfgValues = (vscode as any).__getMockConfigValues();
+    cfgValues.set('openhands.logging.verbosity', 'verbose');
+    cfgValues.set('openhands.agent.debug', false);
+    cfgValues.set('openhands.devBridge.enabled', false);
+
+    await extension.activate(mockContext);
+
+    const created = (vscode.window.createOutputChannel as Mock).mock.results[0]?.value;
+    expect(created?.show).toHaveBeenCalled();
+    expect(created?.appendLine).toHaveBeenCalledWith('[OpenHands] Logging channel initialized');
+  });
+
+  it('toggles verbose output via command', async () => {
+    (vscode as any).ExtensionMode = { Production: 1, Development: 2, Test: 3 };
+    mockContext.extensionMode = (vscode as any).ExtensionMode.Production;
+
+    const cfgValues = (vscode as any).__getMockConfigValues();
+    cfgValues.set('openhands.logging.verbosity', 'minimal');
+    cfgValues.set('openhands.agent.debug', false);
+    cfgValues.set('openhands.devBridge.enabled', false);
+
+    await extension.activate(mockContext);
+    const created = (vscode.window.createOutputChannel as Mock).mock.results[0]?.value;
+    expect(cfgValues.get('openhands.logging.verbosity')).toBe('minimal');
+    expect(created?.show).not.toHaveBeenCalled();
+
+    await vscode.commands.executeCommand('openhands.toggleVerboseOutput');
+    expect(cfgValues.get('openhands.logging.verbosity')).toBe('verbose');
+    expect(created?.show).toHaveBeenCalled();
+
+    const showCalls = (created?.show as Mock).mock.calls.length;
+    await vscode.commands.executeCommand('openhands.toggleVerboseOutput');
+    expect(cfgValues.get('openhands.logging.verbosity')).toBe('minimal');
+    expect((created?.show as Mock).mock.calls.length).toBe(showCalls);
+  });
 });
 
 describe('Secret indicator sync', () => {
@@ -209,6 +265,7 @@ describe('Secret indicator sync', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     (vscode as any).__resetMocks();
+    delete (vscode as any).ExtensionMode;
     mockSettings = structuredClone(defaultMockSettings);
     mockContext = createMockContext();
     extension = await import('../extension');
@@ -369,6 +426,7 @@ describe('Chat view behavior', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     (vscode as any).__resetMocks();
+    delete (vscode as any).ExtensionMode;
     mockSettings = structuredClone(defaultMockSettings);
 
     mockContext = createMockContext();
@@ -570,6 +628,7 @@ describe('Command handlers', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     (vscode as any).__resetMocks();
+    delete (vscode as any).ExtensionMode;
     mockSettings = structuredClone(defaultMockSettings);
 
     mockContext = createMockContext();
@@ -744,6 +803,7 @@ describe('Settings and modes', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     (vscode as any).__resetMocks();
+    delete (vscode as any).ExtensionMode;
     mockSettings = structuredClone(defaultMockSettings);
     mockContext = createMockContext();
   });

--- a/src/conversation/host/attachConversationListeners.ts
+++ b/src/conversation/host/attachConversationListeners.ts
@@ -5,11 +5,17 @@ import { initialLlmStreamingState, reduceLlmStreamingState } from '../../shared/
 import type { HostToWebviewMessage } from '../../shared/webviewMessages';
 import type { DebugJsonOutputChannel } from '../../extension/debugJsonOutputChannel';
 
+type OutputLog = {
+  info: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+};
+
 export type AttachConversationListenersDeps = {
   context: vscode.ExtensionContext;
   conversation: ConversationInstance;
 
-  getOutputChannel: () => vscode.OutputChannel | undefined;
+  log: OutputLog;
   getDebugJsonChannel?: () => DebugJsonOutputChannel | undefined;
   getChatView: () => vscode.WebviewView | undefined;
   isChatWebviewReady: () => boolean;
@@ -27,6 +33,17 @@ export type AttachConversationListenersDeps = {
   handleTerminalEvent: (event: BashEvent) => void;
 };
 
+function isStatusIssueLike(status: string): boolean {
+  const s = status.toLowerCase();
+  return (
+    s.includes('offline') ||
+    s.includes('error') ||
+    s.includes('failed') ||
+    s.includes('fail') ||
+    s.includes('disconnect')
+  );
+}
+
 function postToChatIfVisible(
   deps: Pick<AttachConversationListenersDeps, 'getChatView' | 'isChatWebviewReady'>,
   message: HostToWebviewMessage
@@ -40,8 +57,12 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
   const { conversation } = deps;
 
   conversation.on('status', (s: string) => {
-    const outputChannel = deps.getOutputChannel();
-    outputChannel?.appendLine(`[status] ${s}`);
+    const line = `[status] ${s}`;
+    if (isStatusIssueLike(s)) {
+      deps.log.warn(line);
+    } else {
+      deps.log.info(line);
+    }
     postToChatIfVisible(deps, {
       type: 'status',
       status: s,
@@ -52,20 +73,20 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
 
   let streamingState = initialLlmStreamingState;
   conversation.on('event', (ev: Event) => {
-    const outputChannel = deps.getOutputChannel();
-
     const streamingUpdate = reduceLlmStreamingState(streamingState, ev);
     streamingState = streamingUpdate.state;
     const isStateUpdate = ev.kind === 'ConversationStateUpdateEvent';
     const isLlmStreamUpdate = isStateUpdate && (ev.key === 'llm_stream' || ev.key === 'llm_tool_call');
 
     if (streamingUpdate.started) {
-      outputChannel?.appendLine('[llm] Streaming started...');
+      deps.log.info('[llm] Streaming started...');
     }
 
     if (ev.kind === 'ConversationStateUpdateEvent' && (ev.key === 'llm_request_payload' || ev.key === 'llm_response_payload')) {
       const key = ev.key ?? 'llm_payload';
-      const shouldLogToDebugConsole = deps.context.extensionMode !== vscode.ExtensionMode.Production;
+      const extensionMode = vscode.ExtensionMode;
+      const shouldLogToDebugConsole =
+        extensionMode?.Production !== undefined ? deps.context.extensionMode !== extensionMode.Production : false;
       const shouldLogToOutputChannel = shouldLogToDebugConsole || deps.isVerboseEventLogging();
 
       // Log pretty-printed JSON to the debug channel (dev/test only)
@@ -77,10 +98,10 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
 
       if (shouldLogToOutputChannel) {
         try {
-          outputChannel?.appendLine(`[llm][${key}]`);
-          outputChannel?.appendLine(deps.safeStringify(ev.value));
+          deps.log.info(`[llm][${key}]`);
+          deps.log.info(deps.safeStringify(ev.value));
         } catch (e) {
-          outputChannel?.appendLine(`[llm][${key}] <failed to stringify: ${String(e)}>`);
+          deps.log.warn(`[llm][${key}] <failed to stringify: ${String(e)}>`);
         }
       }
 
@@ -104,15 +125,15 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
         }
       }
     } catch (e) {
-      outputChannel?.appendLine(`[error] Failed to track agent-edited files: ${String(e)}`);
+      deps.log.error(`[error] Failed to track agent-edited files: ${String(e)}`);
     }
 
     if (!isLlmStreamUpdate) {
       const isErrorLike = ev.kind === 'ConversationErrorEvent' || ev.kind === 'AgentErrorEvent';
-      if (deps.isVerboseEventLogging() || isErrorLike) {
-        outputChannel?.appendLine(`[event] ${deps.safeStringify(ev)}`);
-      } else {
-        outputChannel?.appendLine(`[event] ${ev.kind}`);
+      if (deps.isVerboseEventLogging()) {
+        deps.log.info(`[event] ${deps.safeStringify(ev)}`);
+      } else if (isErrorLike) {
+        deps.log.error(`[event] ${deps.safeStringify(ev)}`);
       }
 
       // Log events to debug JSON channel (dev/test only)
@@ -123,7 +144,7 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
     }
 
     if (streamingUpdate.completed) {
-      outputChannel?.appendLine('[llm] Streaming complete');
+      deps.log.info('[llm] Streaming complete');
     }
 
     try {
@@ -139,10 +160,10 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
           : [];
         const count = typeof raw?.tool_count === 'number' ? raw.tool_count : names.length;
         const summary = `[llm] Sending request${model ? ` to ${model}` : ''} with tools (${count}): ${names.join(', ')}`;
-        outputChannel?.appendLine(summary);
+        deps.log.info(summary);
       }
     } catch (e) {
-      outputChannel?.appendLine(`[error] Failed to create LLM request summary: ${String(e)}`);
+      deps.log.error(`[error] Failed to create LLM request summary: ${String(e)}`);
     }
 
     const shouldBufferForReplay = !isLlmStreamUpdate;
@@ -157,19 +178,16 @@ export function attachConversationListeners(deps: AttachConversationListenersDep
   });
 
   conversation.on('error', (err: unknown) => {
-    const outputChannel = deps.getOutputChannel();
-
     const rendered = deps.renderError(err);
-    outputChannel?.appendLine(`[error] ${rendered}`);
+    deps.log.error(`[error] ${rendered}`);
     if (err instanceof Error && err.stack) {
-      outputChannel?.appendLine(err.stack);
+      deps.log.error(err.stack);
     }
     postToChatIfVisible(deps, { type: 'error', error: rendered });
   });
 
   conversation.on('conversationStarted', (id: string | undefined) => {
-    const outputChannel = deps.getOutputChannel();
-    outputChannel?.appendLine(`[conversation] active=${id ?? 'undefined'}`);
+    deps.log.info(`[conversation] active=${id ?? 'undefined'}`);
     streamingState = initialLlmStreamingState;
 
     deps.resetConversationEventBacklog(id);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,12 @@ import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import {
+  createOutputLogger,
+  normalizeOutputVerbosity,
+  type OutputLogger,
+  type OutputVerbosity,
+} from './extension/outputLogger';
+import {
   AgentContext,
   Conversation,
   type ConversationInstance,
@@ -56,6 +62,8 @@ let chatWebviewReady = false; // Track if chat WebviewView is ready
 let chatLastConversationId: string | undefined;
 let chatLastSeenSeq: number | undefined;
 let outputChannel: vscode.OutputChannel | undefined;
+let outputLogger: OutputLogger | undefined;
+let outputVerbosity: OutputVerbosity = 'minimal';
 let debugJsonChannel: DebugJsonOutputChannel | undefined;
 let secretRegistry: SecretRegistry | undefined;
 let conversationStoreRoot: string | undefined;
@@ -75,7 +83,7 @@ const pastedImagesCleanupScheduler = createPastedImagesCleanupScheduler({
   getBaseDir: () => pastedImagesBaseDir,
   maxFiles: MAX_PASTED_IMAGES_STORAGE_FILES,
   maxBytes: MAX_PASTED_IMAGES_STORAGE_BYTES,
-  log: (line) => outputChannel?.appendLine(line),
+  log: (line) => outputLogger?.info(line),
   renderError,
 });
 // Buffer of test events sent via _sendTestEvent (used as fallback in E2E query)
@@ -164,13 +172,36 @@ export function activate(context: vscode.ExtensionContext) {
   secretRegistry = secrets;
 
   const devBridgeLogger = createDevBridgeLogger({ secretRegistry: secrets });
+  const cfg = vscode.workspace.getConfiguration();
+  outputVerbosity = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
+  verboseEventLogging =
+    outputVerbosity === 'verbose' ||
+    Boolean(cfg.get<boolean>('openhands.agent.debug')) ||
+    Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
+  outputLogger = createOutputLogger({
+    getOutputChannel: () => outputChannel,
+    getExtensionMode: () => context.extensionMode,
+    getVerbosity: () => (verboseEventLogging ? 'verbose' : 'minimal'),
+  });
 
   try {
     const channel = vscode.window.createOutputChannel('OpenHands', { log: true });
     outputChannel = createMaskedOutputChannel(channel, secrets);
     context.subscriptions.push(channel);
-    outputChannel.show(true);
-    outputChannel.appendLine('[OpenHands] Logging channel initialized');
+
+    const extensionMode = vscode.ExtensionMode;
+    const isProduction =
+      extensionMode?.Production !== undefined ? context.extensionMode === extensionMode.Production : true;
+    const shouldShowOnActivation =
+      !isProduction ||
+      outputVerbosity === 'verbose' ||
+      Boolean(cfg.get<boolean>('openhands.agent.debug')) ||
+      Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
+
+    if (shouldShowOnActivation) {
+      outputLogger?.show(true);
+    }
+    outputLogger?.info('[OpenHands] Logging channel initialized');
   } catch (err) {
     console.warn('[OpenHands] Failed to create output channel:', err);
     outputChannel = undefined;
@@ -179,7 +210,7 @@ export function activate(context: vscode.ExtensionContext) {
   // Create debug JSON output channel (only in dev/test modes or with devBridge enabled)
   debugJsonChannel = createDebugJsonOutputChannel({ context, secretRegistry: secrets });
   if (debugJsonChannel.isEnabled()) {
-    outputChannel?.appendLine('[OpenHands-DEBUG] Debug JSON channel initialized');
+    outputLogger?.info('[OpenHands-DEBUG] Debug JSON channel initialized');
   }
 
   pastedImagesBaseDir = getGlobalStorageBaseDir(context.globalStorageUri?.fsPath);
@@ -346,7 +377,11 @@ export function activate(context: vscode.ExtensionContext) {
     lastKnownLlmLabel = resolveConfiguredLlmLabel(settings);
 
     const cfg = vscode.workspace.getConfiguration();
-    verboseEventLogging = Boolean(settings.agent?.debug) || Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
+    outputVerbosity = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
+    verboseEventLogging =
+      outputVerbosity === 'verbose' ||
+      Boolean(settings.agent?.debug) ||
+      Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
 
     if (!settings.serverUrl && settings.agent?.summarizeToolCalls === true) {
       const hasGeminiKey = await (async (): Promise<boolean> => {
@@ -466,7 +501,11 @@ export function activate(context: vscode.ExtensionContext) {
       attachConversationListeners({
         context,
         conversation,
-        getOutputChannel: () => outputChannel,
+        log: {
+          info: (line) => outputLogger?.info(line),
+          warn: (line) => outputLogger?.warn(line),
+          error: (line) => outputLogger?.error(line),
+        },
         getDebugJsonChannel: () => debugJsonChannel,
         getChatView: () => chatView,
         isChatWebviewReady: () => chatWebviewReady,
@@ -591,6 +630,23 @@ export function activate(context: vscode.ExtensionContext) {
     await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
   });
 
+  const toggleVerboseOutput = vscode.commands.registerCommand('openhands.toggleVerboseOutput', async () => {
+    const cfg = vscode.workspace.getConfiguration();
+    const current = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
+    const next: OutputVerbosity = current === 'verbose' ? 'minimal' : 'verbose';
+    await cfg.update('openhands.logging.verbosity', next, vscode.ConfigurationTarget.Global);
+    outputVerbosity = next;
+    verboseEventLogging =
+      outputVerbosity === 'verbose' ||
+      Boolean(cfg.get<boolean>('openhands.agent.debug')) ||
+      Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
+    outputLogger?.info(`[settings] Output verbosity set to ${next}`);
+    if (next === 'verbose') {
+      outputLogger?.show(true);
+    }
+    void vscode.window.showInformationMessage(`OpenHands output verbosity: ${next}`);
+  });
+
   const secretCommands = registerSecretCommands({
     context,
     secrets,
@@ -641,10 +697,17 @@ export function activate(context: vscode.ExtensionContext) {
     setConversationStoreRoot: (root) => {
       conversationStoreRoot = root;
     },
+    setOutputVerbosity: (value) => {
+      outputVerbosity = value;
+    },
     setVerboseEventLogging: (value) => {
       verboseEventLogging = value;
     },
-    getOutputChannel: () => outputChannel,
+    log: {
+      info: (line) => outputLogger?.info(line),
+      warn: (line) => outputLogger?.warn(line),
+      error: (line) => outputLogger?.error(line),
+    },
     renderError,
   });
   const onHalConfigurationChange = createHalConfigurationChangeHandler({
@@ -667,6 +730,7 @@ export function activate(context: vscode.ExtensionContext) {
     ...halCommands,
     startNew,
     configure,
+    toggleVerboseOutput,
     ...secretCommands,
     reconnect,
     pause,
@@ -678,14 +742,21 @@ export function deactivate() {
   try { conversation?.disconnect(); } catch { }
   try { terminal?.dispose(); } catch { }
   try { debugJsonChannel?.dispose(); } catch { }
+  try { outputChannel?.dispose(); } catch { }
   // Reset module state to ensure clean slate for tests and re-activation
   chatView = undefined;
   conversation = undefined;
   terminal = undefined;
   terminalLogPty = undefined;
   debugJsonChannel = undefined;
+  outputChannel = undefined;
+  outputLogger = undefined;
+  outputVerbosity = 'minimal';
+  verboseEventLogging = false;
   localAgentContext = undefined;
   activeEditorFilePath = undefined;
+  secretRegistry = undefined;
+  lastKnownLlmLabel = null;
   pendingRenderedEventsRequests.clear();
   pendingUiStateRequests.clear();
   pendingHalStateRequests.clear();

--- a/src/extension/outputLogger.ts
+++ b/src/extension/outputLogger.ts
@@ -1,0 +1,71 @@
+import * as vscode from 'vscode';
+
+export type OutputVerbosity = 'minimal' | 'verbose';
+
+export function normalizeOutputVerbosity(value: unknown): OutputVerbosity {
+  return value === 'verbose' ? 'verbose' : 'minimal';
+}
+
+export type OutputLogger = {
+  show: (preserveFocus?: boolean) => void;
+  info: (line: string) => void;
+  warn: (line: string) => void;
+  error: (line: string) => void;
+};
+
+function isProductionExtensionMode(extensionMode: unknown): boolean {
+  // VS Code defines: Production=1, Development=2, Test=3.
+  const maybeVscode = vscode as unknown as { ExtensionMode?: { Production?: number } };
+  const productionValue = typeof maybeVscode.ExtensionMode?.Production === 'number' ? maybeVscode.ExtensionMode.Production : 1;
+  if (typeof extensionMode !== 'number') return true;
+  return extensionMode === productionValue;
+}
+
+export function createOutputLogger(deps: {
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  getExtensionMode: () => unknown;
+  getVerbosity: () => OutputVerbosity;
+}): OutputLogger {
+  let didAutoShowOnIssue = false;
+
+  const shouldLogInfo = () => !isProductionExtensionMode(deps.getExtensionMode()) || deps.getVerbosity() === 'verbose';
+
+  const append = (line: string) => {
+    const channel = deps.getOutputChannel();
+    channel?.appendLine(line);
+  };
+
+  const maybeAutoShow = () => {
+    if (didAutoShowOnIssue) return;
+    if (!isProductionExtensionMode(deps.getExtensionMode())) return;
+    if (deps.getVerbosity() === 'verbose') return;
+    const channel = deps.getOutputChannel();
+    if (!channel) return;
+    didAutoShowOnIssue = true;
+    try {
+      channel.show(true);
+    } catch {
+      // ignore
+    }
+  };
+
+  return {
+    show: (preserveFocus = true) => {
+      const channel = deps.getOutputChannel();
+      if (!channel) return;
+      channel.show(preserveFocus);
+    },
+    info: (line) => {
+      if (!shouldLogInfo()) return;
+      append(line);
+    },
+    warn: (line) => {
+      append(line);
+      maybeAutoShow();
+    },
+    error: (line) => {
+      append(line);
+      maybeAutoShow();
+    },
+  };
+}

--- a/src/settings/host/__tests__/createConfigurationChangeHandler.test.ts
+++ b/src/settings/host/__tests__/createConfigurationChangeHandler.test.ts
@@ -25,8 +25,13 @@ describe('createConfigurationChangeHandler', () => {
       getTerminalLogPty: vi.fn().mockReturnValue(undefined),
       setTerminalLogPty: vi.fn(),
       setConversationStoreRoot: vi.fn(),
+      setOutputVerbosity: vi.fn(),
       setVerboseEventLogging: vi.fn(),
-      getOutputChannel: vi.fn().mockReturnValue({ appendLine: vi.fn() }),
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      },
       renderError: vi.fn((err) => String(err)),
     };
     handler = createConfigurationChangeHandler(deps);
@@ -44,8 +49,6 @@ describe('createConfigurationChangeHandler', () => {
     });
 
     it('logs appropriate message for local mode', async () => {
-      const appendLine = vi.fn();
-      deps.getOutputChannel = vi.fn().mockReturnValue({ appendLine });
       deps.getConversationMode = vi.fn().mockReturnValue('local');
       handler = createConfigurationChangeHandler(deps);
 
@@ -55,13 +58,11 @@ describe('createConfigurationChangeHandler', () => {
 
       await handler(event as any);
 
-      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('Max iterations setting updated'));
-      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('local mode'));
+      expect(deps.log.info).toHaveBeenCalledWith(expect.stringContaining('Max iterations setting updated'));
+      expect(deps.log.info).toHaveBeenCalledWith(expect.stringContaining('local mode'));
     });
 
     it('logs appropriate message for remote mode', async () => {
-      const appendLine = vi.fn();
-      deps.getOutputChannel = vi.fn().mockReturnValue({ appendLine });
       deps.getConversationMode = vi.fn().mockReturnValue('remote');
       handler = createConfigurationChangeHandler(deps);
 
@@ -71,13 +72,11 @@ describe('createConfigurationChangeHandler', () => {
 
       await handler(event as any);
 
-      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('Max iterations setting updated'));
-      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('remote mode'));
+      expect(deps.log.info).toHaveBeenCalledWith(expect.stringContaining('Max iterations setting updated'));
+      expect(deps.log.info).toHaveBeenCalledWith(expect.stringContaining('remote mode'));
     });
 
     it('logs error when ensureConversationAndConnection fails', async () => {
-      const appendLine = vi.fn();
-      deps.getOutputChannel = vi.fn().mockReturnValue({ appendLine });
       deps.ensureConversationAndConnection = vi.fn().mockRejectedValue(new Error('test error'));
       handler = createConfigurationChangeHandler(deps);
 
@@ -87,7 +86,7 @@ describe('createConfigurationChangeHandler', () => {
 
       await handler(event as any);
 
-      expect(appendLine).toHaveBeenCalledWith(expect.stringContaining('Failed to apply max iterations update'));
+      expect(deps.log.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to apply max iterations update'));
     });
   });
 });

--- a/src/settings/host/createConfigurationChangeHandler.ts
+++ b/src/settings/host/createConfigurationChangeHandler.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
+import { normalizeOutputVerbosity, type OutputVerbosity } from '../../extension/outputLogger';
 
 type TerminalLogPtyLike = { ensureNewline?: () => void };
 
@@ -23,9 +24,14 @@ export type CreateConfigurationChangeHandlerDeps = {
   setTerminalLogPty: (pty: TerminalLogPtyLike | undefined) => void;
 
   setConversationStoreRoot: (root: string | undefined) => void;
+  setOutputVerbosity: (value: OutputVerbosity) => void;
   setVerboseEventLogging: (value: boolean) => void;
 
-  getOutputChannel: () => vscode.OutputChannel | undefined;
+  log: {
+    info: (line: string) => void;
+    warn: (line: string) => void;
+    error: (line: string) => void;
+  };
   renderError: (err: unknown) => string;
 };
 
@@ -64,19 +70,25 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
       return;
     }
 
-    if (e.affectsConfiguration('openhands.agent.debug') || e.affectsConfiguration('openhands.devBridge.enabled')) {
+    if (
+      e.affectsConfiguration('openhands.agent.debug') ||
+      e.affectsConfiguration('openhands.devBridge.enabled') ||
+      e.affectsConfiguration('openhands.logging.verbosity')
+    ) {
       const cfg = vscode.workspace.getConfiguration();
       const debug = cfg.get<boolean>('openhands.agent.debug') ?? false;
       const devBridgeEnabled = cfg.get<boolean>('openhands.devBridge.enabled') ?? false;
-      deps.setVerboseEventLogging(debug || devBridgeEnabled);
+      const verbosity = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
+      deps.setOutputVerbosity(verbosity);
+      deps.setVerboseEventLogging(debug || devBridgeEnabled || verbosity === 'verbose');
     }
 
     if (e.affectsConfiguration('openhands.agent.summarizeToolCalls')) {
       try {
         await deps.ensureConversationAndConnection();
-        deps.getOutputChannel()?.appendLine('[settings] Tool-call summarization setting updated');
+        deps.log.info('[settings] Tool-call summarization setting updated');
       } catch (err: unknown) {
-        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply tool-call summarization update: ${deps.renderError(err)}`);
+        deps.log.warn(`[settings] Failed to apply tool-call summarization update: ${deps.renderError(err)}`);
       }
     }
 
@@ -84,12 +96,12 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
       try {
         await deps.ensureConversationAndConnection();
         if (deps.getConversationMode() === 'remote') {
-          deps.getOutputChannel()?.appendLine('[settings] LLM settings updated (remote mode: applies on next conversation)');
+          deps.log.info('[settings] LLM settings updated (remote mode: applies on next conversation)');
         } else {
-          deps.getOutputChannel()?.appendLine('[settings] LLM settings updated (local mode: applies immediately)');
+          deps.log.info('[settings] LLM settings updated (local mode: applies immediately)');
         }
       } catch (err: unknown) {
-        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply LLM settings update: ${deps.renderError(err)}`);
+        deps.log.warn(`[settings] Failed to apply LLM settings update: ${deps.renderError(err)}`);
       }
     }
 
@@ -97,12 +109,12 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
       try {
         await deps.ensureConversationAndConnection();
         if (deps.getConversationMode() === 'remote') {
-          deps.getOutputChannel()?.appendLine('[settings] Confirmation settings updated (remote mode: applies on next conversation)');
+          deps.log.info('[settings] Confirmation settings updated (remote mode: applies on next conversation)');
         } else {
-          deps.getOutputChannel()?.appendLine('[settings] Confirmation settings updated (local mode: applies immediately)');
+          deps.log.info('[settings] Confirmation settings updated (local mode: applies immediately)');
         }
       } catch (err: unknown) {
-        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply confirmation settings update: ${deps.renderError(err)}`);
+        deps.log.warn(`[settings] Failed to apply confirmation settings update: ${deps.renderError(err)}`);
       }
     }
 
@@ -110,12 +122,12 @@ export function createConfigurationChangeHandler(deps: CreateConfigurationChange
       try {
         await deps.ensureConversationAndConnection();
         if (deps.getConversationMode() === 'remote') {
-          deps.getOutputChannel()?.appendLine('[settings] Max iterations setting updated (remote mode: applies on next conversation)');
+          deps.log.info('[settings] Max iterations setting updated (remote mode: applies on next conversation)');
         } else {
-          deps.getOutputChannel()?.appendLine('[settings] Max iterations setting updated (local mode: applies on next run)');
+          deps.log.info('[settings] Max iterations setting updated (local mode: applies on next run)');
         }
       } catch (err: unknown) {
-        deps.getOutputChannel()?.appendLine(`[settings] Failed to apply max iterations update: ${deps.renderError(err)}`);
+        deps.log.warn(`[settings] Failed to apply max iterations update: ${deps.renderError(err)}`);
       }
     }
   };


### PR DESCRIPTION
### Bead

id: oh-tab-ta4
title: Output channel: production should be quiet by default

description:
Current behavior: Debug JSON channel and dev-bridge file logging are correctly gated to Development/Test or the openhands.devBridge.enabled setting. However, we always create and show the main 'OpenHands' Output channel at activation and write informational lines in production. This can feel noisy for end users.

Proposal:
- Do not auto-show the 'OpenHands' Output channel in Production mode.
- Gate routine info logs behind a verbosity setting (default: minimal); keep warnings/errors visible.
- Keep the debug JSON channel and dev-bridge logs as-is for dev/debug.
- Add a quick command to toggle verbose/debug logging.

Rationale: Preserve rich diagnostics in dev, reduce distraction for users in production.

acceptance_criteria:
- In Production mode (ExtensionMode.Production) with openhands.devBridge.enabled=false and agent.debug unset, the extension does not auto-open the 'OpenHands' Output channel at activation.
- In that state, routine informational lines are suppressed; only warnings/errors or critical status (e.g., connection failures) appear in the Output channel.
- A user-facing setting exists to enable verbose output (boolean or verbosity enum), defaulting to minimal.
- A command exists to quickly toggle verbose/debug logging on/off.
- Documentation updated to describe the logging behavior differences between dev/debug and production.

### Summary
- Stop auto-showing the OpenHands Output channel at activation in Production+minimal.
- Add `openhands.logging.verbosity` (minimal|verbose) and `openhands.toggleVerboseOutput`.
- Route conversation/status/event logs through a central Output logger so routine info is suppressed in Production+minimal.

### Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to toggle verbose output mode for better visibility of routine logs
  * Added a logging configuration setting to control output verbosity (minimal or verbose)

* **Documentation**
  * Updated guidance on accessing logs and enabling verbose diagnostics in different modes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->