### PR TITLE
oh-tab-f2x: dedupe E2E OpenAI tool-calls mock

### DIFF
--- a/tests/e2e/suite/helpers/openAiToolCallsServer.ts
+++ b/tests/e2e/suite/helpers/openAiToolCallsServer.ts
@@ -1,0 +1,181 @@
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+
+const REDACTED = '<redacted>';
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'proxy-authorization',
+  'x-api-key',
+  'x-goog-api-key',
+  'cookie',
+  'set-cookie',
+]);
+
+export type ToolCallArgs = Record<string, unknown>;
+
+export type ToolCallSpec = {
+  name: string;
+  args: ToolCallArgs;
+};
+
+export type OpenAiToolCallsMockRequest = {
+  method: string;
+  path: string;
+  headers: Record<string, string | string[] | undefined>;
+  bodyText: string;
+  json?: unknown;
+};
+
+export type OpenAiToolCallsMockServer = {
+  baseUrl: string;
+  requests: OpenAiToolCallsMockRequest[];
+  close: () => Promise<void>;
+};
+
+export type OpenAiToolCallsMockServerOptions = {
+  toolCalls: ToolCallSpec[];
+  includeFinishCall?: boolean;
+};
+
+function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string | string[] | undefined> {
+  const sanitized: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
+      if (Array.isArray(value)) {
+        sanitized[key] = value.map(() => REDACTED);
+      } else if (typeof value === 'string') {
+        sanitized[key] = REDACTED;
+      } else {
+        sanitized[key] = value;
+      }
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
+function sendOpenAiToolCallsSse(res: http.ServerResponse, toolCalls: Array<{ id: string; name: string; args: string }>): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+
+  res.write(
+    `data: ${JSON.stringify({
+      choices: [
+        {
+          delta: {
+            tool_calls: toolCalls.map((call, index) => ({
+              index,
+              id: call.id,
+              type: 'function',
+              function: { name: call.name, arguments: call.args },
+            })),
+          },
+        },
+      ],
+    })}\n`,
+  );
+
+  res.write(
+    `data: ${JSON.stringify({
+      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
+    })}\n`,
+  );
+
+  res.write('data: [DONE]\n');
+  res.end();
+}
+
+export async function startOpenAiToolCallsMockServer(
+  options: OpenAiToolCallsMockServerOptions,
+): Promise<OpenAiToolCallsMockServer> {
+  const requests: OpenAiToolCallsMockRequest[] = [];
+  let port = 0;
+
+  const includeFinishCall = options.includeFinishCall ?? true;
+  const toolCalls: ToolCallSpec[] = [
+    ...options.toolCalls,
+    ...(includeFinishCall ? [{ name: 'finish', args: {} }] : []),
+  ];
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? 'GET';
+      const rawUrl = req.url ?? '/';
+      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
+      const path = url.pathname;
+
+      const bodyChunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
+      await new Promise<void>((resolve) => req.on('end', resolve));
+      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
+      let json: unknown;
+      try {
+        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
+      } catch {
+        json = undefined;
+      }
+
+      requests.push({
+        method,
+        path,
+        headers: sanitizeHeaders(req.headers),
+        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
+        ...(json !== undefined ? { json } : {}),
+      });
+
+      if (method !== 'POST') {
+        res.writeHead(405, { 'Content-Type': 'text/plain' });
+        res.end('Method not allowed');
+        return;
+      }
+
+      if (path === '/v1/chat/completions' || path === '/api/v1/chat/completions') {
+        const now = Date.now();
+        sendOpenAiToolCallsSse(
+          res,
+          toolCalls.map((call) => ({
+            id: `call_${call.name}_${now}`,
+            name: call.name,
+            args: JSON.stringify(call.args),
+          })),
+        );
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end(`Not found: ${path}`);
+    })().catch((err) => {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to bind mock server to a port'));
+        return;
+      }
+      port = (addr as AddressInfo).port;
+      resolve();
+    });
+    server.once('error', reject);
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+

