### PR TITLE
docs(parity): comprehensive update to Python-TypeScript SDK parity doc

### DIFF
--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -561,7 +561,7 @@ classDiagram
 | Event Type | Python | TypeScript | Notes |
 |------------|--------|-----------|-------|
 | SystemPromptEvent | ✓ | ✓ | Aligned |
-| ActionEvent | ✓ | ✓ | TS lacks `summary` |
+| ActionEvent | ✓ | ✓ | TS lacks `summary` field; OpenHands-Tab compensates via runtime summarization |
 | ObservationEvent | ✓ | ✓ | Aligned |
 | UserRejectObservation | ✓ | ✓ | Aligned |
 | MessageEvent | ✓ | ✓ | Aligned |

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -278,7 +278,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def completion(messages, tools, ...) -> LLMResponse
 ```
 
-**Router (Python)**:
+#### Router (Python)
 ```python
 class RouterLLM(LLM):
     llms_for_routing: dict[str, LLM]

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -1,6 +1,6 @@
 # Python ↔︎ TypeScript SDK parity guide
 
-This document compares the Python `agent-sdk` (reference implementation) with the TypeScript `@openhands/agent-sdk-ts` (VS Code-focused SDK). It highlights where interfaces align, where behavior diverges, and what is missing for parity. Mermaid diagrams summarize key classes and relationships in each layer.
+This document compares the Python `agent-sdk` (reference implementation) with the TypeScript `@openhands/agent-sdk-ts` (VS Code-focused SDK). Note that agent-sdk-ts is basically a transpilation of the Python agent-sdk. It highlights where interfaces align, where behavior diverges, and what is missing for parity. Mermaid diagrams summarize key classes and relationships in each layer.
 
 ## Audit scope (oh-tab-0rq)
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -22,72 +22,69 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 | critic/ | ✓ | ✗ | Evaluation framework, Python only (not planned) |
 | event/ | ✓ | ✓ types/ | Different patterns (class vs interface) |
 | git/ | ✓ | ✗ | Full git utilities, Python only (not planned) |
-| hooks/ | ✓ | ✗ | Hook execution pipeline (pre/post tool use, stop hook) |
-| io/ | ✓ `FileStore` | ✗ | Abstracted file storage, Python only (not planned) |
-| llm/ | ✓ | ✓ | Different approaches (LiteLLM vs native) |
+| hooks/ | ✓ full | ✓ partial | Python: config-driven + executor; TS: inline interface only |
+| io/ | ✓ `FileStore` | ✓ `FileStore` | Both have persistence support |
+| llm/ | ✓ LiteLLM | ✓ native | Different approaches (LiteLLM vs native providers) |
 | logger/ | ✓ Rich/JSON | ✗ | Comprehensive logging, Python only (not planned) |
-| mcp/ | ✓ | ✗ | Model Context Protocol, Python only (not planned) |
+| mcp/ | ✓ full | ✓ config only | Python has MCPClient; TS only parses .mcp.json for skills |
 | observability/ | ✓ Laminar/OTEL | ✗ | Telemetry, Python only (not planned) |
 | secret/ | ✓ | ✓ runtime/ | TS has `SecretRegistry` in runtime |
-| security/ | ✓ module | ✓ inline in Agent | Python has separate module; TS has inline handling |
+| security/ | ✓ module | ✓ inline + module | Python has separate module; TS has inline + security/ |
 | tool/ | ✓ | ✓ tools/ | Different validation approaches (Pydantic vs Zod) |
 | workspace/ | ✓ | ✓ | Python has more complete remote support |
 
+## Features comparison (2026-01-13)
+
 ### Features in Python but NOT in TypeScript
 
-1. **Security Module** (separate module vs inline)
-   - Python has dedicated `security/` module with `SecurityAnalyzer`, `LLMSecurityAnalyzer`
-   - TypeScript has inline security risk handling in `Agent.ts`:
-     - `SecurityRisk` type: `'UNKNOWN' | 'LOW' | 'MEDIUM' | 'HIGH'`
-     - `security_risk` field on `ActionEvent`
-     - `parseSecurityRisk()` and `requiresConfirmation()` methods
-     - Confirmation settings with `policy`, `riskyThreshold`, `confirmUnknown`
-   - Both use LLM to assess risk per tool call (TS via system prompt instructions, Python via analyzer)
-   - **Gap**: Python has separate analyzer classes for modularity; TS has inline implementation
+1. **Hooks System - Config-driven execution**
+   - Python: Full `HookManager` with `HookConfig` loading from `.openhands/hooks.json`, `HookExecutor` with subprocess execution, pattern matching (wildcard/regex), decision blocking (ALLOW/DENY), environment variable injection
+   - TypeScript: `AgentHook` interface with `beforeToolCall`, `afterToolCall`, `afterEvent`, `shouldStop` - inline implementation only, no config file support, no subprocess execution
+   - **Status**: TS has basic hook interface; missing config loading, subprocess executor, and pattern matching
 
-2. **Critic Module** - `CriticBase`, `AgentFinishedCritic`, `EmptyPatchCritic`, `PassCritic` (not planned)
+2. **MCP Client for tool execution**
+   - Python: Full `MCPClient` (fastmcp-based) with `MCPToolExecutor`, dynamic action/observation types, async/sync bridge
+   - TypeScript: Only `.mcp.json` config parsing/validation with variable expansion for skills; no MCPClient for tool execution
+   - **Status**: TS can parse MCP configs but cannot execute MCP tools
 
-3. **Git Module** - `GitDiff`, `GitChanges`, `GitManager` (not planned)
+3. **Critic Module** - `CriticBase`, `AgentFinishedCritic`, `EmptyPatchCritic`, `PassCritic` (not planned)
 
-4. **IO/FileStore Module** - `FileStore` abstract base, `LocalFileStore`, `InMemoryFileStore` (not planned)
+4. **Git Module** - `GitDiff`, `GitChanges`, `GitManager` (not planned)
 
 5. **Observability Module** - Laminar integration, OpenTelemetry, `@observe` decorator (not planned)
 
 6. **Logger Module** - Rich console logging, JSON logging, rotating file handlers (not planned)
 
-7. **MCP** - `MCPClient` for external tool integration (not planned)
+7. **Tom Consult Tools** - `ConsultTomTool`, `SleeptimeComputeTool` for user modeling/personalization (not planned)
 
