### PR TITLE
oh-tab-1t4: add ask_oracle tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,6 +165,20 @@
       },
       {
         "type": "object",
+        "title": "OpenHands: Oracle",
+        "order": 1.5,
+        "properties": {
+          "openhands.oracle.profileId": {
+            "type": "string",
+            "default": "",
+            "scope": "machine",
+            "order": 0,
+            "markdownDescription": "LLM profile identifier (filename stem) used by the `ask_oracle` tool.\n\nWhen unset, `ask_oracle` returns an instructive error and suggests configuring this setting."
+          }
+        }
+      },
+      {
+        "type": "object",
         "title": "OpenHands: Agent",
         "order": 2,
         "properties": {

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1268,7 +1268,7 @@ export class Agent extends EventEmitter {
         }
       }
 
-      const context = { workspace: this.workspace, events: this.events, secrets: this.secrets };
+      const context = { workspace: this.workspace, events: this.events, secrets: this.secrets, settings: this.options.settings };
       const result = await tool.execute(validated, context);
       // Attach specialized summaries first (file diff, terminal), then general tool call summary as fallback
       let enrichedResult = await this.toolSummarizer.maybeAttachFileDiffSummary(toolCall, result);

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -103,8 +103,17 @@ export type ConfirmationSettings = {
   confirmUnknown?: boolean;
 };
 
+export type OracleSettings = {
+  /**
+   * LLM profile identifier (filename stem) used for the ask_oracle tool.
+   * When unset, ask_oracle returns an instructive error prompting configuration.
+   */
+  profileId?: string | null;
+};
+
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
+  oracle?: OracleSettings;
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;

--- a/packages/agent-sdk-ts/src/sdk/types/tools.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/tools.ts
@@ -2,11 +2,13 @@ import type { EventLog } from '../runtime/EventLog';
 import type { SecretRegistry } from '../runtime/SecretRegistry';
 import type { LLMToolDefinition } from '../llm';
 import type { BaseWorkspace } from '../../workspace';
+import type { OpenHandsSettings } from './settings';
 
 export interface ToolContext {
   workspace: BaseWorkspace;
   events?: EventLog;
   secrets?: SecretRegistry;
+  settings?: OpenHandsSettings;
 }
 
 export interface ToolDefinition<TArgs, TResult> {

--- a/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
+++ b/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
@@ -3,7 +3,7 @@ import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
 import { LLMFactory } from '../sdk/llm';
 
-const MAX_CONTEXT_CHARS = 20_000;
+const MAX_CONTEXT_CHARS = 100_000;
 
 const askOracleSchema = z.object({
   question: z

--- a/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
+++ b/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
@@ -1,0 +1,103 @@
+import { z } from 'zod';
+import type { ToolContext } from './types';
+import { ZodTool } from './zod-tool';
+import { LLMFactory } from '../sdk/llm';
+
+const MAX_CONTEXT_CHARS = 20_000;
+
+const askOracleSchema = z.object({
+  question: z
+    .string()
+    .trim()
+    .min(1)
+    .describe('The exact question to ask the oracle LLM.'),
+  context: z
+    .string()
+    .optional()
+    .describe('Optional additional context (code snippets, logs, etc.).'),
+});
+
+export type AskOracleToolArgs = z.infer<typeof askOracleSchema>;
+
+export type AskOracleToolResult = string;
+
+const normalizeNonEmptyString = (value: unknown): string | undefined => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed ? trimmed : undefined;
+};
+
+const truncateContext = (raw: string): string => {
+  if (raw.length <= MAX_CONTEXT_CHARS) return raw;
+  const head = raw.slice(0, Math.floor(MAX_CONTEXT_CHARS / 2));
+  const tail = raw.slice(-Math.floor(MAX_CONTEXT_CHARS / 2));
+  return `${head}\n<context clipped>\n${tail}`;
+};
+
+export class AskOracleTool extends ZodTool<AskOracleToolArgs, AskOracleToolResult> {
+  readonly name = 'ask_oracle';
+  readonly description =
+    'Ask a dedicated oracle LLM a question when you are unsure or want a second opinion. ' +
+    'You MUST include relevant context (code snippets, logs, diagrams) so the oracle can answer correctly.';
+  readonly schema = askOracleSchema;
+
+  async execute(args: AskOracleToolArgs, context: ToolContext): Promise<AskOracleToolResult> {
+    const question = normalizeNonEmptyString(args.question);
+    if (!question) {
+      return 'ask_oracle: question must be a non-empty string';
+    }
+
+    const oracleProfileId =
+      normalizeNonEmptyString(context.settings?.oracle?.profileId) ??
+      undefined;
+    if (!oracleProfileId) {
+      return 'ask_oracle is not configured. Set the oracle LLM profile id via openhands.oracle.profileId.';
+    }
+
+    const secrets = context.secrets;
+    if (!secrets) {
+      return 'ask_oracle cannot run because SecretRegistry is unavailable in this runtime.';
+    }
+
+    const extraContext = normalizeNonEmptyString(args.context);
+    const contextBlock = extraContext
+      ? `\n\n<environment/context>\n${truncateContext(extraContext)}\n</environment/context>`
+      : '';
+
+    const request = {
+      systemPrompt:
+        'You are an Oracle. Provide a careful, direct answer. ' +
+        'If you are uncertain, say so and suggest next steps. ' +
+        'Be concise unless the question asks for detail.',
+      messages: [
+        {
+          role: 'user' as const,
+          content: [{ type: 'text' as const, text: `${question}${contextBlock}` }],
+        },
+      ],
+    };
+
+    try {
+      const factory = new LLMFactory({
+        profileId: oracleProfileId,
+        // Keep model populated for error context when the profile load fails.
+        model: 'oracle',
+        usageId: 'oracle',
+      }, {
+        secrets,
+        preferredApiKeys: [`openhands.llmProfileApiKey.${oracleProfileId}`],
+      });
+
+      const client = await factory.createClient();
+      let text = '';
+      for await (const chunk of client.streamChat(request)) {
+        if (chunk.type === 'text') text += chunk.text;
+      }
+      const answer = text.trim();
+      if (!answer) return 'ask_oracle: oracle returned an empty response';
+      return answer;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      return `ask_oracle failed: ${reason}`;
+    }
+  }
+}

--- a/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
+++ b/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
@@ -46,9 +46,7 @@ export class AskOracleTool extends ZodTool<AskOracleToolArgs, AskOracleToolResul
       return 'ask_oracle: question must be a non-empty string';
     }
 
-    const oracleProfileId =
-      normalizeNonEmptyString(context.settings?.oracle?.profileId) ??
-      undefined;
+    const oracleProfileId = normalizeNonEmptyString(context.settings?.oracle?.profileId);
     if (!oracleProfileId) {
       return 'ask_oracle is not configured. Set the oracle LLM profile id via openhands.oracle.profileId.';
     }

--- a/packages/agent-sdk-ts/src/tools/__tests__/AskOracleTool.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/AskOracleTool.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocalWorkspace } from '../../workspace';
+import { SecretRegistry } from '../../sdk/runtime/SecretRegistry';
+
+const streamChatMock = vi.fn();
+const createClientMock = vi.fn(async () => ({ streamChat: streamChatMock }));
+const LLMFactoryMock = vi.fn().mockImplementation(() => ({ createClient: createClientMock }));
+
+vi.mock('../../sdk/llm', () => ({
+  LLMFactory: LLMFactoryMock,
+}));
+
+describe('AskOracleTool', () => {
+  beforeEach(() => {
+    streamChatMock.mockReset();
+    createClientMock.mockClear();
+    LLMFactoryMock.mockClear();
+  });
+
+  it('validates required question and optional context', async () => {
+    const { AskOracleTool } = await import('..');
+    const tool = new AskOracleTool();
+    expect(() => tool.validate({})).toThrow();
+    expect(() => tool.validate({ question: '   ' })).toThrow();
+    expect(tool.validate({ question: 'hi' })).toEqual({ question: 'hi' });
+    expect(tool.validate({ question: 'hi', context: 'more' })).toEqual({ question: 'hi', context: 'more' });
+  });
+
+  it('returns an instructive error when oracle profileId is unset', async () => {
+    const { AskOracleTool } = await import('..');
+    const tool = new AskOracleTool();
+    const workspace = new LocalWorkspace(process.cwd());
+    const secrets = new SecretRegistry(undefined, null);
+
+    const result = await tool.execute(tool.validate({ question: 'what now?' }), {
+      workspace,
+      secrets,
+      settings: { llm: {}, agent: {}, conversation: {}, confirmation: {}, secrets: {} } as any,
+    });
+
+    expect(result).toContain('openhands.oracle.profileId');
+    expect(LLMFactoryMock).not.toHaveBeenCalled();
+  });
+
+  it('invokes the configured oracle LLM and returns the answer', async () => {
+    const { AskOracleTool } = await import('..');
+    const tool = new AskOracleTool();
+    const workspace = new LocalWorkspace(process.cwd());
+    const secrets = new SecretRegistry(undefined, null);
+
+    let request: any;
+    streamChatMock.mockImplementation((req: any) => (async function* () {
+      request = req;
+      yield { type: 'text', text: 'Hello' };
+      yield { type: 'text', text: ' world' };
+    })());
+
+    const result = await tool.execute(tool.validate({ question: 'Question?', context: 'Some code' }), {
+      workspace,
+      secrets,
+      settings: {
+        llm: {},
+        agent: {},
+        conversation: {},
+        confirmation: {},
+        secrets: {},
+        oracle: { profileId: 'oracle-profile' },
+      } as any,
+    });
+
+    expect(LLMFactoryMock).toHaveBeenCalled();
+    expect(createClientMock).toHaveBeenCalled();
+    expect(request.systemPrompt).toContain('You are an Oracle');
+    const userText = request.messages?.[0]?.content?.[0]?.text ?? '';
+    expect(userText).toContain('Question?');
+    expect(userText).toContain('<environment/context>');
+    expect(userText).toContain('Some code');
+
+    expect(result).toEqual('Hello world');
+  });
+
+  it('truncates overly large context before sending to the oracle', async () => {
+    const { AskOracleTool } = await import('..');
+    const tool = new AskOracleTool();
+    const workspace = new LocalWorkspace(process.cwd());
+    const secrets = new SecretRegistry(undefined, null);
+
+    let request: any;
+    streamChatMock.mockImplementation((req: any) => (async function* () {
+      request = req;
+      yield { type: 'text', text: 'ok' };
+    })());
+
+    const huge = 'x'.repeat(50_000);
+    await tool.execute(tool.validate({ question: 'Q', context: huge }), {
+      workspace,
+      secrets,
+      settings: {
+        llm: {},
+        agent: {},
+        conversation: {},
+        confirmation: {},
+        secrets: {},
+        oracle: { profileId: 'oracle-profile' },
+      } as any,
+    });
+
+    const userText = request.messages?.[0]?.content?.[0]?.text ?? '';
+    expect(userText.length).toBeLessThan(60_000);
+    expect(userText).toContain('<context clipped>');
+  });
+
+  it('returns a friendly error when the oracle client cannot be created', async () => {
+    const { AskOracleTool } = await import('..');
+    const tool = new AskOracleTool();
+    const workspace = new LocalWorkspace(process.cwd());
+    const secrets = new SecretRegistry(undefined, null);
+
+    createClientMock.mockRejectedValueOnce(new Error('bad profile'));
+
+    const result = await tool.execute(tool.validate({ question: 'Q' }), {
+      workspace,
+      secrets,
+      settings: {
+        llm: {},
+        agent: {},
+        conversation: {},
+        confirmation: {},
+        secrets: {},
+        oracle: { profileId: 'oracle-profile' },
+      } as any,
+    });
+
+    expect(result).toContain('ask_oracle failed');
+  });
+});

--- a/packages/agent-sdk-ts/src/tools/index.ts
+++ b/packages/agent-sdk-ts/src/tools/index.ts
@@ -11,6 +11,7 @@ export * from './GlobTool';
 export * from './GrepTool';
 export * from './PlanningFileEditorTool';
 export * from './ApplyPatchTool';
+export * from './AskOracleTool';
 export * from './zod-tool';
 export * from './types';
 export * from './validation';

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -128,6 +128,7 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     GlobTool: vi.fn(() => new StubTool('glob')),
     GrepTool: vi.fn(() => new StubTool('grep')),
     BrowserTool: vi.fn(() => new StubTool('browser')),
+    AskOracleTool: vi.fn(() => new StubTool('ask_oracle')),
     FinishTool: vi.fn(() => new StubTool('finish')),
   };
 });