--- a/tests/e2e/suite/oracleConfigured.ts
+++ b/tests/e2e/suite/oracleConfigured.ts
@@ -1,173 +1,7 @@
-import * as http from 'http';
-import type { AddressInfo } from 'net';
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
-
-const REDACTED = '<redacted>';
-const SENSITIVE_HEADERS = new Set([
-  'authorization',
-  'proxy-authorization',
-  'x-api-key',
-  'x-goog-api-key',
-  'cookie',
-  'set-cookie',
-]);
-
-type MockRequest = {
-  method: string;
-  path: string;
-  headers: Record<string, string | string[] | undefined>;
-  bodyText: string;
-  json?: unknown;
-};
-
-type MockServer = {
-  baseUrl: string;
-  requests: MockRequest[];
-  close: () => Promise<void>;
-};
-
-function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string | string[] | undefined> {
-  const sanitized: Record<string, string | string[] | undefined> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-      if (Array.isArray(value)) {
-        sanitized[key] = value.map(() => REDACTED);
-      } else if (typeof value === 'string') {
-        sanitized[key] = REDACTED;
-      } else {
-        sanitized[key] = value;
-      }
-      continue;
-    }
-    sanitized[key] = value;
-  }
-  return sanitized;
-}
-
-function sendOpenAiToolCallsSse(res: http.ServerResponse, toolCalls: Array<{ id: string; name: string; args: string }>): void {
-  res.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    Connection: 'keep-alive',
-  });
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [
-        {
-          delta: {
-            tool_calls: toolCalls.map((call, index) => ({
-              index,
-              id: call.id,
-              type: 'function',
-              function: { name: call.name, arguments: call.args },
-            })),
-          },
-        },
-      ],
-    })}\n`,
-  );
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
-      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
-  );
-
-  res.write('data: [DONE]\n');
-  res.end();
-}
-
-async function startToolCallingMockServer(): Promise<MockServer> {
-  const requests: MockRequest[] = [];
-  let port = 0;
-
-  const server = http.createServer((req, res) => {
-    void (async () => {
-      const method = req.method ?? 'GET';
-      const rawUrl = req.url ?? '/';
-      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
-      const path = url.pathname;
-
-      const bodyChunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
-      await new Promise<void>((resolve) => req.on('end', resolve));
-      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
-      let json: unknown;
-      try {
-        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
-      } catch {
-        json = undefined;
-      }
-
-      requests.push({
-        method,
-        path,
-        headers: sanitizeHeaders(req.headers),
-        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
-        ...(json !== undefined ? { json } : {}),
-      });
-
-      if (method !== 'POST') {
-        res.writeHead(405, { 'Content-Type': 'text/plain' });
-        res.end('Method not allowed');
-        return;
-      }
-
-      if (path === '/v1/chat/completions' || path === '/api/v1/chat/completions') {
-        const now = Date.now();
-        sendOpenAiToolCallsSse(res, [
-          {
-            id: `call_ask_${now}`,
-            name: 'ask_oracle',
-            args: JSON.stringify({
-              question: 'What does the oracle think?',
-              context: 'E2E: oracle configured test',
-            }),
-          },
-          {
-            id: `call_finish_${now}`,
-            name: 'finish',
-            args: JSON.stringify({}),
-          },
-        ]);
-        return;
-      }
-
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end(`Not found: ${path}`);
-    })().catch((err) => {
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to bind mock server to a port'));
-        return;
-      }
-      port = (addr as AddressInfo).port;
-      resolve();
-    });
-    server.once('error', reject);
-  });
-
-  return {
-    baseUrl: `http://127.0.0.1:${port}`,
-    requests,
-    close: async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()));
-      });
-    },
-  };
-}
+import { startOpenAiToolCallsMockServer } from './helpers/openAiToolCallsServer';
 
 type WebviewActionResult = { sent?: boolean };
 