-8. **LLM routing + provider error normalization**
-   - Python: LiteLLM-based routing strategies and provider exception mapping into typed SDK exceptions.
-   - TypeScript: native provider clients + LLM Profiles + an `LLMRegistry` + `Metrics` exist, but there is no router/fallback layer and provider-specific exception normalization is tracked as parity work (GH #661).
+8. **Plugins + custom tool loading** - plugin data model, directory loading, and remote custom tools support
 
-9. **Hooks System** - `HookManager`, `HookExecutor`, event interception (pre/post tool use, post event, stop hook)
+9. **RemoteConversation extended API**
+   - Python: `set_confirmation_policy()`, `set_security_analyzer()`, `update_secrets()`, `ask_agent()` (stateless question), `generate_title()`, `condense()` (force condensation)
+   - TypeScript: `setServerUrl()`, `setSettings()`, `reconnect()` (TS-only dynamic features)
+   - **Status**: Different feature sets; TS has dynamic URL/settings mutation, Python has more server-side control
 
 10. **Public skills repo loading** (`load_public_skills`)
-    - TypeScript: not implemented.
-    - Note (2026-01-12): TypeScript now supports AgentSkills (SKILL.md directories) with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` loading with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
-
-11. **Plugins + custom tool loading** - plugin data model, directory loading, and remote custom tools support
-
-12. **Tools** - `TomConsultTool`, extended `BrowserUseTool` with Windows impl
-
-13. **Conversation Features** - `ConversationVisualizer`, `ConversationStats`, `StuckDetector`, `TitleUtils`
+    - Python: Can load skills from external OpenHands/skills repository
+    - TypeScript: Only local skill loading
 
 ### Features in TypeScript but NOT in Python
 
-1. **LLMStreamer** - Separate orchestration layer (Python has this in Agent class)
+1. **LLM Profiles System** - Profile-based provider management in `~/.openhands/llm-profiles/` (JSON), validation, profiles-first config approach
 
-2. **LLM Profiles System** - Profile-based provider management, native clients (Anthropic, OpenAI-compatible, Gemini)
+2. **Native LLM Clients** - Direct Anthropic, OpenAI, OpenAI Responses (gpt-5), Gemini clients without LiteLLM dependency
 
-3. **Summarization Utilities** - `fileDiffSummarizer`, `gitChangeSummarizer`, `terminalObservationSummarizer`
+3. **LLM Router + Fallback** - Generic router interface with `createRouterLlmClient()` and `createFallbackLlmClient()` with error-based switching
 
-4. **Error Handling** - `errorPolicy.ts`, `toolCallErrorEvents.ts`
+4. **Tool Summarization** - Gemini Flash-based summarization for large tool outputs (`toolSummarizer.ts`, `fileDiffSummarizer.ts`, `terminalObservationSummarizer.ts`, `gitChangeSummarizer.ts`)
 
-5. **Tool Validation** - `ZodTool` wrapper for zod schema-based validation
+5. **AskOracleTool** - Delegates questions to a configurable oracle LLM profile
 
-6. **IntegratedTerminalRunner** - Direct VS Code terminal integration
+6. **BrowserTool (HTTP)** - Simple HTTP/HTTPS fetch tool (separate from BrowserUseTool automation)
 
-7. **ApplyPatchTool** - TypeScript-only builtin tool (not present in the Python fork at `~/repos/agent-sdk`)
+7. **IntegratedTerminalRunner** - VS Code pseudoterminal integration with spawn fallback
+
+8. **LLM Client Caching** - `LlmClientCache` for reusing LLMStreamer instances per profile
 
 ### Cross-cutting differences
 
@@ -99,161 +96,250 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 | LLM abstraction | LiteLLM (provider agnostic) | Native provider clients |
 | Async handling | Sync-first with optional async | Async-first (Promise-based) |
 | Execution status | `ConversationExecutionStatus` enum | String literals |
+| Tool registration | `register_tool()` + registry | Direct tool instantiation |
+| Observation formatting | `to_llm_content` property on class | External `observationToLLMText()` function |
 
-## Current parity snapshot (2026-01-10)
+## Tool comparison (2026-01-13)
 
-This section summarizes concrete behavior alignment between Python agent-sdk and TypeScript @openhands/agent-sdk-ts observed today, with pointers to code/tests and gaps to close.
+| Tool | Python | TypeScript | Parity Status |
+|------|--------|-----------|---------------|
+| **terminal** | Full: tmux/subprocess backends, is_input, reset, timeout, metadata | Full: subprocess-based, is_input, reset, timeout | ✓ Aligned (TS lacks tmux) |
+| **file_editor** | view/create/str_replace/insert/undo_edit, diff, image support | Same commands, undo_edit, image viewing | ✓ Aligned |
+| **glob** | Pattern matching, 100 result limit, mtime sort | Same features | ✓ Aligned |
+| **grep** | Regex search, include filter, 100 result limit | Same features | ✓ Aligned |
+| **browser_use** | Full Chromium automation: navigate, click, type, scroll, tabs, storage, screenshots | Stubbed: all methods return placeholders | ⚠️ TS is stubbed only |
+| **apply_patch** | Unified patch format, fuzzy matching, commit tracking | Same format, fuzzy matching | ✓ Aligned |
+| **delegate** | spawn/delegate sub-agents, task assignment | Stubbed: returns mock completions | ⚠️ TS is stubbed only |
+| **task_tracker** | TASKS.json management, view/plan commands | Same implementation | ✓ Aligned |
+| **planning_file_editor** | Restricted to PLAN.md editing | Same restrictions | ✓ Aligned |
+| **think** | Logging-only reasoning tool | Same implementation | ✓ Aligned (description matched) |
+| **finish** | Task completion signal | Same implementation | ✓ Aligned |
+| **tom_consult** | User modeling, RAG support | ✗ Not implemented | Python only (not planned) |
+| **ask_oracle** | ✗ Not in Python | Delegates to oracle LLM | TS only |
+| **browser (HTTP)** | ✗ Not in Python | Simple HTTP fetch | TS only |
 
-- Tool error messages (MessageEvent with role="tool")
-  - Python: events_to_messages converts AgentErrorEvent to a tool Message with plain text error content. No JSON encoding. See tests/sdk/event/test_events_to_messages.py::test_agent_error_event.
-  - TypeScript: createToolCallErrorEvents emits a tool MessageEvent with plain text error content (not JSON). See src/sdk/runtime/toolCallErrorEvents.ts.
-  - Truncation: TS caps error text at 4096 chars and appends " (truncated)"; Python does not enforce a 4096 cap in conversion (viewer utilities may truncate for display). Status: content format aligned (plain text); truncation policy diverges.
+## Current parity snapshot (2026-01-13)
 
-- Tool-call argument redaction (llm_tool_call_raw and logs)
-  - Python: Secrets masking is applied to tool observations (e.g., Terminal) via SecretRegistry.mask_secrets_in_output; broader recursive argument redaction is not centrally enforced for tool-call argument logging.
-  - TypeScript: Agent redacts recursively with heuristics, masking known keys (apiKey, token, password, client_secret, etc.) to "***" and masking Authorization: Bearer tokens in strings. See src/sdk/runtime/Agent.ts redactObject/redactStringHeuristics and tests: `Agent.redaction.test.ts` and `Agent.tool-call-redaction.test.ts`.
-  - Status: TS adds stronger argument redaction for logs; Python focuses on observation output masking. Parity gap: but we are fine with it as long as the TS version doesn't display keys to the user or save them in logs.
+### Tool error messages (MessageEvent with role="tool")
+- Python: `events_to_messages` converts `AgentErrorEvent` to a tool Message with plain text error content. No JSON encoding.
+- TypeScript: `createToolCallErrorEvents` emits a tool MessageEvent with plain text error content (not JSON).
+- Truncation: TS caps error text at 4096 chars and appends " (truncated)"; Python does not enforce a 4096 cap in conversion.
+- **Status**: Content format aligned (plain text); truncation policy diverges.
 
-- security_risk on ActionEvent
-  - Python: ActionEvent always has security_risk (defaults to UNKNOWN if omitted). See tests/cross/test_remote_conversation_live_server.py and tests/sdk/agent/test_extract_security_risk.py.
-  - TypeScript: security_risk is optional; parseToolArgs pops security_risk from arguments and returns undefined when missing/invalid. See src/sdk/runtime/Agent.ts parseToolArgs/parseSecurityRisk and tests: `Agent.security-risk.test.ts`.
-  - Status: Divergence. Consider adding defaulting to UNKNOWN in TS when integrating with agent-server.
+### Tool-call argument redaction
+- Python: Secrets masking via `SecretRegistry.mask_secrets_in_output` for tool observations.
+- TypeScript: Agent redacts recursively with heuristics, masking known keys (apiKey, token, password, client_secret, etc.) to "***" and masking Authorization: Bearer tokens in strings.
+- **Status**: TS adds stronger argument redaction for logs; Python focuses on observation output masking. This is acceptable.
 
-- ActionEvent summary + reasoning metadata
-  - Python: ActionEvent includes `summary`, `thinking_blocks`, and `responses_reasoning_item` (for Responses API), and uses these in UI/visualization. See openhands/sdk/event/llm_convertible/action.py.
-  - TypeScript: ActionEvent includes `thought`, `reasoning_content`, `thinking_blocks`, and `responses_reasoning_item`; `summary` is not represented in the TypeScript ActionEvent model. See packages/agent-sdk-ts/src/sdk/types/index.ts ActionEvent.
-  - Status:
-    - `summary`: not a TS parity gap for OpenHands-Tab, because we don’t rely on server-provided action summaries (Gemini Flash generates summaries on the fly).
-    - `thinking_blocks` and `responses_reasoning_item`: aligned for parity/debuggability.
+### security_risk on ActionEvent
+- Python: `ActionEvent` always has `security_risk` (defaults to UNKNOWN if omitted).
+- TypeScript: `security_risk` is optional; `parseToolArgs` pops it from arguments and returns undefined when missing/invalid.
+- **Status**: Divergence. Consider adding defaulting to UNKNOWN in TS when integrating with agent-server.
 
-- ConversationErrorEvent visualization
-  - Python: ConversationErrorEvent now defines `visualize()` for UI output. See openhands/sdk/event/conversation_error.py.
-  - TypeScript: no visualization helpers for ConversationErrorEvent (type only).
-  - Status: Divergence in UI/event rendering.
+### ActionEvent metadata
+- Python: `ActionEvent` includes `summary`, `thinking_blocks`, `responses_reasoning_item`.
+- TypeScript: `ActionEvent` includes `thought`, `reasoning_content`, `thinking_blocks`, `responses_reasoning_item`; `summary` is not represented.
+- **Status**:
+  - `summary`: Not a TS parity gap for OpenHands-Tab (Gemini Flash generates summaries on the fly).
+  - `thinking_blocks` and `responses_reasoning_item`: Aligned for parity/debuggability.
 
-- Default LLM timeout
-  - Python: LLM default timeout raised to 300s (`timeout` default in LLM config). See openhands/sdk/llm config defaults.
-  - TypeScript: DEFAULT_TIMEOUT_MS is 300s (300_000ms) unless overridden. See packages/agent-sdk-ts/src/sdk/llm/types.ts.
-  - Status: Aligned.
+### Default LLM timeout
+- Python: 300s default.
+- TypeScript: 300_000ms (300s) default.
+- **Status**: Aligned.
 
-- include_default_tools option
-  - Python: Agent supports `include_default_tools` to selectively include built-in tools or disable all defaults. See openhands/sdk/agent/base.py and tests/sdk/agent/test_agent_tool_init.py.
-  - TypeScript: supports `includeDefaultTools?: boolean | string[]` to disable defaults or select a subset when tools are omitted. See packages/agent-sdk-ts/src/sdk/conversation/index.ts and tests: packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.test.ts.
-  - Status: Aligned (API naming differs).
+### include_default_tools option
+- Python: `include_default_tools` to selectively include built-in tools.
+- TypeScript: `includeDefaultTools?: boolean | string[]` to disable defaults or select a subset.
+- **Status**: Aligned (API naming differs).
 
-- AgentSkills (SKILL.md) + repo skill files
-  - Python: SKILL.md directories with strict naming, progressive disclosure (`to_prompt()` XML), resources, `.mcp.json` support, and optional public skills loading. See openhands/sdk/context/skills/*.py and openhands/sdk/context/agent_context.py.
-  - TypeScript: supports SKILL.md directories with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` parsing/validation with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
-  - Status: Parity largely aligned; remaining gap is public skills repo loading.
+### AgentSkills (SKILL.md) + repo skill files
+- Python: SKILL.md directories with strict naming, progressive disclosure (`to_prompt()` XML), resources, `.mcp.json` support, and optional public skills loading.
+- TypeScript: SKILL.md directories with strict naming, `<available_skills>` progressive disclosure, resource discovery, `.mcp.json` parsing/validation with variable expansion, and third-party repo skill files (`.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`) with truncation + vendor-family gating.
+- **Status**: Parity largely aligned; remaining gap is public skills repo loading.
 
-- tool_call_id propagation
-  - Python: tool_call_id is preserved across ActionEvent, ObservationEvent, AgentErrorEvent, and tool MessageEvent. See tests/sdk/event/test_events_to_messages.py and cross tests.
-  - TypeScript: tool_call_id is populated consistently in ActionEvent/ObservationEvent and in error/tool messages. See src/sdk/runtime/Agent.ts and toolCallErrorEvents.ts and tests: `Agent.tool-errors.test.ts`.
-  - Status: Aligned.
+### tool_call_id propagation
+- Python: `tool_call_id` preserved across ActionEvent, ObservationEvent, AgentErrorEvent, and tool MessageEvent.
+- TypeScript: `tool_call_id` populated consistently in ActionEvent/ObservationEvent and in error/tool messages.
+- **Status**: Aligned.
 
-- AgentErrorEvent shape
-  - Python: includes error (text), tool_name, tool_call_id. See tests/sdk/event/test_event_serialization.py and test_events_to_messages.py.
-  - TypeScript: same fields present. See src/sdk/types/index.ts and toolCallErrorEvents.ts. Status: Aligned.
+### AgentErrorEvent shape
+- Python: includes error (text), tool_name, tool_call_id.
+- TypeScript: same fields present.
+- **Status**: Aligned.
 
-- Message roles and conversion
-  - Python: LLMConvertibleEvent.events_to_messages builds system/user/assistant/tool messages; tool responses set role="tool" and include tool_call_id/name; agent errors become role="tool" messages with the error text. See tests/sdk/event/test_events_to_messages.py.
-  - TypeScript: Agent pushes MessageEvents with role="tool" for observations and errors; assistant messages carry tool_calls; schemas mirror Python. See src/sdk/runtime/Agent.ts and tests.
-  - Status: Aligned for core paths used by VS Code extension.
+### Message roles and conversion
+- Python: `LLMConvertibleEvent.events_to_messages` builds system/user/assistant/tool messages.
+- TypeScript: Agent pushes MessageEvents with appropriate roles; schemas mirror Python.
+- **Status**: Aligned for core paths used by VS Code extension.
 
-- Persistence and EventLog
-  - Python: File-backed EventLog, deterministic IDs, resume-from-disk via ConversationState.create, FIFO locks, etc.
-  - TypeScript: FileStore-backed persistence exists (events + state) and LocalConversation supports restore. See `packages/agent-sdk-ts/src/sdk/runtime/persistence.ts` and tests: `packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts`.
+### Persistence and EventLog
+- Python: File-backed EventLog, deterministic IDs, resume-from-disk via `ConversationState.create`, FIFO locks.
+- TypeScript: `FileStore`-backed persistence exists (events JSONL + state JSON) and LocalConversation supports restore.
+- **Status**: Aligned for VS Code local-mode usage.
 
-- Tool observation content (role="tool" messages)
-  - Python: tool observations are LLM-facing plain text via Observation helpers (e.g., TerminalObservation appends metadata and uses `<response clipped>` truncation). See `tests/tools/terminal/test_observation_truncation.py`.
-  - TypeScript: Agent formats tool MessageEvent content as plain text for core tools (terminal, file_editor), applies secret masking, and clips oversized outputs with `<response clipped>`. See `packages/agent-sdk-ts/src/sdk/runtime/Agent.ts` and tests: `packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts` (PR #250 / `oh-tab-bcu`).
-  - Status: Aligned for VS Code local-mode usage (minor policy differences remain, e.g., default clip length).
+### Terminal session semantics
+- Python: Persistent shell session; supports `is_input` (stdin/log polling) and `reset`.
+- TypeScript: Persistent session semantics (cwd/env persistence), `is_input`/`reset` support.
+- **Status**: Aligned for VS Code local-mode usage.
 
-- Terminal session semantics
-  - Python: persistent shell session; supports `is_input` (stdin/log polling) and `reset`. See `tests/tools/terminal/test_terminal_session.py`.
-  - TypeScript: supports persistent session semantics (cwd/env persistence), rejects concurrent non-empty commands, and supports `is_input`/`reset`. See `packages/agent-sdk-ts/src/tools/TerminalTool.ts` and `packages/agent-sdk-ts/src/tools/TerminalSession.ts` (PR #251 / `oh-tab-wmn`).
-  - Status: Aligned for VS Code local-mode usage.
+### Stuck detection
+- Python: `StuckDetector` in conversation module.
+- TypeScript: `StuckDetector` class with configurable thresholds for actionObservation, actionError, monologue, alternatingPattern.
+- **Status**: Aligned.
 
-Other gaps to consider
-- security_risk defaulting: consider default UNKNOWN in TS when interoperating with an agent-server (remote conversation) to match Python expectations.
-- Remote workspace behaviors: not planned in TS today (remote mode is handled via agent-server + RemoteConversation).
+### ConversationVisualizer
+- Python: `DefaultVisualizer` with Rich formatting for CLI output.
+- TypeScript: `ConversationVisualizer` with markdown rendering, optional timestamps, skip options.
+- **Status**: Aligned (different output formats: Rich vs Markdown).
 
-## Candidate test cases to mirror (from `~/repos/agent-sdk`)
+### ConversationStats
+- Python: `ConversationStats` for metrics aggregation.
+- TypeScript: `ConversationStats` with serialization/restoration support.
+- **Status**: Aligned.
 
-These Python tests are the most directly relevant “spec” for VS Code local-mode parity work. Use them to drive new Vitest coverage in `packages/agent-sdk-ts` (tests first, then implementation).
+## Hooks system comparison
 
-### Terminal tool
+### Python hooks (full implementation)
 
-- Python: `tests/tools/terminal/test_terminal_tool.py` (basic execution, schema) → TypeScript: `packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts` (expand coverage).
-- Python: `tests/tools/terminal/test_observation_truncation.py` (LLM-facing output formatting + `<response clipped>`) → TypeScript: `packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts` (PR #250 / `oh-tab-bcu`).
-- Python: `tests/tools/terminal/test_terminal_session.py`, `tests/tools/terminal/test_shutdown_handling.py`, `tests/tools/terminal/test_shell_path_configuration.py` → TypeScript: `packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts` (PR #251 / `oh-tab-wmn`).
-- Python: `tests/tools/terminal/test_secrets_masking.py` → TypeScript: `packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-messages.test.ts` (PR #250 / `oh-tab-bcu`).
+```python
+# HookEventType enum
+PRE_TOOL_USE     # Before tool execution
+POST_TOOL_USE    # After tool execution
+USER_PROMPT_SUBMIT # When user submits prompt
+SESSION_START    # When conversation starts
+SESSION_END      # When conversation ends
+STOP             # Stop hook
 
-### File editor tool
+# HookManager methods
+run_pre_tool_use(tool_name, tool_input) -> (should_continue, results)
+run_post_tool_use(tool_name, tool_input, tool_response) -> results
+run_user_prompt_submit(message) -> (should_continue, additional_context, results)
+run_session_start() -> results
+run_session_end() -> results
+run_stop(reason) -> (should_stop, results)
 
-- Python: `tests/tools/file_editor/test_basic_operations.py` (create/view/str_replace/insert/undo_edit) → TypeScript: covered by `packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts` + FileEditorTool tests (PR #245 / `oh-tab-nbc`).
-- Python: `tests/tools/file_editor/test_schema.py` (command enum includes undo_edit) → TypeScript: schema/docs updates in PR #252 / `oh-tab-8zn`.
-- Python: `tests/tools/file_editor/test_workspace_root.py`, `tests/tools/file_editor/test_file_validation.py`, `tests/tools/file_editor/test_view_supported_binary_files.py` → TypeScript: implemented in PR #253 / `oh-tab-7d4`.
+# Features
+- Config loading from .openhands/hooks.json
+- HookExecutor with subprocess execution
+- Pattern matching (wildcard, exact, regex) for tool names
+- HookResult with decision (ALLOW/DENY), reason, additional_context
+- Environment variables: OPENHANDS_PROJECT_DIR, SESSION_ID, EVENT_TYPE, TOOL_NAME
+```
 
-### Glob/Grep tools
+### TypeScript hooks (interface only)
 
-- Python: `tests/tools/glob/test_glob_tool.py`, `tests/tools/glob/test_consistency.py` → TypeScript: implemented in PR #248 / `oh-tab-2wx` (fixtures, ignore, truncation).
-- Python: `tests/tools/grep/test_grep_tool.py`, `tests/tools/grep/test_consistency.py` → TypeScript: implemented in PR #248 / `oh-tab-2wx` (fixtures, ignore, truncation).
+```typescript
+interface AgentHook {
+  beforeToolCall?: (params: BeforeToolCallHookParams) => BeforeToolCallHookResult | Promise<BeforeToolCallHookResult>;
+  afterToolCall?: (params: AfterToolCallHookParams) => void | Promise<void>;
+  afterEvent?: (params: AfterEventHookParams) => void | Promise<void>;
+  shouldStop?: (params: ShouldStopHookParams) => boolean | Promise<boolean>;
+}
 
-### Runtime/events/workspace
+// BeforeToolCallHookResult can return modified args
+type BeforeToolCallHookResult = void | { args?: Record<string, unknown> };
 
-- Python: `tests/sdk/event/test_events_to_messages.py`, `tests/sdk/event/test_event_serialization.py` → TypeScript: `packages/agent-sdk-ts/src/sdk/__tests__/agent-sdk.guards.test.ts` + runtime tests (expand into message conversion parity).
-- Python: `tests/sdk/security/test_confirmation_policy.py` → TypeScript: `packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts` and `packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.security-risk.test.ts`.
-- Python: `tests/sdk/io/test_local_filestore_security.py` → TypeScript: `packages/agent-sdk-ts/src/workspace/__tests__/local.workspace.test.ts` (PR #244 / `oh-tab-pla`).
+// Features
+- Inline implementation (no config file)
+- Can modify tool args before execution
+- Can halt agent via shouldStop
+- Async-safe with Promise support
+```
 
-## Beads follow-ups (created from this audit)
+### Hooks parity gaps
+- No config file loading (`.openhands/hooks.json`)
+- No subprocess-based hook execution
+- No pattern matching for tool names
+- No USER_PROMPT_SUBMIT, SESSION_START, SESSION_END hooks
+- No decision blocking with ALLOW/DENY
+- No additional context injection
 
-- `oh-tab-wmn` — agent-sdk-ts: TerminalTool persistent session + is_input/reset parity
-- `oh-tab-bcu` — agent-sdk-ts: Tool MessageEvent content parity (avoid JSON-only tool outputs)
-- `oh-tab-nbc` — agent-sdk-ts: FileEditorTool undo_edit parity
-- `oh-tab-7d4` — agent-sdk-ts: FileEditorTool directory view + binary handling parity
-- `oh-tab-pla` — agent-sdk-ts: LocalWorkspace symlink/path security parity
-- `oh-tab-2wx` — agent-sdk-ts: GlobTool/GrepTool parity (fixtures, ignore, truncation)
+## LLM layer comparison
+
+### Python LLM (LiteLLM-based)
+
+```python
+class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
+    model: str  # Default: "claude-sonnet-4-20250514"
+    api_key: str | SecretStr | None
+    base_url: str | None
+    timeout: int | None  # Default: 300s
+    temperature: float | None
+    max_input_tokens: int | None
+    max_output_tokens: int | None
+    stream: bool
+    native_tool_calling: bool
+    reasoning_effort: Literal["low", "medium", "high", "xhigh", "none"]
+    extended_thinking_budget: int | None  # Default: 200,000
+    num_retries: int  # Default: 5
+    retry_multiplier: float  # Default: 8.0
+
+    def completion(messages, tools, ...) -> LLMResponse
+```
+
+**Router (Python)**:
+```python
+class RouterLLM(LLM):
+    llms_for_routing: dict[str, LLM]
+    active_llm: LLM | None
+
+    def select_llm(messages) -> str  # Abstract
+    def completion(messages, tools, ...) -> LLMResponse  # Routes to selected LLM
+```
+
+### TypeScript LLM (native clients)
+
+```typescript
+// Four provider clients
+AnthropicClient      // Anthropic API with thinking blocks
+OpenAICompatibleClient  // OpenAI, LiteLLM proxy, OpenRouter
+OpenAIResponsesClient   // OpenAI gpt-5.* with Responses API
+GeminiClient           // Google Gemini with extended thinking
+
+// LLM factory
+createLLMClient(config: LLMConfiguration, options): LLMClient
+
+// Router
+createRouterLlmClient({ clients, router }): LLMClient
+createFallbackLlmClient({ primary, fallback, shouldFallback }): LLMClient
+
+// Profiles
+loadProfiles()  // Loads from ~/.openhands/llm-profiles/
+getProfile(profileId): LLMProfile | undefined
+```
+
+### LLM parity status
+- **Provider support**: Both support Anthropic, OpenAI, Gemini. Python uses LiteLLM abstraction; TS uses native clients.
+- **Router**: Both have routing capability. Python has `RouterLLM` class; TS has functional `createRouterLlmClient`.
+- **Fallback**: TS has `createFallbackLlmClient` with error-based switching; Python routing is message-based.
+- **Profiles**: TS-only feature for profile-based configuration.
+- **Error mapping**: TS has `classifyLlmErrorCode` for auth, rate_limit, timeout, context_limit, network, service_unavailable.
+- **Metrics**: Both track token usage; TS has `Metrics` class with serialization support.
 
 ## Workspace layer
 
 ### Python shape
 
-- Factory `Workspace()`
-  - Returns `LocalWorkspace` or `RemoteWorkspace` based on `host`/`api_key`
-  - Shares `BaseWorkspace` with `working_dir`, context-manager support, and discriminated union typing
-- `LocalWorkspace`
-  - Command execution with timeout/error metadata
-  - Git change/diff helpers
-  - Upload/download/copy operations
-  - Strict path validation
-  - `pause()`/`resume()` hooks (no-ops locally, implemented for remote)
-- `RemoteWorkspace`
-  - Wraps HTTP endpoints for commands, file transfer, and git metadata
-  - Mirrors `CommandResult`/`FileOperationResult` schemas
-  - Queue-based locking
-  - `alive` property for readiness checks
+- Factory `Workspace()` returns `LocalWorkspace` or `RemoteWorkspace` based on `host`/`api_key`
+- Shares `BaseWorkspace` with `working_dir`, context-manager support
+- `LocalWorkspace`: Command execution, git helpers, upload/download, path validation, `pause()`/`resume()` hooks
+- `RemoteWorkspace`: HTTP endpoints for commands, file transfer, git metadata, queue-based locking, `alive` property
 
 ### TypeScript shape
 
-- Only `LocalWorkspace` exists (no `RemoteWorkspace` today).
-  - Resolves workspace root
-  - Reads/writes/removes files
-  - Creates directories
-  - Runs commands via VS Code APIs with minimal metadata
-- No shared base class or factory.
-- No remote workspace or file transfer helpers.
+- `BaseWorkspace`: Abstract interface for file operations
+- `LocalWorkspace`: File system access with path resolution, symlink handling
+- `RemoteWorkspace`: HTTP client wrapper for remote agent-server file operations
 
-### Gaps to close
-
-- Add workspace factory + base abstraction with `working_dir`, context manager/cleanup semantics, and discriminated typing for local vs remote
-- Port upload/download/copy helpers, git change/diff models, and richer `CommandResult` fields (timeout, stderr segmentation)
-- Implement remote workspace with HTTP-backed command lifecycle and path validation parity
-- Add `pause()`/`resume()` plumbing and `alive` readiness surface for remote workspaces
+### Workspace gaps
+- No factory for workspace type selection
+- No git change/diff helpers in TS
+- Limited `pause()`/`resume()` plumbing
 
 ```mermaid
 classDiagram
-    class BaseWorkspace {
+    class BaseWorkspacePython {
       <<Python>>
       +working_dir: str
       +execute_command(cmd, cwd?, timeout?)
@@ -277,8 +363,8 @@ classDiagram
       +upload/download()
       +git_changes_remote()
     }
-    BaseWorkspace <|-- LocalWorkspacePython
-    BaseWorkspace <|-- RemoteWorkspacePython
+    BaseWorkspacePython <|-- LocalWorkspacePython
+    BaseWorkspacePython <|-- RemoteWorkspacePython
     class LocalWorkspaceTS {
       <<TypeScript>>
       +root: string
@@ -289,51 +375,44 @@ classDiagram
     }
 ```
 
-### Source references
-- Python: openhands/sdk/workspace/base.py BaseWorkspace; openhands/sdk/workspace/local.py LocalWorkspace; openhands/sdk/workspace/remote/base.py RemoteWorkspace; openhands/sdk/workspace/remote/remote_workspace_mixin.py RemoteWorkspaceMixin.
-- TypeScript: packages/agent-sdk-ts/src/workspace/LocalWorkspace.ts LocalWorkspace.
-
 ## Conversation layer
 
 ### Python shape
 
-- Factory `Conversation()`
-  - Chooses `LocalConversation` vs `RemoteConversation` based on workspace type
-  - Passes `persistence_dir`, `conversation_id`, callback stack, `max_iteration_per_run`, stuck detection toggle, visualizer implementation, and secrets
-- `LocalConversation`
-  - Runs the `Agent` loop
-  - Persists events/state
-  - Supports resume-from-disk
-  - Exposes context-manager cleanup
-- `RemoteConversation`
-  - Prohibits persistence dir
-  - Relays messages over HTTP/WebSocket
-  - Mirrors confirmation/status callbacks
-  - Replays history from the agent server
+- Factory `Conversation()` chooses `LocalConversation` vs `RemoteConversation` based on workspace type
+- `LocalConversation`: Runs Agent loop, persists events/state, supports resume-from-disk, context-manager cleanup
+- `RemoteConversation`: Relays messages over HTTP/WebSocket, mirrors confirmation/status callbacks, replays history
 
 ### TypeScript shape
 
-- `Conversation()`
-  - Selects `LocalConversation` (in-process) or `RemoteConversation` (WebSocket with HTTP history replay) based on `serverUrl` presence
-- `LocalConversation`
-  - Builds fresh `Agent`, `EventLog`, `ConversationState`, and `SecretRegistry`
-  - Emits `status/event/error/conversationStarted/terminal`
-  - Has no persistence or cleanup hooks
-- `RemoteConversation`
-  - Manages reconnect/replay and exposes settings mutation
-  - Only proxies chat/events (no remote workspace/file helpers)
+- `Conversation()` selects `LocalConversation` (in-process) or `RemoteConversation` (WebSocket) based on `serverUrl` presence
+- `LocalConversation`: Builds Agent, EventLog, ConversationState, SecretRegistry; emits status/event/error/terminal
+- `RemoteConversation`: WebSocket client with reconnect/replay, event deduplication, dynamic settings mutation
 
-### Gaps to close
+### RemoteConversation API comparison
 
-- Persistence-aware construction (resume from disk, persistence directory validation) and context-manager cleanup
-- Visualizer/stuck-detection hooks, richer callback chaining, and secret injection aligned with Python's constructor signature
-- Remote workspace-aware commands, git/file helpers, and HTTP fallback parity (TS remote mode only streams chat/events)
+| Method | Python | TypeScript |
+|--------|--------|-----------|
+| `send_message()` | ✓ | ✓ `sendUserMessage()` |
+| `run()` | ✓ | ✓ `resume()` |
+| `pause()` | ✓ | ✓ |
+| `approveAction()`/`rejectAction()` | ✓ | ✓ |
+| `set_confirmation_policy()` | ✓ | ✗ |
+| `set_security_analyzer()` | ✓ | ✗ |
+| `update_secrets()` | ✓ | ✗ |
+| `ask_agent()` | ✓ | ✗ |
+| `generate_title()` | ✓ | ✗ |
+| `condense()` | ✓ | ✗ |
+| `close()` | ✓ | ✓ `disconnect()` |
+| `setServerUrl()` | ✗ | ✓ |
+| `setSettings()` | ✗ | ✓ |
+| `reconnect()` | ✗ | ✓ |
 
 ```mermaid
 classDiagram
     class ConversationPython {
       <<Factory>>
-      +__new__(agent, workspace, persistence_dir?, conversation_id?, callbacks?, max_iteration_per_run?, stuck_detection?, visualizer?, secrets?)
+      +__new__(agent, workspace, persistence_dir?, callbacks?, max_iteration_per_run?, stuck_detection?, visualizer?, secrets?)
     }
     ConversationPython --> LocalConversationPython
     ConversationPython --> RemoteConversationPython
@@ -349,7 +428,10 @@ classDiagram
       +send_message()
       +run()
       +reject_pending_actions()
-      +callbacks
+      +set_confirmation_policy()
+      +ask_agent()
+      +generate_title()
+      +condense()
     }
     class ConversationTS {
       <<Factory>>
@@ -371,100 +453,43 @@ classDiagram
       +restoreConversation()
       +sendUserMessage()
       +disconnect()/reconnect()
+      +setServerUrl()/setSettings()
       -WebSocket
       -historyReplay()
     }
 ```
 
-### Source references
-- Python: openhands/sdk/conversation/conversation.py Conversation; openhands/sdk/conversation/base.py BaseConversation, ConversationStateProtocol; openhands/sdk/conversation/impl/local_conversation.py LocalConversation; openhands/sdk/conversation/impl/remote_conversation.py RemoteConversation; openhands/sdk/conversation/state.py ConversationState.
-- TypeScript: packages/agent-sdk-ts/src/sdk/conversation/index.ts Conversation factory; packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts LocalConversation; packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts RemoteConversation; packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts ConversationState.
-
-### RemoteConversation detailed comparison (2025-12-25)
-
-Python's RemoteConversation has significantly more features than TypeScript's implementation.
-
-#### Helper classes
-
-| Class | Python | TypeScript | Notes |
-|-------|--------|-----------|-------|
-| `WebSocketCallbackClient` | ✓ separate class with thread, retry | ✓ inline in RemoteConversation | Similar reconnect logic |
-| `RemoteEventsList` | ✓ list-like with caching, indexing, `__getitem__` | ✗ only `seenEventIds` Set | Python caches events with full list interface |
-| `RemoteState` | ✓ full state interface | ✗ no remote state abstraction | Python exposes execution_status, confirmation_policy, security_analyzer, stats, agent, workspace, persistence_dir |
-
-#### API methods
-
-| Method | Python | TypeScript | Notes |
-|--------|--------|-----------|-------|
-| `send_message()` | ✓ | ✓ `sendUserMessage()` | Aligned |
-| `run()` | ✓ | ✓ `resume()` | Aligned (different name) |
-| `pause()` | ✓ | ✓ | Aligned |
-| `approveAction()`/`rejectAction()` | ✓ `run()` (approve/continue), `reject_pending_actions()` (reject) | ✓ | Aligned (Python approve is implicit via `run()`) |
-| `set_confirmation_policy()` | ✓ | ✗ | Python only |
-| `set_security_analyzer()` | ✓ | ✗ | Python only |
-| `update_secrets()` | ✓ | ✗ | Python only |
-| `ask_agent()` | ✓ stateless question endpoint | ✗ | Python only |
-| `generate_title()` | ✓ | ✗ | Python only |
-| `condense()` | ✓ force condensation | ✗ | Python only |
-| `close()` | ✓ | ✓ `disconnect()` | Aligned |
-| `setServerUrl()` | ✗ | ✓ | TypeScript only - dynamic URL change |
-| `setSettings()` | ✗ | ✓ | TypeScript only - dynamic settings change |
-| `reconnect()` | ✗ | ✓ | TypeScript only - manual reconnect trigger |
-
-#### Callback system
-
-| Feature | Python | TypeScript |
-|---------|--------|-----------|
-| Event callbacks | ✓ composable callback stack | ✓ EventEmitter pattern |
-| Visualizer callbacks | ✓ | ✗ |
-| State update callbacks | ✓ `create_state_update_callback()` | ✗ |
-| LLM completion log callbacks | ✓ | ✗ |
-
-#### Gaps to close for RemoteConversation
-
-- Add `RemoteState` class or equivalent state abstraction for accessing remote execution_status, confirmation_policy, stats
-- Implement `ask_agent()` for stateless questions
-- Implement `generate_title()` for conversation titling
-- Implement `condense()` for forcing condensation
-- Implement `set_confirmation_policy()` and `set_security_analyzer()` for runtime policy changes
-- Implement `update_secrets()` for runtime secret injection
-- Add callback composition pattern matching Python's `compose_callbacks()`
-
 ## Agent lifecycle and orchestration
 
 ### Python shape
 
-- `Agent` extends `AgentBase`
-  - Injects system prompt with serialized tool schemas
-  - Enforces confirmation/security via analyzers
-  - Supports condenser pipelines plus observability hooks
-- Drives `_step` loop
-  - Deduplication
-  - Condensed event windows
-  - Dual LLM APIs (responses vs completions)
-  - Pending-action replay with disk-backed `ConversationState`
-- Integrates with `SecretRegistry` persistence, stuck detection, and configurable confirmation policies
-- Confirmation: approval is implicit (call `run()` again); rejection uses `reject_pending_actions(reason)`
+- `Agent` extends `AgentBase`: Injects system prompt with tool schemas, enforces confirmation/security via analyzers, supports condenser pipelines
+- Drives `_step` loop: Deduplication, condensed event windows, dual LLM APIs (responses vs completions), pending-action replay
+- Integrates with `SecretRegistry` persistence, stuck detection, configurable confirmation policies
 
 ### TypeScript shape
 
-- `Agent` wraps `LLMStreamer`
-  - Builds/attaches `EventLog`, `ConversationState`, `SecretRegistry`
-  - Optional tools/LLM client and optional `AgentContext`
+- `Agent` wraps `LLMStreamer`: Builds/attaches EventLog, ConversationState, SecretRegistry
 - Methods: `run`, `pause/resume`, `cancel`, `approveAction/rejectAction`
-  - Enforces iteration cap
-  - Confirmation policy enum
-  - Executes tool calls with basic error handling
-- No condenser, security analyzer, or persisted state replay
-- Confirmation logic is minimal and local-only
+- Enforces iteration cap, confirmation policy, executes tool calls with error handling
+- Supports hooks (beforeToolCall, afterToolCall, afterEvent, shouldStop)
+- Tool summarization with Gemini Flash (configurable)
+- Condensation with token budget tracking
 
-### Gaps to close
+### Agent feature comparison
 
-- Add tool schema/security analyzer injection, condenser pipeline
-- Note: we do not want observability in TS.
-- Support persisted `ConversationState` restoration and pending-action replay (implemented in PR #246 / `oh-tab-wc7`).
-- Implement responses-API parity and richer confirmation policies akin to Python analyzers
-- Add hook execution pipeline (pre/post tool use, post event, stop hook)
+| Feature | Python | TypeScript |
+|---------|--------|-----------|
+| System prompt injection | ✓ | ✓ |
+| Tool schema generation | ✓ | ✓ |
+| Security analyzer | ✓ separate module | ✓ inline + `security/` module |
+| Condenser pipeline | ✓ | ✓ `llmSummarizingCondenser` |
+| Stuck detection | ✓ | ✓ |
+| Persistence | ✓ file-backed | ✓ `FileStore` |
+| Hooks | ✓ full system | ✓ interface only |
+| Tool summarization | ✓ | ✓ Gemini Flash |
+| Iteration limits | ✓ | ✓ |
+| Confirmation policies | ✓ | ✓ |
 
 ```mermaid
 classDiagram
@@ -478,261 +503,78 @@ classDiagram
       -ConversationState (persisted)
       -SecretRegistry (persisted)
     }
-    class AgentTSPython {
-      note "TypeScript" as n1
-    }
     class AgentTS {
       +run()
       +pause()/resume()/cancel()
       +approveAction()/rejectAction()
       -LLMStreamer
-      -ConversationState (in-memory)
-      -EventLog (in-memory)
-      -SecretRegistry (in-memory)
+      -ConversationState
+      -EventLog
+      -SecretRegistry
       -AgentContext?
+      -hooks: AgentHook[]
     }
     AgentPython --> ConversationStatePython
     AgentTS --> ConversationStateTS
 ```
-
-### Source references
-- Python: openhands/sdk/agent/base.py AgentBase; openhands/sdk/agent/agent.py Agent; openhands/sdk/conversation/state.py ConversationState; openhands/sdk/conversation/conversation.py Conversation factory glue.
-- TypeScript: packages/agent-sdk-ts/src/sdk/runtime/Agent.ts Agent; packages/agent-sdk-ts/src/sdk/runtime/LLMStreamer.ts LLMStreamer; packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts ConversationState; packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts SecretRegistry.
 
 ## AgentContext and skills
 
 ### Python AgentContext
 
 - Pydantic model with repo-skill templating
-  - Uses `system_message_suffix.j2` templates
-  - Triggered knowledge rendering
-  - Duplicate detection
-  - Auto-loading of user skills with warnings (skills). Note: Python also supports legacy “microagents”; TypeScript does not load legacy microagents today.
-  - Optional public skills loading from OpenHands/skills
-  - Structured metadata
-- Produces both system and user suffixes
-  - Templated variables
-  - Activation tracking
-  - `<available_skills>` XML via `to_prompt()` for progressive disclosure
-  - Model-family gating for vendor-specific repo skills (CLAUDE.md/GEMINI.md)
+- Uses `system_message_suffix.j2` templates
+- Duplicate detection, auto-loading of user skills
+- Optional public skills loading from OpenHands/skills
+- `<available_skills>` XML via `to_prompt()` for progressive disclosure
+- Model-family gating for vendor-specific repo skills
 
 ### TypeScript AgentContext
 
-- Lightweight class that concatenates repo skills into a system suffix and triggered skills into a user suffix
-  - Matches triggers (keyword/task) and logs warnings for duplicates
-- Supports AgentSkills progressive disclosure via `<available_skills>` (lists available skills by name/description/location; full content is injected only when triggered)
-- Supports model-family gating for vendor-specific repo instructions (`CLAUDE.md`/`GEMINI.md`) and handles profiles-first settings (when `llm.profileId` is selected)
+- Lightweight class concatenating repo skills into system suffix and triggered skills into user suffix
+- Matches triggers (keyword/task) and logs warnings for duplicates
+- `<available_skills>` progressive disclosure (lists available skills by name/description/location)
+- Model-family gating for vendor-specific repo instructions (`CLAUDE.md`/`GEMINI.md`)
 - No public skills repo loading
 
-### Skill models
+### Skill models comparison
 
-- **Python `Skill`**
-  - Pydantic validation
-  - Keyword/task triggers
-  - Auto `/name` trigger for task skills
-  - Input validation helpers (`requires_user_input`)
-  - Third-party aliasing
-  - AgentSkills standard fields (name/description/metadata)
-  - SKILL.md directory convention with strict name validation
-  - Progressive disclosure metadata + `<available_skills>` prompt format
-  - Resource discovery (`scripts/`, `references/`, `assets/`)
-  - MCP tool metadata + `.mcp.json` loading with variable expansion
-  - Third-party files: `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` (truncates oversized files)
+| Feature | Python | TypeScript |
+|---------|--------|-----------|
+| SKILL.md directories | ✓ | ✓ |
+| Strict name validation | ✓ | ✓ |
+| Keyword/task triggers | ✓ | ✓ |
+| Auto `/name` trigger | ✓ | ✗ |
+| Input validation helpers | ✓ | ✗ |
+| Third-party aliasing | ✓ | ✓ |
+| Progressive disclosure | ✓ `to_prompt()` | ✓ `<available_skills>` |
+| Resource discovery | ✓ scripts/references/assets | ✓ scripts/references/assets |
+| MCP tool metadata | ✓ | ✓ config parsing only |
+| .mcp.json loading | ✓ with expansion | ✓ with expansion |
+| Third-party files | ✓ .cursorrules, AGENTS.md, etc. | ✓ .cursorrules, AGENTS.md, etc. |
+| Public skills repo | ✓ | ✗ |
 
-- **TypeScript `Skill`**
-  - Mirrors keyword/task/always-on triggers
-  - Aliasing and missing-variable prompts
-  - AgentSkills (SKILL.md directories) with strict naming validation
-  - Resource discovery (`scripts/`, `references/`, `assets/`) and optional `.mcp.json` parsing/validation with variable expansion
-  - Third-party files: `.cursorrules`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md` (truncates oversized files; vendor-gated where applicable)
-  - Trigger matching is substring-based (same as Python); template-driven prompt rendering and richer trigger semantics are optional enhancements (not parity)
-
-### Gaps to close
-- Add public skills repo loading (`load_public_skills`)
-- Optional enhancements (not python parity): template-driven prompt rendering and richer trigger semantics (regex/weights, scoring)
-
-```mermaid
-classDiagram
-    class AgentContextPython {
-      +system_suffix(skills)
-      +user_suffix(activated_skills)
-      +render_templates()
-      +validate_duplicates()
-      +auto_load_user_skills()
-    }
-    class SkillPython {
-      +name
-      +description
-      +keywords/tasks
-      +aliases
-      +mcp_tool
-      +requires_user_input()
-    }
-    AgentContextPython --> SkillPython
-    class AgentContextTS {
-      +systemSuffix()
-      +userSuffix()
-      +loadUserSkills()
-      -string concatenation
-    }
-    class SkillTS {
-      +name
-      +description
-      +keywords/tasks/alwaysOn
-      +aliases
-      +validateInput()
-    }
-    AgentContextTS --> SkillTS
-```
-
-### Source references
-- Python: openhands/sdk/context/agent_context.py AgentContext; openhands/sdk/context/skills/skill.py Skill; openhands/sdk/context/skills/types.py SkillKnowledge, SkillResponse, SkillContentResponse.
-- TypeScript: packages/agent-sdk-ts/src/sdk/context/agent-context.ts AgentContext; packages/agent-sdk-ts/src/sdk/context/skills/skill.ts Skill, SkillValidationError.
-
-## Tool and event parity
-
-### Python tool architecture
-
-In Python, tools are modeled as `ToolDefinition[ActionT, ObservationT]` with a few key components:
-
-- `Action` and `Observation` are Pydantic models (see `openhands.sdk.tool.schema`) that define the structured input/output for a tool.
-- A `ToolDefinition` instance carries:
-  - `name`, `description`, `annotations`, `meta`
-  - `action_type` and `observation_type` (the concrete `Action`/`Observation` subclasses)
-  - a runtime-only `executor: ToolExecutor[ActionT, ObservationT] | None` which performs the side effects
-- `ToolExecutor.__call__(self, action: ActionT, conversation: LocalConversation | None) -> ObservationT` is responsible for executing the tool logic. For example, the Terminal tool uses an executor that runs shell commands in the workspace and returns an `ExecuteBashObservation`.
-- The `Agent` never calls tools directly with raw args. Instead, the flow is:
-  1. LLM produces a tool call (function name + JSON arguments).
-  2. `_get_action_event` parses/validates arguments into an `Action` instance (e.g., `ExecuteBashAction`) and emits an `ActionEvent`.
-  3. `_execute_action_event` looks up the corresponding `ToolDefinition`, invokes its `executor(action, conversation)`, and receives an `Observation`.
-  4. The `Observation` is wrapped in an `ObservationEvent` and appended to the conversation.
-- The `ConversationState` ties everything together by tracking events (including `ActionEvent`/`ObservationEvent`) and execution status.
-
-### TypeScript tool architecture today
-
-In TypeScript, the core tool abstraction is `ToolDefinition<TArgs, TResult>` (see `src/sdk/types/tools.ts`):
-
-- `ToolDefinition` defines:
-  - `name`, optional `description` and `parameters` (for schema)
-  - `validate(input: unknown): TArgs` to coerce LLM arguments into a concrete args object
-  - `execute(args: TArgs, context: ToolContext): Promise<TResult>` which performs the side effects and returns a result
-  - an optional `getToolDefinition()` to expose an LLM-facing tool schema (`LLMToolDefinition`).
-- Tools like `TerminalTool`, `FileEditorTool`, etc. currently implement `execute()` directly and return a simple result object (`TerminalResult`, `FileEditorResult`, ...). There are no explicit `Action`/`Observation` classes.
-- The `Agent` loop (`src/sdk/runtime/Agent.ts`) handles tool calls by:
-  1. Parsing `tool_call.arguments` as JSON.
-  2. Validating arguments via `tool.validate()`.
-  3. Emitting an `ActionEvent` (using the validated args as a plain record, not a typed `Action` subclass).
-  4. Executing `tool.execute(args, context)` once confirmation policy allows.
-  5. Wrapping the returned result in an `ObservationEvent` where `observation` is a plain JSON object.
-- Event interfaces in `src/sdk/types/index.ts` mirror the Python wire format: `ActionEvent` and `ObservationEvent` are present, but they carry raw records (`Record<string, unknown>`) instead of strongly-typed `Action`/`Observation` models.
-
-**Built-in tools parity note (product decision / source of truth):** Python includes built-in `finish` and `think` tools by default. TypeScript includes both as built-ins in `src/sdk/runtime/Agent.ts` (unless `includeDefaultTools === false`).
-
-For `think`, **the TypeScript SDK MUST keep the tool description text identical to the Python SDK** (i.e., copy the Python `THINK_DESCRIPTION` verbatim). Even though the TS implementation is simpler, the tool description is part of the LLM-facing contract and directly affects agent behavior. We prioritize **cross-SDK behavioral parity** over minimizing prompt size for all common tools.
-
-If any future optimization is desired (e.g., shorter descriptions to reduce prompt tokens), it must be treated as an explicit product decision, applied consistently across Python and TS (not a TS-only divergence) and approved by Mail by the Human Overseer.
-
-#### ThinkTool details
-
-- **Tool name:** Python `think`; TypeScript `think`.
-- **Input schema:** Python `{ thought: string }`; TypeScript `{ thought: string }` (required).
-- **Behavior:** no side effects; returns a simple confirmation message which is emitted as a tool message and included in subsequent LLM requests.
-- **Description text:** TypeScript matches Python’s built-in tool description verbatim (including usage examples) for parity, per HUMAN OVERSEER guidance. This is longer but ensures identical tool guidance across SDKs.
-
-### Gaps and intended direction
-
-- The TS runtime currently has **ActionEvent/ObservationEvent types but no first-class Action/Observation classes**. The Python stack uses Pydantic models for validation, kind resolution, and serialization; TS simply forwards validated args/results as plain JSON.
-- There is no `ToolDefinition`/`ToolExecutor` split in TS. `ToolDefinition.execute` is both the definition and executor. This is enough for VS Code usage but diverges from Python, where the executor can be swapped or wrapped (e.g., for remote execution, observability, or sandboxing).
-- The Python Agent works in terms of `ActionEvent`→`ToolExecutor`→`ObservationEvent`. TS mirrors the **event shapes** but shortcuts the intermediate typed models.
-- This is fine.
-
-**Practical parity goal for now:**
-
-Rather than fully re-implementing Pydantic-style action/observation classes in TS, the near-term goal is:
-
-- Keep the event wire format aligned (ActionEvent/ObservationEvent shapes stay compatible with Python).
-- Ensure each tool has a well-defined input/result schema and that the Agent loop always:
-  - emits an `ActionEvent` when the LLM calls a tool;
-  - executes the corresponding tool;
-  - emits an `ObservationEvent` with the structured result.
-
-`TerminalTool` is the first place where we validate this end-to-end behavior for a “real” environment-interacting tool.
-
-## Event logging, persistence, and events
-
-### EventLog/persistence
-
-- **Python `EventLog`**
-  - File-backed with deterministic filenames/indices
-  - Duplicate-ID detection
-  - Slicing/iteration helpers
-  - Integration with:
-    - `EventsListBase`: iteration and index helpers
-    - `persistence_const`: directory and filename patterns
-    - `serialization_diff`: state diffing
-    - FIFO locks: cross-process locking
-  - `ConversationState.create`: hydrates state (iteration counts, stuck detection) from disk
-  - `SecretRegistry`: persists secrets
-- **TypeScript `EventLog`**
-  - Normalizes IDs/timestamps
-  - Broadcasts listeners
-  - Supports `push/list/on`
-  - `ConversationState`: in-memory with optional `attachEventLog`
-  - `SecretRegistry`: non-persisted
-
-### Gaps to close
-
-- Port persistence constants, diffing, and cross-process locks
-- Persist secrets: in TS we want to always use VSCode secret manager
-- Persist conversation state for resume/replay - probably already done
-
-## Tool schema parity
-
-- Introduced zod-backed tool definitions for `browser_use`, `delegate`, `glob`, `grep`, and `planning_file_editor` so the TypeScript
-  SDK mirrors the Python tool descriptions and annotations. Structured tools now surface JSON Schema parameters in the system
-  prompt to keep VS Code behavior aligned with the reference SDK.
-- Expose hydration helpers mirroring Python's `ConversationState.create`
+## Event and type parity
 
 ### Event interface coverage
 
-- **Python event classes** (Pydantic models in `openhands.sdk.event`):
-  - A suite of event classes including:
-    - `SystemPromptEvent`
-    - `ActionEvent`
-    - `ObservationEvent`
-    - `UserRejectObservation`
-    - `MessageEvent`
-    - `AgentErrorEvent`
-    - `ConversationErrorEvent`
-    - `TokenEvent`
-    - `PauseEvent`
-    - `Condensation`
-    - `CondensationRequest`
-    - `CondensationSummaryEvent`
-    - `ConversationStateUpdateEvent`
-  - All events extend `Event`/`LLMConvertibleEvent`
-  - Include fields: `id`, `timestamp`, `source`, and type-specific data (tool call IDs, reasoning; optional summaries in Python)
-- **TypeScript event interfaces** (`src/sdk/types`):
-  - Mirrors most Python events using discriminated `kind` property:
-    - `SystemPromptEvent`
-    - `ActionEvent`
-    - `ObservationEvent`
-    - `UserRejectObservation`
-    - `MessageEvent`
-    - `AgentErrorEvent`
-    - `ConversationErrorEvent`
-    - `PauseEvent`
-    - `Condensation`
-    - `ConversationStateUpdateEvent`
-  - Lacks:
-    - `TokenEvent`
-    - Condensation request/summary variants
-  - Metadata fields are narrower (e.g., no stuck-detection or condenser fields)
-  - Missing ActionEvent additions from Python:
-    - `summary`: **not required for OpenHands-Tab**, since Gemini Flash generates summaries on the fly
-  - Implemented ActionEvent reasoning metadata:
-    - `thinking_blocks`: Anthropic “thinking” blocks (structured reasoning trace content)
-    - `responses_reasoning_item`: OpenAI Responses API reasoning metadata item
+| Event Type | Python | TypeScript | Notes |
+|------------|--------|-----------|-------|
+| SystemPromptEvent | ✓ | ✓ | Aligned |
+| ActionEvent | ✓ | ✓ | TS lacks `summary` |
+| ObservationEvent | ✓ | ✓ | Aligned |
+| UserRejectObservation | ✓ | ✓ | Aligned |
+| MessageEvent | ✓ | ✓ | Aligned |
+| AgentErrorEvent | ✓ | ✓ | Aligned |
+| ConversationErrorEvent | ✓ | ✓ | Aligned |
+| TokenEvent | ✓ | ✗ | Python only |
+| PauseEvent | ✓ | ✓ | Aligned |
+| Condensation | ✓ | ✓ | Aligned |
+| CondensationRequest | ✓ | ✗ | Python only |
+| CondensationSummaryEvent | ✓ | ✗ | Python only |
+| ConversationStateUpdateEvent | ✓ | ✓ | Aligned |
+
+### Event log and persistence
 
 ```mermaid
 classDiagram
@@ -748,9 +590,6 @@ classDiagram
       +create(persistence_dir)
       +hydrate()
       +stuck_detection
-    }
-    class SecretRegistryPython {
-      +persisted_secrets
     }
     class EventLogTS {
       +push(event)
@@ -769,104 +608,90 @@ classDiagram
       +readEvents()
       +readState()
     }
-    class SecretRegistryTS {
-      +in_memory_secrets
-      +env_fallback
-      +vscode_secret_storage
-    }
     EventLogPython --> ConversationStatePython
     EventLogTS --> ConversationStateTS
     EventLogTS --> FileStore
     ConversationStateTS --> FileStore
 ```
 
-### Source references
-- Python: openhands/sdk/conversation/event_store.py EventLog; openhands/sdk/conversation/state.py ConversationState; openhands/sdk/conversation/persistence_const.py persistence constants; openhands/sdk/event/types.py event discriminators; openhands/sdk/event/conversation_state.py ConversationStateUpdateEvent; openhands/sdk/event/conversation_error.py ConversationErrorEvent; openhands/sdk/event/token.py TokenEvent; openhands/sdk/event/user_action.py ActionEvent/UserRejectObservation; openhands/sdk/event/condenser.py condensation events; openhands/sdk/event/base.py Event/LLMConvertibleEvent.
-- TypeScript: packages/agent-sdk-ts/src/sdk/runtime/EventLog.ts EventLog; packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts ConversationState; packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts SecretRegistry; packages/agent-sdk-ts/src/sdk/types/index.ts SystemPromptEvent, MessageEvent, ActionEvent, ObservationEvent, ConversationStateUpdateEvent, ConversationErrorEvent, PauseEvent, Condensation, is* guards.
-
-## Observation LLM/UI formatting (Issue #587)
-
-A key architectural difference: in Python, **Observations own their LLM and UI representations**.
+## Observation LLM/UI formatting
 
 ### Python design
 
 Each `Observation` subclass defines how it formats for LLM vs UI:
 
 ```python
-# openhands/sdk/tool/schema.py
 class Observation(Schema, ABC):
     @property
     def to_llm_content(self) -> Sequence[TextContent | ImageContent]:
-        """Content formatting for LLM. Subclasses override for custom formatting."""
-        
+        """Content formatting for LLM. Subclasses override."""
+
     @property
     def visualize(self) -> Text:
         """Rich Text representation for UI display."""
 ```
 
-Tool-specific observations override these (e.g., `TerminalObservation` in `openhands/tools/terminal/definition.py`):
+### TypeScript design
 
-```python
-class TerminalObservation(Observation):
-    @property
-    def to_llm_content(self) -> Sequence[TextContent | ImageContent]:
-        # Only includes relevant fields (command, stdout, stderr, exit_code)
-        # Adds metadata suffix, applies truncation
-        
-    @property
-    def visualize(self) -> Text:
-        # Rich formatting with colors, icons for UI
-```
-
-The `ObservationEvent` delegates to these methods:
-
-```python
-# openhands/sdk/event/llm_convertible/observation.py
-class ObservationEvent(LLMConvertibleEvent):
-    def to_llm_message(self) -> Message:
-        return Message(role="tool", content=self.observation.to_llm_content, ...)
-```
-
-### TypeScript current state
-
-Tool execution produces **two separate events**:
-1. `ObservationEvent` - full result object (for UI)
-2. `MessageEvent` with `role: 'tool'` - formatted text (for LLM)
-
-Formatting logic lives externally in `toolMessageFormatting.ts` with hardcoded tool name checks:
+Tool execution produces observation events; formatting is external:
 
 ```typescript
-// toolMessageFormatting.ts
-export function formatToolMessageText(toolCall: ToolCall, result: unknown): string {
-  if (toolName === 'terminal') { /* terminal-specific */ }
-  if (toolName === 'file_editor') { /* file editor-specific */ }
-  // Generic fallback - JSON.stringify(result) - leaks everything!
+// observations/index.ts
+export function observationToLLMText(observation: Observation): string {
+  if (observation.kind === 'terminal') { /* terminal-specific formatting */ }
+  if (observation.kind === 'file_editor') { /* file editor-specific */ }
+  // Generic fallback
   return JSON.stringify(result, null, 2);
 }
 ```
 
-**Problems:**
-- Formatting logic external to tools, not owned by them
-- Generic fallback leaks internal fields (like `summary`) to the LLM
-- Adding a new tool requires updating `toolMessageFormatting.ts`
+### Formatting status
+- Terminal: Both format with command, output, exit code
+- File editor: Both format with command, path, content
+- Generic: TS falls back to JSON stringify (may leak internal fields)
 
-### Migration plan
+## Quick checklist for remaining parity work
 
-1. Add `formatForLLM?(result: TResult): string` to `ToolDefinition` interface
-2. Implement in each tool (move logic from `toolMessageFormatting.ts`)
-3. Update `Agent.ts` to use tool's formatter
-4. Remove generic JSON.stringify fallback (or make it throw)
+- [ ] **Hooks system**: Add config file loading, subprocess executor, pattern matching
+- [ ] **MCP Client**: Add MCPClient for tool execution (not just config parsing)
+- [ ] **BrowserUseTool**: Implement actual browser automation (currently stubbed)
+- [ ] **DelegateTool**: Implement sub-agent orchestration (currently stubbed)
+- [ ] **Public skills**: Add public skills repo loading (`load_public_skills`)
+- [ ] **RemoteConversation**: Add `set_confirmation_policy`, `ask_agent`, `generate_title`, `condense`
+- [ ] **security_risk defaulting**: Consider defaulting to UNKNOWN in TS for remote mode
+- [ ] **Observation formatting**: Add `formatForLLM()` to tools so observations own their LLM representation
 
-### Source references
-- Python: `openhands-sdk/openhands/sdk/tool/schema.py` (Observation.to_llm_content); `openhands-sdk/openhands/sdk/event/llm_convertible/observation.py` (ObservationEvent.to_llm_message); `openhands-tools/openhands/tools/terminal/definition.py` (TerminalObservation)
-- TypeScript: `packages/agent-sdk-ts/src/sdk/types/tools.ts` (ToolDefinition); `packages/agent-sdk-ts/src/sdk/runtime/toolMessageFormatting.ts`; `packages/agent-sdk-ts/src/sdk/runtime/Agent.ts`
+## Not planned for TypeScript
 
-## Quick checklist for parity work
-- **Observation formatting (#587)**: Add `formatForLLM()` to tools so observations own their LLM representation (like Python's `to_llm_content`).
-- Implement workspace factory/base with remote support, and maybe richer command metadata.
-- Extend conversations with visualizer/stuck-detection hooks, callback stacks, and remote workspace helpers.
-- Augment agent with what is missing from condenser/security analyzers, and test confirmation policies.
-- Add template-aware `AgentContext`, `Skill` metadata/validation, and richer trigger matching.
-- Align tool message formatting (Terminal/FileEditor) with Python’s LLM-facing observations (truncation markers, optional metadata, secrets masking).
-- Add missing event variants (condensation request/summary) if VS Code needs them for UI parity.
-- NOT PLANNED: MCP, `TokenEvent`.
+- **Critic module**: Evaluation framework
+- **Git module**: Full git utilities (TS uses terminal for git commands)
+- **Logger module**: Rich/JSON logging (VS Code has its own logging)
+- **Observability**: Laminar/OpenTelemetry integration
+- **TomConsult tools**: User modeling/personalization
+- **TokenEvent**: Token-level streaming events
+- **Condensation request/summary events**: If VS Code doesn't need them for UI
+
+## Source references
+
+### Python
+- Agent: `openhands/sdk/agent/base.py`, `openhands/sdk/agent/agent.py`
+- Conversation: `openhands/sdk/conversation/conversation.py`, `impl/local_conversation.py`, `impl/remote_conversation.py`
+- Context/Skills: `openhands/sdk/context/agent_context.py`, `skills/skill.py`
+- Events: `openhands/sdk/event/`
+- Hooks: `openhands/sdk/hooks/manager.py`, `config.py`, `executor.py`
+- LLM: `openhands/sdk/llm/llm.py`, `router/base.py`
+- MCP: `openhands/sdk/mcp/client.py`, `tool.py`
+- Tools: `openhands-tools/openhands/tools/`
+- Workspace: `openhands/sdk/workspace/`
+
+### TypeScript
+- Agent: `src/sdk/runtime/Agent.ts`, `LLMStreamer.ts`
+- Conversation: `src/sdk/conversation/LocalConversation.ts`, `RemoteConversation.ts`
+- Context/Skills: `src/sdk/context/agent-context.ts`, `skills/skill.ts`
+- Events/Types: `src/sdk/types/`
+- Hooks: `src/sdk/runtime/hooks.ts`
+- LLM: `src/sdk/llm/`, `factory.ts`, `router.ts`
+- MCP: `src/sdk/context/skills/mcp.ts` (config parsing only)
+- Observations: `src/sdk/observations/index.ts`
+- Tools: `src/tools/`
+- Workspace: `src/workspace/`

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -631,9 +631,9 @@ class Observation(Schema, ABC):
         """Rich Text representation for UI display."""
 ```
 
-### TypeScript design
+### TypeScript design (intentional difference)
 
-Tool execution produces observation events; formatting is external:
+TypeScript uses centralized function-based formatting rather than method-on-class:
 
 ```typescript
 // observations/index.ts
@@ -643,12 +643,23 @@ export function observationToLLMText(observation: Observation): string {
   // Generic fallback
   return JSON.stringify(observation, null, 2);
 }
+
+// toolMessageFormatting.ts - thin wrapper that delegates
+export function formatToolMessageText(toolCall: ToolCall, result: unknown): string {
+  return toolResultToLLMText(toolCall, result);
+}
 ```
 
+This is an **intentional design choice**, not a parity gap:
+- Centralized formatting is simpler to maintain
+- Tool-specific formatting exists for terminal and file_editor
+- Generic JSON fallback is acceptable for most tools
+- Summarizer handles large outputs separately
+
 ### Formatting status
-- Terminal: Both format with command, output, exit code
-- File editor: Both format with command, path, content
-- Generic: TS falls back to JSON stringify (may leak internal fields)
+- Terminal: Both format with command, output, exit code - **Aligned**
+- File editor: Both format with command, path, content - **Aligned**
+- Generic: TS falls back to JSON stringify (acceptable for most tools)
 
 ## Quick checklist for remaining parity work
 
@@ -659,7 +670,6 @@ export function observationToLLMText(observation: Observation): string {
 - [ ] **Public skills**: Add public skills repo loading (`load_public_skills`)
 - [ ] **RemoteConversation**: Add `set_confirmation_policy`, `ask_agent`, `generate_title`, `condense`
 - [ ] **security_risk defaulting**: Consider defaulting to UNKNOWN in TS for remote mode
-- [ ] **Observation formatting**: Add `formatForLLM()` to tools so observations own their LLM representation
 
 ## Not planned for TypeScript
 

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -631,38 +631,50 @@ class Observation(Schema, ABC):
         """Rich Text representation for UI display."""
 ```
 
-### TypeScript design (intentional difference)
+### TypeScript design (technical debt)
 
-TypeScript uses centralized function-based formatting rather than method-on-class:
+TypeScript uses centralized function-based formatting in `observations/index.ts`:
 
 ```typescript
-// observations/index.ts
 export function observationToLLMText(observation: Observation): string {
   if (observation.kind === 'terminal') { /* terminal-specific formatting */ }
   if (observation.kind === 'file_editor') { /* file editor-specific */ }
-  // Generic fallback
+  // Generic fallback - everything else gets JSON dumped
   return JSON.stringify(observation, null, 2);
-}
-
-// toolMessageFormatting.ts - thin wrapper that delegates
-export function formatToolMessageText(toolCall: ToolCall, result: unknown): string {
-  return toolResultToLLMText(toolCall, result);
 }
 ```
 
-This is an **intentional design choice**, not a parity gap:
-- Centralized formatting is simpler to maintain
-- Tool-specific formatting exists for terminal and file_editor
-- Generic JSON fallback is acceptable for most tools
-- Summarizer handles large outputs separately
+**Current reality**: Only 2 tools have proper LLM-facing formatting:
+
+| Tool | LLM sees | Status |
+|------|----------|--------|
+| **terminal** | `$ cmd\noutput\n[exit code 0]` | ✓ Formatted |
+| **file_editor** | `file_editor view /path\ncontent` | ✓ Formatted |
+| **ask_oracle** | String response | ✓ Pass-through |
+| **think** | `{"message": "Your thought has been logged."}` | ✗ JSON dump |
+| **glob** | `{"files": [...], "pattern": "...", "truncated": false}` | ✗ JSON dump with internal fields |
+| **grep** | `{"matches": [...], "pattern": "...", "truncated": false}` | ✗ JSON dump with internal fields |
+| **apply_patch** | `{"message": "Done!", "fuzz": 0, "commit": {...}}` | ✗ JSON dump (similar to file_editor but unformatted) |
+| **task_tracker** | `{"command": "view", "task_list": [...]}` | ✗ JSON dump |
+| **browser** | `{"url": "...", "status": 200, "content": "..."}` | ✗ JSON dump |
+| **finish** | `{"message": "..."}` | ✗ JSON dump |
+
+**Problems with current approach**:
+1. Most tools dump raw JSON including internal fields (`truncated`, `fuzz`, etc.) that are noise for the LLM
+2. Adding a new tool with proper formatting requires modifying `observations/index.ts` (violates Open/Closed)
+3. Easy to forget - new tools silently fall back to JSON
+4. `apply_patch` does file operations similar to `file_editor` but has no formatting
+
+**Potential fix**: Add optional `formatForLLM?(result: TResult): string` method to `ToolDefinition` interface, allowing tools to own their formatting while keeping backward compatibility via JSON fallback.
 
 ### Formatting status
-- Terminal: Both format with command, output, exit code - **Aligned**
-- File editor: Both format with command, path, content - **Aligned**
-- Generic: TS falls back to JSON stringify (acceptable for most tools)
+- Terminal: **Aligned** - both format with command, output, exit code
+- File editor: **Aligned** - both format with command, path, content
+- Other tools: **Gap** - TS dumps JSON; Python has tool-specific `to_llm_content` methods
 
 ## Quick checklist for remaining parity work
 
+- [ ] **Observation formatting**: Most tools dump raw JSON to LLM; add `formatForLLM()` to tools or extend centralized formatter
 - [ ] **Hooks system**: Add config file loading, subprocess executor, pattern matching
 - [ ] **MCP Client**: Add MCPClient for tool execution (not just config parsing)
 - [ ] **BrowserUseTool**: Implement actual browser automation (currently stubbed)

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -641,7 +641,7 @@ export function observationToLLMText(observation: Observation): string {
   if (observation.kind === 'terminal') { /* terminal-specific formatting */ }
   if (observation.kind === 'file_editor') { /* file editor-specific */ }
   // Generic fallback
-  return JSON.stringify(result, null, 2);
+  return JSON.stringify(observation, null, 2);
 }
 ```
 


### PR DESCRIPTION
Deep investigation of both Python software-agent-sdk and TypeScript agent-sdk-ts codebases. Updated document reflects accurate current status:

- Updated module structure table with correct parity status
- Added detailed tool comparison table with parity indicators
- Documented hooks system differences (Python full vs TS interface only)
- Clarified MCP support (Python full client vs TS config parsing only)
- Added LLM layer comparison (LiteLLM vs native providers)
- Updated conversation/RemoteConversation API comparison
- Added Agent feature comparison table
- Consolidated current parity snapshot with accurate dates
- Added quick checklist for remaining parity work
- Cleaned up outdated sections and removed stale TODO items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked and greatly expanded Python ↔ TypeScript SDK parity docs into a detailed feature-by-feature audit, including a front‑matter note clarifying TS is largely a transpilation of Python
  * Added a "Features comparison (2026-01-13)" snapshot with Python-only and TypeScript-only blocks, parity tables, diagrams, and per-feature status indicators
  * Added Tool comparison, RemoteConversation API comparison table, expanded Hooks, FileEditor/Layers, LLM parity, events, persistence, and migration guidance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->