### PR TITLE
oh-tab-cxl: document openhands.oracle.profileId

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -128,6 +128,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - `openhands.serverUrl` - agent-server URL (blank for local mode)
 - `openhands.servers` - saved server list [{ url, label? }]
 - `openhands.llm.profileId` - selected LLM profile id from `~/.openhands/llm-profiles` (local alias; remote mode expands into `agent.llm` fields, no `profile_id` sent)
+- `openhands.oracle.profileId` - selected LLM profile id used by the local-only `ask_oracle` tool (if unset, `ask_oracle` returns an instructive error prompting you to configure it)
 
 For internal diagnostics and the dev logging bridge, see docs/vscode_local_setup.md.
 - `openhands.agent.enableSecurityAnalyzer`

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -45,6 +45,9 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
     1) A profile that already has a per-profile API key stored in SecretStorage.
     2) A profile suggested by provider-specific API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`).
     3) The fallback profile ID `sonnet-45`.
+- `openhands.oracle.profileId` (string, machine scope)
+  - Optional. Selects the LLM profile used by the local-only `ask_oracle` tool.
+  - If unset, `ask_oracle` returns an instructive error prompting you to configure it.
 
 ### Profile expansion (remote compatibility)
 - The agent-server schema is strict; it does **not** accept `profile_id` fields.


### PR DESCRIPTION
Implements **oh-tab-cxl**: document the new setting `openhands.oracle.profileId` in `docs/PRD.md` and `docs/settings_prd.md`.

This makes it easier for users to discover/configure the oracle profile selector used by the local-only `ask_oracle` tool.

### Bead

[
  {
    "id": "oh-tab-cxl",
    "title": "Docs: document openhands.oracle.profileId",
    "description": "Document the new OpenHands setting openhands.oracle.profileId in docs/PRD.md and docs/settings_prd.md so users discover the oracle profile selector.",
    "acceptance_criteria": "- docs/PRD.md mentions openhands.oracle.profileId in the Settings section.\n- docs/settings_prd.md documents openhands.oracle.profileId under LLM settings.",
    "notes": "OrangeCastle taking as tech-debt while BlackDog works oh-tab-ox2",
    "status": "in_progress",
    "priority": 4,
    "issue_type": "chore",
    "created_at": "2026-01-13T09:50:05.414264+01:00",
    "updated_at": "2026-01-13T09:50:08.367693+01:00",
    "labels": [
      "docs",
      "tech-debt"
    ]
  }
]
