### PR TITLE
test(e2e): HAL negative coverage

### DIFF
--- a/tests/e2e/halNegative.test.ts
+++ b/tests/e2e/halNegative.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-hal-negative-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab HAL negative cases E2E', function () {
+  this.timeout(180000);
+
+  it('does not trigger HAL overlay for non-HIGH risk or when disabled', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
+    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir',
+        userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'halNegative',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+        OPENAI_API_KEY: '',
+        ANTHROPIC_API_KEY: '',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -1,0 +1,103 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function assertHalStaysIdle(durationMs: number): Promise<void> {
+  const deadline = Date.now() + durationMs;
+  while (Date.now() < deadline) {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    if (hal?.phase && hal.phase !== 'idle') {
+      throw new Error(`Expected HAL phase to remain idle; got ${JSON.stringify(hal)}`);
+    }
+    await sleep(200);
+  }
+}
+
+export async function run(): Promise<void> {
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  const cfg = vscode.workspace.getConfiguration();
+
+  // Force local mode (no network), and ensure confirmation events are respected.
+  await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.servers', [], vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.confirmation.policy', 'risky', vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.confirmation.risky.threshold', 'HIGH', vscode.ConfigurationTarget.Global);
+
+  await vscode.commands.executeCommand('openhands.reconnect');
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+
+  // Case 1: HAL enabled, but security risk is MEDIUM => HAL should not trigger.
+  await cfg.update('openhands.hal.enabled', true, vscode.ConfigurationTarget.Global);
+  await cfg.update('openhands.hal.mode', 'bundled', vscode.ConfigurationTarget.Global);
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.enabled === true && hal?.mode === 'bundled' && hal?.phase === 'idle';
+  }, 15000);
+
+  const mediumRiskToolCallId = `call_hal_medium_${Date.now()}`;
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'Medium-risk action' }],
+    action: { command: 'echo medium-risk' },
+    tool_name: 'terminal',
+    tool_call_id: mediumRiskToolCallId,
+    tool_call: {
+      id: mediumRiskToolCallId,
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"echo medium-risk"}' },
+    },
+    llm_response_id: 'resp_hal_medium',
+    security_risk: 'MEDIUM',
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION',
+  });
+
+  await assertHalStaysIdle(2000);
+
+  // Case 2: HAL disabled, but security risk is HIGH => HAL should not trigger.
+  await cfg.update('openhands.hal.enabled', false, vscode.ConfigurationTarget.Global);
+
+  await pollUntil(async () => {
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    return hal?.enabled === false && hal?.phase === 'idle';
+  }, 15000);
+
+  const highRiskToolCallId = `call_hal_high_${Date.now()}`;
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ActionEvent',
+    source: 'agent',
+    thought: [{ type: 'text', text: 'High-risk action (HAL disabled)' }],
+    action: { command: 'echo high-risk' },
+    tool_name: 'terminal',
+    tool_call_id: highRiskToolCallId,
+    tool_call: {
+      id: highRiskToolCallId,
+      type: 'function',
+      function: { name: 'terminal', arguments: '{"command":"echo high-risk"}' },
+    },
+    llm_response_id: 'resp_hal_high_disabled',
+    security_risk: 'HIGH',
+  });
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'ConversationStateUpdateEvent',
+    source: 'agent',
+    agent_status: 'WAITING_FOR_CONFIRMATION',
+  });
+
+  await assertHalStaysIdle(2000);
+}
+

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -8,7 +8,7 @@ async function sleep(ms: number): Promise<void> {
 async function assertHalStaysIdle(durationMs: number): Promise<void> {
   const deadline = Date.now() + durationMs;
   while (Date.now() < deadline) {
-    const hal: HalStateSnapshot = await vscode.commands.executeCommand('openhands._queryHalState');
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
     if (hal?.phase && hal.phase !== 'idle') {
       throw new Error(`Expected HAL phase to remain idle; got ${JSON.stringify(hal)}`);
     }
@@ -20,7 +20,7 @@ export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
-    const diag: UiStateSnapshot = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
     return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
@@ -40,7 +40,7 @@ export async function run(): Promise<void> {
   await cfg.update('openhands.hal.mode', 'bundled', vscode.ConfigurationTarget.Global);
 
   await pollUntil(async () => {
-    const hal: HalStateSnapshot = await vscode.commands.executeCommand('openhands._queryHalState');
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
     return hal?.enabled === true && hal?.mode === 'bundled' && hal?.phase === 'idle';
   }, 15000);
 
@@ -72,7 +72,7 @@ export async function run(): Promise<void> {
   await cfg.update('openhands.hal.enabled', false, vscode.ConfigurationTarget.Global);
 
   await pollUntil(async () => {
-    const hal: HalStateSnapshot = await vscode.commands.executeCommand('openhands._queryHalState');
+    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
     return hal?.enabled === false && hal?.phase === 'idle';
   }, 15000);
 

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -40,7 +40,7 @@ export async function run(): Promise<void> {
   await cfg.update('openhands.hal.mode', 'bundled', vscode.ConfigurationTarget.Global);
 
   await pollUntil(async () => {
-    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    const hal: HalStateSnapshot = await vscode.commands.executeCommand('openhands._queryHalState');
     return hal?.enabled === true && hal?.mode === 'bundled' && hal?.phase === 'idle';
   }, 15000);
 

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -8,7 +8,7 @@ async function sleep(ms: number): Promise<void> {
 async function assertHalStaysIdle(durationMs: number): Promise<void> {
   const deadline = Date.now() + durationMs;
   while (Date.now() < deadline) {
-    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    const hal: HalStateSnapshot = await vscode.commands.executeCommand('openhands._queryHalState');
     if (hal?.phase && hal.phase !== 'idle') {
       throw new Error(`Expected HAL phase to remain idle; got ${JSON.stringify(hal)}`);
     }

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -20,7 +20,7 @@ export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag: UiStateSnapshot = await vscode.commands.executeCommand('openhands._diagnostics');
     return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -72,7 +72,7 @@ export async function run(): Promise<void> {
   await cfg.update('openhands.hal.enabled', false, vscode.ConfigurationTarget.Global);
 
   await pollUntil(async () => {
-    const hal: any = await vscode.commands.executeCommand('openhands._queryHalState');
+    const hal: HalStateSnapshot = await vscode.commands.executeCommand('openhands._queryHalState');
     return hal?.enabled === false && hal?.phase === 'idle';
   }, 15000);
 

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -79,6 +79,11 @@ export async function run(): Promise<void> {
     return runOracleConfiguredTest();
   }
 
+  if (testName === 'halNegative') {
+    const { run: runHalNegativeTest } = await import('./halNegative');
+    return runHalNegativeTest();
+  }
+
   if (testName === 'terminalProgress') {
     const { run: runTerminalProgressTest } = await import('./terminalProgress');
     return runTerminalProgressTest();


### PR DESCRIPTION
[oh-tab-b0h] Add hermetic E2E coverage for negative HAL cases.

Assertions:
- With `openhands.hal.enabled=true`, an ActionEvent with `security_risk=MEDIUM` and `WAITING_FOR_CONFIRMATION` does not trigger the HAL overlay.
- With `openhands.hal.enabled=false`, an ActionEvent with `security_risk=HIGH` and `WAITING_FOR_CONFIRMATION` does not trigger the HAL overlay.

Implementation:
- New suite `tests/e2e/suite/halNegative.ts` routed via `TEST_NAME=halNegative`.
- New runner `tests/e2e/halNegative.test.ts`.

Local verification:
- `npm run compile && npx tsc -p tests/e2e/tsconfig.suite.json && npx tsc -p tsconfig.e2e.json && npx mocha tests/e2e/out/halNegative.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests covering HAL negative scenarios to validate that the HAL overlay remains idle when expected (e.g., feature disabled or non-high-risk events), and integrated the test into the dynamic test runner for automated execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->