### PR TITLE
HistoryView: tokens row, titles, prompt clamp

### DIFF
--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -49,6 +49,7 @@ export type HostToWebviewMessage =
       firstMessage?: string;
       timestamp: number;
       messageCount?: number;
+      contextTokens?: number;
     }>;
   }
   | { type: 'workspaceFiles'; files: string[] }

--- a/src/webview-src/__tests__/HistoryView.test.tsx
+++ b/src/webview-src/__tests__/HistoryView.test.tsx
@@ -153,6 +153,54 @@ describe('HistoryView', () => {
     expect(screen.getByText('31 conversations')).toBeInTheDocument();
   });
 
+  it('shows context token usage under the time-ago row', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: 'hey', timestamp: 1000, contextTokens: 42 },
+        ]}
+        onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    const contextLabel = screen.getByText('Context:');
+    expect(contextLabel.closest('div')).toHaveTextContent('Context: 42 tokens');
+  });
+
+  it('uses a 5-line clamp for the prompt preview', () => {
+    const onClose = vi.fn();
+    const onSelectConversation = vi.fn();
+    const onDeleteConversation = vi.fn();
+    const longPrompt = 'This is a long prompt. '.repeat(200);
+
+    render(
+      <HistoryView
+        isOpen
+        onClose={onClose}
+        conversations={[
+          { id: 'abc123', title: 'Fix sidebar issue', firstMessage: longPrompt, timestamp: 1000 },
+        ]}
+        onSelectConversation={onSelectConversation}
+        onDeleteConversation={onDeleteConversation}
+      />
+    );
+
+    act(() => { vi.advanceTimersByTime(150); });
+
+    const snippet = longPrompt.slice(0, 20);
+    const previewText = screen.getByText((content) => content.includes(snippet));
+    expect(previewText.closest('div')?.className).toContain('line-clamp-5');
+  });
+
   it('calls onDeleteConversation when trash icon is clicked', () => {
     const onClose = vi.fn();
     const onSelectConversation = vi.fn();

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -82,7 +82,7 @@ export function App() {
   const [enabledToolIds, setEnabledToolIds] = useState<string[]>([]);
 
   // History state
-  const [history, setHistory] = useState<Array<{ id: string; title?: string; firstMessage?: string; timestamp: number; messageCount?: number }>>([]);
+  const [history, setHistory] = useState<Array<{ id: string; title?: string; firstMessage?: string; timestamp: number; messageCount?: number; contextTokens?: number }>>([]);
 
   // Server selection state
   const [servers, setServers] = useState<{ url: string; label?: string }[]>([]);

--- a/src/webview-src/components/HistoryView.tsx
+++ b/src/webview-src/components/HistoryView.tsx
@@ -4,7 +4,7 @@ import { Tooltip } from './Tooltip';
 
 // --- Constants ---
 
-const PROMPT_PREVIEW_MAX_LENGTH = 100;
+const PROMPT_PREVIEW_MAX_LENGTH = 500;
 const HISTORY_PAGE_SIZE = 30;
 
 // --- Types ---
@@ -15,6 +15,7 @@ interface Conversation {
   firstMessage?: string;
   timestamp: number;
   messageCount?: number;
+  contextTokens?: number;
 }
 
 interface HistoryViewProps {
@@ -97,6 +98,7 @@ function ConversationItem({
   const displayTitle = getDisplayTitle(conversation);
   const promptPreview = getPromptPreview(conversation.firstMessage);
   const timeAgo = formatTimeAgo(conversation.timestamp);
+  const contextTokens = typeof conversation.contextTokens === 'number' ? conversation.contextTokens : 0;
 
   return (
     <div
@@ -128,7 +130,7 @@ function ConversationItem({
 
         {/* Prompt Preview */}
         {promptPreview && (
-          <div className="text-xs text-stone-500 line-clamp-2 mb-2">
+          <div className="text-xs text-stone-500 line-clamp-5 mb-2">
             {promptPreview}
           </div>
         )}
@@ -145,6 +147,12 @@ function ConversationItem({
               {conversation.messageCount}
             </span>
           )}
+        </div>
+
+        <div className="mt-1 text-xs text-stone-500 flex items-center gap-1.5">
+          <span>Context:</span>{' '}
+          <span className="font-mono text-stone-300">{contextTokens}</span>{' '}
+          <span>tokens</span>
         </div>
       </button>
 

--- a/src/webview/host/__tests__/conversationHistory.test.ts
+++ b/src/webview/host/__tests__/conversationHistory.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { getConversationHistoryList, persistConversationTitle } from '../conversationHistory';
+
+const writeJson = async (filePath: string, value: unknown) => {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(value), 'utf8');
+};
+
+describe('conversationHistory', () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(async () => {
+    if (tmpRoot) {
+      await fs.rm(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  it('includes contextTokens from state.values.llm_usage when present', async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-history-'));
+    const id = 'local-test-1';
+    const dir = path.join(tmpRoot, id);
+
+    await writeJson(path.join(dir, 'state.json'), {
+      status: 'idle',
+      iteration: 0,
+      values: { llm_usage: { input: 123 } },
+    });
+    await fs.writeFile(
+      path.join(dir, 'events.jsonl'),
+      `${JSON.stringify({
+        kind: 'MessageEvent',
+        llm_message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+      })}\n`,
+      'utf8'
+    );
+
+    const outputChannel = { appendLine: vi.fn() };
+    const items = await getConversationHistoryList(tmpRoot, outputChannel);
+    const item = items.find((x) => x.id === id);
+    expect(item).toBeTruthy();
+    expect(item?.contextTokens).toBe(123);
+  });
+
+  it('falls back to stats when llm_usage is missing', async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-history-'));
+    const id = 'local-test-2';
+    const dir = path.join(tmpRoot, id);
+
+    await writeJson(path.join(dir, 'state.json'), {
+      status: 'idle',
+      iteration: 0,
+      values: {
+        stats: {
+          usage_to_metrics: {
+            agent: { lastTokenUsage: { promptTokens: 77 } },
+          },
+        },
+      },
+    });
+    await fs.writeFile(path.join(dir, 'events.jsonl'), '', 'utf8');
+
+    const items = await getConversationHistoryList(tmpRoot);
+    const item = items.find((x) => x.id === id);
+    expect(item).toBeTruthy();
+    expect(item?.contextTokens).toBe(77);
+  });
+
+  it('reads persisted titles from conversation.json and can persist new titles', async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'oh-tab-history-'));
+    const id = 'local-test-3';
+    const dir = path.join(tmpRoot, id);
+
+    await writeJson(path.join(dir, 'state.json'), { status: 'idle', iteration: 0, values: {} });
+    await writeJson(path.join(dir, 'conversation.json'), { title: 'Existing title' });
+    await fs.writeFile(path.join(dir, 'events.jsonl'), '', 'utf8');
+
+    const initial = await getConversationHistoryList(tmpRoot);
+    expect(initial.find((x) => x.id === id)?.title).toBe('Existing title');
+
+    await persistConversationTitle(tmpRoot, id, 'New title');
+    const updated = await getConversationHistoryList(tmpRoot);
+    expect(updated.find((x) => x.id === id)?.title).toBe('New title');
+  });
+});
+

--- a/src/webview/host/conversationHistory.ts
+++ b/src/webview/host/conversationHistory.ts
@@ -6,12 +6,111 @@ import { FileStore, isEvent, isMessageEvent, isTextContent } from '@openhands/ag
 
 export type ConversationHistoryItem = {
   id: string;
+  title?: string;
   timestamp: number;
   firstMessage?: string;
+  contextTokens?: number;
 };
 
 const MAX_HISTORY_SCAN_BYTES = 512 * 1024;
 const MAX_HISTORY_SCAN_LINES = 2000;
+const CONVERSATION_BASE_JSON = 'conversation.json';
+
+const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
+  !!candidate && typeof candidate === 'object' && !Array.isArray(candidate);
+
+const toNonNegativeInt = (value: unknown): number | null => {
+  const num = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(num)) return null;
+  return Math.max(0, Math.trunc(num));
+};
+
+function getContextTokensFromLlmUsage(value: unknown): number | null {
+  if (!isRecord(value)) return null;
+  const raw = value.input ?? value.inputTokens ?? value.promptTokens ?? value.prompt_tokens;
+  return toNonNegativeInt(raw);
+}
+
+function getContextTokensFromStats(value: unknown): number | null {
+  if (!isRecord(value)) return null;
+  const usageToMetricsRaw = value.usage_to_metrics ?? value.usageToMetrics ?? value.service_to_metrics ?? value.serviceToMetrics;
+  if (!isRecord(usageToMetricsRaw)) return null;
+  const metricRaw = usageToMetricsRaw.agent;
+  if (!isRecord(metricRaw)) return null;
+
+  const lastUsageRaw = metricRaw.lastTokenUsage ?? metricRaw.last_token_usage;
+  if (isRecord(lastUsageRaw)) {
+    const prompt = toNonNegativeInt(lastUsageRaw.promptTokens ?? lastUsageRaw.prompt_tokens);
+    if (prompt !== null) return prompt;
+  }
+
+  const tokenUsagesRaw =
+    metricRaw.tokenUsages ?? metricRaw.token_usages ?? metricRaw.token_usages_history ?? metricRaw.tokenUsagesHistory;
+  if (Array.isArray(tokenUsagesRaw) && tokenUsagesRaw.length > 0) {
+    const last = (tokenUsagesRaw as unknown[])[tokenUsagesRaw.length - 1];
+    if (isRecord(last)) {
+      const prompt = toNonNegativeInt(last.promptTokens ?? last.prompt_tokens);
+      if (prompt !== null) return prompt;
+    }
+  }
+
+  const usageRaw = metricRaw.accumulatedTokenUsage ?? metricRaw.accumulated_token_usage;
+  if (isRecord(usageRaw)) {
+    const perTurn = toNonNegativeInt(usageRaw.perTurnToken ?? usageRaw.per_turn_token);
+    if (perTurn !== null) return perTurn;
+  }
+
+  return null;
+}
+
+function getContextTokensFromStateFile(state: unknown): number | undefined {
+  if (!isRecord(state)) return undefined;
+  const values = state.values;
+  if (!isRecord(values)) return undefined;
+  const llmUsageTokens = getContextTokensFromLlmUsage(values.llm_usage);
+  if (llmUsageTokens !== null) return llmUsageTokens;
+  const statsTokens = getContextTokensFromStats(values.stats);
+  if (statsTokens !== null) return statsTokens;
+  return undefined;
+}
+
+function getConversationTitleFromBaseJson(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const raw = value.title;
+  if (typeof raw !== 'string') return undefined;
+  const trimmed = raw.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export async function persistConversationTitle(
+  conversationStoreRoot: string,
+  conversationId: string,
+  title: string,
+  outputChannel?: { appendLine(line: string): void },
+): Promise<void> {
+  const trimmed = title.trim();
+  if (!trimmed) return;
+  const dir = path.join(conversationStoreRoot, conversationId);
+  const filePath = path.join(dir, CONVERSATION_BASE_JSON);
+
+  let next: Record<string, unknown> = { title: trimmed };
+  try {
+    const content = await fs.readFile(filePath, 'utf8');
+    const parsed: unknown = JSON.parse(content);
+    if (isRecord(parsed)) {
+      next = { ...parsed, title: trimmed };
+    }
+  } catch {
+    // ignore (missing or invalid file); we overwrite below.
+  }
+
+  try {
+    await fs.writeFile(filePath, JSON.stringify(next), 'utf8');
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    outputChannel?.appendLine(`[history] Failed to persist title for ${conversationId}: ${reason}`);
+  }
+}
 
 async function findFirstMessageEventLine(eventsPath: string): Promise<string | undefined> {
   const stream = nodeFs.createReadStream(eventsPath, { encoding: 'utf8' });
@@ -57,8 +156,36 @@ export async function getConversationHistoryList(
       try {
         const statePath = path.join(conversationStoreRoot, id, 'state.json');
         const eventsPath = path.join(conversationStoreRoot, id, 'events.jsonl');
+        const basePath = path.join(conversationStoreRoot, id, CONVERSATION_BASE_JSON);
         const stat = await fs.stat(statePath).catch(async () => fs.stat(eventsPath));
         const timestamp = stat?.mtimeMs ?? Date.now();
+
+        let title: string | undefined;
+        try {
+          const content = await fs.readFile(basePath, 'utf8');
+          const parsed: unknown = JSON.parse(content);
+          title = getConversationTitleFromBaseJson(parsed);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== 'ENOENT') {
+            const reason = err instanceof Error ? err.message : String(err);
+            outputChannel?.appendLine(`[history] Failed to read conversation base JSON for ${id}: ${reason}`);
+          }
+        }
+
+        let contextTokens: number | undefined;
+        try {
+          const stateContent = await fs.readFile(statePath, 'utf8');
+          const parsed: unknown = JSON.parse(stateContent);
+          contextTokens = getContextTokensFromStateFile(parsed);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== 'ENOENT') {
+            const reason = err instanceof Error ? err.message : String(err);
+            outputChannel?.appendLine(`[history] Failed to read state for ${id}: ${reason}`);
+          }
+        }
+
         let firstMessage: string | undefined;
         try {
           const line = await findFirstMessageEventLine(eventsPath);
@@ -84,11 +211,10 @@ export async function getConversationHistoryList(
             outputChannel?.appendLine(`[history] Failed to scan events for ${id}: ${reason}`);
           }
         }
-        return { id, timestamp: Math.floor(timestamp), firstMessage };
+        return { id, title, timestamp: Math.floor(timestamp), firstMessage, contextTokens };
       } catch {
         return { id, timestamp: Date.now() };
       }
     })
   );
 }
-

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -18,7 +18,7 @@ import { normalizeServerUrl } from '../../shared/serverUrls';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS, type HostToWebviewMessage, type WebviewToHostMessage } from '../../shared/webviewMessages';
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
 import { formatEnvironmentInformation } from '../../shared/environmentInformation';
-import { getConversationHistoryList } from './conversationHistory';
+import { getConversationHistoryList, persistConversationTitle } from './conversationHistory';
 import { showWorkspaceDiff } from './diffDocuments';
 import { resolveGitHeadDiffContents } from './gitHeadDiff';
 import * as llmProfilesStore from './llmProfilesStore';
@@ -26,6 +26,7 @@ import { listSkillFiles } from './skills';
 import { listWorkspaceFiles } from './workspaceFiles';
 import { resolveWorkspaceFilePath } from './workspacePaths';
 import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools, type LocalToolId } from '../../shared/localTools';
