### PR TITLE
Fix missed review feedback

### DIFF
--- a/packages/agent-sdk-ts/src/tools/__tests__/ThinkTool.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/ThinkTool.test.ts
@@ -11,5 +11,11 @@ describe('ThinkTool', () => {
     const result = await tool.execute(args, { workspace: new LocalWorkspace(process.cwd()) });
     expect(result.message).toBe('Your thought has been logged.');
   });
+
+  it('rejects invalid thought edge cases', () => {
+    const tool = new ThinkTool();
+    expect(() => tool.validate({ thought: '' })).toThrow();
+    expect(() => tool.validate({ thought: 123 } as any)).toThrow();
+  });
 });
 

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -24,7 +24,7 @@ export type HalSettings = {
 
 export type OpenHandsSettings = ServerSettings & {
   llm: LLMSettings;
-  oracle?: { profileId?: string };
+  oracle?: { profileId?: string | null };
   agent: AgentSettings;
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
@@ -47,7 +47,7 @@ const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',
   servers: [],
   llm: { provider: 'anthropic', model: 'claude-sonnet-4-20250514' },
-  oracle: { profileId: '' },
+  oracle: { profileId: null },
   agent: { enableSecurityAnalyzer: true, debug: false, summarizeToolCalls: false },
   conversation: { maxIterations: 50 },
   confirmation: { policy: 'never', riskyThreshold: 'MEDIUM', confirmUnknown: true },
@@ -157,6 +157,7 @@ const normalizeSavedServers = (value: unknown, defaultValue: SavedServer[]): { s
 
 export class SettingsManager {
   private serverNormalizationWarnings: string[] = [];
+  private validationWarnings: string[] = [];
 
   constructor(
     private adapter: SettingsAdapter,
@@ -200,8 +201,9 @@ export class SettingsManager {
   }
 
   drainServerNormalizationWarnings(): string[] {
-    const warnings = this.serverNormalizationWarnings;
+    const warnings = [...this.serverNormalizationWarnings, ...this.validationWarnings];
     this.serverNormalizationWarnings = [];
+    this.validationWarnings = [];
     return warnings;
   }
 
@@ -246,6 +248,8 @@ export class SettingsManager {
       } catch {
         // Best effort: still return normalized values even if persistence fails.
       }
+    } else {
+      this.serverNormalizationWarnings = [];
     }
 
     const configuredProfileId = normalizeNonEmptyString(this.adapter.getExplicit<string>('openhands.llm.profileId'));
@@ -300,13 +304,18 @@ export class SettingsManager {
       outputCostPerToken: profileConfig?.outputCostPerToken ?? undefined,
     };
 
-    const oracleProfileIdRaw = normalizeNonEmptyString(
-      this.adapter.get<string | null>('openhands.oracle.profileId', DEFAULTS.oracle?.profileId ?? '') ?? DEFAULTS.oracle?.profileId ?? ''
-    );
+    const oracleWarnings: string[] = [];
+    const rawOracleProfileId = this.adapter.get<unknown>('openhands.oracle.profileId', DEFAULTS.oracle?.profileId ?? null);
+    if (rawOracleProfileId === null) {
+      oracleWarnings.push('Oracle profile id is null. Clear the setting or set a valid string.');
+    }
+
+    const oracleProfileIdRaw = normalizeNonEmptyString(typeof rawOracleProfileId === 'string' ? rawOracleProfileId : undefined);
     const oracleProfileId = oracleProfileIdRaw && isSafeProfileId(oracleProfileIdRaw) ? oracleProfileIdRaw : undefined;
     if (oracleProfileIdRaw && !oracleProfileId) {
-      warnings.push(`Invalid oracle LLM profile id: ${oracleProfileIdRaw}`);
+      oracleWarnings.push(`Invalid oracle LLM profile id: ${oracleProfileIdRaw}`);
     }
+    this.validationWarnings = oracleWarnings;
     const oracle = { profileId: oracleProfileId };
     const agent: AgentSettings = {
       enableSecurityAnalyzer: this.adapter.get<boolean>('openhands.agent.enableSecurityAnalyzer', DEFAULTS.agent.enableSecurityAnalyzer) ?? DEFAULTS.agent.enableSecurityAnalyzer,

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -150,6 +150,20 @@ describe('SettingsManager', () => {
     expect(s.llm.model).toBe(defaults.llm.model);
   });
 
+
+  it('surfaces invalid oracle profile ids as warnings', async () => {
+    a.cfg.set('openhands.oracle.profileId', 'bad/id');
+    await mgr.get();
+    expect(mgr.drainServerNormalizationWarnings()).toContain('Invalid oracle LLM profile id: bad/id');
+  });
+
+  it('treats oracle profileId set to null as a warning (cannot be stored via VS Code settings UI)', async () => {
+    a.cfg.set('openhands.oracle.profileId', null);
+    await mgr.get();
+    expect(mgr.drainServerNormalizationWarnings()).toContain('Oracle profile id is null. Clear the setting or set a valid string.');
+  });
+
+
   it('normalizes saved servers', async () => {
     a.cfg.set('openhands.servers', [
       { url: ' http://localhost:3000 ', label: '   ' },

--- a/src/webview/host/__tests__/createWebviewMessageHandler.send.environmentInfo.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.send.environmentInfo.test.ts
@@ -59,4 +59,53 @@ describe('createWebviewMessageHandler(send) environment info suffix', () => {
     expect(sent).not.toContain('b.ts —');
     expect(sent).toContain('</environment information>');
   });
+
+  it('does not append <environment information> to user messages in remote mode', async () => {
+    const conversation = {
+      sendUserMessage: vi.fn(async () => {}),
+    };
+
+    (vscode.window as any).activeTextEditor = {
+      document: { uri: { scheme: 'file', fsPath: '/test/workspace/src/a.ts' } },
+    };
+    (vscode.window as any).visibleTextEditors = [
+      { document: { uri: { scheme: 'file', fsPath: '/test/workspace/src/a.ts' } } },
+      { document: { uri: { scheme: 'file', fsPath: '/test/workspace/src/b.ts' } } },
+    ];
+
+    const handler = createWebviewMessageHandler({
+      context: { subscriptions: [] } as any,
+      host: { postMessage: vi.fn(async () => true) },
+      getConversation: () => conversation as any,
+      getConversationMode: () => 'remote',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp',
+      setWebviewReadyState: () => {},
+      setLastKnownLlmLabel: () => {},
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => {},
+      onRenderedEventsResponse: () => {},
+      onUiStateResponse: () => {},
+      onHalStateResponse: () => {},
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => {},
+    });
+
+    await handler({
+      type: 'send',
+      text: 'hello',
+      contextFiles: [],
+      attachments: [],
+    } as any);
+
+    expect(conversation.sendUserMessage).toHaveBeenCalledTimes(1);
+    const sent = (conversation.sendUserMessage as any).mock.calls[0][0] as string;
+    expect(sent).toContain('hello');
+    expect(sent).not.toContain('<environment information>');
+    expect(sent).not.toContain('Active editor:');
+    expect(sent).not.toContain('Open editors:');
+    expect(sent).not.toContain('</environment information>');
+  });
+
 });

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -407,7 +407,6 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           postStatusError(warning);
         }
 
-
         deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(initSettings));
 
         void host.postMessage({

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -406,6 +406,8 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         for (const warning of serverWarnings) {
           postStatusError(warning);
         }
+
+
         deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(initSettings));
 
         void host.postMessage({


### PR DESCRIPTION
## Summary
Addresses missed review feedback from recent merged PRs.

- Add negative test to ensure `<environment information>` suffix is **not** appended in remote mode.
- Add ThinkTool schema validation tests for edge cases (`{ thought: "" }`, `{ thought: 123 }`).
- Align `openhands.oracle.profileId` typing with SDK (`string | null`) and surface oracle validation warnings (via existing warning drain).

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`

Closes #748


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1a301bf6eadd44e5bd4037d7954811b7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Oracle profile ID now supports null values with enhanced validation handling

* **Improvements**
  * Validation warnings for invalid or null oracle configuration
  * Environment information correctly excluded in remote mode
  * LLM label tracking improved during initialization

* **Tests**
  * Added test coverage for validation edge cases
  * Added tests for remote mode environment info behavior
  * Added tests for oracle configuration warnings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->