### PR TITLE
Settings: only warn on null oracle profileId when explicitly set

### DIFF
--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -305,10 +305,15 @@ export class SettingsManager {
     };
 
     const oracleWarnings: string[] = [];
-    const rawOracleProfileId = this.adapter.get<unknown>('openhands.oracle.profileId', DEFAULTS.oracle?.profileId ?? null);
-    if (rawOracleProfileId === null) {
+
+    const explicitOracleProfileId = this.adapter.getExplicit<unknown>('openhands.oracle.profileId');
+    if (explicitOracleProfileId === null) {
       oracleWarnings.push('Oracle profile id is null. Clear the setting or set a valid string.');
     }
+
+    const rawOracleProfileId = explicitOracleProfileId === undefined
+      ? this.adapter.get<unknown>('openhands.oracle.profileId', DEFAULTS.oracle?.profileId ?? null)
+      : explicitOracleProfileId;
 
     const oracleProfileIdRaw = normalizeNonEmptyString(typeof rawOracleProfileId === 'string' ? rawOracleProfileId : undefined);
     const oracleProfileId = oracleProfileIdRaw && isSafeProfileId(oracleProfileIdRaw) ? oracleProfileIdRaw : undefined;

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -163,6 +163,11 @@ describe('SettingsManager', () => {
     expect(mgr.drainServerNormalizationWarnings()).toContain('Oracle profile id is null. Clear the setting or set a valid string.');
   });
 
+  it('does not warn when oracle profileId is unset (default null)', async () => {
+    await mgr.get();
+    expect(mgr.drainServerNormalizationWarnings()).not.toContain('Oracle profile id is null. Clear the setting or set a valid string.');
+  });
+
 
   it('normalizes saved servers', async () => {
     a.cfg.set('openhands.servers', [


### PR DESCRIPTION
## Summary
Fixes a false-positive warning in `SettingsManager` for `openhands.oracle.profileId`.

Previously, the code emitted "Oracle profile id is null..." whenever the resolved value was `null`, including when the user never explicitly set the setting (and the default is `null`).

This change:
- Checks `getExplicit('openhands.oracle.profileId')` first
- Emits the `null` warning **only** when the explicit value is `=== null`
- Treats `undefined` as unset (no warning) and falls back to `get(...)`/defaults for normalization/validation
- Leaves the existing `validationWarnings` assignment and `oracle = { profileId: oracleProfileId }` logic intact

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1a301bf6eadd44e5bd4037d7954811b7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved oracle profile ID handling to eliminate unnecessary warning messages when using default settings.

* **Tests**
  * Added test coverage for default oracle profile ID behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->