@@ -179,7 +13,17 @@ type LastObservationInfo = {
 } | null;
 
 export async function run(): Promise<void> {
-  const mainMock = await startToolCallingMockServer();
+  const mainMock = await startOpenAiToolCallsMockServer({
+    toolCalls: [
+      {
+        name: 'ask_oracle',
+        args: {
+          question: 'What does the oracle think?',
+          context: 'E2E: oracle configured test',
+        },
+      },
+    ],
+  });
   const oracleMock = await startMockLlmServer();
 
   try {

--- a/tests/e2e/suite/oracleUnset.ts
+++ b/tests/e2e/suite/oracleUnset.ts
@@ -1,172 +1,6 @@
-import * as http from 'http';
-import type { AddressInfo } from 'net';
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
-
-const REDACTED = '<redacted>';
-const SENSITIVE_HEADERS = new Set([
-  'authorization',
-  'proxy-authorization',
-  'x-api-key',
-  'x-goog-api-key',
-  'cookie',
-  'set-cookie',
-]);
-
-type MockRequest = {
-  method: string;
-  path: string;
-  headers: Record<string, string | string[] | undefined>;
-  bodyText: string;
-  json?: unknown;
-};
-
-type MockServer = {
-  baseUrl: string;
-  requests: MockRequest[];
-  close: () => Promise<void>;
-};
-
-function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string | string[] | undefined> {
-  const sanitized: Record<string, string | string[] | undefined> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-      if (Array.isArray(value)) {
-        sanitized[key] = value.map(() => REDACTED);
-      } else if (typeof value === 'string') {
-        sanitized[key] = REDACTED;
-      } else {
-        sanitized[key] = value;
-      }
-      continue;
-    }
-    sanitized[key] = value;
-  }
-  return sanitized;
-}
-
-function sendOpenAiToolCallsSse(res: http.ServerResponse, toolCalls: Array<{ id: string; name: string; args: string }>): void {
-  res.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    Connection: 'keep-alive',
-  });
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [
-        {
-          delta: {
-            tool_calls: toolCalls.map((call, index) => ({
-              index,
-              id: call.id,
-              type: 'function',
-              function: { name: call.name, arguments: call.args },
-            })),
-          },
-        },
-      ],
-    })}\n`,
-  );
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
-      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
-  );
-
-  res.write('data: [DONE]\n');
-  res.end();
-}
-
-async function startOracleUnsetMockServer(): Promise<MockServer> {
-  const requests: MockRequest[] = [];
-  let port = 0;
-
-  const server = http.createServer((req, res) => {
-    void (async () => {
-      const method = req.method ?? 'GET';
-      const rawUrl = req.url ?? '/';
-      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
-      const path = url.pathname;
-
-      const bodyChunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
-      await new Promise<void>((resolve) => req.on('end', resolve));
-      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
-      let json: unknown;
-      try {
-        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
-      } catch {
-        json = undefined;
-      }
-
-      requests.push({
-        method,
-        path,
-        headers: sanitizeHeaders(req.headers),
-        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
-        ...(json !== undefined ? { json } : {}),
-      });
-
-      if (method !== 'POST') {
-        res.writeHead(405, { 'Content-Type': 'text/plain' });
-        res.end('Method not allowed');
-        return;
-      }
-
-      if (path === '/v1/chat/completions' || path === '/api/v1/chat/completions') {
-        const now = Date.now();
-        sendOpenAiToolCallsSse(res, [
-          {
-            id: `call_ask_${now}`,
-            name: 'ask_oracle',
-            args: JSON.stringify({
-              question: 'Should we proceed?',
-              context: 'E2E: oracle unset test',
-            }),
-          },
-          {
-            id: `call_finish_${now}`,
-            name: 'finish',
-            args: JSON.stringify({}),
-          },
-        ]);
-        return;
-      }
-
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end(`Not found: ${path}`);
-    })().catch((err) => {
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to bind mock server to a port'));
-        return;
-      }
-      port = (addr as AddressInfo).port;
-      resolve();
-    });
-    server.once('error', reject);
-  });
-
-  return {
-    baseUrl: `http://127.0.0.1:${port}`,
-    requests,
-    close: async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()));
-      });
-    },
-  };
-}
+import { startOpenAiToolCallsMockServer } from './helpers/openAiToolCallsServer';
 
 type WebviewActionResult = { sent?: boolean };
 
@@ -178,7 +12,17 @@ type LastObservationInfo = {
 } | null;
 
 export async function run(): Promise<void> {
-  const mock = await startOracleUnsetMockServer();
+  const mock = await startOpenAiToolCallsMockServer({
+    toolCalls: [
+      {
+        name: 'ask_oracle',
+        args: {
+          question: 'Should we proceed?',
+          context: 'E2E: oracle unset test',
+        },
+      },
+    ],
+  });
 
   try {
     await vscode.commands.executeCommand('openhands.open');
@@ -263,4 +107,3 @@ export async function run(): Promise<void> {
     await mock.close();
   }
 }
-


### PR DESCRIPTION
Implements **oh-tab-f2x**: dedupe the OpenAI `chat_completions` SSE tool_calls mock server used by E2E.

- New helper: `tests/e2e/suite/helpers/openAiToolCallsServer.ts`
- `oracleUnset` and `oracleConfigured` suites now use the helper (no behavior changes).

### Bead

[
  {
    "id": "oh-tab-f2x",
    "title": "Tech debt: dedupe E2E OpenAI tool-calls mock server",
    "description": "Refactor the duplicated OpenAI chat_completions SSE tool_calls mock server code used by tests/e2e/suite/oracleUnset.ts and tests/e2e/suite/oracleConfigured.ts into a shared helper under tests/e2e/suite/helpers/. No behavior changes.",
    "acceptance_criteria": "- Shared helper exists for the OpenAI tool_calls SSE mock.\n- oracleUnset and oracleConfigured suites use the helper.\n- CI (unit + e2e) remains green.",
    "status": "in_progress",
    "priority": 4,
    "issue_type": "chore",
    "created_at": "2026-01-13T10:32:07.332598+01:00",
    "updated_at": "2026-01-13T10:32:12.323045+01:00",
    "labels": [
      "e2e",
      "tech-debt",
      "tests"
    ]
  }
]