+import { summarizeWithLocalLlm } from '../../extension/summarizeWithLocalLlm';
 
 export type WebviewHost = {
   postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
@@ -56,6 +57,24 @@ function execFileText(command: string, args: string[], cwd?: string): Promise<st
       resolve(typeof stdout === 'string' ? stdout : String(stdout));
     });
   });
+}
+
+function normalizeGeneratedConversationTitle(raw: string): string | undefined {
+  const firstLine = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return undefined;
+
+  const unquoted = firstLine.replace(/^["'`]+/, '').replace(/["'`]+$/, '').trim();
+  if (!unquoted) return undefined;
+
+  const strippedPrefix = unquoted.replace(/^title\\s*:\\s*/i, '').trim();
+  if (!strippedPrefix) return undefined;
+
+  const words = strippedPrefix.split(/\\s+/).filter(Boolean);
+  if (words.length === 0) return undefined;
+  return words.slice(0, 7).join(' ');
 }
 
 async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
@@ -195,6 +214,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
   const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
   const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
   let elevenlabsTtsGate: TtsConversationGate | null = null;
+  const historyTitleGenerationInFlight = new Set<string>();
 
   const postToolsList = async (): Promise<void> => {
     const mode = deps.getConversationMode();
@@ -329,6 +349,47 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
         const conversations = await getConversationHistoryList(convRoot, outputChannel);
         void host.postMessage({ type: 'historyList', conversations });
+
+        // Best-effort: generate short titles for items that don't have one persisted yet.
+        // Non-blocking: HistoryView should render immediately and then update as titles become available.
+        void (async () => {
+          const secrets = deps.secretRegistry;
+          if (!secrets) return;
+
+          const missing = conversations
+            .filter((c) => !c.title && typeof c.firstMessage === 'string' && c.firstMessage.trim().length > 0)
+            .sort((a, b) => b.timestamp - a.timestamp)
+            .slice(0, 30);
+          if (missing.length === 0) return;
+
+          const settings = await settingsMgr.get();
+
+          for (const convo of missing) {
+            if (historyTitleGenerationInFlight.has(convo.id)) continue;
+            historyTitleGenerationInFlight.add(convo.id);
+            try {
+              const prompt =
+                `Generate a short conversation title (max 7 words).\\n` +
+                `Return ONLY the title text (no quotes, no punctuation at the end).\\n\\n` +
+                `First user message:\\n${convo.firstMessage}`;
+
+              const raw = await summarizeWithLocalLlm(settings, prompt, secrets);
+              const title = normalizeGeneratedConversationTitle(raw);
+              if (!title) continue;
+
+              await persistConversationTitle(convRoot, convo.id, title, outputChannel);
+              convo.title = title;
+              void host.postMessage({ type: 'historyList', conversations });
+            } catch (err) {
+              const reason = err instanceof Error ? err.message : String(err);
+              outputChannel?.appendLine(`[history] Failed to generate title for ${convo.id}: ${reason}`);
+              // If this fails once (missing key/profile/etc.), avoid spamming more calls this round.
+              break;
+            } finally {
+              historyTitleGenerationInFlight.delete(convo.id);
+            }
+          }
+        })();
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
         outputChannel?.appendLine(`[history] ${reason}`);


### PR DESCRIPTION
### Bead

id: oh-tab-fu6
title: HistoryView: tokens row + titles + prompt clamp

description:
HistoryView is currently visually bland and not very informative (see the screenshot from 2026-01-13 03:46).

Requested improvements:
- Under the relative time (e.g. “56m ago”), add a row showing per-conversation context token usage: `Context: <n> tokens` (same value/source as the Header totals row for the active ConversationView).
- Conversation title: display a real title if we have one; if not, generate one (max 7 words) using the same Gemini-flash setup used for tool summaries, persist it into the conversation base JSON, and load it for HistoryView.
- Prompt preview: clamp the displayed first user prompt to a maximum of 5 lines (not just a character limit).

Notes:
- Title generation should be cached/persisted so HistoryView opening does not re-request titles for previously-titled conversations.
- If title generation fails/unavailable, fall back to the current title heuristic.

acceptance_criteria:
- History list items show `Context: <n> tokens` under the time-ago for each conversation.
- If a persisted title exists, it is used; titles are max 7 words.
- If no title exists, the app generates one via Gemini-flash and persists it to the conversation base JSON; subsequent HistoryView opens reuse it.
- First user prompt preview is visually clamped to 5 lines.
- No UX regression: HistoryView search/filter and selection still behave as before.

### Summary
- Add per-conversation `Context: <n> tokens` row to HistoryView (from persisted `state.json`, preferring `llm_usage` then `stats`).
- Persist/load conversation titles via per-conversation `conversation.json` (generated title limited to 7 words).
- Clamp prompt preview to 5 lines.

### Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation history now displays context token usage for each conversation.
  * Conversation titles are automatically generated and persisted based on conversation content.
  * Prompt previews are enhanced with longer content display and improved text wrapping (clamped to 5 lines).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->