### PR TITLE
oh-tab-dzn: fix ask_oracle context truncation

### DIFF
--- a/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
+++ b/packages/agent-sdk-ts/src/tools/AskOracleTool.ts
@@ -3,7 +3,9 @@ import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
 import { LLMFactory } from '../sdk/llm';
 
-const MAX_CONTEXT_CHARS = 100_000;
+// Keep the full user message (question + wrappers + clipped context) within a reasonable size.
+// This is a char-based heuristic, not a token-based limit.
+const MAX_CONTEXT_CHARS = 50_000;
 
 const askOracleSchema = z.object({
   question: z

--- a/packages/agent-sdk-ts/src/tools/__tests__/AskOracleTool.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/AskOracleTool.test.ts
@@ -91,7 +91,7 @@ describe('AskOracleTool', () => {
       yield { type: 'text', text: 'ok' };
     })());
 
-    const huge = 'x'.repeat(50_000);
+    const huge = 'x'.repeat(80_000);
     await tool.execute(tool.validate({ question: 'Q', context: huge }), {
       workspace,
       secrets,


### PR DESCRIPTION
Fixes **oh-tab-dzn**: align `AskOracleTool` context truncation with the unit test / intended message-size cap.

- Truncates context at ~50k chars and inserts `<context clipped>`.
- Updates the truncation test to actually exceed the cap.

### Bead

[
  {
    "id": "oh-tab-dzn",
    "title": "Fix: ask_oracle context truncation limit",
    "description": "CI currently fails in AskOracleTool truncation test due to mismatch between MAX_CONTEXT_CHARS and test inputs/expectations. Align implementation + test so overly-large context is truncated and the user message stays within ~60k chars.",
    "acceptance_criteria": "- AskOracleTool truncates large context and inserts \u003ccontext clipped\u003e marker.\n- Unit test for truncation reliably triggers and passes.\n- CI passes.",
    "notes": "OrangeCastle: fix CI break uncovered by PR #749",
    "status": "in_progress",
    "priority": 2,
    "issue_type": "bug",
    "created_at": "2026-01-13T09:54:56.091457+01:00",
    "updated_at": "2026-01-13T09:55:01.268561+01:00",
    "labels": [
      "ci",
      "sdk",
      "tools"
    ]
  }
]
