### PR TITLE
test(e2e): dedupe oracle tool-call mock server

### DIFF
--- a/tests/e2e/suite/mockLlmServer.ts
+++ b/tests/e2e/suite/mockLlmServer.ts
@@ -46,6 +46,44 @@ function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, stri
   return sanitized;
 }
 
+function sendOpenAiToolCallsSse(
+  res: http.ServerResponse,
+  toolCalls: Array<{ id: string; name: string; args: string }>,
+): void {
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+
+  res.write(
+    `data: ${JSON.stringify({
+      choices: [
+        {
+          delta: {
+            tool_calls: toolCalls.map((call, index) => ({
+              index,
+              id: call.id,
+              type: 'function',
+              function: { name: call.name, arguments: call.args },
+            })),
+          },
+        },
+      ],
+    })}\n`,
+  );
+
+  res.write(
+    `data: ${JSON.stringify({
+      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
+    })}\n`,
+  );
+
+  res.write('data: [DONE]\n');
+  res.end();
+}
+
 function sendOpenAiChatCompletionsSse(res: http.ServerResponse, text: string): void {
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
@@ -107,6 +145,106 @@ function sendGeminiStreamGenerateContentSse(res: http.ServerResponse, text: stri
   );
   res.write('data: [DONE]\n');
   res.end();
+}
+
+export async function startMockOpenAiToolCallsServer(options: {
+  toolCalls: Array<{ id: string; name: string; args: unknown }>;
+}): Promise<MockLlmServer> {
+  const requests: MockLlmRequest[] = [];
+  let port = 0;
+
+  const toolCalls = options.toolCalls.map((call) => ({
+    id: call.id,
+    name: call.name,
+    args: typeof call.args === 'string' ? call.args : JSON.stringify(call.args),
+  }));
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      const method = req.method ?? 'GET';
+      const rawUrl = req.url ?? '/';
+      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
+      const path = url.pathname;
+
+      if (path === '/__log' && method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ requests }));
+        return;
+      }
+
+      if (path === '/__reset' && method === 'POST') {
+        requests.splice(0, requests.length);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+        return;
+      }
+
+      const bodyChunks: Buffer[] = [];
+      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
+      await new Promise<void>((resolve) => req.on('end', resolve));
+      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
+      let json: unknown;
+      try {
+        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
+      } catch {
+        json = undefined;
+      }
+
+      requests.push({
+        method,
+        path,
+        headers: sanitizeHeaders(req.headers),
+        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
+        ...(json !== undefined ? { json } : {}),
+      });
+
+      if (method !== 'POST') {
+        res.writeHead(405, { 'Content-Type': 'text/plain' });
+        res.end('Method not allowed');
+        return;
+      }
+
+      const prefix = PATH_PREFIXES.find((p) => path.startsWith(p + '/'));
+      const normalizedPath = prefix ? path.slice(prefix.length) : path;
+
+      if (normalizedPath === '/chat/completions') {
+        sendOpenAiToolCallsSse(res, toolCalls);
+        return;
+      }
+
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end(`Not found: ${path}`);
+    })().catch((err) => {
+      res.writeHead(500, { 'Content-Type': 'text/plain' });
+      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to bind mock server to a port'));
+        return;
+      }
+      port = (addr as AddressInfo).port;
+      resolve();
+    });
+    server.once('error', reject);
+  });
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    requests,
+    reset: () => {
+      requests.splice(0, requests.length);
+    },
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
 }
 
 export async function startMockLlmServer(): Promise<MockLlmServer> {

--- a/tests/e2e/suite/oracleConfigured.ts
+++ b/tests/e2e/suite/oracleConfigured.ts
@@ -1,173 +1,6 @@
-import * as http from 'http';
-import type { AddressInfo } from 'net';
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
-import { startMockLlmServer } from './mockLlmServer';
-
-const REDACTED = '<redacted>';
-const SENSITIVE_HEADERS = new Set([
-  'authorization',
-  'proxy-authorization',
-  'x-api-key',
-  'x-goog-api-key',
-  'cookie',
-  'set-cookie',
-]);
-
-type MockRequest = {
-  method: string;
-  path: string;
-  headers: Record<string, string | string[] | undefined>;
-  bodyText: string;
-  json?: unknown;
-};
-
-type MockServer = {
-  baseUrl: string;
-  requests: MockRequest[];
-  close: () => Promise<void>;
-};
-
-function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string | string[] | undefined> {
-  const sanitized: Record<string, string | string[] | undefined> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-      if (Array.isArray(value)) {
-        sanitized[key] = value.map(() => REDACTED);
-      } else if (typeof value === 'string') {
-        sanitized[key] = REDACTED;
-      } else {
-        sanitized[key] = value;
-      }
-      continue;
-    }
-    sanitized[key] = value;
-  }
-  return sanitized;
-}
-
-function sendOpenAiToolCallsSse(res: http.ServerResponse, toolCalls: Array<{ id: string; name: string; args: string }>): void {
-  res.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    Connection: 'keep-alive',
-  });
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [
-        {
-          delta: {
-            tool_calls: toolCalls.map((call, index) => ({
-              index,
-              id: call.id,
-              type: 'function',
-              function: { name: call.name, arguments: call.args },
-            })),
-          },
-        },
-      ],
-    })}\n`,
-  );
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
-      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
-  );
-
-  res.write('data: [DONE]\n');
-  res.end();
-}
-
-async function startToolCallingMockServer(): Promise<MockServer> {
-  const requests: MockRequest[] = [];
-  let port = 0;
-
-  const server = http.createServer((req, res) => {
-    void (async () => {
-      const method = req.method ?? 'GET';
-      const rawUrl = req.url ?? '/';
-      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
-      const path = url.pathname;
-
-      const bodyChunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
-      await new Promise<void>((resolve) => req.on('end', resolve));
-      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
-      let json: unknown;
-      try {
-        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
-      } catch {
-        json = undefined;
-      }
-
-      requests.push({
-        method,
-        path,
-        headers: sanitizeHeaders(req.headers),
-        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
-        ...(json !== undefined ? { json } : {}),
-      });
-
-      if (method !== 'POST') {
-        res.writeHead(405, { 'Content-Type': 'text/plain' });
-        res.end('Method not allowed');
-        return;
-      }
-
-      if (path === '/v1/chat/completions' || path === '/api/v1/chat/completions') {
-        const now = Date.now();
-        sendOpenAiToolCallsSse(res, [
-          {
-            id: `call_ask_${now}`,
-            name: 'ask_oracle',
-            args: JSON.stringify({
-              question: 'What does the oracle think?',
-              context: 'E2E: oracle configured test',
-            }),
-          },
-          {
-            id: `call_finish_${now}`,
-            name: 'finish',
-            args: JSON.stringify({}),
-          },
-        ]);
-        return;
-      }
-
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end(`Not found: ${path}`);
-    })().catch((err) => {
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to bind mock server to a port'));
-        return;
-      }
-      port = (addr as AddressInfo).port;
-      resolve();
-    });
-    server.once('error', reject);
-  });
-
-  return {
-    baseUrl: `http://127.0.0.1:${port}`,
-    requests,
-    close: async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()));
-      });
-    },
-  };
-}
+import { startMockLlmServer, startMockOpenAiToolCallsServer } from './mockLlmServer';
 
 type WebviewActionResult = { sent?: boolean };
 
