### PR TITLE
test(e2e): centralize argv.json setup

### DIFF
--- a/tests/e2e/defaultProfileSelection.test.ts
+++ b/tests/e2e/defaultProfileSelection.test.ts
@@ -3,7 +3,7 @@ import { runTests } from '@vscode/test-electron';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `oh-tab-default-profile-${Date.now().toString(36)}`);
 
@@ -20,8 +20,7 @@ describe('OpenHands-Tab default profile selection E2E', function () {
     const extensionTestsPath = path.resolve(__dirname, './suite');
 
     // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
-    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/llmProfiles.test.ts
+++ b/tests/e2e/llmProfiles.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `oh-tab-profiles-${Date.now().toString(36)}`);
 
@@ -16,8 +15,7 @@ describe('OpenHands-Tab LLM Profiles E2E', function () {
     const extensionTestsPath = path.resolve(__dirname, './suite');
 
     // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
-    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/llmSwitching.test.ts
+++ b/tests/e2e/llmSwitching.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `oh-tab-llm-${Date.now().toString(36)}`);
 
@@ -18,8 +17,7 @@ describe('OpenHands-Tab LLM Switching E2E', function () {
 
     // We override HOME/USERPROFILE for this suite to keep ~/.openhands/llm-profiles isolated.
     // VS Code also looks for runtime args in $HOME/.vscode/argv.json, and will show an error dialog if missing/invalid.
-    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/oracleConfigured.test.ts
+++ b/tests/e2e/oracleConfigured.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `oh-tab-oracle-configured-${Date.now().toString(36)}`);
 
@@ -15,8 +14,7 @@ describe('OpenHands-Tab ask_oracle configured profile E2E', function () {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
 
-    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,
@@ -43,4 +41,3 @@ describe('OpenHands-Tab ask_oracle configured profile E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/oracleUnset.test.ts
+++ b/tests/e2e/oracleUnset.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `oh-tab-oracle-unset-${Date.now().toString(36)}`);
 
@@ -16,8 +15,7 @@ describe('OpenHands-Tab ask_oracle unset profileId E2E', function () {
     const extensionTestsPath = path.resolve(__dirname, './suite');
 
     // Isolate ~/.openhands + VS Code argv settings for this suite.
-    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,
@@ -44,4 +42,3 @@ describe('OpenHands-Tab ask_oracle unset profileId E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/testHelpers.ts
+++ b/tests/e2e/testHelpers.ts
@@ -41,6 +41,7 @@ export async function downloadVSCodeWithRetry(
 }
 
 export async function ensureVsCodeArgvJson(userDataDir: string): Promise<void> {
-  await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-  await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+  const vscodeDir = path.join(userDataDir, '.vscode');
+  await fs.mkdir(vscodeDir, { recursive: true });
+  await fs.writeFile(path.join(vscodeDir, 'argv.json'), '{}\n', 'utf8');
 }

--- a/tests/e2e/testHelpers.ts
+++ b/tests/e2e/testHelpers.ts
@@ -1,4 +1,6 @@
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 
 /**
  * Downloads VS Code with retry logic to handle transient network errors
@@ -36,4 +38,9 @@ export async function downloadVSCodeWithRetry(
   throw new Error(
     `Failed to download VS Code after ${maxRetries} attempts. Last error: ${lastError?.message}`
   );
+}
+
+export async function ensureVsCodeArgvJson(userDataDir: string): Promise<void> {
+  await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+  await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
 }


### PR DESCRIPTION
Tech-debt (tests only): centralize the common VS Code user-data `argv.json` setup used by several E2E suites.

- Adds `ensureVsCodeArgvJson(userDataDir)` helper in `tests/e2e/testHelpers.ts`
- Updates `oracleUnset`, `oracleConfigured`, `llmProfiles`, `llmSwitching`, and `defaultProfileSelection` E2E tests to use it

Local verification:
- `npx tsc -p tests/e2e/tsconfig.suite.json --noEmit`
- `npx tsc -p tsconfig.e2e.json --noEmit`
- `npx mocha tests/e2e/out/oracleUnset.test.js`
- `npx mocha tests/e2e/out/oracleConfigured.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored end-to-end test infrastructure to use a shared helper function for VS Code configuration setup, improving consistency and maintainability across test files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->