### PR TITLE
docs: HAL 9000 easter egg naming

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -16,7 +16,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - Action confirmation with security risk indicators (LOW/MEDIUM/HIGH)
 - Skills file picker (local `~/.openhands/skills`)
 - Terminal integration for local tool execution
-- HAL high-risk confirmation flow (optional)
+- HAL 9000 easter egg (high-risk confirmation flow) (optional)
 
 ### Out of scope (v1)
 - Reproducing the full OpenHands web UI
@@ -138,7 +138,7 @@ For internal diagnostics and the dev logging bridge, see docs/vscode_local_setup
 - `openhands.confirmation.policy` - never/always/risky
 - `openhands.confirmation.risky.threshold` default MEDIUM
 - `openhands.confirmation.risky.confirmUnknown`
-- `openhands.hal.*` (HAL high-risk confirmation settings)
+- `openhands.hal.*` (HAL 9000 easter egg settings)
 - `openhands.conversation.maxIterations`
 - `openhands.conversation.storeRoot` (local persistence path override)
 - `openhands.terminal.renderProgress`

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -83,7 +83,7 @@ The extension reads these fields from the profile and passes them to the SDK:
 
 These values map directly to the SDK confirmation policy and drive the confirmation UI.
 
-## 6) HAL (high-risk confirmation flow)
+## 6) HAL 9000 easter egg (high-risk confirmation flow)
 
 - `openhands.hal.enabled` (bool, default: false)
 - `openhands.hal.mode` = `bundled | tts_only | voice_confirm`


### PR DESCRIPTION
[oh-tab-avg] Align user-facing docs naming to “HAL 9000 easter egg”.

- Rename `docs/settings_prd.md` section title from “HAL (high-risk confirmation flow)” to “HAL 9000 easter egg (high-risk confirmation flow)”.
- Update `docs/PRD.md` bullets to match.

Acceptance:
- `rg "HAL (high-risk confirmation flow)" docs` returns no matches.