@@ -179,7 +12,21 @@ type LastObservationInfo = {
 } | null;
 
 export async function run(): Promise<void> {
-  const mainMock = await startToolCallingMockServer();
+  const now = Date.now();
+  const mainMock = await startMockOpenAiToolCallsServer({
+    toolCalls: [
+      {
+        id: `call_ask_${now}`,
+        name: 'ask_oracle',
+        args: { question: 'What does the oracle think?', context: 'E2E: oracle configured test' },
+      },
+      {
+        id: `call_finish_${now}`,
+        name: 'finish',
+        args: {},
+      },
+    ],
+  });
   const oracleMock = await startMockLlmServer();
 
   try {

--- a/tests/e2e/suite/oracleUnset.ts
+++ b/tests/e2e/suite/oracleUnset.ts
@@ -1,172 +1,6 @@
-import * as http from 'http';
-import type { AddressInfo } from 'net';
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
-
-const REDACTED = '<redacted>';
-const SENSITIVE_HEADERS = new Set([
-  'authorization',
-  'proxy-authorization',
-  'x-api-key',
-  'x-goog-api-key',
-  'cookie',
-  'set-cookie',
-]);
-
-type MockRequest = {
-  method: string;
-  path: string;
-  headers: Record<string, string | string[] | undefined>;
-  bodyText: string;
-  json?: unknown;
-};
-
-type MockServer = {
-  baseUrl: string;
-  requests: MockRequest[];
-  close: () => Promise<void>;
-};
-
-function sanitizeHeaders(headers: http.IncomingHttpHeaders): Record<string, string | string[] | undefined> {
-  const sanitized: Record<string, string | string[] | undefined> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    if (SENSITIVE_HEADERS.has(key.toLowerCase())) {
-      if (Array.isArray(value)) {
-        sanitized[key] = value.map(() => REDACTED);
-      } else if (typeof value === 'string') {
-        sanitized[key] = REDACTED;
-      } else {
-        sanitized[key] = value;
-      }
-      continue;
-    }
-    sanitized[key] = value;
-  }
-  return sanitized;
-}
-
-function sendOpenAiToolCallsSse(res: http.ServerResponse, toolCalls: Array<{ id: string; name: string; args: string }>): void {
-  res.writeHead(200, {
-    'Content-Type': 'text/event-stream',
-    'Cache-Control': 'no-cache',
-    Connection: 'keep-alive',
-  });
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [
-        {
-          delta: {
-            tool_calls: toolCalls.map((call, index) => ({
-              index,
-              id: call.id,
-              type: 'function',
-              function: { name: call.name, arguments: call.args },
-            })),
-          },
-        },
-      ],
-    })}\n`,
-  );
-
-  res.write(
-    `data: ${JSON.stringify({
-      choices: [{ delta: {}, finish_reason: 'tool_calls' }],
-      usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
-  );
-
-  res.write('data: [DONE]\n');
-  res.end();
-}
-
-async function startOracleUnsetMockServer(): Promise<MockServer> {
-  const requests: MockRequest[] = [];
-  let port = 0;
-
-  const server = http.createServer((req, res) => {
-    void (async () => {
-      const method = req.method ?? 'GET';
-      const rawUrl = req.url ?? '/';
-      const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
-      const path = url.pathname;
-
-      const bodyChunks: Buffer[] = [];
-      req.on('data', (chunk: Buffer) => bodyChunks.push(chunk));
-      await new Promise<void>((resolve) => req.on('end', resolve));
-      const bodyText = Buffer.concat(bodyChunks).toString('utf8');
-      let json: unknown;
-      try {
-        json = bodyText ? (JSON.parse(bodyText) as unknown) : undefined;
-      } catch {
-        json = undefined;
-      }
-
-      requests.push({
-        method,
-        path,
-        headers: sanitizeHeaders(req.headers),
-        bodyText: bodyText.length > 20_000 ? `${bodyText.slice(0, 20_000)}…(truncated)` : bodyText,
-        ...(json !== undefined ? { json } : {}),
-      });
-
-      if (method !== 'POST') {
-        res.writeHead(405, { 'Content-Type': 'text/plain' });
-        res.end('Method not allowed');
-        return;
-      }
-
-      if (path === '/v1/chat/completions' || path === '/api/v1/chat/completions') {
-        const now = Date.now();
-        sendOpenAiToolCallsSse(res, [
-          {
-            id: `call_ask_${now}`,
-            name: 'ask_oracle',
-            args: JSON.stringify({
-              question: 'Should we proceed?',
-              context: 'E2E: oracle unset test',
-            }),
-          },
-          {
-            id: `call_finish_${now}`,
-            name: 'finish',
-            args: JSON.stringify({}),
-          },
-        ]);
-        return;
-      }
-
-      res.writeHead(404, { 'Content-Type': 'text/plain' });
-      res.end(`Not found: ${path}`);
-    })().catch((err) => {
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end(`Mock server error: ${err instanceof Error ? err.message : String(err)}`);
-    });
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to bind mock server to a port'));
-        return;
-      }
-      port = (addr as AddressInfo).port;
-      resolve();
-    });
-    server.once('error', reject);
-  });
-
-  return {
-    baseUrl: `http://127.0.0.1:${port}`,
-    requests,
-    close: async () => {
-      await new Promise<void>((resolve, reject) => {
-        server.close((err) => (err ? reject(err) : resolve()));
-      });
-    },
-  };
-}
+import { startMockOpenAiToolCallsServer } from './mockLlmServer';
 
 type WebviewActionResult = { sent?: boolean };
 
