### PR TITLE
oh-tab-h5i: tighten ask_oracle truncation unit test

### DIFF
--- a/packages/agent-sdk-ts/src/tools/__tests__/AskOracleTool.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/AskOracleTool.test.ts
@@ -91,7 +91,7 @@ describe('AskOracleTool', () => {
       yield { type: 'text', text: 'ok' };
     })());
 
-    const huge = 'x'.repeat(250_000);
+    const huge = 'x'.repeat(80_000);
     await tool.execute(tool.validate({ question: 'Q', context: huge }), {
       workspace,
       secrets,
@@ -106,7 +106,7 @@ describe('AskOracleTool', () => {
     });
 
     const userText = request.messages?.[0]?.content?.[0]?.text ?? '';
-    expect(userText.length).toBeLessThan(130_000);
+    expect(userText.length).toBeLessThan(60_000);
     expect(userText).toContain('<context clipped>');
   });
 


### PR DESCRIPTION
Implements **oh-tab-h5i**: restore a stricter cap in the AskOracleTool truncation unit test.

This matches the current `AskOracleTool` behavior (context char cap ~50k) and keeps the user message under ~60k chars.

### Bead

[
  {
    "id": "oh-tab-h5i",
    "title": "Unit: tighten ask_oracle context truncation assertion",
    "description": "After merging oh-tab-ox2, AskOracleTool truncation unit test assertion was loosened. Restore the stricter expectation to ensure user message stays under ~60k chars when truncating context.",
    "acceptance_criteria": "- AskOracleTool truncation unit test asserts the final user message length stays under ~60k chars and contains \u003ccontext clipped\u003e.",
    "status": "in_progress",
    "priority": 4,
    "issue_type": "chore",
    "created_at": "2026-01-13T10:10:20.647209+01:00",
    "updated_at": "2026-01-13T10:10:29.155827+01:00",
    "labels": [
      "tech-debt",
      "tests"
    ]
  }
]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test parameters to reflect stricter context truncation expectations for oracle requests, reducing maximum context size and enforcing more aggressive content limits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->