### PR TITLE
Test: add ExtensionMode to vscode mock

### DIFF
--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -55,6 +55,12 @@ export const ConfigurationTarget = {
   WorkspaceFolder: 3,
 } as const;
 
+export const ExtensionMode = {
+  Production: 1,
+  Development: 2,
+  Test: 3,
+} as const;
+
 // Window mock
 const outputChannels: any[] = [];
 


### PR DESCRIPTION
Adds the ExtensionMode enum to the Vitest vscode mock so unit tests can exercise Production vs Development/Test gating (useful for oh-tab-ta4 logging behavior tests).