--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -79,6 +79,7 @@ describe('Tools picker host messages', () => {
       { id: 'glob', label: 'File Search (Glob)', description: 'Find files by name patterns (e.g., **/*.ts)', isDefault: false },
       { id: 'grep', label: 'Content Search (Grep)', description: 'Search file contents using regex patterns', isDefault: false },
       { id: 'browser', label: 'Web Fetch', description: 'Make HTTP GET/POST requests to fetch web content', isDefault: false },
+      { id: 'ask_oracle', label: 'Ask Oracle', description: 'Ask a dedicated oracle LLM for a second opinion (requires openhands.oracle.profileId)', isDefault: false },
       { id: 'finish', label: 'Finish', description: 'Signal that the agent has completed its task (always enabled)', isDefault: true },
     ]);
   });

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -24,6 +24,7 @@ export type HalSettings = {
 
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
+  oracle?: { profileId?: string };
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
@@ -46,6 +47,7 @@ const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
   servers: [],
   llm: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
+  oracle: { profileId: '' },
   agent: { enableSecurityAnalyzer: true, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
@@ -297,6 +299,15 @@ export class SettingsManager {
       inputCostPerToken: profileConfig?.inputCostPerToken ?? undefined,
       outputCostPerToken: profileConfig?.outputCostPerToken ?? undefined,
     };
+
+    const oracleProfileIdRaw = normalizeNonEmptyString(
+      this.adapter.get<string | null>('openhands.oracle.profileId', DEFAULTS.oracle?.profileId ?? '') ?? DEFAULTS.oracle?.profileId ?? ''
+    );
+    const oracleProfileId = oracleProfileIdRaw && isSafeProfileId(oracleProfileIdRaw) ? oracleProfileIdRaw : undefined;
+    if (oracleProfileIdRaw && !oracleProfileId) {
+      warnings.push(`Invalid oracle LLM profile id: ${oracleProfileIdRaw}`);
+    }
+    const oracle = { profileId: oracleProfileId };
     const agent: AgentSettings = {
       enableSecurityAnalyzer: this.adapter.get<boolean>('openhands.agent.enableSecurityAnalyzer', DEFAULTS.agent.enableSecurityAnalyzer) ?? DEFAULTS.agent.enableSecurityAnalyzer,
       debug: this.adapter.get<boolean>('openhands.agent.debug', DEFAULTS.agent.debug) ?? DEFAULTS.agent.debug,
@@ -343,7 +354,7 @@ export class SettingsManager {
       customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
       customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
     };
-    return { serverUrl, servers, llm, agent, conversation, confirmation, hal, secrets };
+    return { serverUrl, servers, llm, oracle, agent, conversation, confirmation, hal, secrets };
   }
 
   async update(partial: Partial<OpenHandsSettings>, target: 'workspace' | 'global' = 'workspace'): Promise<void> {
@@ -359,6 +370,12 @@ export class SettingsManager {
 
     if (partial.llm) {
       if (partial.llm.profileId !== undefined) ops.push(this.adapter.update('openhands.llm.profileId', partial.llm.profileId, target));
+    }
+
+    if (partial.oracle) {
+      if (partial.oracle.profileId !== undefined) {
+        ops.push(this.adapter.update('openhands.oracle.profileId', partial.oracle.profileId ?? '', 'global'));
+      }
     }
 
     if (partial.agent) {

--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -9,7 +9,10 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
   }
 
   private isGlobalOnlyKey(key: string): boolean {
-    return key === 'openhands.serverUrl' || key === 'openhands.servers' || key === 'openhands.llm.profileId';
+    return key === 'openhands.serverUrl'
+      || key === 'openhands.servers'
+      || key === 'openhands.llm.profileId'
+      || key === 'openhands.oracle.profileId';
   }
 
   private getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {

--- a/src/shared/localTools.ts
+++ b/src/shared/localTools.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from '@openhands/agent-sdk-ts';
 import {
+  AskOracleTool,
   BrowserTool,
   FileEditorTool,
   FinishTool,
@@ -16,6 +17,7 @@ export type LocalToolId =
   | 'glob'
   | 'grep'
   | 'browser'
+  | 'ask_oracle'
   | 'finish';
 
 export type LocalToolDescriptor = {
@@ -60,6 +62,12 @@ const LOCAL_TOOLS: LocalToolDescriptor[] = [
     id: 'browser',
     label: 'Web Fetch',
     description: 'Make HTTP GET/POST requests to fetch web content',
+    isDefault: false,
+  },
+  {
+    id: 'ask_oracle',
+    label: 'Ask Oracle',
+    description: 'Ask a dedicated oracle LLM for a second opinion (requires openhands.oracle.profileId)',
     isDefault: false,
   },
   {
@@ -114,6 +122,7 @@ function getOrCreateLocalToolInstances(): LocalToolInstances {
     glob: new GlobTool(),
     grep: new GrepTool(),
     browser: new BrowserTool(),
+    ask_oracle: new AskOracleTool(),
     finish: new FinishTool(),
   };
   return instances;


### PR DESCRIPTION
Implements **oh-tab-1t4**: adds an `ask_oracle` tool that queries a dedicated “oracle” LLM profile for second opinions.

- Tool: `AskOracleTool` (schema `{ question, context? }`), builds an Oracle system prompt, delimits extra context with `<environment/context>`, truncates very large context.
- Settings: `openhands.oracle.profileId` (uses existing LLM Profiles; unset => instructive error).
- Wiring: passes `settings` into tool context; registers `ask_oracle` in local tools list.

**Tests**
- `npm test`
- `npm run typecheck`
- `npm run lint`

### Bead
```json
[
  {
    "id": "oh-tab-1t4",
    "title": "ask_oracle tool: query a high-quality LLM for second opinion",
    "description": "Inspiration: AMP’s ‘oracle’ pattern — a separate, very-strong LLM (e.g., Anthropic Claude Opus 4.5) that the agent can consult when stuck or needing a second opinion on complex questions.\n\nGoal: Add an ask_oracle tool the agent can call to query an external ‘oracle’ LLM.\n\nTool contract:\n- name: ask_oracle\n- description: Ask a dedicated oracle LLM a question when you are unsure or want a second opinion. You MUST include relevant context in your question so the oracle can answer correctly (e.g., code snippets, markdown explanations, or diagrams in Mermaid if helpful).\n- input schema:\n  - question: string (required) — the exact question to ask the oracle.\n  - context: string (optional) — additional detail the agent assembles to provide sufficient background.\n- output: string (the oracle’s answer). Consider returning a structured envelope with { answer, citations? } later; start simple with plaintext answer.\n\nSettings:\n- Add a setting to select the oracle LLM profile by id (e.g., openhands.oracle.profileId). Reuse the existing LLM Profiles store. If unset, tool returns an instructive error and suggests configuring the oracle profile.\n\nRuntime behavior:\n- On tool call, resolve the oracle LLM client from the selected profile.\n- Build a concise system prompt like: ‘You are an Oracle. Provide a careful, direct answer. If you are uncertain, say so and suggest next steps. Be concise unless the question asks for detail.’\n- Construct the user message using input.question and append the provided context (clearly delimited) to ensure the oracle has sufficient background.\n- Respect token limits; truncate overly large context sensibly (optional follow-up).\n\nTests (unit; no integration needed):\n- Mock the oracle LLM client and verify:\n  - Tool validates required ‘question’ and accepts optional ‘context’.\n  - It builds the prompt with an <environment/context> style delimiter (or equivalent) and passes it to the LLM.\n  - It returns the mocked answer plain-text to the observation.\n  - When oracle profile is missing/misconfigured, the tool returns a friendly error prompting to set openhands.oracle.profileId.\n- Cover edge cases: empty/whitespace question (reject), large context (truncate), non-string inputs (schema validation).\n\nNotes:\n- Future: consider structured output, references, and cost/usage telemetry.\n- UI: Settings pane entry for selecting the oracle profile from existing profiles.",
    "acceptance_criteria": "- New ask_oracle tool available in @openhands/agent-sdk-ts tools package with JSON schema { question: string (required), context: string (optional) }.\n- Tool reads oracle LLM profileId from settings (e.g., openhands.oracle.profileId). If unset, returns an instructive error.\n- Tool invokes the configured LLM and returns the oracle’s answer as the observation result.\n- Unit tests thoroughly cover success and error paths using a mocked LLM client. No integration tests are required.\n- Clear tool description instructs the agent to include sufficient context (code snippets, markdown, diagrams) when calling the tool.",
    "status": "open",
    "priority": 4,
    "issue_type": "feature",
    "created_at": "2026-01-13T06:14:05.382738+01:00",
    "updated_at": "2026-01-13T06:14:05.382738+01:00",
    "labels": [
      "llm",
      "sdk",
      "tools"
    ]
  }
]
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced "Ask Oracle" tool that enables querying a dedicated oracle LLM instance
  * Added configuration option to set your oracle LLM profile, with helpful error messaging if not configured

* **Tests**
  * Added comprehensive test coverage for the Ask Oracle tool, including validation, error scenarios, and response handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->