@@ -178,7 +12,21 @@ type LastObservationInfo = {
 } | null;
 
 export async function run(): Promise<void> {
-  const mock = await startOracleUnsetMockServer();
+  const now = Date.now();
+  const mock = await startMockOpenAiToolCallsServer({
+    toolCalls: [
+      {
+        id: `call_ask_${now}`,
+        name: 'ask_oracle',
+        args: { question: 'Should we proceed?', context: 'E2E: oracle unset test' },
+      },
+      {
+        id: `call_finish_${now}`,
+        name: 'finish',
+        args: {},
+      },
+    ],
+  });
 
   try {
     await vscode.commands.executeCommand('openhands.open');
@@ -256,11 +104,10 @@ export async function run(): Promise<void> {
       const recent = mock.requests.map((r) => `${r.method} ${r.path}`).join(', ');
       throw new Error(`Expected exactly 1 LLM request; got ${mock.requests.length}: ${recent}`);
     }
-    if (mock.requests[0]?.path !== '/v1/chat/completions') {
-      throw new Error(`Expected request path /v1/chat/completions; got ${mock.requests[0]?.path}`);
+    if (!mock.requests[0]?.path?.endsWith('/chat/completions')) {
+      throw new Error(`Expected request path to end with /chat/completions; got ${mock.requests[0]?.path}`);
     }
   } finally {
     await mock.close();
   }
 }
-


### PR DESCRIPTION
Tech-debt (tests only): remove duplicate request-capture + OpenAI `tool_calls` SSE mock server code in the oracle E2E suites by centralizing it in `tests/e2e/suite/mockLlmServer.ts`.

- Adds `startMockOpenAiToolCallsServer({ toolCalls })`
- Updates `tests/e2e/suite/oracleUnset.ts` + `tests/e2e/suite/oracleConfigured.ts` to use it

Local verification:
- `npx tsc -p tests/e2e/tsconfig.suite.json --noEmit`
- `npm run compile`
- `npx tsc -p tests/e2e/tsconfig.suite.json && npx tsc -p tsconfig.e2e.json`
- `npx mocha tests/e2e/out/oracleUnset.test.js`
- `npx mocha tests/e2e/out/oracleConfigured.test.js`
