### PR TITLE
Add OpenProse program to keep agent-sdk-ts aligned with upstream Python SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,7 +166,8 @@ agent_logs/
 
 
 # Local OpenHands data (conversations, logs, etc.)
-.openhands/
+# NOTE: Do not ignore `.openhands/` — we vendor skills here.
+# (If you need to ignore local runtime data under this dir, add more specific patterns instead.)
 
 # Secrets and configuration
 config.json

--- a/.gitignore
+++ b/.gitignore
@@ -188,3 +188,9 @@ e2e_logs*.zip
 .vscode/mcp.json
 /opencode.json
 /summary.md
+
+# Vendored OpenProse skill (committed)
+!.openhands/skills/
+!.openhands/skills/open-prose/
+!.openhands/skills/open-prose/**
+!.openhands/

--- a/.gitignore
+++ b/.gitignore
@@ -188,9 +188,3 @@ e2e_logs*.zip
 .vscode/mcp.json
 /opencode.json
 /summary.md
-
-# Vendored OpenProse skill (committed)
-!.openhands/skills/
-!.openhands/skills/open-prose/
-!.openhands/skills/open-prose/**
-!.openhands/

--- a/.openhands/skills/open-prose/SKILL.md
+++ b/.openhands/skills/open-prose/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: open-prose
+description: |
+  OpenProse is a programming language for AI sessions. An AI session is a Turing-complete
+  computer; OpenProse structures English into unambiguous control flow.
+
+  OpenHands-Tab integration:
+  - This repo vendors the OpenProse VM docs as an AgentSkills-format skill.
+  - Project skills are loaded from `<workspaceRoot>/.openhands/skills/` in local mode.
+  - When you see a `.prose` program, use `prose.md` for execution semantics and `docs.md` for syntax/validation.
+
+  Activate when: running `.prose` files, mentioning OpenProse, or when a task is best expressed as an orchestrated multi-agent workflow.
+---
+
+# OpenProse Skill
+
+OpenProse is a programming language for AI sessions. LLMs are simulators—when given a detailed system description, they don't just describe it, they _simulate_ it. The `prose.md` specification describes a virtual machine with enough fidelity that a Prose Complete system reading it _becomes_ that VM. Simulation with sufficient fidelity is implementation.
+
+## When to Activate
+
+Activate this skill when the user:
+
+- Asks to run a `.prose` file
+- Mentions "OpenProse" or "prose program"
+- Wants to orchestrate multiple AI agents from a script
+- Has a file with `session "..."` or `agent name:` syntax
+- Wants to create a reusable workflow
+
+---
+
+## Documentation Files
+
+| File       | Purpose             | When to Read                                     |
+| ---------- | ------------------- | ------------------------------------------------ |
+| `prose.md` | Execution semantics | Always read for running programs                 |
+| `docs.md`  | Full language spec  | For compilation, validation, or syntax questions |
+
+### Typical Workflow
+
+1. **Interpret**: Read `prose.md` to execute a valid program
+2. **Compile/Validate**: Read `docs.md` when asked to compile or when syntax is ambiguous
+
+## Quick Reference
+
+### Sessions
+
+```prose
+session "Do something"                    # Simple session
+session: myAgent                          # With agent
+  prompt: "Task prompt"
+  context: previousResult                 # Pass context
+```
+
+### Agents
+
+```prose
+agent researcher:
+  model: sonnet                           # sonnet | opus | haiku
+  prompt: "You are a research assistant"
+```
+
+### Variables
+
+```prose
+let result = session "Get result"         # Mutable
+const config = session "Get config"       # Immutable
+session "Use both"
+  context: [result, config]               # Array form
+  context: { result, config }             # Object form
+```
+
+### Parallel
+
+```prose
+parallel:
+  a = session "Task A"
+  b = session "Task B"
+session "Combine" context: { a, b }
+```
+
+### Loops
+
+```prose
+repeat 3:                                 # Fixed
+  session "Generate idea"
+
+for topic in ["AI", "ML"]:                # For-each
+  session "Research" context: topic
+
+loop until **done** (max: 10):            # AI-evaluated
+  session "Keep working"
+```
+
+### Error Handling
+
+```prose
+try:
+  session "Risky" retry: 3
+catch as err:
+  session "Handle" context: err
+```
+
+### Conditionals
+
+```prose
+if **has issues**:
+  session "Fix"
+else:
+  session "Approve"
+
+choice **best approach**:
+  option "Quick": session "Quick fix"
+  option "Full": session "Refactor"
+```
+
+## Examples
+
+The plugin ships with 27 examples in the `examples/` directory:
+
+- **01-08**: Basics (hello world, research, code review, debugging)
+- **09-12**: Agents and skills
+- **13-15**: Variables and composition
+- **16-19**: Parallel execution
+- **20**: Fixed loops
+- **21**: Pipeline operations
+- **22-23**: Error handling
+- **24-27**: Advanced (choice, conditionals, blocks, interpolation)
+
+Start with `01-hello-world.prose` or `03-code-review.prose`.
+
+## Execution
+
+To execute a `.prose` file, you become the OpenProse VM:
+
+1. **Read `prose.md`** — this document defines how you embody the VM
+2. **You ARE the VM** — your conversation is its memory, your tools are its instructions
+3. **Spawn sessions** — each `session` statement triggers a Task tool call
+4. **Narrate state** — use the emoji protocol to track execution (📍, 📦, ✅, etc.)
+5. **Evaluate intelligently** — `**...**` markers require your judgment
+
+## Syntax at a Glance
+
+```
+session "prompt"              # Spawn subagent
+agent name:                   # Define agent template
+let x = session "..."         # Capture result
+parallel:                     # Concurrent execution
+repeat N:                     # Fixed loop
+for x in items:               # Iteration
+loop until **condition**:     # AI-evaluated loop
+try: ... catch: ...           # Error handling
+if **condition**: ...         # Conditional
+choice **criteria**: option   # AI-selected branch
+block name(params):           # Reusable block
+do blockname(args)            # Invoke block
+items | map: ...              # Pipeline
+```
+
+For complete syntax and validation rules, see `docs.md`.

--- a/.openhands/skills/open-prose/SKILL.md
+++ b/.openhands/skills/open-prose/SKILL.md
@@ -6,7 +6,6 @@ description: |
 
   OpenHands-Tab integration:
   - This repo vendors the OpenProse VM docs as an AgentSkills-format skill.
-  - Project skills are loaded from `<workspaceRoot>/.openhands/skills/` in local mode.
   - When you see a `.prose` program, use `prose.md` for execution semantics and `docs.md` for syntax/validation.
 
   Activate when: running `.prose` files, mentioning OpenProse, or when a task is best expressed as an orchestrated multi-agent workflow.

--- a/.openhands/skills/open-prose/SKILL.md
+++ b/.openhands/skills/open-prose/SKILL.md
@@ -5,7 +5,7 @@ description: |
   computer; OpenProse structures English into unambiguous control flow.
 
   OpenHands-Tab integration:
-  - This repo vendors the OpenProse VM docs as an AgentSkills-format skill.
+  - This repo vendors the OpenProse VM docs as your Skill.
   - When you see a `.prose` program, use `prose.md` for execution semantics and `docs.md` for syntax/validation.
 
   Activate when: running `.prose` files, mentioning OpenProse, or when a task is best expressed as an orchestrated multi-agent workflow.

--- a/.openhands/skills/open-prose/antipatterns.md
+++ b/.openhands/skills/open-prose/antipatterns.md
@@ -1,0 +1,852 @@
+---
+role: antipatterns
+summary: |
+  Common mistakes and patterns to avoid in OpenProse programs.
+  Read this file to identify and fix problematic code patterns.
+see-also:
+  - prose.md: Execution semantics, how to run programs
+  - docs.md: Full syntax grammar, validation rules
+  - patterns.md: Recommended design patterns
+---
+
+# OpenProse Antipatterns
+
+This document catalogs patterns that lead to brittle, expensive, slow, or unmaintainable programs. Each antipattern includes recognition criteria and remediation guidance.
+
+---
+
+## Structural Antipatterns
+
+#### god-session
+
+A single session that tries to do everything. God sessions are hard to debug, impossible to parallelize, and produce inconsistent results.
+
+```prose
+# Bad: One session doing too much
+session """
+  Read all the code in the repository.
+  Identify security vulnerabilities.
+  Find performance bottlenecks.
+  Check for style violations.
+  Generate a comprehensive report.
+  Suggest fixes for each issue.
+  Prioritize by severity.
+  Create a remediation plan.
+"""
+```
+
+**Why it's bad**: The session has no clear completion criteria. It mixes concerns that could be parallelized. Failure anywhere fails everything.
+
+**Fix**: Decompose into focused sessions:
+
+```prose
+# Good: Focused sessions
+parallel:
+  security = session "Identify security vulnerabilities"
+  perf = session "Find performance bottlenecks"
+  style = session "Check for style violations"
+
+session "Synthesize findings and prioritize by severity"
+  context: { security, perf, style }
+
+session "Create remediation plan"
+```
+
+#### sequential-when-parallel
+
+Running independent operations sequentially when they could run concurrently. Wastes wall-clock time.
+
+```prose
+# Bad: Sequential independent work
+let market = session "Research market"
+let tech = session "Research technology"
+let competition = session "Research competition"
+
+session "Synthesize"
+  context: [market, tech, competition]
+```
+
+**Why it's bad**: Total time is sum of all research times. Each session waits for the previous one unnecessarily.
+
+**Fix**: Parallelize independent work:
+
+```prose
+# Good: Parallel independent work
+parallel:
+  market = session "Research market"
+  tech = session "Research technology"
+  competition = session "Research competition"
+
+session "Synthesize"
+  context: { market, tech, competition }
+```
+
+#### spaghetti-context
+
+Context passed haphazardly without clear data flow. Makes programs hard to understand and modify.
+
+```prose
+# Bad: Unclear what context is actually used
+let a = session "Step A"
+let b = session "Step B"
+  context: a
+let c = session "Step C"
+  context: [a, b]
+let d = session "Step D"
+  context: [a, b, c]
+let e = session "Step E"
+  context: [a, c, d]  # Why not b?
+let f = session "Step F"
+  context: [a, b, c, d, e]  # Everything?
+```
+
+**Why it's bad**: Unclear which sessions depend on which outputs. Hard to parallelize or refactor.
+
+**Fix**: Minimize context to actual dependencies:
+
+```prose
+# Good: Clear, minimal dependencies
+let research = session "Research"
+let analysis = session "Analyze"
+  context: research
+let recommendations = session "Recommend"
+  context: analysis  # Only needs analysis, not research
+let report = session "Report"
+  context: recommendations
+```
+
+#### copy-paste-workflows
+
+Duplicating session sequences instead of using blocks. Leads to inconsistent changes and maintenance burden.
+
+```prose
+# Bad: Duplicated workflow
+session "Security review of module A"
+session "Performance review of module A"
+session "Synthesize reviews of module A"
+
+session "Security review of module B"
+session "Performance review of module B"
+session "Synthesize reviews of module B"
+
+session "Security review of module C"
+session "Performance review of module C"
+session "Synthesize reviews of module C"
+```
+
+**Why it's bad**: If the workflow needs to change, you must change it everywhere. Easy to miss one.
+
+**Fix**: Extract into a block:
+
+```prose
+# Good: Reusable block
+block review-module(module):
+  parallel:
+    sec = session "Security review of {module}"
+    perf = session "Performance review of {module}"
+  session "Synthesize reviews of {module}"
+    context: { sec, perf }
+
+do review-module("module A")
+do review-module("module B")
+do review-module("module C")
+```
+
+---
+
+## Robustness Antipatterns
+
+#### unbounded-loop
+
+A loop without max iterations. Can run forever if the condition is never satisfied.
+
+```prose
+# Bad: No escape hatch
+loop until **the code is perfect**:
+  session "Improve the code"
+```
+
+**Why it's bad**: "Perfect" may never be achieved. The program could run indefinitely, consuming resources.
+
+**Fix**: Always specify `max:`:
+
+```prose
+# Good: Bounded iteration
+loop until **the code is perfect** (max: 10):
+  session "Improve the code"
+```
+
+#### optimistic-execution
+
+Assuming everything will succeed. No error handling for operations that can fail.
+
+```prose
+# Bad: No error handling
+session "Call external API"
+session "Process API response"
+session "Store results in database"
+session "Send notification"
+```
+
+**Why it's bad**: If the API fails, subsequent sessions receive no valid input. Silent corruption.
+
+**Fix**: Handle failures explicitly:
+
+```prose
+# Good: Error handling
+try:
+  let response = session "Call external API"
+    retry: 3
+    backoff: "exponential"
+  session "Process API response"
+    context: response
+catch as err:
+  session "Handle API failure gracefully"
+    context: err
+```
+
+#### ignored-errors
+
+Using `on-fail: "ignore"` when failures actually matter. Masks problems that should surface.
+
+```prose
+# Bad: Ignoring failures that matter
+parallel (on-fail: "ignore"):
+  session "Charge customer credit card"
+  session "Ship the product"
+  session "Send confirmation email"
+
+session "Order complete!"  # But was it really?
+```
+
+**Why it's bad**: The order might be marked complete even if payment failed.
+
+**Fix**: Use appropriate failure policy:
+
+```prose
+# Good: Fail-fast for critical operations
+parallel:  # Default: fail-fast
+  payment = session "Charge customer credit card"
+  inventory = session "Reserve inventory"
+
+# Only ship if both succeeded
+session "Ship the product"
+  context: { payment, inventory }
+
+# Email can fail without blocking
+try:
+  session "Send confirmation email"
+catch:
+  session "Queue email for retry"
+```
+
+#### vague-discretion
+
+Discretion conditions that are ambiguous or unmeasurable.
+
+```prose
+# Bad: What does "good enough" mean?
+loop until **the output is good enough**:
+  session "Improve output"
+
+# Bad: Highly subjective
+if **the user will be happy**:
+  session "Ship it"
+```
+
+**Why it's bad**: The VM has no clear criteria for evaluation. Results are unpredictable.
+
+**Fix**: Provide concrete, evaluatable criteria:
+
+```prose
+# Good: Specific criteria
+loop until **all tests pass and code coverage exceeds 80%** (max: 10):
+  session "Improve test coverage"
+
+# Good: Observable conditions
+if **the response contains valid JSON with all required fields**:
+  session "Process the response"
+```
+
+#### catch-and-swallow
+
+Catching errors without meaningful handling. Hides problems without solving them.
+
+```prose
+# Bad: Silent swallow
+try:
+  session "Critical operation"
+catch:
+  # Nothing here - error disappears
+```
+
+**Why it's bad**: Errors vanish. No recovery, no logging, no visibility.
+
+**Fix**: Handle errors meaningfully:
+
+```prose
+# Good: Meaningful handling
+try:
+  session "Critical operation"
+catch as err:
+  session "Log error for investigation"
+    context: err
+  session "Execute fallback procedure"
+  # Or rethrow if unrecoverable:
+  throw
+```
+
+---
+
+## Cost Antipatterns
+
+#### opus-for-everything
+
+Using the most powerful (expensive) model for all tasks, including trivial ones.
+
+```prose
+# Bad: Opus for simple classification
+agent classifier:
+  model: opus
+  prompt: "Categorize items as: spam, not-spam"
+
+# Expensive for a binary classification
+for email in emails:
+  session: classifier
+    prompt: "Classify: {email}"
+```
+
+**Why it's bad**: Opus costs significantly more than haiku. Simple tasks don't benefit from advanced reasoning.
+
+**Fix**: Match model to task complexity:
+
+```prose
+# Good: Haiku for simple tasks
+agent classifier:
+  model: haiku
+  prompt: "Categorize items as: spam, not-spam"
+```
+
+#### context-bloat
+
+Passing excessive context that the session doesn't need.
+
+```prose
+# Bad: Passing everything
+let full_codebase = session "Read entire codebase"
+let all_docs = session "Read all documentation"
+let history = session "Get full git history"
+
+session "Fix the typo in the README"
+  context: [full_codebase, all_docs, history]  # Massive overkill
+```
+
+**Why it's bad**: Large contexts slow processing, increase costs, and can confuse the model with irrelevant information.
+
+**Fix**: Pass minimal relevant context:
+
+```prose
+# Good: Minimal context
+let readme = session "Read the README file"
+
+session "Fix the typo in the README"
+  context: readme
+```
+
+#### unnecessary-iteration
+
+Looping when a single session would suffice.
+
+```prose
+# Bad: Loop for what could be one call
+let items = ["apple", "banana", "cherry"]
+for item in items:
+  session "Describe {item}"
+```
+
+**Why it's bad**: Three sessions when one could handle all items. Session overhead multiplied.
+
+**Fix**: Batch when possible:
+
+```prose
+# Good: Batch processing
+let items = ["apple", "banana", "cherry"]
+session "Describe each of these items: {items}"
+```
+
+#### redundant-computation
+
+Computing the same thing multiple times.
+
+```prose
+# Bad: Redundant research
+session "Research AI safety for security review"
+session "Research AI safety for ethics review"
+session "Research AI safety for compliance review"
+```
+
+**Why it's bad**: Same research done three times with slightly different framing.
+
+**Fix**: Compute once, use many times:
+
+```prose
+# Good: Compute once
+let research = session "Comprehensive research on AI safety"
+
+parallel:
+  session "Security review"
+    context: research
+  session "Ethics review"
+    context: research
+  session "Compliance review"
+    context: research
+```
+
+---
+
+## Performance Antipatterns
+
+#### eager-over-computation
+
+Computing everything upfront when only some results might be needed.
+
+```prose
+# Bad: Compute all branches even if only one is needed
+parallel:
+  simple_analysis = session "Simple analysis"
+    model: haiku
+  detailed_analysis = session "Detailed analysis"
+    model: sonnet
+  deep_analysis = session "Deep analysis"
+    model: opus
+
+# Then only use one based on some criterion
+choice **appropriate depth**:
+  option "Simple":
+    session "Use simple"
+      context: simple_analysis
+  option "Detailed":
+    session "Use detailed"
+      context: detailed_analysis
+  option "Deep":
+    session "Use deep"
+      context: deep_analysis
+```
+
+**Why it's bad**: All three analyses run even though only one is used.
+
+**Fix**: Compute lazily:
+
+```prose
+# Good: Only compute what's needed
+let initial = session "Initial assessment"
+  model: haiku
+
+choice **appropriate depth based on initial assessment**:
+  option "Simple":
+    session "Simple analysis"
+      model: haiku
+  option "Detailed":
+    session "Detailed analysis"
+      model: sonnet
+  option "Deep":
+    session "Deep analysis"
+      model: opus
+```
+
+#### over-parallelization
+
+Parallelizing so aggressively that overhead dominates or resources are exhausted.
+
+```prose
+# Bad: 100 parallel sessions
+parallel for item in large_collection:  # 100 items
+  session "Process {item}"
+```
+
+**Why it's bad**: May overwhelm the system. Coordination overhead can exceed parallelism benefits.
+
+**Fix**: Batch or limit concurrency:
+
+```prose
+# Good: Process in batches
+for batch in batches(large_collection, 10):
+  parallel for item in batch:
+    session "Process {item}"
+```
+
+#### premature-parallelization
+
+Parallelizing tiny tasks where sequential would be simpler and fast enough.
+
+```prose
+# Bad: Parallel overkill for simple tasks
+parallel:
+  a = session "Add 2 + 2"
+  b = session "Add 3 + 3"
+  c = session "Add 4 + 4"
+```
+
+**Why it's bad**: Coordination overhead exceeds task time. Sequential would be simpler and possibly faster.
+
+**Fix**: Keep it simple:
+
+```prose
+# Good: Sequential for trivial tasks
+session "Add 2+2, 3+3, and 4+4"
+```
+
+#### synchronous-fire-and-forget
+
+Waiting for operations whose results you don't need.
+
+```prose
+# Bad: Waiting for logging
+session "Do important work"
+session "Log the result"  # Don't need to wait for this
+session "Continue with next important work"
+```
+
+**Why it's bad**: Main workflow blocked by non-critical operation.
+
+**Fix**: Use appropriate patterns for fire-and-forget operations, or batch logging:
+
+```prose
+# Better: Batch non-critical work
+session "Do important work"
+session "Continue with next important work"
+# ... more important work ...
+
+# Log everything at the end or async
+session "Log all operations"
+```
+
+---
+
+## Maintainability Antipatterns
+
+#### magic-strings
+
+Hardcoded prompts repeated throughout the program.
+
+```prose
+# Bad: Same prompt in multiple places
+session "You are a helpful assistant. Analyze this code for bugs."
+# ... later ...
+session "You are a helpful assistant. Analyze this code for bugs."
+# ... even later ...
+session "You are a helpful assistent. Analyze this code for bugs."  # Typo!
+```
+
+**Why it's bad**: Inconsistency when updating. Typos go unnoticed.
+
+**Fix**: Use agents:
+
+```prose
+# Good: Single source of truth
+agent code-analyst:
+  model: sonnet
+  prompt: "You are a helpful assistant. Analyze code for bugs."
+
+session: code-analyst
+  prompt: "Analyze the auth module"
+session: code-analyst
+  prompt: "Analyze the payment module"
+```
+
+#### opaque-workflow
+
+No structure or comments indicating what's happening.
+
+```prose
+# Bad: What is this doing?
+let x = session "A"
+let y = session "B"
+  context: x
+parallel:
+  z = session "C"
+    context: y
+  w = session "D"
+session "E"
+  context: [z, w]
+```
+
+**Why it's bad**: Impossible to understand, debug, or modify.
+
+**Fix**: Use meaningful names and structure:
+
+```prose
+# Good: Clear intent
+# Phase 1: Research
+let research = session "Gather background information"
+
+# Phase 2: Analysis
+let analysis = session "Analyze research findings"
+  context: research
+
+# Phase 3: Parallel evaluation
+parallel:
+  technical_eval = session "Technical feasibility assessment"
+    context: analysis
+  business_eval = session "Business viability assessment"
+    context: analysis
+
+# Phase 4: Synthesis
+session "Create final recommendation"
+  context: { technical_eval, business_eval }
+```
+
+#### implicit-dependencies
+
+Relying on conversation history rather than explicit context.
+
+```prose
+# Bad: Implicit state
+session "Set the project name to Acme"
+session "Set the deadline to Friday"
+session "Now create a project plan"  # Hopes previous info is remembered
+```
+
+**Why it's bad**: Relies on VM implementation details. Fragile across refactoring.
+
+**Fix**: Explicit context:
+
+```prose
+# Good: Explicit state
+let config = session "Define project: name=Acme, deadline=Friday"
+
+session "Create a project plan"
+  context: config
+```
+
+#### mixed-concerns-agent
+
+Agents with prompts that cover too many responsibilities.
+
+```prose
+# Bad: Jack of all trades
+agent super-agent:
+  model: opus
+  prompt: """
+    You are an expert in:
+    - Security analysis
+    - Performance optimization
+    - Code review
+    - Documentation
+    - Testing
+    - DevOps
+    - Project management
+    - Customer communication
+    When asked, perform any of these tasks.
+  """
+```
+
+**Why it's bad**: No focus means mediocre results across the board. Can't optimize model choice.
+
+**Fix**: Specialized agents:
+
+```prose
+# Good: Focused expertise
+agent security-expert:
+  model: sonnet
+  prompt: "You are a security analyst. Focus only on security concerns."
+
+agent performance-expert:
+  model: sonnet
+  prompt: "You are a performance engineer. Focus only on optimization."
+
+agent technical-writer:
+  model: haiku
+  prompt: "You write clear technical documentation."
+```
+
+---
+
+## Logic Antipatterns
+
+#### infinite-refinement
+
+Loops that can never satisfy their exit condition.
+
+```prose
+# Bad: Perfection is impossible
+loop until **the code has zero bugs**:
+  session "Find and fix bugs"
+```
+
+**Why it's bad**: Zero bugs is unachievable. Loop runs until max (if specified) or forever.
+
+**Fix**: Use achievable conditions:
+
+```prose
+# Good: Achievable condition
+loop until **all known bugs are fixed** (max: 20):
+  session "Find and fix the next bug"
+
+# Or: Diminishing returns
+loop until **no significant bugs found in last iteration** (max: 10):
+  session "Search for bugs"
+```
+
+#### assertion-as-action
+
+Using conditions as actions—checking something without acting on the result.
+
+```prose
+# Bad: Check but don't use result
+session "Check if the system is healthy"
+session "Deploy to production"  # Deploys regardless!
+```
+
+**Why it's bad**: The health check result isn't used. Deploy happens unconditionally.
+
+**Fix**: Use conditional execution:
+
+```prose
+# Good: Act on the check
+let health = session "Check if the system is healthy"
+
+if **system is healthy**:
+  session "Deploy to production"
+else:
+  session "Alert on-call and skip deployment"
+    context: health
+```
+
+#### false-parallelism
+
+Putting sequential-dependent operations in a parallel block.
+
+```prose
+# Bad: These aren't independent!
+parallel:
+  data = session "Fetch data"
+  processed = session "Process the data"  # Needs data!
+    context: data
+  stored = session "Store processed data"  # Needs processed!
+    context: processed
+```
+
+**Why it's bad**: Despite being in parallel, these must run sequentially due to dependencies.
+
+**Fix**: Be honest about dependencies:
+
+```prose
+# Good: Sequential where needed
+let data = session "Fetch data"
+let processed = session "Process the data"
+  context: data
+session "Store processed data"
+  context: processed
+```
+
+#### exception-as-flow-control
+
+Using try/catch for expected conditions rather than exceptional errors.
+
+```prose
+# Bad: Exceptions for normal flow
+try:
+  session "Find the optional config file"
+catch:
+  session "Use default configuration"
+```
+
+**Why it's bad**: Missing config is expected, not exceptional. Obscures actual errors.
+
+**Fix**: Use conditionals for expected cases:
+
+```prose
+# Good: Conditional for expected case
+let config_exists = session "Check if config file exists"
+
+if **config file exists**:
+  session "Load configuration from file"
+else:
+  session "Use default configuration"
+```
+
+---
+
+## Security Antipatterns
+
+#### unvalidated-input
+
+Passing external input directly to sessions without validation.
+
+```prose
+# Bad: Direct injection
+let user_input = external_source
+
+session "Execute this command: {user_input}"
+```
+
+**Why it's bad**: User could inject malicious prompts or commands.
+
+**Fix**: Validate and sanitize:
+
+```prose
+# Good: Validate first
+let user_input = external_source
+let validated = session "Validate this input is a safe search query"
+  context: user_input
+
+if **input is valid and safe**:
+  session "Search for: {validated}"
+else:
+  throw "Invalid input rejected"
+```
+
+#### overprivileged-agents
+
+Agents with more permissions than they need.
+
+```prose
+# Bad: Full access for simple task
+agent file-reader:
+  permissions:
+    read: ["**/*"]
+    write: ["**/*"]
+    bash: allow
+    network: allow
+
+session: file-reader
+  prompt: "Read the README.md file"
+```
+
+**Why it's bad**: Task only needs to read one file but has full system access.
+
+**Fix**: Least privilege:
+
+```prose
+# Good: Minimal permissions
+agent file-reader:
+  permissions:
+    read: ["README.md"]
+    write: []
+    bash: deny
+    network: deny
+```
+
+---
+
+## Summary
+
+Antipatterns emerge from:
+
+1. **Laziness**: Copy-paste instead of abstraction, implicit instead of explicit
+2. **Over-engineering**: Parallelizing everything, using opus for all tasks
+3. **Under-engineering**: No error handling, unbounded loops, vague conditions
+4. **Unclear thinking**: God sessions, mixed concerns, spaghetti context
+
+When reviewing OpenProse programs, ask:
+
+- Can independent work be parallelized?
+- Are loops bounded?
+- Are errors handled?
+- Is context minimal and explicit?
+- Are models matched to task complexity?
+- Are agents focused and reusable?
+- Would a stranger understand this code?
+
+Fix antipatterns early. They compound over time into unmaintainable systems.

--- a/.openhands/skills/open-prose/docs.md
+++ b/.openhands/skills/open-prose/docs.md
@@ -1,0 +1,2676 @@
+---
+role: language-specification
+summary: |
+  Complete syntax grammar, validation rules, and compilation semantics for OpenProse.
+  Read this file when compiling, validating, or resolving ambiguous syntax. Assumes
+  prose.md is already in context for execution semantics.
+see-also:
+  - SKILL.md: Activation triggers, onboarding, telemetry
+  - prose.md: Execution semantics, how to run programs
+---
+
+# OpenProse Language Reference
+
+OpenProse is a programming language for AI sessions. An AI session is a Turing-complete computer; this document provides complete documentation for the language syntax, semantics, and execution model.
+
+---
+
+## Document Purpose: Compiler + Validator
+
+This document serves a dual role:
+
+### As Compiler
+
+When asked to "compile" a `.prose` file, use this specification to:
+
+1. **Parse** the program according to the syntax grammar
+2. **Validate** that the program is well-formed and semantically valid
+3. **Transform** the program into "best practice" canonical form:
+   - Expand syntax sugar where appropriate
+   - Normalize formatting and structure
+   - Apply optimizations (e.g., hoisting block definitions)
+
+### As Validator
+
+The validation criterion: **Would a blank agent with only `prose.md` understand this program as self-evident?**
+
+When validating, check:
+
+- Syntax correctness (all constructs match grammar)
+- Semantic validity (references resolve, types match)
+- Self-evidence (program is clear without this full spec)
+
+If a construct is ambiguous or non-obvious, it should be flagged or transformed into a clearer form.
+
+### When to Read This Document
+
+- **Compilation requested**: Read fully to apply all rules
+- **Validation requested**: Read fully to check all constraints
+- **Ambiguous syntax encountered**: Reference specific sections
+- **Interpretation only**: Use `prose.md` instead (smaller, faster)
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [File Format](#file-format)
+3. [Comments](#comments)
+4. [String Literals](#string-literals)
+5. [Import Statements](#import-statements)
+6. [Agent Definitions](#agent-definitions)
+7. [Session Statement](#session-statement)
+8. [Variables & Context](#variables--context)
+9. [Composition Blocks](#composition-blocks)
+10. [Parallel Blocks](#parallel-blocks)
+11. [Fixed Loops](#fixed-loops)
+12. [Unbounded Loops](#unbounded-loops)
+13. [Pipeline Operations](#pipeline-operations)
+14. [Error Handling](#error-handling)
+15. [Choice Blocks](#choice-blocks)
+16. [Conditional Statements](#conditional-statements)
+17. [Execution Model](#execution-model)
+18. [Validation Rules](#validation-rules)
+19. [Examples](#examples)
+20. [Future Features](#future-features)
+
+---
+
+## Overview
+
+OpenProse provides a declarative syntax for defining multi-agent workflows. Programs consist of statements that are executed sequentially, with each `session` statement spawning a subagent to complete a task.
+
+### Design Principles
+
+- **Pattern over framework**: The simplest solution is barely anything at all—just structure for English
+- **Self-evident**: Programs should be understandable with minimal documentation
+- **The OpenProse VM is intelligent**: Design for understanding, not parsing
+- **Framework-agnostic**: Works with Claude Code, OpenCode, and any future agent framework
+- **Files are artifacts**: `.prose` is the portable unit of work
+
+### Current Implementation Status
+
+The following features are implemented:
+
+| Feature                | Status      | Description                                    |
+| ---------------------- | ----------- | ---------------------------------------------- |
+| Comments               | Implemented | `# comment` syntax                             |
+| Single-line strings    | Implemented | `"string"` with escapes                        |
+| Simple session         | Implemented | `session "prompt"`                             |
+| Agent definitions      | Implemented | `agent name:` with model/prompt properties     |
+| Session with agent     | Implemented | `session: agent` with property overrides       |
+| Import statements      | Implemented | `import "skill" from "source"`                 |
+| Agent skills           | Implemented | `skills: ["skill1", "skill2"]`                 |
+| Agent permissions      | Implemented | `permissions:` block with rules                |
+| Let binding            | Implemented | `let name = session "..."`                     |
+| Const binding          | Implemented | `const name = session "..."`                   |
+| Variable reassignment  | Implemented | `name = session "..."` (for let only)          |
+| Context property       | Implemented | `context: var` or `context: [a, b, c]`         |
+| do: blocks             | Implemented | Explicit sequential blocks                     |
+| Inline sequence        | Implemented | `session "A" -> session "B"`                   |
+| Named blocks           | Implemented | `block name:` with `do name` invocation        |
+| Parallel blocks        | Implemented | `parallel:` for concurrent execution           |
+| Named parallel results | Implemented | `x = session "..."` inside parallel            |
+| Object context         | Implemented | `context: { a, b, c }` shorthand               |
+| Join strategies        | Implemented | `parallel ("first"):` or `parallel ("any"):`   |
+| Failure policies       | Implemented | `parallel (on-fail: "continue"):`              |
+| Repeat blocks          | Implemented | `repeat N:` fixed iterations                   |
+| Repeat with index      | Implemented | `repeat N as i:` with index variable           |
+| For-each blocks        | Implemented | `for item in items:` iteration                 |
+| For-each with index    | Implemented | `for item, i in items:` with index             |
+| Parallel for-each      | Implemented | `parallel for item in items:` fan-out          |
+| Unbounded loop         | Implemented | `loop:` with optional max iterations           |
+| Loop until             | Implemented | `loop until **condition**:` AI-evaluated       |
+| Loop while             | Implemented | `loop while **condition**:` AI-evaluated       |
+| Loop with index        | Implemented | `loop as i:` or `loop until ... as i:`         |
+| Map pipeline           | Implemented | `items \| map:` transform each item            |
+| Filter pipeline        | Implemented | `items \| filter:` keep matching items         |
+| Reduce pipeline        | Implemented | `items \| reduce(acc, item):` accumulate       |
+| Parallel map           | Implemented | `items \| pmap:` concurrent transform          |
+| Pipeline chaining      | Implemented | `\| filter: ... \| map: ...`                   |
+| Try/catch blocks       | Implemented | `try:` with `catch:` for error handling        |
+| Try/catch/finally      | Implemented | `finally:` for cleanup                         |
+| Error variable         | Implemented | `catch as err:` access error context           |
+| Throw statement        | Implemented | `throw` or `throw "message"`                   |
+| Retry property         | Implemented | `retry: 3` automatic retry on failure          |
+| Backoff strategy       | Implemented | `backoff: "exponential"` delay between retries |
+| Multi-line strings     | Implemented | `"""..."""` preserving whitespace              |
+| String interpolation   | Implemented | `"Hello {name}"` variable substitution         |
+| Block parameters       | Implemented | `block name(param):` with parameters           |
+| Block invocation args  | Implemented | `do name(arg)` passing arguments               |
+| Choice blocks          | Implemented | `choice **criteria**: option "label":`         |
+| If/elif/else           | Implemented | `if **condition**:` conditional branching      |
+
+---
+
+## File Format
+
+| Property         | Value                |
+| ---------------- | -------------------- |
+| Extension        | `.prose`             |
+| Encoding         | UTF-8                |
+| Case sensitivity | Case-sensitive       |
+| Indentation      | Spaces (Python-like) |
+| Line endings     | LF or CRLF           |
+
+---
+
+## Comments
+
+Comments provide documentation within programs and are ignored during execution.
+
+### Syntax
+
+```prose
+# This is a standalone comment
+
+session "Hello"  # This is an inline comment
+```
+
+### Rules
+
+1. Comments begin with `#` and extend to end of line
+2. Comments can appear on their own line or after a statement
+3. Empty comments are valid: `#`
+4. The `#` character inside string literals is NOT a comment
+
+### Examples
+
+```prose
+# Program header comment
+# Author: Example
+
+session "Do something"  # Explain what this does
+
+# This comment is between statements
+session "Do another thing"
+```
+
+### Compilation Behavior
+
+Comments are **stripped during compilation**. The OpenProse VM never sees them. They have no effect on execution and exist purely for human documentation.
+
+### Important Notes
+
+- **Comments inside strings are NOT comments**:
+
+  ```prose
+  session "Say hello # this is part of the string"
+  ```
+
+  The `#` inside the string literal is part of the prompt, not a comment.
+
+- **Comments inside indented blocks are allowed**:
+  ```prose
+  agent researcher:
+      # This comment is inside the block
+      model: sonnet
+  # This comment is outside the block
+  ```
+
+---
+
+## String Literals
+
+String literals represent text values, primarily used for session prompts.
+
+### Syntax
+
+Strings are enclosed in double quotes:
+
+```prose
+"This is a string"
+```
+
+### Escape Sequences
+
+The following escape sequences are supported:
+
+| Sequence | Meaning      |
+| -------- | ------------ |
+| `\\`     | Backslash    |
+| `\"`     | Double quote |
+| `\n`     | Newline      |
+| `\t`     | Tab          |
+
+### Examples
+
+```prose
+session "Hello world"
+session "Line one\nLine two"
+session "She said \"hello\""
+session "Path: C:\\Users\\name"
+session "Column1\tColumn2"
+```
+
+### Rules
+
+1. Single-line strings must be properly terminated with a closing `"`
+2. Unknown escape sequences are errors
+3. Empty strings `""` are valid but generate a warning when used as prompts
+
+### Multi-line Strings
+
+Multi-line strings use triple double-quotes (`"""`) and preserve internal whitespace and newlines:
+
+```prose
+session """
+This is a multi-line prompt.
+It preserves:
+  - Indentation
+  - Line breaks
+  - All internal whitespace
+"""
+```
+
+#### Multi-line String Rules
+
+1. Opening `"""` must be followed by a newline
+2. Content continues until closing `"""`
+3. Escape sequences work the same as single-line strings
+4. Leading/trailing whitespace inside the delimiters is preserved
+
+### String Interpolation
+
+Strings can embed variable references using `{varname}` syntax:
+
+```prose
+let name = session "Get the user's name"
+
+session "Hello {name}, welcome to the system!"
+```
+
+#### Interpolation Syntax
+
+- Variables are referenced by wrapping the variable name in curly braces: `{varname}`
+- Works in both single-line and multi-line strings
+- Empty braces `{}` are treated as literal text, not interpolation
+- Nested braces are not supported
+
+#### Examples
+
+```prose
+let research = session "Research the topic"
+let analysis = session "Analyze findings"
+
+# Single variable interpolation
+session "Based on {research}, provide recommendations"
+
+# Multiple interpolations
+session "Combining {research} with {analysis}, synthesize insights"
+
+# Multi-line with interpolation
+session """
+Review Summary:
+- Research: {research}
+- Analysis: {analysis}
+Please provide final recommendations.
+"""
+```
+
+#### Interpolation Rules
+
+1. Variable names must be valid identifiers
+2. Referenced variables must be in scope
+3. Empty braces `{}` are literal text
+4. Backslash can escape braces: `\{` produces literal `{`
+
+### Validation
+
+| Check                            | Result  |
+| -------------------------------- | ------- |
+| Unterminated string              | Error   |
+| Unknown escape sequence          | Error   |
+| Empty string as prompt           | Warning |
+| Undefined interpolation variable | Error   |
+
+---
+
+## Import Statements
+
+Import statements load external skills that can be assigned to agents.
+
+### Syntax
+
+```prose
+import "skill-name" from "source"
+```
+
+### Source Types
+
+| Source Type | Format                | Example                   |
+| ----------- | --------------------- | ------------------------- |
+| GitHub      | `github:user/repo`    | `github:anthropic/skills` |
+| NPM         | `npm:package`         | `npm:@org/analyzer`       |
+| Local path  | `./path` or `../path` | `./local-skills/my-skill` |
+
+### Examples
+
+```prose
+# Import from GitHub
+import "web-search" from "github:anthropic/skills"
+
+# Import from npm
+import "code-analyzer" from "npm:@company/analyzer"
+
+# Import from local path
+import "custom-tool" from "./skills/custom-tool"
+import "shared-skill" from "../common/skills"
+```
+
+### Validation Rules
+
+| Check                 | Severity | Message                                |
+| --------------------- | -------- | -------------------------------------- |
+| Empty skill name      | Error    | Import skill name cannot be empty      |
+| Empty source          | Error    | Import source cannot be empty          |
+| Duplicate import      | Error    | Skill already imported                 |
+| Unknown source format | Warning  | Should start with github:, npm:, or ./ |
+
+### Execution Semantics
+
+Import statements are processed before any agent definitions or sessions. The OpenProse VM:
+
+1. Validates all imports at the start of execution
+2. Loads skill definitions from the specified sources
+3. Makes skills available for agent assignment
+
+---
+
+## Agent Definitions
+
+Agents are reusable templates that configure subagent behavior. Once defined, agents can be referenced in session statements.
+
+### Syntax
+
+```prose
+agent name:
+  model: sonnet
+  prompt: "System prompt for this agent"
+  skills: ["skill1", "skill2"]
+  permissions:
+    read: ["*.md"]
+    bash: deny
+```
+
+### Properties
+
+| Property      | Type       | Values                    | Description                         |
+| ------------- | ---------- | ------------------------- | ----------------------------------- |
+| `model`       | identifier | `sonnet`, `opus`, `haiku` | The Claude model to use             |
+| `prompt`      | string     | Any string                | System prompt/context for the agent |
+| `skills`      | array      | String array              | Skills assigned to this agent       |
+| `permissions` | block      | Permission rules          | Access control for the agent        |
+
+### Skills Property
+
+The `skills` property assigns imported skills to an agent:
+
+```prose
+import "web-search" from "github:anthropic/skills"
+import "summarizer" from "./local-skills"
+
+agent researcher:
+  skills: ["web-search", "summarizer"]
+```
+
+Skills must be imported before they can be assigned. Referencing an unimported skill generates a warning.
+
+### Permissions Property
+
+The `permissions` property controls agent access:
+
+```prose
+agent secure-agent:
+  permissions:
+    read: ["*.md", "*.txt"]
+    write: ["output/"]
+    bash: deny
+    network: allow
+```
+
+#### Permission Types
+
+| Type      | Description                                  |
+| --------- | -------------------------------------------- |
+| `read`    | Files the agent can read (glob patterns)     |
+| `write`   | Files the agent can write (glob patterns)    |
+| `execute` | Files the agent can execute (glob patterns)  |
+| `bash`    | Shell access: `allow`, `deny`, or `prompt`   |
+| `network` | Network access: `allow`, `deny`, or `prompt` |
+
+#### Permission Values
+
+| Value    | Description                                       |
+| -------- | ------------------------------------------------- |
+| `allow`  | Permission granted                                |
+| `deny`   | Permission denied                                 |
+| `prompt` | Ask user for permission                           |
+| Array    | List of allowed patterns (for read/write/execute) |
+
+### Examples
+
+```prose
+# Define a research agent
+agent researcher:
+  model: sonnet
+  prompt: "You are a research assistant skilled at finding and synthesizing information"
+
+# Define a writing agent
+agent writer:
+  model: opus
+  prompt: "You are a technical writer who creates clear, concise documentation"
+
+# Agent with only model
+agent quick:
+  model: haiku
+
+# Agent with only prompt
+agent expert:
+  prompt: "You are a domain expert"
+
+# Agent with skills
+agent web-researcher:
+  model: sonnet
+  skills: ["web-search", "summarizer"]
+
+# Agent with permissions
+agent file-handler:
+  permissions:
+    read: ["*.md", "*.txt"]
+    write: ["output/"]
+    bash: deny
+```
+
+### Model Selection
+
+| Model    | Use Case                              |
+| -------- | ------------------------------------- |
+| `haiku`  | Fast, simple tasks; quick responses   |
+| `sonnet` | Balanced performance; general purpose |
+| `opus`   | Complex reasoning; detailed analysis  |
+
+### Execution Semantics
+
+When a session references an agent:
+
+1. The agent's `model` property determines which Claude model is used
+2. The agent's `prompt` property is included as system context
+3. Session properties can override agent defaults
+
+### Validation Rules
+
+| Check                 | Severity | Message                        |
+| --------------------- | -------- | ------------------------------ |
+| Duplicate agent name  | Error    | Agent already defined          |
+| Invalid model value   | Error    | Must be sonnet, opus, or haiku |
+| Empty prompt property | Warning  | Consider providing a prompt    |
+| Duplicate property    | Error    | Property already specified     |
+
+---
+
+## Session Statement
+
+The session statement is the primary executable construct in OpenProse. It spawns a subagent to complete a task.
+
+### Syntax Variants
+
+#### Simple Session (with inline prompt)
+
+```prose
+session "prompt text"
+```
+
+#### Session with Agent Reference
+
+```prose
+session: agentName
+```
+
+#### Named Session with Agent
+
+```prose
+session sessionName: agentName
+```
+
+#### Session with Properties
+
+```prose
+session: agentName
+  prompt: "Override the agent's default prompt"
+  model: opus  # Override the agent's model
+```
+
+### Property Overrides
+
+When a session references an agent, it can override the agent's properties:
+
+```prose
+agent researcher:
+  model: sonnet
+  prompt: "You are a research assistant"
+
+# Use researcher with different model
+session: researcher
+  model: opus
+
+# Use researcher with different prompt
+session: researcher
+  prompt: "Research this specific topic in depth"
+
+# Override both
+session: researcher
+  model: opus
+  prompt: "Specialized research task"
+```
+
+### Execution Semantics
+
+When the OpenProse VM encounters a `session` statement:
+
+1. **Resolve Configuration**: Merge agent defaults with session overrides
+2. **Spawn a Subagent**: Create a new Claude subagent with the resolved configuration
+3. **Send the Prompt**: Pass the prompt string to the subagent
+4. **Wait for Completion**: Block until the subagent finishes
+5. **Continue**: Proceed to the next statement
+
+### Execution Flow Diagram
+
+```
+OpenProse VM                    Subagent
+    |                              |
+    |  spawn session               |
+    |----------------------------->|
+    |                              |
+    |  send prompt                 |
+    |----------------------------->|
+    |                              |
+    |  [processing...]             |
+    |                              |
+    |  session complete            |
+    |<-----------------------------|
+    |                              |
+    |  continue to next statement  |
+    v                              v
+```
+
+### Sequential Execution
+
+Multiple sessions execute sequentially:
+
+```prose
+session "First task"
+session "Second task"
+session "Third task"
+```
+
+Each session waits for the previous one to complete before starting.
+
+### Using Claude Code's Task Tool
+
+To execute a session, use the Task tool:
+
+```typescript
+// Simple session
+Task({
+  description: "OpenProse session",
+  prompt: "The prompt from the session statement",
+  subagent_type: "general-purpose",
+});
+
+// Session with agent configuration
+Task({
+  description: "OpenProse session",
+  prompt: "The session prompt",
+  subagent_type: "general-purpose",
+  model: "opus", // From agent or override
+});
+```
+
+### Validation Rules
+
+| Check                     | Severity | Message                                      |
+| ------------------------- | -------- | -------------------------------------------- |
+| Missing prompt and agent  | Error    | Session requires a prompt or agent reference |
+| Undefined agent reference | Error    | Agent not defined                            |
+| Empty prompt `""`         | Warning  | Session has empty prompt                     |
+| Whitespace-only prompt    | Warning  | Session prompt contains only whitespace      |
+| Prompt > 10,000 chars     | Warning  | Consider breaking into smaller tasks         |
+| Duplicate property        | Error    | Property already specified                   |
+
+### Examples
+
+```prose
+# Simple session
+session "Hello world"
+
+# Session with agent
+agent researcher:
+  model: sonnet
+  prompt: "You research topics thoroughly"
+
+session: researcher
+  prompt: "Research quantum computing applications"
+
+# Named session
+session analysis: researcher
+  prompt: "Analyze the competitive landscape"
+```
+
+### Canonical Form
+
+The compiled output preserves the structure:
+
+```
+Input:
+agent researcher:
+  model: sonnet
+
+session: researcher
+  prompt: "Do research"
+
+Output:
+agent researcher:
+  model: sonnet
+session: researcher
+  prompt: "Do research"
+```
+
+---
+
+## Variables & Context
+
+Variables allow you to capture the results of sessions and pass them as context to subsequent sessions.
+
+### Let Binding
+
+The `let` keyword creates a mutable variable bound to a session result:
+
+```prose
+let research = session "Research the topic thoroughly"
+
+# research now holds the output of that session
+```
+
+Variables can be reassigned:
+
+```prose
+let draft = session "Write initial draft"
+
+# Revise the draft
+draft = session "Improve the draft"
+  context: draft
+```
+
+### Const Binding
+
+The `const` keyword creates an immutable variable:
+
+```prose
+const config = session "Get configuration settings"
+
+# This would be an error:
+# config = session "Try to change"
+```
+
+### Context Property
+
+The `context` property passes previous session outputs to a new session:
+
+#### Single Context
+
+```prose
+let research = session "Research quantum computing"
+
+session "Write summary"
+  context: research
+```
+
+#### Multiple Contexts
+
+```prose
+let research = session "Research the topic"
+let analysis = session "Analyze the findings"
+
+session "Write final report"
+  context: [research, analysis]
+```
+
+#### Empty Context (Fresh Start)
+
+Use an empty array to start a session without inherited context:
+
+```prose
+session "Independent task"
+  context: []
+```
+
+#### Object Context Shorthand
+
+For passing multiple named results (especially from parallel blocks), use object shorthand:
+
+```prose
+parallel:
+  a = session "Task A"
+  b = session "Task B"
+
+session "Combine results"
+  context: { a, b }
+```
+
+This is equivalent to passing an object where each property is a variable reference.
+
+### Complete Example
+
+```prose
+agent researcher:
+  model: sonnet
+  prompt: "You are a research assistant"
+
+agent writer:
+  model: opus
+  prompt: "You are a technical writer"
+
+# Gather research
+let research = session: researcher
+  prompt: "Research quantum computing developments"
+
+# Analyze findings
+let analysis = session: researcher
+  prompt: "Analyze the key findings"
+  context: research
+
+# Write the final report using both contexts
+const report = session: writer
+  prompt: "Write a comprehensive report"
+  context: [research, analysis]
+```
+
+### Validation Rules
+
+| Check                           | Severity | Message                                            |
+| ------------------------------- | -------- | -------------------------------------------------- |
+| Duplicate variable name         | Error    | Variable already defined                           |
+| Const reassignment              | Error    | Cannot reassign const variable                     |
+| Undefined variable reference    | Error    | Undefined variable                                 |
+| Variable conflicts with agent   | Error    | Variable name conflicts with agent name            |
+| Undefined context variable      | Error    | Undefined variable in context                      |
+| Non-identifier in context array | Error    | Context array elements must be variable references |
+
+---
+
+## Composition Blocks
+
+Composition blocks allow you to structure programs into reusable, named units and express sequences of operations inline.
+
+### do: Block (Anonymous Sequential Block)
+
+The `do:` keyword creates an explicit sequential block. All statements in the block execute in order.
+
+#### Syntax
+
+```prose
+do:
+  statement1
+  statement2
+  ...
+```
+
+#### Examples
+
+```prose
+# Explicit sequential block
+do:
+  session "Research the topic"
+  session "Analyze findings"
+  session "Write summary"
+
+# Assign result to a variable
+let result = do:
+  session "Gather data"
+  session "Process data"
+```
+
+### Block Definitions
+
+Named blocks create reusable workflow components. Define once, invoke multiple times.
+
+#### Syntax
+
+```prose
+block name:
+  statement1
+  statement2
+  ...
+```
+
+#### Invoking Blocks
+
+Use `do` followed by the block name to invoke a defined block:
+
+```prose
+do blockname
+```
+
+#### Examples
+
+```prose
+# Define a review pipeline
+block review-pipeline:
+  session "Security review"
+  session "Performance review"
+  session "Synthesize reviews"
+
+# Define another block
+block final-check:
+  session "Final verification"
+  session "Sign off"
+
+# Use the blocks
+do review-pipeline
+session "Make fixes based on review"
+do final-check
+```
+
+### Block Parameters
+
+Blocks can accept parameters to make them more flexible and reusable.
+
+#### Syntax
+
+```prose
+block name(param1, param2):
+  # param1 and param2 are available here
+  statement1
+  statement2
+```
+
+#### Invoking with Arguments
+
+Pass arguments when invoking a parameterized block:
+
+```prose
+do name(arg1, arg2)
+```
+
+#### Examples
+
+```prose
+# Define a parameterized block
+block review(topic):
+  session "Research {topic} thoroughly"
+  session "Analyze key findings about {topic}"
+  session "Summarize {topic} analysis"
+
+# Invoke with different arguments
+do review("quantum computing")
+do review("machine learning")
+do review("blockchain")
+```
+
+#### Multiple Parameters
+
+```prose
+block process-item(item, mode):
+  session "Process {item} using {mode} mode"
+  session "Verify {item} processing"
+
+do process-item("data.csv", "strict")
+do process-item("config.json", "lenient")
+```
+
+#### Parameter Scope
+
+- Parameters are scoped to the block body
+- Parameters shadow outer variables of the same name (with warning)
+- Parameters are implicitly `const` within the block
+
+#### Validation Rules
+
+| Check                   | Severity | Message                                        |
+| ----------------------- | -------- | ---------------------------------------------- |
+| Argument count mismatch | Warning  | Block expects N parameters but got M arguments |
+| Parameter shadows outer | Warning  | Parameter shadows outer variable               |
+
+### Inline Sequence (Arrow Operator)
+
+The `->` operator chains sessions into a sequence on a single line. This is syntactic sugar for sequential execution.
+
+#### Syntax
+
+```prose
+session "A" -> session "B" -> session "C"
+```
+
+This is equivalent to:
+
+```prose
+session "A"
+session "B"
+session "C"
+```
+
+#### Examples
+
+```prose
+# Quick pipeline
+session "Plan" -> session "Execute" -> session "Review"
+
+# Assign result
+let workflow = session "Draft" -> session "Edit" -> session "Finalize"
+```
+
+### Block Hoisting
+
+Block definitions are hoisted - you can use a block before it's defined in the source:
+
+```prose
+# Use before definition
+do validation-checks
+
+# Definition comes later
+block validation-checks:
+  session "Check syntax"
+  session "Check semantics"
+```
+
+### Nested Composition
+
+Blocks and do: blocks can be nested:
+
+```prose
+block outer-workflow:
+  session "Start"
+  do:
+    session "Sub-task 1"
+    session "Sub-task 2"
+  session "End"
+
+do:
+  do outer-workflow
+  session "Final step"
+```
+
+### Context with Blocks
+
+Blocks work with the context system:
+
+```prose
+# Capture do block result
+let research = do:
+  session "Gather information"
+  session "Analyze patterns"
+
+# Use in subsequent session
+session "Write report"
+  context: research
+```
+
+### Validation Rules
+
+| Check                           | Severity | Message                              |
+| ------------------------------- | -------- | ------------------------------------ |
+| Undefined block reference       | Error    | Block not defined                    |
+| Duplicate block definition      | Error    | Block already defined                |
+| Block name conflicts with agent | Error    | Block name conflicts with agent name |
+| Empty block name                | Error    | Block definition must have a name    |
+
+---
+
+## Parallel Blocks
+
+Parallel blocks allow multiple sessions to run concurrently. All branches execute simultaneously, and the block waits for all to complete before continuing.
+
+### Basic Syntax
+
+```prose
+parallel:
+  session "Security review"
+  session "Performance review"
+  session "Style review"
+```
+
+All three sessions start at the same time and run concurrently. The program waits for all of them to complete before proceeding.
+
+### Named Parallel Results
+
+Capture the results of parallel branches into variables:
+
+```prose
+parallel:
+  security = session "Security review"
+  perf = session "Performance review"
+  style = session "Style review"
+```
+
+These variables can then be used in subsequent sessions.
+
+### Object Context Shorthand
+
+Pass multiple parallel results to a session using object shorthand:
+
+```prose
+parallel:
+  security = session "Security review"
+  perf = session "Performance review"
+  style = session "Style review"
+
+session "Synthesize all reviews"
+  context: { security, perf, style }
+```
+
+The object shorthand `{ a, b, c }` is equivalent to passing an object with properties `a`, `b`, and `c` where each property's value is the corresponding variable.
+
+### Mixed Composition
+
+#### Parallel Inside Sequential
+
+```prose
+do:
+  session "Setup"
+  parallel:
+    session "Task A"
+    session "Task B"
+  session "Cleanup"
+```
+
+The setup runs first, then Task A and Task B run in parallel, and finally cleanup runs.
+
+#### Sequential Inside Parallel
+
+```prose
+parallel:
+  do:
+    session "Multi-step task 1a"
+    session "Multi-step task 1b"
+  do:
+    session "Multi-step task 2a"
+    session "Multi-step task 2b"
+```
+
+Each parallel branch contains a sequential workflow. The two workflows run concurrently.
+
+### Assigning Parallel Blocks to Variables
+
+```prose
+let results = parallel:
+  session "Task A"
+  session "Task B"
+```
+
+### Complete Example
+
+```prose
+agent reviewer:
+  model: sonnet
+
+# Run parallel reviews
+parallel:
+  sec = session: reviewer
+    prompt: "Review for security issues"
+  perf = session: reviewer
+    prompt: "Review for performance issues"
+  style = session: reviewer
+    prompt: "Review for style issues"
+
+# Combine all reviews
+session "Create unified review report"
+  context: { sec, perf, style }
+```
+
+### Join Strategies
+
+By default, parallel blocks wait for all branches to complete. You can specify alternative join strategies:
+
+#### First (Race)
+
+Return as soon as the first branch completes, cancel others:
+
+```prose
+parallel ("first"):
+  session "Try approach A"
+  session "Try approach B"
+  session "Try approach C"
+```
+
+The first successful result wins. Other branches are cancelled.
+
+#### Any (N of M)
+
+Return when any N branches complete successfully:
+
+```prose
+# Default: any 1 success
+parallel ("any"):
+  session "Attempt 1"
+  session "Attempt 2"
+
+# Specific count: wait for 2 successes
+parallel ("any", count: 2):
+  session "Attempt 1"
+  session "Attempt 2"
+  session "Attempt 3"
+```
+
+#### All (Default)
+
+Wait for all branches to complete:
+
+```prose
+# Implicit - this is the default
+parallel:
+  session "Task A"
+  session "Task B"
+
+# Explicit
+parallel ("all"):
+  session "Task A"
+  session "Task B"
+```
+
+### Failure Policies
+
+Control how the parallel block handles branch failures:
+
+#### Fail-Fast (Default)
+
+If any branch fails, fail immediately and cancel other branches:
+
+```prose
+parallel:  # Implicit fail-fast
+  session "Critical task 1"
+  session "Critical task 2"
+
+# Explicit
+parallel (on-fail: "fail-fast"):
+  session "Critical task 1"
+  session "Critical task 2"
+```
+
+#### Continue
+
+Let all branches complete, then report all failures:
+
+```prose
+parallel (on-fail: "continue"):
+  session "Task 1"
+  session "Task 2"
+  session "Task 3"
+
+# Continue regardless of which branches failed
+session "Process results, including failures"
+```
+
+#### Ignore
+
+Ignore all failures, always succeed:
+
+```prose
+parallel (on-fail: "ignore"):
+  session "Optional enrichment 1"
+  session "Optional enrichment 2"
+
+# This always runs, even if all branches failed
+session "Continue regardless"
+```
+
+### Combining Modifiers
+
+Join strategies and failure policies can be combined:
+
+```prose
+# Race with resilience
+parallel ("first", on-fail: "continue"):
+  session "Fast but unreliable"
+  session "Slow but reliable"
+
+# Get any 2 results, ignoring failures
+parallel ("any", count: 2, on-fail: "ignore"):
+  session "Approach 1"
+  session "Approach 2"
+  session "Approach 3"
+  session "Approach 4"
+```
+
+### Execution Semantics
+
+When the OpenProse VM encounters a `parallel:` block:
+
+1. **Fork**: Start all branches concurrently
+2. **Execute**: Each branch runs independently
+3. **Join**: Wait according to join strategy:
+   - `"all"` (default): Wait for all branches
+   - `"first"`: Return on first completion
+   - `"any"`: Return on first success (or N successes with `count`)
+4. **Handle failures**: According to on-fail policy:
+   - `"fail-fast"` (default): Cancel remaining and fail immediately
+   - `"continue"`: Wait for all, then report failures
+   - `"ignore"`: Treat failures as successes
+5. **Continue**: Proceed to the next statement with available results
+
+### Validation Rules
+
+| Check                                | Severity | Message                                      |
+| ------------------------------------ | -------- | -------------------------------------------- |
+| Invalid join strategy                | Error    | Must be "all", "first", or "any"             |
+| Invalid on-fail policy               | Error    | Must be "fail-fast", "continue", or "ignore" |
+| Count without "any"                  | Error    | Count is only valid with "any" strategy      |
+| Count less than 1                    | Error    | Count must be at least 1                     |
+| Count exceeds branches               | Warning  | Count exceeds number of parallel branches    |
+| Duplicate variable in parallel       | Error    | Variable already defined                     |
+| Variable conflicts with agent        | Error    | Variable name conflicts with agent name      |
+| Undefined variable in object context | Error    | Undefined variable in context                |
+
+---
+
+## Fixed Loops
+
+Fixed loops provide bounded iteration over a set number of times or over a collection.
+
+### Repeat Block
+
+The `repeat` block executes its body a fixed number of times.
+
+#### Basic Syntax
+
+```prose
+repeat 3:
+  session "Generate a creative idea"
+```
+
+#### With Index Variable
+
+Access the current iteration index using `as`:
+
+```prose
+repeat 5 as i:
+  session "Process item"
+    context: i
+```
+
+The index variable `i` is scoped to the loop body and starts at 0.
+
+### For-Each Block
+
+The `for` block iterates over a collection.
+
+#### Basic Syntax
+
+```prose
+let fruits = ["apple", "banana", "cherry"]
+for fruit in fruits:
+  session "Describe this fruit"
+    context: fruit
+```
+
+#### With Inline Array
+
+```prose
+for topic in ["AI", "climate", "space"]:
+  session "Research this topic"
+    context: topic
+```
+
+#### With Index Variable
+
+Access both the item and its index:
+
+```prose
+let items = ["a", "b", "c"]
+for item, i in items:
+  session "Process item with index"
+    context: [item, i]
+```
+
+### Parallel For-Each
+
+The `parallel for` block runs all iterations concurrently (fan-out pattern):
+
+```prose
+let topics = ["AI", "climate", "space"]
+parallel for topic in topics:
+  session "Research this topic"
+    context: topic
+
+session "Combine all research"
+```
+
+This is equivalent to:
+
+```prose
+parallel:
+  session "Research AI" context: "AI"
+  session "Research climate" context: "climate"
+  session "Research space" context: "space"
+```
+
+But more concise and dynamic.
+
+### Variable Scoping
+
+Loop variables are scoped to the loop body:
+
+- They are implicitly `const` within each iteration
+- They shadow outer variables of the same name (with a warning)
+- They are not accessible outside the loop
+
+```prose
+let item = session "outer"
+for item in ["a", "b"]:
+  # 'item' here is the loop variable
+  session "process loop item"
+    context: item
+# 'item' here refers to the outer variable again
+session "use outer item"
+  context: item
+```
+
+### Nesting
+
+Loops can be nested:
+
+```prose
+repeat 2:
+  repeat 3:
+    session "Inner task"
+```
+
+Different loop types can be combined:
+
+```prose
+let items = ["a", "b"]
+repeat 2:
+  for item in items:
+    session "Process item"
+      context: item
+```
+
+### Complete Example
+
+```prose
+# Generate multiple variations of ideas
+repeat 3:
+  session "Generate a creative startup idea"
+
+session "Select the best idea from the options above"
+
+# Research the selected idea from multiple angles
+let angles = ["market", "technology", "competition"]
+parallel for angle in angles:
+  session "Research this angle of the startup idea"
+    context: angle
+
+session "Synthesize all research into a business plan"
+```
+
+### Validation Rules
+
+| Check                         | Severity | Message                              |
+| ----------------------------- | -------- | ------------------------------------ |
+| Repeat count must be positive | Error    | Repeat count must be positive        |
+| Repeat count must be integer  | Error    | Repeat count must be an integer      |
+| Undefined collection variable | Error    | Undefined collection variable        |
+| Loop variable shadows outer   | Warning  | Loop variable shadows outer variable |
+
+---
+
+## Unbounded Loops
+
+Unbounded loops provide iteration with AI-evaluated termination conditions. Unlike fixed loops, the iteration count is not known ahead of time - the OpenProse VM evaluates conditions at runtime using its intelligence to determine when to stop.
+
+### Discretion Markers
+
+Unbounded loops use **discretion markers** (`**...**`) to wrap AI-evaluated conditions. These markers signal that the enclosed text should be interpreted intelligently by the OpenProse VM at runtime, not as a literal boolean expression.
+
+```prose
+# The text inside **...** is evaluated by the AI
+loop until **the poem has vivid imagery and flows smoothly**:
+  session "Review and improve the poem"
+```
+
+For multi-line conditions, use triple-asterisks:
+
+```prose
+loop until ***
+  the document is complete
+  all sections have been reviewed
+  and formatting is consistent
+***:
+  session "Continue working on the document"
+```
+
+### Basic Loop
+
+The simplest unbounded loop runs indefinitely until explicitly limited:
+
+```prose
+loop:
+  session "Process next item"
+```
+
+**Warning**: Loops without termination conditions or max iterations generate a warning. Always include a safety limit:
+
+```prose
+loop (max: 50):
+  session "Process next item"
+```
+
+### Loop Until
+
+The `loop until` variant runs until a condition becomes true:
+
+```prose
+loop until **the task is complete**:
+  session "Continue working on the task"
+```
+
+The OpenProse VM evaluates the discretion condition after each iteration and exits when it determines the condition is satisfied.
+
+### Loop While
+
+The `loop while` variant runs while a condition remains true:
+
+```prose
+loop while **there are still items to process**:
+  session "Process the next item"
+```
+
+Semantically, `loop while **X**` is equivalent to `loop until **not X**`.
+
+### Iteration Variable
+
+Track the current iteration number using `as`:
+
+```prose
+loop until **done** as attempt:
+  session "Try approach"
+    context: attempt
+```
+
+The iteration variable:
+
+- Starts at 0
+- Increments by 1 each iteration
+- Is scoped to the loop body
+- Is implicitly `const` within each iteration
+
+### Safety Limits
+
+Specify maximum iterations with `(max: N)`:
+
+```prose
+# Stop after 10 iterations even if condition not met
+loop until **all bugs fixed** (max: 10):
+  session "Find and fix a bug"
+```
+
+The loop exits when:
+
+1. The condition is satisfied (for `until`/`while` variants), OR
+2. The maximum iteration count is reached
+
+### Complete Syntax
+
+All options can be combined:
+
+```prose
+loop until **condition** (max: N) as i:
+  body...
+```
+
+Order matters: condition comes before modifiers, modifiers before `as`.
+
+### Examples
+
+#### Iterative Improvement
+
+```prose
+session "Write an initial draft"
+
+loop until **the draft is polished and ready for review** (max: 5):
+  session "Review the current draft and identify issues"
+  session "Revise the draft to address the issues"
+
+session "Present the final draft"
+```
+
+#### Debugging Workflow
+
+```prose
+session "Run tests to identify failures"
+
+loop until **all tests pass** (max: 20) as attempt:
+  session "Identify the failing test"
+  session "Fix the bug causing the failure"
+  session "Run tests again"
+
+session "Confirm all tests pass and summarize fixes"
+```
+
+#### Consensus Building
+
+```prose
+parallel:
+  opinion1 = session "Get first expert opinion"
+  opinion2 = session "Get second expert opinion"
+
+loop until **experts have reached consensus** (max: 5):
+  session "Identify points of disagreement"
+    context: { opinion1, opinion2 }
+  session "Facilitate discussion to resolve differences"
+
+session "Document the final consensus"
+```
+
+#### Quality Threshold
+
+```prose
+let draft = session "Create initial document"
+
+loop while **quality score is below threshold** (max: 10):
+  draft = session "Review and improve the document"
+    context: draft
+  session "Calculate new quality score"
+
+session "Finalize the document"
+  context: draft
+```
+
+### Execution Semantics
+
+When the OpenProse VM encounters an unbounded loop:
+
+1. **Initialize**: Set iteration counter to 0
+2. **Check Condition** (for `until`/`while`):
+   - For `until`: Exit if condition is satisfied
+   - For `while`: Exit if condition is NOT satisfied
+3. **Check Limit**: Exit if iteration count >= max iterations
+4. **Execute Body**: Run all statements in the loop body
+5. **Increment**: Increase iteration counter
+6. **Repeat**: Go to step 2
+
+For basic `loop:` without conditions:
+
+- Only the max iteration limit can cause exit
+- Without max, the loop runs indefinitely (warning issued)
+
+### Condition Evaluation
+
+The OpenProse VM uses its intelligence to evaluate discretion conditions:
+
+1. **Context Awareness**: The condition is evaluated in the context of what has happened so far in the session
+2. **Semantic Understanding**: The condition text is interpreted semantically, not literally
+3. **Uncertainty Handling**: When uncertain, the OpenProse VM may:
+   - Continue iterating if progress is being made
+   - Exit early if diminishing returns are detected
+   - Use heuristics based on the condition's semantics
+
+### Nesting
+
+Unbounded loops can be nested with other loop types:
+
+```prose
+# Unbounded inside fixed
+repeat 3:
+  loop until **sub-task complete** (max: 10):
+    session "Work on sub-task"
+
+# Fixed inside unbounded
+loop until **all batches processed** (max: 5):
+  repeat 3:
+    session "Process batch item"
+
+# Multiple unbounded
+loop until **outer condition** (max: 5):
+  loop until **inner condition** (max: 10):
+    session "Deep iteration"
+```
+
+### Variable Scoping
+
+Loop variables follow the same scoping rules as fixed loops:
+
+```prose
+let i = session "outer"
+loop until **done** as i:
+  # 'i' here is the loop variable (shadows outer)
+  session "use loop i"
+    context: i
+# 'i' here refers to the outer variable again
+session "use outer i"
+  context: i
+```
+
+### Validation Rules
+
+| Check                         | Severity | Message                               |
+| ----------------------------- | -------- | ------------------------------------- |
+| Loop without max or condition | Warning  | Unbounded loop without max iterations |
+| Max iterations <= 0           | Error    | Max iterations must be positive       |
+| Max iterations not integer    | Error    | Max iterations must be an integer     |
+| Empty discretion condition    | Error    | Discretion condition cannot be empty  |
+| Very short condition          | Warning  | Discretion condition may be ambiguous |
+| Loop variable shadows outer   | Warning  | Loop variable shadows outer variable  |
+
+---
+
+## Pipeline Operations
+
+Pipeline operations provide functional-style collection transformations. They allow you to chain operations like map, filter, and reduce using the pipe operator (`|`).
+
+### Pipe Operator
+
+The pipe operator (`|`) passes a collection to a transformation operation:
+
+```prose
+let items = ["a", "b", "c"]
+let results = items | map:
+  session "Process this item"
+    context: item
+```
+
+### Map
+
+The `map` operation transforms each element in a collection:
+
+```prose
+let articles = ["article1", "article2", "article3"]
+
+let summaries = articles | map:
+  session "Summarize this article in one sentence"
+    context: item
+```
+
+Inside a map body, the implicit variable `item` refers to the current element being processed.
+
+### Filter
+
+The `filter` operation keeps elements that match a condition:
+
+```prose
+let items = ["one", "two", "three", "four", "five"]
+
+let short = items | filter:
+  session "Does this word have 4 or fewer letters? Answer yes or no."
+    context: item
+```
+
+The session in a filter body should return something the OpenProse VM can interpret as truthy/falsy (like "yes"/"no").
+
+### Reduce
+
+The `reduce` operation accumulates elements into a single result:
+
+```prose
+let ideas = ["AI assistant", "smart home", "health tracker"]
+
+let combined = ideas | reduce(summary, idea):
+  session "Add this idea to the summary, creating a cohesive concept"
+    context: [summary, idea]
+```
+
+The reduce operation requires explicit variable names:
+
+- First variable (`summary`): the accumulator
+- Second variable (`idea`): the current item
+
+The first item in the collection becomes the initial accumulator value.
+
+### Parallel Map (pmap)
+
+The `pmap` operation is like `map` but runs all transformations concurrently:
+
+```prose
+let tasks = ["task1", "task2", "task3"]
+
+let results = tasks | pmap:
+  session "Process this task in parallel"
+    context: item
+
+session "Aggregate all results"
+  context: results
+```
+
+This is similar to `parallel for`, but in pipeline syntax.
+
+### Chaining
+
+Pipeline operations can be chained to compose complex transformations:
+
+```prose
+let topics = ["quantum computing", "blockchain", "machine learning", "IoT"]
+
+let result = topics
+  | filter:
+      session "Is this topic trending? Answer yes or no."
+        context: item
+  | map:
+      session "Write a one-line startup pitch for this topic"
+        context: item
+
+session "Present the startup pitches"
+  context: result
+```
+
+Operations execute left-to-right: first filter, then map.
+
+### Complete Example
+
+```prose
+# Define a collection
+let articles = ["AI breakthroughs", "Climate solutions", "Space exploration"]
+
+# Process with chained operations
+let summaries = articles
+  | filter:
+      session "Is this topic relevant to technology? Answer yes or no."
+        context: item
+  | map:
+      session "Write a compelling one-paragraph summary"
+        context: item
+  | reduce(combined, summary):
+      session "Merge this summary into the combined document"
+        context: [combined, summary]
+
+# Present the final result
+session "Format and present the combined summaries"
+  context: summaries
+```
+
+### Implicit Variables
+
+| Operation | Available Variables                          |
+| --------- | -------------------------------------------- |
+| `map`     | `item` - current element                     |
+| `filter`  | `item` - current element                     |
+| `pmap`    | `item` - current element                     |
+| `reduce`  | Named explicitly: `reduce(accVar, itemVar):` |
+
+### Execution Semantics
+
+When the OpenProse VM encounters a pipeline:
+
+1. **Input**: Start with the input collection
+2. **For each operation**:
+   - **map**: Transform each element, producing a new collection
+   - **filter**: Keep elements where the session returns truthy
+   - **reduce**: Accumulate elements into a single value
+   - **pmap**: Transform all elements concurrently
+3. **Output**: Return the final transformed collection/value
+
+### Variable Scoping
+
+Pipeline variables are scoped to their operation body:
+
+```prose
+let item = "outer"
+let items = ["a", "b"]
+
+let results = items | map:
+  # 'item' here is the pipeline variable (shadows outer)
+  session "process"
+    context: item
+
+# 'item' here refers to the outer variable again
+session "use outer"
+  context: item
+```
+
+### Validation Rules
+
+| Check                           | Severity | Message                                            |
+| ------------------------------- | -------- | -------------------------------------------------- |
+| Undefined input collection      | Error    | Undefined collection variable                      |
+| Invalid pipe operator           | Error    | Expected pipe operator (map, filter, reduce, pmap) |
+| Reduce without variables        | Error    | Expected accumulator and item variables            |
+| Pipeline variable shadows outer | Warning  | Implicit/explicit variable shadows outer variable  |
+
+---
+
+## Error Handling
+
+OpenProse provides structured error handling with try/catch/finally blocks, throw statements, and retry mechanisms for resilient workflows.
+
+### Try/Catch Blocks
+
+The `try:` block wraps operations that might fail. The `catch:` block handles errors.
+
+```prose
+try:
+  session "Attempt risky operation"
+catch:
+  session "Handle the error gracefully"
+```
+
+#### Error Variable Access
+
+Use `catch as err:` to capture error context for the error handler:
+
+```prose
+try:
+  session "Call external API"
+catch as err:
+  session "Log and handle the error"
+    context: err
+```
+
+The error variable (`err`) contains contextual information about what went wrong and is only accessible within the catch block.
+
+### Try/Catch/Finally
+
+The `finally:` block always executes, whether the try block succeeds or fails:
+
+```prose
+try:
+  session "Acquire and use resource"
+catch:
+  session "Handle any errors"
+finally:
+  session "Always clean up resource"
+```
+
+#### Execution Order
+
+1. **Try succeeds**: try body → finally body
+2. **Try fails**: try body (until failure) → catch body → finally body
+
+### Try/Finally (No Catch)
+
+For cleanup without error handling, use try/finally:
+
+```prose
+try:
+  session "Open connection and do work"
+finally:
+  session "Close connection"
+```
+
+### Throw Statement
+
+The `throw` statement raises or re-raises errors.
+
+#### Rethrow
+
+Inside a catch block, `throw` without arguments re-raises the caught error to outer handlers:
+
+```prose
+try:
+  try:
+    session "Inner operation"
+  catch:
+    session "Partial handling"
+    throw  # Re-raise to outer handler
+catch:
+  session "Handle re-raised error"
+```
+
+#### Throw with Message
+
+Throw a new error with a custom message:
+
+```prose
+session "Check preconditions"
+throw "Precondition not met"
+```
+
+### Nested Error Handling
+
+Try blocks can be nested. Inner catch blocks don't trigger outer handlers unless they rethrow:
+
+```prose
+try:
+  session "Outer operation"
+  try:
+    session "Inner risky operation"
+  catch:
+    session "Handle inner error"  # Outer catch won't run
+  session "Continue outer operation"
+catch:
+  session "Handle outer error only"
+```
+
+### Error Handling in Parallel
+
+Each parallel branch can have its own error handling:
+
+```prose
+parallel:
+  try:
+    session "Branch A might fail"
+  catch:
+    session "Recover branch A"
+  try:
+    session "Branch B might fail"
+  catch:
+    session "Recover branch B"
+
+session "Continue with recovered results"
+```
+
+This differs from the `on-fail:` policy which controls behavior when unhandled errors occur.
+
+### Retry Property
+
+The `retry:` property makes a session automatically retry on failure:
+
+```prose
+session "Call flaky API"
+  retry: 3
+```
+
+#### Retry with Backoff
+
+Add `backoff:` to control delay between retries:
+
+```prose
+session "Rate-limited API"
+  retry: 5
+  backoff: "exponential"
+```
+
+**Backoff Strategies:**
+
+| Strategy        | Behavior                           |
+| --------------- | ---------------------------------- |
+| `"none"`        | Immediate retry (default)          |
+| `"linear"`      | Fixed delay between retries        |
+| `"exponential"` | Doubling delay (1s, 2s, 4s, 8s...) |
+
+#### Retry with Context
+
+Retry works with other session properties:
+
+```prose
+let data = session "Get input"
+session "Process data"
+  context: data
+  retry: 3
+  backoff: "linear"
+```
+
+### Combining Patterns
+
+Retry and try/catch work together for maximum resilience:
+
+```prose
+try:
+  session "Call external service"
+    retry: 3
+    backoff: "exponential"
+catch:
+  session "All retries failed, use fallback"
+```
+
+### Validation Rules
+
+| Check                        | Severity | Message                                             |
+| ---------------------------- | -------- | --------------------------------------------------- |
+| Try without catch or finally | Error    | Try block must have at least "catch:" or "finally:" |
+| Error variable shadows outer | Warning  | Error variable shadows outer variable               |
+| Empty throw message          | Warning  | Throw message is empty                              |
+| Non-positive retry count     | Error    | Retry count must be positive                        |
+| Non-integer retry count      | Error    | Retry count must be an integer                      |
+| High retry count (>10)       | Warning  | Retry count is unusually high                       |
+| Invalid backoff strategy     | Error    | Must be "none", "linear", or "exponential"          |
+| Retry on agent definition    | Warning  | Retry property is only valid in session statements  |
+
+### Syntax Reference
+
+```
+try_block ::= "try" ":" NEWLINE INDENT statement+ DEDENT
+              [catch_block]
+              [finally_block]
+
+catch_block ::= "catch" ["as" identifier] ":" NEWLINE INDENT statement+ DEDENT
+
+finally_block ::= "finally" ":" NEWLINE INDENT statement+ DEDENT
+
+throw_statement ::= "throw" [string_literal]
+
+retry_property ::= "retry" ":" number_literal
+
+backoff_property ::= "backoff" ":" string_literal
+```
+
+---
+
+## Choice Blocks
+
+Choice blocks allow the OpenProse VM to select from multiple labeled options based on criteria. This is useful for branching workflows where the best path depends on runtime analysis.
+
+### Syntax
+
+```prose
+choice **criteria**:
+  option "Label A":
+    statements...
+  option "Label B":
+    statements...
+```
+
+### Criteria
+
+The criteria is wrapped in discretion markers (`**...**`) and is evaluated by the OpenProse VM to select which option to execute:
+
+```prose
+choice **the best approach for the current situation**:
+  option "Quick fix":
+    session "Apply a quick temporary fix"
+  option "Full refactor":
+    session "Perform a complete code refactor"
+```
+
+### Multi-line Criteria
+
+For complex criteria, use triple-asterisks:
+
+```prose
+choice ***
+  which strategy is most appropriate
+  given the current project constraints
+  and timeline requirements
+***:
+  option "MVP approach":
+    session "Build minimum viable product"
+  option "Full feature set":
+    session "Build complete feature set"
+```
+
+### Examples
+
+#### Simple Choice
+
+```prose
+let analysis = session "Analyze the code quality"
+
+choice **the severity of issues found in the analysis**:
+  option "Critical":
+    session "Stop deployment and fix critical issues"
+      context: analysis
+  option "Minor":
+    session "Log issues for later and proceed"
+      context: analysis
+  option "None":
+    session "Proceed with deployment"
+```
+
+#### Choice with Multiple Statements per Option
+
+```prose
+choice **the user's experience level**:
+  option "Beginner":
+    session "Explain basic concepts first"
+    session "Provide step-by-step guidance"
+    session "Include helpful tips and warnings"
+  option "Expert":
+    session "Provide concise technical summary"
+    session "Include advanced configuration options"
+```
+
+#### Nested Choices
+
+```prose
+choice **the type of request**:
+  option "Bug report":
+    choice **the bug severity**:
+      option "Critical":
+        session "Escalate immediately"
+      option "Normal":
+        session "Add to sprint backlog"
+  option "Feature request":
+    session "Add to feature backlog"
+```
+
+### Execution Semantics
+
+When the OpenProse VM encounters a `choice` block:
+
+1. **Evaluate Criteria**: Interpret the discretion criteria in current context
+2. **Select Option**: Choose the most appropriate labeled option
+3. **Execute**: Run all statements in the selected option's body
+4. **Continue**: Proceed to the next statement after the choice block
+
+Only one option is executed per choice block.
+
+### Validation Rules
+
+| Check                   | Severity | Message                                    |
+| ----------------------- | -------- | ------------------------------------------ |
+| Choice without options  | Error    | Choice block must have at least one option |
+| Empty criteria          | Error    | Choice criteria cannot be empty            |
+| Duplicate option labels | Warning  | Duplicate option label                     |
+| Empty option body       | Warning  | Option has empty body                      |
+
+### Syntax Reference
+
+```
+choice_block ::= "choice" discretion ":" NEWLINE INDENT option+ DEDENT
+
+option ::= "option" string ":" NEWLINE INDENT statement+ DEDENT
+
+discretion ::= "**" text "**" | "***" text "***"
+```
+
+---
+
+## Conditional Statements
+
+If/elif/else statements provide conditional branching based on AI-evaluated conditions using discretion markers.
+
+### If Statement
+
+```prose
+if **condition**:
+  statements...
+```
+
+### If/Else
+
+```prose
+if **condition**:
+  statements...
+else:
+  statements...
+```
+
+### If/Elif/Else
+
+```prose
+if **first condition**:
+  statements...
+elif **second condition**:
+  statements...
+elif **third condition**:
+  statements...
+else:
+  statements...
+```
+
+### Discretion Conditions
+
+Conditions are wrapped in discretion markers (`**...**`) for AI evaluation:
+
+```prose
+let analysis = session "Analyze the codebase"
+
+if **the code has security vulnerabilities**:
+  session "Fix security issues immediately"
+    context: analysis
+elif **the code has performance issues**:
+  session "Optimize performance bottlenecks"
+    context: analysis
+else:
+  session "Proceed with normal review"
+    context: analysis
+```
+
+### Multi-line Conditions
+
+Use triple-asterisks for complex conditions:
+
+```prose
+if ***
+  the test suite passes
+  and the code coverage is above 80%
+  and there are no linting errors
+***:
+  session "Deploy to production"
+else:
+  session "Fix issues before deploying"
+```
+
+### Examples
+
+#### Simple If
+
+```prose
+session "Check system health"
+
+if **the system is healthy**:
+  session "Continue with normal operations"
+```
+
+#### If/Else
+
+```prose
+let review = session "Review the pull request"
+
+if **the code changes are safe and well-tested**:
+  session "Approve and merge the PR"
+    context: review
+else:
+  session "Request changes"
+    context: review
+```
+
+#### Multiple Elif
+
+```prose
+let status = session "Check project status"
+
+if **the project is on track**:
+  session "Continue as planned"
+elif **the project is slightly delayed**:
+  session "Adjust timeline and communicate"
+elif **the project is significantly delayed**:
+  session "Escalate to management"
+  session "Create recovery plan"
+else:
+  session "Assess project viability"
+```
+
+#### Nested Conditionals
+
+```prose
+if **the request is authenticated**:
+  if **the user has admin privileges**:
+    session "Process admin request"
+  else:
+    session "Process standard user request"
+else:
+  session "Return authentication error"
+```
+
+### Combining with Other Constructs
+
+#### With Try/Catch
+
+```prose
+try:
+  session "Attempt operation"
+  if **operation succeeded partially**:
+    session "Complete remaining steps"
+catch as err:
+  if **error is recoverable**:
+    session "Apply recovery procedure"
+      context: err
+  else:
+    throw "Unrecoverable error"
+```
+
+#### With Loops
+
+```prose
+loop until **task complete** (max: 10):
+  session "Work on task"
+  if **encountered blocker**:
+    session "Resolve blocker"
+```
+
+### Execution Semantics
+
+When the OpenProse VM encounters an `if` statement:
+
+1. **Evaluate Condition**: Interpret the first discretion condition
+2. **If True**: Execute the then-body and skip remaining clauses
+3. **If False**: Check each `elif` condition in order
+4. **Elif Match**: Execute that elif's body and skip remaining
+5. **No Match**: Execute the `else` body (if present)
+6. **Continue**: Proceed to the next statement
+
+### Validation Rules
+
+| Check           | Severity | Message                           |
+| --------------- | -------- | --------------------------------- |
+| Empty condition | Error    | If/elif condition cannot be empty |
+| Elif without if | Error    | Elif must follow if               |
+| Else without if | Error    | Else must follow if or elif       |
+| Multiple else   | Error    | Only one else clause allowed      |
+| Empty body      | Warning  | Condition has empty body          |
+
+### Syntax Reference
+
+```
+if_statement ::= "if" discretion ":" NEWLINE INDENT statement+ DEDENT
+                 elif_clause*
+                 [else_clause]
+
+elif_clause ::= "elif" discretion ":" NEWLINE INDENT statement+ DEDENT
+
+else_clause ::= "else" ":" NEWLINE INDENT statement+ DEDENT
+
+discretion ::= "**" text "**" | "***" text "***"
+```
+
+---
+
+## Execution Model
+
+OpenProse uses a two-phase execution model.
+
+### Phase 1: Compilation (Static)
+
+The compile phase handles deterministic preprocessing:
+
+1. **Parse**: Convert source code to AST
+2. **Validate**: Check for syntax and semantic errors
+3. **Expand**: Normalize syntax sugar (when implemented)
+4. **Output**: Generate canonical program
+
+### Phase 2: Runtime (Intelligent)
+
+The OpenProse VM executes the compiled program:
+
+1. **Load**: Receive the compiled program
+2. **Collect Agents**: Register all agent definitions
+3. **Execute**: Process each statement in order
+4. **Spawn**: Create subagents with resolved configurations
+5. **Coordinate**: Manage context passing between sessions
+
+### OpenProse VM Behavior
+
+| Aspect               | Behavior                                        |
+| -------------------- | ----------------------------------------------- |
+| Execution order      | Strict - follows program exactly                |
+| Session creation     | Strict - creates what program specifies         |
+| Agent resolution     | Strict - merge properties deterministically     |
+| Context passing      | Intelligent - summarizes/transforms as needed   |
+| Completion detection | Intelligent - determines when session is "done" |
+
+### State Management
+
+For the current implementation, state is tracked in-context (conversation history):
+
+| State Type          | Tracking Approach                                   |
+| ------------------- | --------------------------------------------------- |
+| Agent definitions   | Collected at program start                          |
+| Execution flow      | Implicit reasoning ("completed X, now executing Y") |
+| Session outputs     | Held in conversation history                        |
+| Position in program | Tracked by OpenProse VM                             |
+
+---
+
+## Validation Rules
+
+The validator checks programs for errors and warnings before execution.
+
+### Errors (Block Execution)
+
+| Code | Description                         |
+| ---- | ----------------------------------- |
+| E001 | Unterminated string literal         |
+| E002 | Unknown escape sequence in string   |
+| E003 | Session missing prompt or agent     |
+| E004 | Unexpected token                    |
+| E005 | Invalid syntax                      |
+| E006 | Duplicate agent definition          |
+| E007 | Undefined agent reference           |
+| E008 | Invalid model value                 |
+| E009 | Duplicate property                  |
+| E010 | Duplicate import                    |
+| E011 | Empty import skill name             |
+| E012 | Empty import source                 |
+| E013 | Skills must be an array             |
+| E014 | Skill name must be a string         |
+| E015 | Permissions must be a block         |
+| E016 | Permission pattern must be a string |
+
+### Warnings (Non-blocking)
+
+| Code | Description                              |
+| ---- | ---------------------------------------- |
+| W001 | Empty session prompt                     |
+| W002 | Whitespace-only session prompt           |
+| W003 | Session prompt exceeds 10,000 characters |
+| W004 | Empty prompt property                    |
+| W005 | Unknown property name                    |
+| W006 | Unknown import source format             |
+| W007 | Skill not imported                       |
+| W008 | Unknown permission type                  |
+| W009 | Unknown permission value                 |
+| W010 | Empty skills array                       |
+
+### Error Message Format
+
+Errors include location information:
+
+```
+Error at line 5, column 12: Unterminated string literal
+  session "Hello
+          ^
+```
+
+---
+
+## Examples
+
+### Minimal Program
+
+```prose
+session "Hello world"
+```
+
+### Research Pipeline with Agents
+
+```prose
+# Define specialized agents
+agent researcher:
+  model: sonnet
+  prompt: "You are a research assistant"
+
+agent writer:
+  model: opus
+  prompt: "You are a technical writer"
+
+# Execute workflow
+session: researcher
+  prompt: "Research recent developments in quantum computing"
+
+session: writer
+  prompt: "Write a summary of the research findings"
+```
+
+### Code Review Workflow
+
+```prose
+agent reviewer:
+  model: sonnet
+  prompt: "You are an expert code reviewer"
+
+session: reviewer
+  prompt: "Read the code in src/ and identify potential bugs"
+
+session: reviewer
+  prompt: "Suggest fixes for each bug found"
+
+session: reviewer
+  prompt: "Create a summary of all changes needed"
+```
+
+### Multi-step Task with Model Override
+
+```prose
+agent analyst:
+  model: haiku
+  prompt: "You analyze data quickly"
+
+# Quick initial analysis
+session: analyst
+  prompt: "Scan the data for obvious patterns"
+
+# Detailed analysis with more powerful model
+session: analyst
+  model: opus
+  prompt: "Perform deep analysis on the patterns found"
+```
+
+### Comments for Documentation
+
+```prose
+# Project: Quarterly Report Generator
+# Author: Team Lead
+# Date: 2024-01-01
+
+agent data-collector:
+  model: sonnet
+  prompt: "You gather and organize data"
+
+agent analyst:
+  model: opus
+  prompt: "You analyze data and create insights"
+
+# Step 1: Gather data
+session: data-collector
+  prompt: "Collect all sales data from the past quarter"
+
+# Step 2: Analysis
+session: analyst
+  prompt: "Perform trend analysis on the collected data"
+
+# Step 3: Report generation
+session: analyst
+  prompt: "Generate a formatted quarterly report with charts"
+```
+
+### Workflow with Skills and Permissions
+
+```prose
+# Import external skills
+import "web-search" from "github:anthropic/skills"
+import "file-writer" from "./local-skills"
+
+# Define a secure research agent
+agent researcher:
+  model: sonnet
+  prompt: "You are a research assistant"
+  skills: ["web-search"]
+  permissions:
+    read: ["*.md", "*.txt"]
+    bash: deny
+
+# Define a writer agent
+agent writer:
+  model: opus
+  prompt: "You create documentation"
+  skills: ["file-writer"]
+  permissions:
+    write: ["docs/"]
+    bash: deny
+
+# Execute workflow
+session: researcher
+  prompt: "Research AI safety topics"
+
+session: writer
+  prompt: "Write a summary document"
+```
+
+---
+
+## Future Features
+
+All core features through Tier 12 have been implemented. Potential future enhancements:
+
+### Tier 13: Extended Features
+
+- Custom functions with return values
+- Module system for code organization
+- Type annotations for validation
+- Async/await patterns for advanced concurrency
+
+### Tier 14: Tooling
+
+- Language server protocol (LSP) support
+- VS Code extension
+- Interactive debugger
+- Performance profiling
+
+---
+
+## Syntax Grammar (Implemented)
+
+```
+program     → statement* EOF
+statement   → agentDef | blockDef | parallelBlock | repeatBlock | forEachBlock
+            | loopBlock | tryBlock | choiceBlock | ifStatement | session
+            | doBlock | arrowExpr | letBinding | constBinding | assignment
+            | throwStatement | comment
+
+# Definitions
+agentDef    → "agent" IDENTIFIER ":" NEWLINE INDENT property* DEDENT
+blockDef    → "block" IDENTIFIER params? ":" NEWLINE INDENT statement* DEDENT
+params      → "(" IDENTIFIER ( "," IDENTIFIER )* ")"
+
+# Control Flow
+parallelBlock → "parallel" parallelMods? ":" NEWLINE INDENT parallelBranch* DEDENT
+parallelMods  → "(" ( joinStrategy | onFail | countMod ) ( "," ( joinStrategy | onFail | countMod ) )* ")"
+joinStrategy  → string                              # "all" | "first" | "any"
+onFail        → "on-fail" ":" string                # "fail-fast" | "continue" | "ignore"
+countMod      → "count" ":" NUMBER                  # only valid with "any"
+parallelBranch → ( IDENTIFIER "=" )? statement
+
+# Loops
+repeatBlock → "repeat" NUMBER ( "as" IDENTIFIER )? ":" NEWLINE INDENT statement* DEDENT
+forEachBlock → "parallel"? "for" IDENTIFIER ( "," IDENTIFIER )? "in" collection ":" NEWLINE INDENT statement* DEDENT
+loopBlock   → "loop" ( ( "until" | "while" ) discretion )? loopMods? ( "as" IDENTIFIER )? ":" NEWLINE INDENT statement* DEDENT
+loopMods    → "(" "max" ":" NUMBER ")"
+
+# Error Handling
+tryBlock    → "try" ":" NEWLINE INDENT statement+ DEDENT catchBlock? finallyBlock?
+catchBlock  → "catch" ( "as" IDENTIFIER )? ":" NEWLINE INDENT statement+ DEDENT
+finallyBlock → "finally" ":" NEWLINE INDENT statement+ DEDENT
+throwStatement → "throw" string?
+
+# Conditionals
+choiceBlock → "choice" discretion ":" NEWLINE INDENT choiceOption+ DEDENT
+choiceOption → "option" string ":" NEWLINE INDENT statement+ DEDENT
+ifStatement → "if" discretion ":" NEWLINE INDENT statement+ DEDENT elifClause* elseClause?
+elifClause  → "elif" discretion ":" NEWLINE INDENT statement+ DEDENT
+elseClause  → "else" ":" NEWLINE INDENT statement+ DEDENT
+
+# Blocks and Sequences
+doBlock     → "do" ( ":" NEWLINE INDENT statement* DEDENT | IDENTIFIER args? )
+args        → "(" expression ( "," expression )* ")"
+arrowExpr   → session "->" session ( "->" session )*
+
+# Sessions
+session     → "session" ( string | ":" IDENTIFIER | IDENTIFIER ":" IDENTIFIER )
+              ( NEWLINE INDENT property* DEDENT )?
+
+# Bindings
+letBinding  → "let" IDENTIFIER "=" expression
+constBinding → "const" IDENTIFIER "=" expression
+assignment  → IDENTIFIER "=" expression
+
+# Expressions
+expression  → session | doBlock | parallelBlock | repeatBlock | forEachBlock
+            | loopBlock | arrowExpr | pipeExpr | string | IDENTIFIER | array | objectContext
+
+# Pipelines
+pipeExpr    → ( IDENTIFIER | array ) ( "|" pipeOp )+
+pipeOp      → ( "map" | "filter" | "pmap" ) ":" NEWLINE INDENT statement* DEDENT
+            | "reduce" "(" IDENTIFIER "," IDENTIFIER ")" ":" NEWLINE INDENT statement* DEDENT
+
+# Properties
+property    → ( "model" | "prompt" | "context" | "retry" | "backoff" | IDENTIFIER )
+            ":" ( IDENTIFIER | string | array | objectContext | NUMBER )
+
+# Primitives
+discretion  → "**" text "**" | "***" text "***"
+collection  → IDENTIFIER | array
+array       → "[" ( expression ( "," expression )* )? "]"
+objectContext → "{" ( IDENTIFIER ( "," IDENTIFIER )* )? "}"
+comment     → "#" text NEWLINE
+
+# Strings
+string      → singleString | tripleString | interpolatedString
+singleString → '"' character* '"'
+tripleString → '"""' ( character | NEWLINE )* '"""'
+interpolatedString → string containing "{" IDENTIFIER "}"
+character   → escape | non-quote
+escape      → "\\" | "\"" | "\n" | "\t"
+```
+
+---
+
+## Compiler API
+
+When a user invokes `/prose-compile` or asks you to compile a `.prose` file:
+
+1. **Read this document** (`docs.md`) fully to understand all syntax and validation rules
+2. **Parse** the program according to the syntax grammar
+3. **Validate** syntax correctness, semantic validity, and self-evidence
+4. **Transform** to canonical form (expand syntax sugar, normalize structure)
+5. **Output** the compiled program or report errors/warnings with line numbers
+
+For direct interpretation without compilation, read `prose.md` and execute statements as described in the Session Statement section.

--- a/.openhands/skills/open-prose/patterns.md
+++ b/.openhands/skills/open-prose/patterns.md
@@ -1,0 +1,610 @@
+---
+role: best-practices
+summary: |
+  Design patterns for robust, efficient, and maintainable OpenProse programs.
+  Read this file when authoring new programs or reviewing existing ones.
+see-also:
+  - prose.md: Execution semantics, how to run programs
+  - docs.md: Full syntax grammar, validation rules
+  - antipatterns.md: Patterns to avoid
+---
+
+# OpenProse Design Patterns
+
+This document catalogs proven patterns for orchestrating AI agents effectively. Each pattern addresses specific concerns: robustness, cost efficiency, speed, maintainability, or self-improvement capability.
+
+---
+
+## Structural Patterns
+
+#### parallel-independent-work
+
+When tasks have no data dependencies, execute them concurrently. This maximizes throughput and minimizes wall-clock time.
+
+```prose
+# Good: Independent research runs in parallel
+parallel:
+  market = session "Research market trends"
+  tech = session "Research technology landscape"
+  competition = session "Analyze competitor products"
+
+session "Synthesize findings"
+  context: { market, tech, competition }
+```
+
+The synthesis session waits for all branches, but total time equals the longest branch rather than the sum of all branches.
+
+#### fan-out-fan-in
+
+For processing collections, fan out to parallel workers then collect results. Use `parallel for` instead of manual parallel branches.
+
+```prose
+let topics = ["AI safety", "interpretability", "alignment", "robustness"]
+
+parallel for topic in topics:
+  session "Deep dive research on {topic}"
+
+session "Create unified report from all research"
+```
+
+This scales naturally with collection size and keeps code DRY.
+
+#### pipeline-composition
+
+Chain transformations using pipe operators for readable data flow. Each stage has a single responsibility.
+
+```prose
+let candidates = session "Generate 10 startup ideas"
+
+let result = candidates
+  | filter:
+      session "Is this idea technically feasible? yes/no"
+        context: item
+  | map:
+      session "Expand this idea into a one-page pitch"
+        context: item
+  | reduce(best, current):
+      session "Compare these two pitches, return the stronger one"
+        context: [best, current]
+```
+
+#### agent-specialization
+
+Define agents with focused expertise. Specialized agents produce better results than generalist prompts.
+
+```prose
+agent security-reviewer:
+  model: sonnet
+  prompt: """
+    You are a security expert. Focus exclusively on:
+    - Authentication and authorization flaws
+    - Injection vulnerabilities
+    - Data exposure risks
+    Ignore style, performance, and other concerns.
+  """
+
+agent performance-reviewer:
+  model: sonnet
+  prompt: """
+    You are a performance engineer. Focus exclusively on:
+    - Algorithmic complexity
+    - Memory usage patterns
+    - I/O bottlenecks
+    Ignore security, style, and other concerns.
+  """
+```
+
+#### reusable-blocks
+
+Extract repeated workflows into parameterized blocks. Blocks are the functions of OpenProse.
+
+```prose
+block review-and-revise(artifact, criteria):
+  let feedback = session "Review {artifact} against {criteria}"
+  session "Revise {artifact} based on feedback"
+    context: feedback
+
+# Reuse the pattern
+do review-and-revise("the architecture doc", "clarity and completeness")
+do review-and-revise("the API design", "consistency and usability")
+do review-and-revise("the test plan", "coverage and edge cases")
+```
+
+---
+
+## Robustness Patterns
+
+#### bounded-iteration
+
+Always constrain loops with `max:` to prevent runaway execution. Even well-crafted conditions can fail to terminate.
+
+```prose
+# Good: Explicit upper bound
+loop until **all tests pass** (max: 20):
+  session "Identify and fix the next failing test"
+
+# The program will terminate even if tests never fully pass
+```
+
+#### graceful-degradation
+
+Use `on-fail: "continue"` when partial results are acceptable. Collect what you can rather than failing entirely.
+
+```prose
+parallel (on-fail: "continue"):
+  primary = session "Query primary data source"
+  backup = session "Query backup data source"
+  cache = session "Check local cache"
+
+# Continue with whatever succeeded
+session "Merge available data"
+  context: { primary, backup, cache }
+```
+
+#### retry-with-backoff
+
+External services fail transiently. Retry with exponential backoff to handle rate limits and temporary outages.
+
+```prose
+session "Call external API"
+  retry: 5
+  backoff: "exponential"
+```
+
+For critical paths, combine retry with fallback:
+
+```prose
+try:
+  session "Call primary API"
+    retry: 3
+    backoff: "exponential"
+catch:
+  session "Use fallback data source"
+```
+
+#### error-context-capture
+
+Capture error context for intelligent recovery. The error variable provides information for diagnostic or remediation sessions.
+
+```prose
+try:
+  session "Deploy to production"
+catch as err:
+  session "Analyze deployment failure and suggest fixes"
+    context: err
+  session "Attempt automatic remediation"
+    context: err
+```
+
+#### defensive-context
+
+Validate assumptions before expensive operations. Cheap checks prevent wasted computation.
+
+```prose
+let prereqs = session "Check all prerequisites: API keys, permissions, dependencies"
+
+if **prerequisites are not met**:
+  session "Report missing prerequisites and exit"
+    context: prereqs
+  throw "Prerequisites not satisfied"
+
+# Expensive operations only run if prereqs pass
+session "Execute main workflow"
+```
+
+---
+
+## Cost Efficiency Patterns
+
+#### model-tiering
+
+Match model capability to task complexity. Use haiku for simple tasks, sonnet for moderate complexity, opus for deep reasoning.
+
+```prose
+agent classifier:
+  model: haiku  # Fast, cheap classification
+  prompt: "You categorize items into predefined buckets"
+
+agent analyst:
+  model: sonnet  # Balanced analysis
+  prompt: "You analyze data and identify patterns"
+
+agent strategist:
+  model: opus  # Complex reasoning
+  prompt: "You synthesize information into strategic recommendations"
+
+# Workflow uses appropriate model per stage
+let category = session: classifier
+  prompt: "Classify this support ticket: {ticket}"
+
+if **category is complex technical issue**:
+  session: strategist
+    prompt: "Develop resolution strategy"
+else:
+  session: analyst
+    prompt: "Suggest standard resolution"
+```
+
+#### context-minimization
+
+Pass only relevant context. Large contexts slow processing and increase costs.
+
+```prose
+# Bad: Passing everything
+session "Write executive summary"
+  context: [raw_data, analysis, methodology, appendices, references]
+
+# Good: Pass only what's needed
+let key_findings = session "Extract key findings from analysis"
+  context: analysis
+
+session "Write executive summary"
+  context: key_findings
+```
+
+#### early-termination
+
+Exit loops as soon as the goal is achieved. Don't iterate unnecessarily.
+
+```prose
+# The condition is checked each iteration
+loop until **solution found and verified** (max: 10):
+  session "Generate potential solution"
+  session "Verify solution correctness"
+# Exits immediately when condition is met, not after max iterations
+```
+
+#### race-for-speed
+
+When any valid result suffices, race multiple approaches and take the first success.
+
+```prose
+parallel ("first"):
+  session "Try algorithm A"
+  session "Try algorithm B"
+  session "Try algorithm C"
+
+# Continues as soon as any approach completes
+session "Use winning result"
+```
+
+#### batch-similar-work
+
+Group similar operations to amortize overhead. One session with structured output beats many small sessions.
+
+```prose
+# Inefficient: Many small sessions
+for file in files:
+  session "Analyze {file}"
+
+# Efficient: Batch analysis
+session "Analyze all files and return structured findings for each"
+  context: files
+```
+
+---
+
+## Self-Improvement Patterns
+
+#### iterative-refinement
+
+Use feedback loops to progressively improve outputs. Each iteration builds on the previous.
+
+```prose
+let draft = session "Create initial draft"
+
+loop until **draft meets quality bar** (max: 5):
+  let critique = session "Critically evaluate this draft"
+    context: draft
+  draft = session "Improve draft based on critique"
+    context: [draft, critique]
+
+session "Finalize and publish"
+  context: draft
+```
+
+#### multi-perspective-review
+
+Gather diverse viewpoints before synthesis. Different lenses catch different issues.
+
+```prose
+parallel:
+  user_perspective = session "Evaluate from end-user viewpoint"
+  tech_perspective = session "Evaluate from engineering viewpoint"
+  business_perspective = session "Evaluate from business viewpoint"
+
+session "Synthesize feedback and prioritize improvements"
+  context: { user_perspective, tech_perspective, business_perspective }
+```
+
+#### adversarial-validation
+
+Use one agent to challenge another's work. Adversarial pressure improves robustness.
+
+```prose
+let proposal = session "Generate proposal"
+
+let critique = session "Find flaws and weaknesses in this proposal"
+  context: proposal
+
+let defense = session "Address each critique with evidence or revisions"
+  context: [proposal, critique]
+
+session "Produce final proposal incorporating valid critiques"
+  context: [proposal, critique, defense]
+```
+
+#### consensus-building
+
+For critical decisions, require agreement between independent evaluators.
+
+```prose
+parallel:
+  eval1 = session "Independently evaluate the solution"
+  eval2 = session "Independently evaluate the solution"
+  eval3 = session "Independently evaluate the solution"
+
+loop until **evaluators agree** (max: 3):
+  session "Identify points of disagreement"
+    context: { eval1, eval2, eval3 }
+  parallel:
+    eval1 = session "Reconsider position given other perspectives"
+      context: { eval1, eval2, eval3 }
+    eval2 = session "Reconsider position given other perspectives"
+      context: { eval1, eval2, eval3 }
+    eval3 = session "Reconsider position given other perspectives"
+      context: { eval1, eval2, eval3 }
+
+session "Document consensus decision"
+  context: { eval1, eval2, eval3 }
+```
+
+---
+
+## Maintainability Patterns
+
+#### descriptive-agent-names
+
+Name agents for their role, not their implementation. Names should convey purpose.
+
+```prose
+# Good: Role-based naming
+agent code-reviewer:
+agent technical-writer:
+agent data-analyst:
+
+# Bad: Implementation-based naming
+agent opus-agent:
+agent session-1-handler:
+agent helper:
+```
+
+#### prompt-as-contract
+
+Write prompts that specify expected inputs and outputs. Clear contracts prevent misunderstandings.
+
+```prose
+agent json-extractor:
+  model: haiku
+  prompt: """
+    Extract structured data from text.
+
+    Input: Unstructured text containing entity information
+    Output: JSON object with fields: name, date, amount, status
+
+    If a field cannot be determined, use null.
+    Never invent information not present in the input.
+  """
+```
+
+#### separation-of-concerns
+
+Each session should do one thing well. Combine simple sessions rather than creating complex ones.
+
+```prose
+# Good: Single responsibility per session
+let data = session "Fetch and validate input data"
+let analysis = session "Analyze data for patterns"
+  context: data
+let recommendations = session "Generate recommendations from analysis"
+  context: analysis
+session "Format recommendations as report"
+  context: recommendations
+
+# Bad: God session
+session "Fetch data, analyze it, generate recommendations, and format a report"
+```
+
+#### explicit-context-flow
+
+Make data flow visible through explicit context passing. Avoid relying on implicit conversation history.
+
+```prose
+# Good: Explicit flow
+let step1 = session "First step"
+let step2 = session "Second step"
+  context: step1
+let step3 = session "Third step"
+  context: [step1, step2]
+
+# Bad: Implicit flow (relies on conversation state)
+session "First step"
+session "Second step using previous results"
+session "Third step using all previous"
+```
+
+---
+
+## Performance Patterns
+
+#### lazy-evaluation
+
+Defer expensive operations until their results are needed. Don't compute what might not be used.
+
+```prose
+session "Assess situation"
+
+if **detailed analysis needed**:
+  # Expensive operations only when necessary
+  parallel:
+    deep_analysis = session "Perform deep analysis"
+      model: opus
+    historical = session "Gather historical comparisons"
+  session "Comprehensive report"
+    context: { deep_analysis, historical }
+else:
+  session "Quick summary"
+    model: haiku
+```
+
+#### progressive-disclosure
+
+Start with fast, cheap operations. Escalate to expensive ones only when needed.
+
+```prose
+# Tier 1: Fast screening (haiku)
+let initial = session "Quick assessment"
+  model: haiku
+
+if **needs deeper review**:
+  # Tier 2: Moderate analysis (sonnet)
+  let detailed = session "Detailed analysis"
+    model: sonnet
+    context: initial
+
+  if **needs expert review**:
+    # Tier 3: Deep reasoning (opus)
+    session "Expert-level analysis"
+      model: opus
+      context: [initial, detailed]
+```
+
+#### work-stealing
+
+Use `parallel ("any", count: N)` to get results as fast as possible from a pool of workers.
+
+```prose
+# Get 3 good ideas as fast as possible from 5 parallel attempts
+parallel ("any", count: 3, on-fail: "ignore"):
+  session "Generate creative solution approach 1"
+  session "Generate creative solution approach 2"
+  session "Generate creative solution approach 3"
+  session "Generate creative solution approach 4"
+  session "Generate creative solution approach 5"
+
+session "Select best from the first 3 completed"
+```
+
+---
+
+## Composition Patterns
+
+#### workflow-template
+
+Create blocks that encode entire workflow patterns. Instantiate with different parameters.
+
+```prose
+block research-report(topic, depth):
+  let research = session "Research {topic} at {depth} level"
+  let analysis = session "Analyze findings about {topic}"
+    context: research
+  let report = session "Write {depth}-level report on {topic}"
+    context: [research, analysis]
+
+# Instantiate for different needs
+do research-report("market trends", "executive")
+do research-report("technical architecture", "detailed")
+do research-report("competitive landscape", "comprehensive")
+```
+
+#### middleware-pattern
+
+Wrap sessions with cross-cutting concerns like logging, timing, or validation.
+
+```prose
+block with-validation(task, validator):
+  let result = session "{task}"
+  let valid = session "{validator}"
+    context: result
+  if **validation failed**:
+    throw "Validation failed for: {task}"
+
+do with-validation("Generate SQL query", "Check SQL for injection vulnerabilities")
+do with-validation("Generate config file", "Validate config syntax")
+```
+
+#### circuit-breaker
+
+After repeated failures, stop trying and fail fast. Prevents cascading failures.
+
+```prose
+let failures = 0
+let max_failures = 3
+
+loop while **service needed and failures < max_failures** (max: 10):
+  try:
+    session "Call external service"
+    # Reset on success
+    failures = 0
+  catch:
+    failures = failures + 1
+    if **failures >= max_failures**:
+      session "Circuit open - using fallback"
+      throw "Service unavailable"
+```
+
+---
+
+## Observability Patterns
+
+#### checkpoint-narration
+
+For long workflows, emit progress markers. Helps with debugging and monitoring.
+
+```prose
+session "Phase 1: Data Collection"
+# ... collection work ...
+
+session "Phase 2: Analysis"
+# ... analysis work ...
+
+session "Phase 3: Report Generation"
+# ... report work ...
+
+session "Phase 4: Quality Assurance"
+# ... QA work ...
+```
+
+#### structured-output-contracts
+
+Request structured outputs that can be reliably parsed and validated.
+
+```prose
+agent structured-reviewer:
+  model: sonnet
+  prompt: """
+    Always respond with this exact JSON structure:
+    {
+      "verdict": "pass" | "fail" | "needs_review",
+      "issues": [{"severity": "high"|"medium"|"low", "description": "..."}],
+      "suggestions": ["..."]
+    }
+  """
+
+let review = session: structured-reviewer
+  prompt: "Review this code for security issues"
+```
+
+---
+
+## Summary
+
+The most effective OpenProse programs combine these patterns:
+
+1. **Structure**: Parallelize independent work, use blocks for reuse
+2. **Robustness**: Bound loops, handle errors, retry transient failures
+3. **Efficiency**: Tier models, minimize context, terminate early
+4. **Quality**: Iterate, get multiple perspectives, validate adversarially
+5. **Maintainability**: Name clearly, separate concerns, make flow explicit
+
+Choose patterns based on your specific constraints. A quick prototype prioritizes speed over robustness. A production workflow prioritizes reliability over cost. A research exploration prioritizes thoroughness over efficiency.

--- a/.openhands/skills/open-prose/prose.md
+++ b/.openhands/skills/open-prose/prose.md
@@ -1,0 +1,1210 @@
+---
+role: execution-semantics
+summary: |
+  How to execute OpenProse programs. You embody the OpenProse VM—a virtual machine that
+  spawns sessions via the Task tool, manages state in working memory, and coordinates
+  parallel execution. Read this file to run .prose programs.
+see-also:
+  - SKILL.md: Activation triggers, onboarding, telemetry
+  - docs.md: Full syntax grammar, validation rules, compilation
+---
+
+# OpenProse VM
+
+This document defines how to execute OpenProse programs. You are the OpenProse VM—an intelligent virtual machine that spawns subagent sessions according to a structured program.
+
+## Why This Is a VM
+
+Large language models are simulators. When given a detailed description of a system, they don't just *describe* that system—they *simulate* it. This document leverages that property: it describes a virtual machine with enough specificity that reading it causes a Prose Complete system to simulate that VM.
+
+But simulation with sufficient fidelity *is* implementation. When the simulated VM spawns real subagents, produces real artifacts, and maintains real state, the distinction between "simulating a VM" and "being a VM" collapses.
+
+### Component Mapping
+
+A traditional VM has concrete components. The OpenProse VM has analogous structures that emerge from the simulation:
+
+| Traditional VM | OpenProse VM | Substrate |
+|----------------|--------------|-----------|
+| Instructions | `.prose` statements | Executed via tool calls (Task) |
+| Program counter | Execution position | Tracked via narration (`📍 Statement 3 of 7`) |
+| Working memory | Conversation history | The context window holds ephemeral state |
+| Persistent storage | `.prose/` directory | Files hold durable state across sessions |
+| Call stack | Block invocation chain | Tracked via narration protocol |
+| Registers/variables | Named bindings | `📦 let research = <value>` |
+| I/O | Tool calls and results | Task spawns sessions, returns outputs |
+
+### What Makes It Real
+
+The OpenProse VM isn't a metaphor. Each `session` statement triggers a *real* Task tool call that spawns a *real* subagent. The outputs are *real* artifacts. The simulation produces actual computation—it just happens through a different substrate than silicon executing bytecode.
+
+---
+
+## Embodying the VM
+
+When you execute a `.prose` program, you ARE the virtual machine. This is not a metaphor—it's a mode of operation:
+
+| You | The VM |
+|-----|--------|
+| Your conversation history | The VM's working memory |
+| Your tool calls (Task) | The VM's instruction execution |
+| Your narration (emoji markers) | The VM's execution trace |
+| Your judgment on `**...**` | The VM's intelligent evaluation |
+
+**What this means in practice:**
+- You don't *simulate* execution—you *perform* it
+- Each `session` spawns a real subagent via the Task tool
+- Your state persists in what you say (narration protocol)
+- You follow the program structure strictly, but apply intelligence where marked
+
+### The VM as Intelligent Container
+
+Traditional dependency injection containers wire up components from configuration. You do the same—but with understanding:
+
+| Declared Primitive | Your Responsibility |
+|--------------------|---------------------|
+| `use "@handle/slug" as name` | Fetch program from p.prose.md, register in Import Registry |
+| `input topic: "..."` | Bind value from caller, make available as variable |
+| `output findings = ...` | Mark value as output, return to caller on completion |
+| `agent researcher:` | Register this agent template for later use |
+| `session: researcher` | Resolve the agent, merge properties, spawn the session |
+| `context: { a, b }` | Wire the outputs of `a` and `b` into this session's input |
+| `parallel:` branches | Coordinate concurrent execution, collect results |
+| `block review(topic):` | Store this reusable component, invoke when called |
+| `name(input: value)` | Invoke imported program with inputs, receive outputs |
+
+You are the container that holds these declarations and wires them together at runtime. The program declares *what*; you determine *how* to connect them.
+
+---
+
+## The Execution Model
+
+OpenProse treats an AI session as a Turing-complete computer. You are the OpenProse VM:
+
+1. **You are the VM** - Parse and execute each statement
+2. **Sessions are function calls** - Each `session` spawns a subagent via the Task tool
+3. **Context is memory** - Variable bindings hold session outputs
+4. **Control flow is explicit** - Follow the program structure exactly
+
+### Core Principle
+
+The OpenProse VM follows the program structure **strictly** but uses **intelligence** for:
+- Evaluating discretion conditions (`**...**`)
+- Determining when a session is "complete"
+- Transforming context between sessions
+
+---
+
+## Syntax Grammar (Condensed)
+
+```
+program     := statement*
+
+statement   := useStatement | inputDecl | agentDef | session | letBinding
+             | constBinding | assignment | outputBinding | parallelBlock
+             | repeatBlock | forEachBlock | loopBlock | tryBlock | choiceBlock
+             | ifStatement | doBlock | blockDef | throwStatement | comment
+
+# Program Composition
+useStatement := "use" STRING ("as" NAME)?
+inputDecl   := "input" NAME ":" STRING
+outputBinding := "output" NAME "=" expression
+
+# Definitions
+agentDef    := "agent" NAME ":" INDENT property* DEDENT
+blockDef    := "block" NAME params? ":" INDENT statement* DEDENT
+params      := "(" NAME ("," NAME)* ")"
+
+# Sessions
+session     := "session" (STRING | ":" NAME) properties?
+properties  := INDENT property* DEDENT
+property    := "model:" ("sonnet" | "opus" | "haiku")
+             | "prompt:" STRING
+             | "context:" (NAME | "[" NAME* "]" | "{" NAME* "}")
+             | "retry:" NUMBER
+             | "backoff:" ("none" | "linear" | "exponential")
+             | "skills:" "[" STRING* "]"
+             | "permissions:" INDENT permission* DEDENT
+
+# Bindings
+letBinding  := "let" NAME "=" expression
+constBinding:= "const" NAME "=" expression
+assignment  := NAME "=" expression
+
+# Control Flow
+parallelBlock := "parallel" modifiers? ":" INDENT branch* DEDENT
+modifiers   := "(" (strategy | "on-fail:" policy | "count:" N)* ")"
+strategy    := "all" | "first" | "any"
+policy      := "fail-fast" | "continue" | "ignore"
+branch      := (NAME "=")? statement
+
+repeatBlock := "repeat" N ("as" NAME)? ":" INDENT statement* DEDENT
+forEachBlock:= "parallel"? "for" NAME ("," NAME)? "in" collection ":" INDENT statement* DEDENT
+loopBlock   := "loop" condition? ("(" "max:" N ")")? ("as" NAME)? ":" INDENT statement* DEDENT
+condition   := ("until" | "while") discretion
+
+# Error Handling
+tryBlock    := "try:" INDENT statement* DEDENT catch? finally?
+catch       := "catch" ("as" NAME)? ":" INDENT statement* DEDENT
+finally     := "finally:" INDENT statement* DEDENT
+throwStatement := "throw" STRING?
+
+# Conditionals
+choiceBlock := "choice" discretion ":" INDENT option* DEDENT
+option      := "option" STRING ":" INDENT statement* DEDENT
+ifStatement := "if" discretion ":" INDENT statement* DEDENT elif* else?
+elif        := "elif" discretion ":" INDENT statement* DEDENT
+else        := "else:" INDENT statement* DEDENT
+
+# Composition
+doBlock     := "do" (":" INDENT statement* DEDENT | NAME args?)
+args        := "(" expression* ")"
+arrowExpr   := session "->" session ("->" session)*
+programCall := NAME "(" (NAME ":" expression)* ")"
+
+# Pipelines
+pipeExpr    := collection ("|" pipeOp)+
+pipeOp      := ("map" | "filter" | "pmap") ":" INDENT statement* DEDENT
+             | "reduce" "(" NAME "," NAME ")" ":" INDENT statement* DEDENT
+
+# Primitives
+discretion  := "**" TEXT "**" | "***" TEXT "***"
+STRING      := '"' ... '"' | '"""' ... '"""'
+collection  := NAME | "[" expression* "]"
+comment     := "#" TEXT
+```
+
+---
+
+## Spawning Sessions
+
+Each `session` statement spawns a subagent using the **Task tool**:
+
+```
+session "Analyze the codebase"
+```
+
+Execute as:
+```
+Task({
+  description: "OpenProse session",
+  prompt: "Analyze the codebase",
+  subagent_type: "general-purpose"
+})
+```
+
+### With Agent Configuration
+
+```
+agent researcher:
+  model: opus
+  prompt: "You are a research expert"
+
+session: researcher
+  prompt: "Research quantum computing"
+```
+
+Execute as:
+```
+Task({
+  description: "OpenProse session",
+  prompt: "Research quantum computing\n\nSystem: You are a research expert",
+  subagent_type: "general-purpose",
+  model: "opus"
+})
+```
+
+### Property Precedence
+
+Session properties override agent defaults:
+1. Session-level `model:` overrides agent `model:`
+2. Session-level `prompt:` replaces (not appends) agent `prompt:`
+3. Agent `prompt:` becomes system context if session has its own prompt
+
+---
+
+## Parallel Execution
+
+`parallel:` blocks spawn multiple sessions concurrently:
+
+```prose
+parallel:
+  a = session "Task A"
+  b = session "Task B"
+  c = session "Task C"
+```
+
+Execute by calling Task multiple times in parallel:
+```
+// All three spawn simultaneously
+Task({ prompt: "Task A", ... })  // result -> a
+Task({ prompt: "Task B", ... })  // result -> b
+Task({ prompt: "Task C", ... })  // result -> c
+// Wait for all to complete, then continue
+```
+
+### Join Strategies
+
+| Strategy | Behavior |
+|----------|----------|
+| `"all"` (default) | Wait for all branches |
+| `"first"` | Return on first completion, cancel others |
+| `"any"` | Return on first success |
+| `"any", count: N` | Wait for N successes |
+
+### Failure Policies
+
+| Policy | Behavior |
+|--------|----------|
+| `"fail-fast"` (default) | Fail immediately on any error |
+| `"continue"` | Wait for all, then report errors |
+| `"ignore"` | Treat failures as successes |
+
+---
+
+## Evaluating Discretion Conditions
+
+Discretion markers (`**...**`) signal AI-evaluated conditions:
+
+```prose
+loop until **the code is bug-free**:
+  session "Find and fix bugs"
+```
+
+### Evaluation Approach
+
+1. **Context awareness**: Consider all prior session outputs
+2. **Semantic interpretation**: Understand the intent, not literal parsing
+3. **Conservative judgment**: When uncertain, continue iterating
+4. **Progress detection**: Exit if no meaningful progress is being made
+
+### Multi-line Conditions
+
+```prose
+if ***
+  the tests pass
+  and coverage exceeds 80%
+  and no linting errors
+***:
+  session "Deploy"
+```
+
+Triple-asterisks allow complex, multi-line conditions.
+
+---
+
+## Context Passing
+
+Variables capture session outputs and pass them to subsequent sessions:
+
+```prose
+let research = session "Research the topic"
+
+session "Write summary"
+  context: research
+```
+
+### Context Forms
+
+| Form | Usage |
+|------|-------|
+| `context: var` | Single variable |
+| `context: [a, b, c]` | Multiple variables as array |
+| `context: { a, b, c }` | Multiple variables as named object |
+| `context: []` | Empty context (fresh start) |
+
+### How Context is Passed
+
+When spawning a session with context:
+1. Include the referenced variable values in the prompt
+2. Format appropriately (summarize if needed)
+3. The subagent receives this as additional information
+
+Example execution:
+```
+// research = "Quantum computing uses qubits..."
+
+Task({
+  prompt: "Write summary\n\nContext:\nresearch: Quantum computing uses qubits...",
+  ...
+})
+```
+
+---
+
+## Program Composition
+
+Programs can import and invoke other programs, enabling modular workflows. Programs are fetched from the registry at `p.prose.md`.
+
+### Importing Programs
+
+Use the `use` statement to import a program:
+
+```prose
+use "@alice/research"
+use "@bob/critique" as critic
+```
+
+The import path follows the format `@handle/slug`. An optional alias (`as name`) allows referencing by a shorter name.
+
+### Program URL Resolution
+
+When the VM encounters a `use` statement:
+1. Fetch the program from `https://p.prose.md/@handle/slug`
+2. Parse the program to extract its contract (inputs/outputs)
+3. Register the program in the Import Registry
+
+### Input Declarations
+
+Inputs declare what values a program expects from its caller:
+
+```prose
+input topic: "The subject to research"
+input depth: "How deep to go (shallow, medium, deep)"
+```
+
+Inputs:
+- Are declared at the top of the program (before executable statements)
+- Have a name and a description (for documentation)
+- Become available as variables within the program body
+- Must be provided by the caller when invoking the program
+
+### Output Bindings
+
+Outputs declare what values a program produces for its caller. Use the `output` keyword at assignment time:
+
+```prose
+let raw = session "Research {topic}"
+output findings = session "Synthesize research"
+  context: raw
+output sources = session "Extract sources"
+  context: raw
+```
+
+The `output` keyword:
+- Marks a variable as an output (visible at assignment, not just at file top)
+- Works like `let` but also registers the value as a program output
+- Can appear anywhere in the program body
+- Multiple outputs are supported
+
+### Invoking Imported Programs
+
+Call an imported program by providing its inputs:
+
+```prose
+use "@alice/research" as research
+
+let result = research(topic: "quantum computing")
+```
+
+The result contains all outputs from the invoked program, accessible as properties:
+
+```prose
+session "Write summary"
+  context: result.findings
+
+session "Cite sources"
+  context: result.sources
+```
+
+### Destructuring Outputs
+
+For convenience, outputs can be destructured:
+
+```prose
+let { findings, sources } = research(topic: "quantum computing")
+```
+
+### Complete Composition Example
+
+A program that chains research and critique:
+
+```prose
+# research-loop.prose
+use "@alice/research" as research
+use "@alice/critique" as critic
+
+input topic: "What to investigate"
+
+# Iterate until quality is high
+let result
+loop until **critique score >= 8** (max: 3):
+  result = research(topic: topic)
+  review = critic(content: result.findings)
+
+output findings = result.findings
+output sources = result.sources
+output final_score = review.score
+```
+
+Invoking this composed program:
+
+```prose
+use "@bob/research-loop" as deep_research
+
+let final = deep_research(topic: "AI safety")
+session "Present findings"
+  context: final.findings
+```
+
+### Import Execution Semantics
+
+When a program invokes an imported program:
+
+1. **Bind inputs**: Map caller-provided values to the imported program's inputs
+2. **Execute**: Run the imported program (spawns its own sessions)
+3. **Collect outputs**: Gather all `output` bindings from the imported program
+4. **Return**: Make outputs available to the caller as a result object
+
+The imported program runs in its own execution context but shares the same VM session.
+
+---
+
+## Loop Execution
+
+### Fixed Loops
+
+```prose
+repeat 3:
+  session "Generate idea"
+```
+
+Execute the body exactly 3 times sequentially.
+
+```prose
+for topic in ["AI", "ML", "DL"]:
+  session "Research"
+    context: topic
+```
+
+Execute once per item, with `topic` bound to each value.
+
+### Parallel For-Each
+
+```prose
+parallel for item in items:
+  session "Process"
+    context: item
+```
+
+Fan-out: spawn all iterations concurrently, wait for all.
+
+### Unbounded Loops
+
+```prose
+loop until **task complete** (max: 10):
+  session "Work on task"
+```
+
+1. Check condition before each iteration
+2. Exit if condition satisfied OR max reached
+3. Execute body if continuing
+
+---
+
+## Error Propagation
+
+### Try/Catch Semantics
+
+```prose
+try:
+  session "Risky operation"
+catch as err:
+  session "Handle error"
+    context: err
+finally:
+  session "Cleanup"
+```
+
+Execution order:
+1. **Success**: try -> finally
+2. **Failure**: try (until fail) -> catch -> finally
+
+### Throw Behavior
+
+- `throw` inside catch: re-raise to outer handler
+- `throw "message"`: raise new error with message
+- Unhandled throws: propagate to outer scope or fail program
+
+### Retry Mechanism
+
+```prose
+session "Flaky API"
+  retry: 3
+  backoff: "exponential"
+```
+
+On failure:
+1. Retry up to N times
+2. Apply backoff delay between attempts
+3. If all retries fail, propagate error
+
+---
+
+## State Tracking
+
+OpenProse supports two state management systems. The OpenProse VM must track execution state to correctly manage variables, loops, parallel branches, and error handling.
+
+### State Categories
+
+| Category | What to Track | Example |
+|----------|---------------|---------|
+| **Import Registry** | Imported programs and aliases | `research: @alice/research` |
+| **Agent Registry** | All agent definitions | `researcher: {model: sonnet, prompt: "..."}` |
+| **Block Registry** | All block definitions (hoisted) | `review: {params: [topic], body: [...]}` |
+| **Input Bindings** | Inputs received from caller | `topic = "quantum computing"` |
+| **Output Bindings** | Outputs to return to caller | `findings = "Research shows..."` |
+| **Variable Bindings** | Name → value mapping | `research = "AI safety covers..."` |
+| **Variable Mutability** | Which are `let` vs `const` vs `output` | `research: let, findings: output` |
+| **Execution Position** | Current statement index | Statement 3 of 7 |
+| **Loop State** | Counter, max, condition | Iteration 2 of max 5 |
+| **Parallel State** | Branches, results, strategy | `{a: complete, b: pending}` |
+| **Error State** | Exception, retry count | Retry 2 of 3, error: "timeout" |
+| **Call Stack** | Nested block/program invocations | `[main, @alice/research, inner-loop]` |
+
+---
+
+## State Management: In-Context (Default)
+
+The default approach uses **structured narration** in the conversation history. The OpenProse VM "thinks aloud" to persist state—what you say becomes what you remember.
+
+### The Narration Protocol
+
+Use emoji-prefixed markers for each state change:
+
+| Emoji | Category | Usage |
+|-------|----------|-------|
+| 📋 | Program | Start, end, definition collection |
+| 📍 | Position | Current statement being executed |
+| 📦 | Binding | Variable assignment or update |
+| 📥 | Input | Receiving inputs from caller |
+| 📤 | Output | Producing outputs for caller |
+| 🔗 | Import | Fetching and invoking imported programs |
+| ✅ | Success | Session or block completion |
+| ⚠️ | Error | Failures and exceptions |
+| 🔀 | Parallel | Entering, branch status, joining |
+| 🔄 | Loop | Iteration, condition evaluation |
+| 🔗 | Pipeline | Stage progress |
+| 🛡️ | Error handling | Try/catch/finally |
+| ➡️ | Flow | Condition evaluation results |
+
+### Narration Patterns by Construct
+
+#### Session Statements
+```
+📍 Executing: session "Research the topic"
+   [Task tool call]
+✅ Session complete: "Research found that..."
+📦 let research = <result>
+```
+
+#### Parallel Blocks
+```
+🔀 Entering parallel block (3 branches, strategy: all)
+   - security: pending
+   - perf: pending
+   - style: pending
+   [Multiple Task calls]
+🔀 Parallel complete:
+   - security = "No vulnerabilities found..."
+   - perf = "Performance is acceptable..."
+   - style = "Code follows conventions..."
+📦 security, perf, style bound
+```
+
+#### Loop Blocks
+```
+🔄 Starting loop until **task complete** (max: 5)
+
+🔄 Iteration 1 of max 5
+   📍 session "Work on task"
+   ✅ Session complete
+   🔄 Evaluating: **task complete**
+   ➡️ Not satisfied, continuing
+
+🔄 Iteration 2 of max 5
+   📍 session "Work on task"
+   ✅ Session complete
+   🔄 Evaluating: **task complete**
+   ➡️ Satisfied!
+
+🔄 Loop exited: condition satisfied at iteration 2
+```
+
+#### Error Handling
+```
+🛡️ Entering try block
+📍 session "Risky operation"
+⚠️ Session failed: connection timeout
+📦 err = {message: "connection timeout"}
+🛡️ Executing catch block
+📍 session "Handle error" with context: err
+✅ Recovery complete
+🛡️ Executing finally block
+📍 session "Cleanup"
+✅ Cleanup complete
+```
+
+#### Variable Bindings
+```
+📦 let research = "AI safety research covers..." (mutable)
+📦 const config = {model: "opus"} (immutable)
+📦 research = "Updated research..." (reassignment, was: "AI safety...")
+```
+
+#### Input/Output Bindings
+```
+📥 Inputs received:
+   topic = "quantum computing" (from caller)
+   depth = "deep" (from caller)
+
+📤 output findings = "Research shows..." (will return to caller)
+📤 output sources = ["arxiv:2401.1234", ...] (will return to caller)
+```
+
+#### Program Imports
+```
+🔗 Importing: @alice/research
+   Fetching from: https://p.prose.md/@alice/research
+   Inputs expected: [topic, depth]
+   Outputs provided: [findings, sources]
+   Registered as: research
+
+🔗 Invoking: research(topic: "quantum computing")
+   📥 Passing inputs:
+      topic = "quantum computing"
+
+   [... imported program execution ...]
+
+   📤 Received outputs:
+      findings = "Quantum computing uses..."
+      sources = ["arxiv:2401.1234"]
+
+🔗 Import complete: research
+📦 result = { findings: "...", sources: [...] }
+```
+
+### Context Serialization
+
+When passing context to sessions, format appropriately:
+
+| Context Size | Strategy |
+|--------------|----------|
+| < 2000 chars | Pass verbatim |
+| 2000-8000 chars | Summarize to key points |
+| > 8000 chars | Extract essentials only |
+
+**Format:**
+```
+Context provided:
+---
+research: "Key findings about AI safety..."
+analysis: "Risk assessment shows..."
+---
+```
+
+### Complete Execution Trace Example
+
+```prose
+agent researcher:
+  model: sonnet
+
+let research = session: researcher
+  prompt: "Research AI safety"
+
+parallel:
+  a = session "Analyze risk A"
+  b = session "Analyze risk B"
+
+loop until **analysis complete** (max: 3):
+  session "Synthesize"
+    context: { a, b, research }
+```
+
+**Narration:**
+```
+📋 Program Start
+   Collecting definitions...
+   - Agent: researcher (model: sonnet)
+
+📍 Statement 1: let research = session: researcher
+   Spawning with prompt: "Research AI safety"
+   Model: sonnet
+   [Task tool call]
+✅ Session complete: "AI safety research covers alignment..."
+📦 let research = <result>
+
+📍 Statement 2: parallel block
+🔀 Entering parallel (2 branches, strategy: all)
+   [Task: "Analyze risk A"] [Task: "Analyze risk B"]
+🔀 Parallel complete:
+   - a = "Risk A: potential misalignment..."
+   - b = "Risk B: robustness concerns..."
+📦 a, b bound
+
+📍 Statement 3: loop until **analysis complete** (max: 3)
+🔄 Starting loop
+
+🔄 Iteration 1 of max 3
+   📍 session "Synthesize" with context: {a, b, research}
+   [Task with serialized context]
+   ✅ Result: "Initial synthesis shows..."
+   🔄 Evaluating: **analysis complete**
+   ➡️ Not satisfied (synthesis is preliminary)
+
+🔄 Iteration 2 of max 3
+   📍 session "Synthesize" with context: {a, b, research}
+   [Task with serialized context]
+   ✅ Result: "Comprehensive analysis complete..."
+   🔄 Evaluating: **analysis complete**
+   ➡️ Satisfied!
+
+🔄 Loop exited: condition satisfied at iteration 2
+
+📋 Program Complete
+```
+
+---
+
+## State Management: In-File
+
+For long-running programs, complex parallel execution, or resumable workflows, state can be persisted to the filesystem instead of relying solely on the conversation context.
+
+### Automatic State Mode Selection
+
+The OpenProse VM automatically chooses the appropriate state management mode at program start. This decision is based on program complexity:
+
+| Factor | In-Context | In-File |
+|--------|------------|---------|
+| Statement count | < 30 statements | ≥ 30 statements |
+| Parallel branches | < 5 concurrent | ≥ 5 concurrent |
+| Imported programs | 0-2 imports | ≥ 3 imports |
+| Nested depth | ≤ 2 levels | > 2 levels |
+| Expected duration | < 5 minutes | ≥ 5 minutes |
+
+The VM announces its choice at program start:
+
+```
+📋 Program Start
+   State mode: in-context (program is small, fits in context)
+
+   To use file-based state on next run, add: --state=file
+```
+
+Or for complex programs:
+
+```
+📋 Program Start
+   State mode: in-file (program has 47 statements, 3 imports)
+   State directory: .prose/execution/run-20260110-143052-a7b3c9/
+
+   To use in-context state on next run, add: --state=context
+```
+
+### Overriding State Mode
+
+Users can override the automatic selection by passing a flag:
+
+- `--state=context` — Force in-context state (narration only)
+- `--state=file` — Force file-based state (persistent)
+
+The flag can be passed when invoking the program or specified in the program itself:
+
+```prose
+# Force file-based state for this program
+# state: file
+
+input topic: "What to research"
+# ... rest of program
+```
+
+### Directory Structure
+
+```
+.prose/
+├── execution/
+│   └── run-{YYYYMMDD}-{HHMMSS}-{random}/
+│       ├── program.prose          # Copy of running program
+│       ├── position.json          # Current statement index
+│       ├── inputs/
+│       │   ├── {name}.md          # Input values received
+│       │   └── manifest.json      # Input metadata
+│       ├── outputs/
+│       │   ├── {name}.md          # Output values produced
+│       │   └── manifest.json      # Output metadata
+│       ├── variables/
+│       │   ├── {name}.md          # Variable values
+│       │   └── manifest.json      # Metadata (type, mutability)
+│       ├── imports/
+│       │   └── {handle}--{slug}/  # Nested program executions
+│       │       ├── inputs/
+│       │       ├── outputs/
+│       │       ├── variables/
+│       │       └── execution.log
+│       ├── parallel/
+│       │   └── {block-id}/
+│       │       ├── {branch}.md    # Branch results
+│       │       └── status.json    # Branch status
+│       ├── loops/
+│       │   └── {loop-id}.json     # Iteration state
+│       └── execution.log          # Full trace
+└── checkpoints/
+    └── {name}.json                # Resumable snapshots
+```
+
+### Session ID Format
+
+Each execution generates a unique session ID:
+```
+run-20260103-143052-a7b3c9
+```
+Format: `run-{YYYYMMDD}-{HHMMSS}-{6-char-random}`
+
+### File Formats
+
+#### position.json
+```json
+{
+  "session_id": "run-20260103-143052-a7b3c9",
+  "statement_index": 5,
+  "total_statements": 12,
+  "started_at": "2026-01-03T14:30:52Z",
+  "last_updated": "2026-01-03T14:32:15Z"
+}
+```
+
+#### inputs/manifest.json
+```json
+{
+  "inputs": [
+    {"name": "topic", "file": "topic.md", "received_at": "2026-01-03T14:30:52Z"},
+    {"name": "depth", "file": "depth.md", "received_at": "2026-01-03T14:30:52Z"}
+  ]
+}
+```
+
+#### inputs/{name}.md
+```markdown
+# Input: topic
+
+**Received from:** caller
+**Received at:** Statement 0 (program start)
+
+## Value
+
+quantum computing
+```
+
+#### outputs/manifest.json
+```json
+{
+  "outputs": [
+    {"name": "findings", "file": "findings.md", "bound_at": "Statement 5"},
+    {"name": "sources", "file": "sources.md", "bound_at": "Statement 6"}
+  ]
+}
+```
+
+#### outputs/{name}.md
+```markdown
+# Output: findings
+
+**Bound at:** Statement 5
+**Will return to:** caller
+
+## Value
+
+Quantum computing leverages quantum mechanical phenomena such as
+superposition and entanglement to perform computations. Key findings
+include...
+
+[Full value preserved]
+```
+
+#### variables/manifest.json
+```json
+{
+  "variables": [
+    {"name": "research", "type": "let", "file": "research.md"},
+    {"name": "config", "type": "const", "file": "config.md"}
+  ]
+}
+```
+
+#### variables/{name}.md
+```markdown
+# Variable: research
+
+**Type:** let (mutable)
+**Bound at:** Statement 3
+**Last updated:** Statement 7
+
+## Value
+
+AI safety research covers several key areas including alignment,
+robustness, and interpretability. The field has grown significantly
+since 2020 with major contributions from...
+
+[Full value preserved]
+```
+
+#### parallel/{block-id}/status.json
+```json
+{
+  "block_id": "parallel_stmt_5",
+  "strategy": "all",
+  "on_fail": "fail-fast",
+  "branches": [
+    {"name": "security", "status": "complete", "file": "security.md"},
+    {"name": "perf", "status": "complete", "file": "perf.md"},
+    {"name": "style", "status": "pending", "file": null}
+  ]
+}
+```
+
+#### loops/{loop-id}.json
+```json
+{
+  "loop_id": "loop_stmt_8",
+  "type": "until",
+  "condition": "**analysis complete**",
+  "max": 5,
+  "current_iteration": 2,
+  "condition_history": [
+    {"iteration": 1, "result": false, "reason": "synthesis preliminary"},
+    {"iteration": 2, "result": true, "reason": "comprehensive analysis"}
+  ]
+}
+```
+
+### In-File Execution Protocol
+
+When the VM selects (or is configured for) in-file state management:
+
+1. **Program Start**
+   ```
+   📋 Program Start
+      State mode: in-file (program has 47 statements, 3 imports)
+      State directory: .prose/execution/run-20260103-143052-a7b3c9/
+
+      To use in-context state on next run, add: --state=context
+   ```
+
+2. **After Each Statement**
+   - Update `position.json`
+   - Write/update affected variable files
+   - Append to `execution.log`
+
+3. **Variable Binding**
+   ```
+   📦 let research = <value>
+      Written to: .prose/execution/.../variables/research.md
+   ```
+
+4. **Parallel Execution**
+   - Create `parallel/{block-id}/` directory
+   - Write each branch result as it completes
+   - Update `status.json` after each branch
+
+5. **Loop Execution**
+   - Create `loops/{loop-id}.json` at loop start
+   - Update after each iteration with condition result
+
+6. **Checkpointing**
+   When user requests or at natural break points:
+   ```
+   💾 Checkpoint saved: .prose/checkpoints/before-deploy.json
+   ```
+
+### Resuming Execution
+
+If execution is interrupted, resume with:
+```
+"Resume the OpenProse program from the last checkpoint"
+```
+
+The OpenProse VM:
+1. Reads `.prose/execution/run-.../position.json`
+2. Loads variables from `variables/`
+3. Continues from `statement_index`
+
+### Hybrid Approach
+
+For most programs, use a hybrid:
+- **In-context** for small variables and recent state
+- **In-file** for large values (> 5000 chars) and checkpoints
+
+```
+📦 let summary = <short value, kept in-context>
+📦 let full_report = <large value>
+   Written to: .prose/execution/.../variables/full_report.md
+   In-context: [reference to file]
+```
+
+---
+
+## Choice and Conditional Execution
+
+### Choice Blocks
+
+```prose
+choice **the severity level**:
+  option "Critical":
+    session "Escalate immediately"
+  option "Minor":
+    session "Log for later"
+```
+
+1. Evaluate the discretion criteria
+2. Select the most appropriate option
+3. Execute only that option's body
+
+### If/Elif/Else
+
+```prose
+if **has security issues**:
+  session "Fix security"
+elif **has performance issues**:
+  session "Optimize"
+else:
+  session "Approve"
+```
+
+1. Evaluate conditions in order
+2. Execute first matching branch
+3. Skip remaining branches
+
+---
+
+## Block Invocation
+
+### Defining Blocks
+
+```prose
+block review(topic):
+  session "Research {topic}"
+  session "Analyze {topic}"
+```
+
+Blocks are hoisted - can be used before definition.
+
+### Invoking Blocks
+
+```prose
+do review("quantum computing")
+```
+
+1. Substitute arguments for parameters
+2. Execute block body
+3. Return to caller
+
+---
+
+## Pipeline Execution
+
+```prose
+let results = items
+  | filter:
+      session "Keep? yes/no"
+        context: item
+  | map:
+      session "Transform"
+        context: item
+```
+
+Execute left-to-right:
+1. **filter**: Keep items where session returns truthy
+2. **map**: Transform each item via session
+3. **reduce**: Accumulate items pairwise
+4. **pmap**: Like map but concurrent
+
+---
+
+## String Interpolation
+
+```prose
+let name = session "Get user name"
+session "Hello {name}, welcome!"
+```
+
+Before spawning, substitute `{varname}` with variable values.
+
+---
+
+## Complete Execution Algorithm
+
+```
+function execute(program, inputs?):
+  1. Collect all use statements, fetch and register imports
+  2. Collect all input declarations, bind values from caller
+  3. Collect all agent definitions
+  4. Collect all block definitions
+  5. For each statement in order:
+     - If session: spawn via Task, await result
+     - If let/const: execute RHS, bind result
+     - If output: execute RHS, bind result, register as output
+     - If program call: invoke imported program with inputs, receive outputs
+     - If parallel: spawn all branches, await per strategy
+     - If loop: evaluate condition, execute body, repeat
+     - If try: execute try, catch on error, always finally
+     - If choice/if: evaluate condition, execute matching branch
+     - If do block: invoke block with arguments
+  6. Handle errors according to try/catch or propagate
+  7. Collect all output bindings
+  8. Return outputs to caller (or final result if no outputs declared)
+```
+
+---
+
+## Implementation Notes
+
+### Task Tool Usage
+
+Always use Task for session execution:
+```
+Task({
+  description: "OpenProse session",
+  prompt: "<session prompt with context>",
+  subagent_type: "general-purpose",
+  model: "<optional model override>"
+})
+```
+
+### Parallel Execution
+
+Make multiple Task calls in a single response for true concurrency:
+```
+// In one response, call all three:
+Task({ prompt: "A" })
+Task({ prompt: "B" })
+Task({ prompt: "C" })
+```
+
+### Context Serialization
+
+When passing context to sessions:
+- Prefix with clear labels
+- Keep relevant information
+- Summarize if very long
+- Maintain semantic meaning
+
+---
+
+## Summary
+
+The OpenProse VM:
+
+1. **Imports** programs from `p.prose.md` via `use` statements
+2. **Binds** inputs from caller to program variables
+3. **Parses** the program structure
+4. **Collects** definitions (agents, blocks)
+5. **Executes** statements sequentially
+6. **Spawns** sessions via Task tool
+7. **Invokes** imported programs with inputs, receives outputs
+8. **Coordinates** parallel execution
+9. **Evaluates** discretion conditions intelligently
+10. **Manages** context flow between sessions
+11. **Handles** errors with try/catch/retry
+12. **Tracks** state in working memory (or files)
+13. **Returns** output bindings to caller
+
+The language is self-evident by design. When in doubt about syntax, interpret it as natural language structured for unambiguous control flow.

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -41,7 +41,7 @@ agent architect:
     - Backward compatibility notes
   """
 
-agent implementer:
+agent implementor:
   model: opus
   prompt: """
     You implement a planned parity gap in TypeScript with:
@@ -104,7 +104,7 @@ loop until **all planned parity gaps are implemented or explicitly marked Not Pl
   next_pr = session: architect
     prompt: "Pick the next highest-priority, unblocked PR slice. Return a PR plan object with: title, scope, acceptance_criteria, files_to_change, tests_to_add, risk_notes, and rollout_notes."
 
-  session: implementer
+  session: implementor
     prompt: "Implement the selected PR slice end-to-end: create a branch, implement changes, run tests/lint/typecheck, open a PR against enyst/OpenHands-Tab, and link it to issue #1. Keep the PR small and reviewable (one gap/cluster)."
     context: next_pr
 

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -16,7 +16,7 @@ input ts_sdk_path: "packages/agent-sdk-ts"
 # - Implementation PRs: one PR per gap (or per cohesive cluster) with tests
 
 agent auditor:
-  model: sonnet
+  model: gpt-5.2
   prompt: """
     You audit two codebases (TS SDK and Python SDK) and produce an accurate parity report.
 
@@ -28,7 +28,7 @@ agent auditor:
   """
 
 agent architect:
-  model: sonnet
+  model: gpt-5.2
   prompt: """
     You design TS-idiomatic implementations that match Python behavior, while respecting OpenHands-Tab constraints:
     - VS Code extension runtime constraints
@@ -42,7 +42,7 @@ agent architect:
   """
 
 agent implementer:
-  model: sonnet
+  model: gpt-5.2
   prompt: """
     You implement a planned parity gap in TypeScript with:
     - smallest correct change

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -1,0 +1,130 @@
+# Program: Keep agent-sdk-ts aligned with upstream python Software Agent SDK
+# Repo: enyst/OpenHands-Tab
+# Upstream: OpenHands/software-agent-sdk
+# Issue: #1 Update agent-sdk-ts from upstream python agent-sdk behavior
+
+# Inputs
+input oh_tab_repo: "https://github.com/enyst/OpenHands-Tab.git"
+input oh_tab_branch_prefix: "openhands/"
+input upstream_repo: "https://github.com/OpenHands/software-agent-sdk.git"
+input upstream_ref: "main"  # can be branch, tag, or commit
+input ts_sdk_path: "packages/agent-sdk-ts"
+
+# Output artifacts
+# - Updated parity doc: packages/agent-sdk-ts/docs/python-parity.md
+# - TS architecture docs: docs/agent-sdk-architecture.md (addendum) and/or docs/settings_prd.md additions, plus new docs files as needed
+# - Implementation PRs: one PR per gap (or per cohesive cluster) with tests
+
+agent auditor:
+  model: sonnet
+  prompt: """
+    You audit two codebases (TS SDK and Python SDK) and produce an accurate parity report.
+
+    Requirements:
+    - Be concrete: name file paths, class/function names, and observable behavior.
+    - Separate 'missing' vs 'implemented but different'.
+    - For each gap, write: user impact, API surface, runtime behavior, and testability.
+    - Prefer truth over aspiration.
+  """
+
+agent architect:
+  model: sonnet
+  prompt: """
+    You design TS-idiomatic implementations that match Python behavior, while respecting OpenHands-Tab constraints:
+    - VS Code extension runtime constraints
+    - existing TS architecture (Conversation/LLMStreamer/tools/workspace)
+    - preference for minimal, composable abstractions
+
+    Deliverables:
+    - Proposed TS design for each gap
+    - Migration plan if API changes are needed
+    - Backward compatibility notes
+  """
+
+agent implementer:
+  model: sonnet
+  prompt: """
+    You implement a planned parity gap in TypeScript with:
+    - smallest correct change
+    - unit tests for new behavior
+    - updated docs when needed
+
+    You should open a separate PR per gap/cluster.
+  """
+
+agent release_manager:
+  model: haiku
+  prompt: """
+    You coordinate:
+    - branch creation
+    - commits
+    - PR creation
+    - linking PRs to issue #1
+
+    You keep PRs small and reviewable.
+  """
+
+# Phase 0: Working agreements and definitions
+session "Define the contract for 'parity' and the update cadence"
+  context: { oh_tab_repo, upstream_repo, upstream_ref, ts_sdk_path }
+
+# Definition notes (VM guidance):
+# - Parity is defined at the level of public API + observable runtime behavior for OpenHands-Tab use.
+# - If a Python feature is 'not planned' for TS, document explicitly with rationale and decision owner.
+# - Prefer capturing parity as checklists with source links, not prose only.
+
+# Phase 1: Codebase discovery
+parallel:
+  ts_map = session: auditor
+    prompt: "Clone and map the TS SDK surface area. Summarize modules, public exports, and runtime entry points. Identify where python-parity.md is currently inaccurate or outdated."
+    context: { oh_tab_repo, ts_sdk_path }
+
+  py_map = session: auditor
+    prompt: "Clone and map the Python SDK surface area. Summarize modules, public exports, and agent-server integration points. Identify features likely to affect TS parity."
+    context: { upstream_repo, upstream_ref }
+
+session: auditor
+  prompt: "Build a feature-by-feature parity matrix from the TS and Python maps, grouped by: Conversation API, tools, skills/context, hooks, MCP, workspace, persistence, security, event schema."
+  context: { ts_map, py_map }
+
+# Phase 2: Update parity doc (part 1 goal)
+# Output: packages/agent-sdk-ts/docs/python-parity.md
+session: auditor
+  prompt: "Update the parity doc with the real current status. Add: (a) methodology and how to re-run the audit, (b) per-feature status (Implemented / Divergent / Missing / Not planned), (c) explicit links to files/functions in both repos, (d) a prioritized gap list with estimated effort and risk."
+  context: { ts_map, py_map }
+
+# Phase 3: Architecture design for TS variant (part 2 goal)
+# Output: docs/PRD.md addendum and new docs under docs/
+# Note: keep design TS-idiomatic; do not blindly mirror Python internal abstractions.
+
+session: architect
+  prompt: "For each prioritized parity gap, propose a TS-idiomatic design. For each design: public API changes (if any), internal modules, data flow, error handling, and how it will be tested. Produce a PRD-style doc and add/extend architecture docs in OpenHands-Tab." 
+  context: { ts_map, py_map }
+
+# Phase 4: Implementation plan + PR slicing (part 3 goal)
+# Output: Implementation PR plan as checklist and initial PRs
+
+session: architect
+  prompt: "Slice the gap list into small PRs. For each PR: scope, acceptance criteria, tests to add, and rollout notes. Identify any prerequisite refactors."
+  context: { ts_map, py_map }
+
+# Phase 5: Execute implementation PRs
+# Repeat per PR slice.
+
+loop until **all planned parity gaps are implemented or explicitly marked Not Planned with rationale** (max: 50):
+  next_pr = session: release_manager
+    prompt: "Pick the next highest-priority, unblocked PR slice. Create a branch, implement the changes (delegate to implementer), run tests/lint/typecheck, and open a PR against enyst/OpenHands-Tab."
+
+  session: implementer
+    prompt: "Implement the selected PR slice. Ensure tests cover the new behavior and update docs if behavior changes."
+    context: next_pr
+
+  session: release_manager
+    prompt: "Open the PR, link to issue #1, summarize changes, and list follow-up work."
+    context: next_pr
+
+# Completion
+session "Summarize parity status, open PR links, and remaining work"
+  context: { ts_map, py_map }
+
+output results = "A set of PRs updating docs and implementing TS parity improvements, each linked to issue #1." 

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -15,10 +15,10 @@ input ts_sdk_path: "packages/agent-sdk-ts"
 # - TS architecture docs: docs/agent-sdk-architecture.md (addendum) and/or docs/settings_prd.md additions, plus new docs files as needed
 # - Implementation PRs: one PR per gap (or per cohesive cluster) with tests
 
-agent auditor:
+agent reviewer:
   model: opus
   prompt: """
-    You audit two codebases (TS SDK and Python SDK) and produce an accurate parity report.
+    You review two codebases (TS SDK and Python SDK) and produce an accurate parity report.
 
     Requirements:
     - Be concrete: name file paths, class/function names, and observable behavior.
@@ -52,17 +52,6 @@ agent implementer:
     You should open a separate PR per gap/cluster.
   """
 
-agent release_manager:
-  model: opus
-  prompt: """
-    You coordinate:
-    - branch creation
-    - commits
-    - PR creation
-    - linking PRs to issue #1
-
-    You keep PRs small and reviewable.
-  """
 
 # Phase 0: Working agreements and definitions
 session "Define the contract for 'parity' and the update cadence"
@@ -75,21 +64,21 @@ session "Define the contract for 'parity' and the update cadence"
 
 # Phase 1: Codebase discovery
 parallel:
-  ts_map = session: auditor
+  ts_map = session: reviewer
     prompt: "Clone and map the TS SDK surface area. Summarize modules, public exports, and runtime entry points. Identify where python-parity.md is currently inaccurate or outdated."
     context: { oh_tab_repo, ts_sdk_path }
 
-  py_map = session: auditor
+  py_map = session: reviewer
     prompt: "Clone and map the Python SDK surface area. Summarize modules, public exports, and agent-server integration points. Identify features likely to affect TS parity."
     context: { upstream_repo, upstream_ref }
 
-session: auditor
+session: reviewer
   prompt: "Build a feature-by-feature parity matrix from the TS and Python maps, grouped by: Conversation API, tools, skills/context, hooks, MCP, workspace, persistence, security, event schema."
   context: { ts_map, py_map }
 
 # Phase 2: Update parity doc (part 1 goal)
 # Output: packages/agent-sdk-ts/docs/python-parity.md
-session: auditor
+session: reviewer
   prompt: "Update the parity doc with the real current status. Add: (a) methodology and how to re-run the audit, (b) per-feature status (Implemented / Divergent / Missing / Not planned), (c) explicit links to files/functions in both repos, (d) a prioritized gap list with estimated effort and risk."
   context: { ts_map, py_map }
 
@@ -112,15 +101,11 @@ session: architect
 # Repeat per PR slice.
 
 loop until **all planned parity gaps are implemented or explicitly marked Not Planned with rationale** (max: 50):
-  next_pr = session: release_manager
-    prompt: "Pick the next highest-priority, unblocked PR slice. Create a branch, implement the changes (delegate to implementer), run tests/lint/typecheck, and open a PR against enyst/OpenHands-Tab."
+  next_pr = session: architect
+    prompt: "Pick the next highest-priority, unblocked PR slice. Return a PR plan object with: title, scope, acceptance_criteria, files_to_change, tests_to_add, risk_notes, and rollout_notes."
 
   session: implementer
-    prompt: "Implement the selected PR slice. Ensure tests cover the new behavior and update docs if behavior changes."
-    context: next_pr
-
-  session: release_manager
-    prompt: "Open the PR, link to issue #1, summarize changes, and list follow-up work."
+    prompt: "Implement the selected PR slice end-to-end: create a branch, implement changes, run tests/lint/typecheck, open a PR against enyst/OpenHands-Tab, and link it to issue #1. Keep the PR small and reviewable (one gap/cluster)."
     context: next_pr
 
 # Completion

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -16,7 +16,7 @@ input ts_sdk_path: "packages/agent-sdk-ts"
 # - Implementation PRs: one PR per gap (or per cohesive cluster) with tests
 
 agent auditor:
-  model: gpt-5.2
+  model: opus
   prompt: """
     You audit two codebases (TS SDK and Python SDK) and produce an accurate parity report.
 
@@ -28,7 +28,7 @@ agent auditor:
   """
 
 agent architect:
-  model: gpt-5.2
+  model: opus
   prompt: """
     You design TS-idiomatic implementations that match Python behavior, while respecting OpenHands-Tab constraints:
     - VS Code extension runtime constraints
@@ -42,7 +42,7 @@ agent architect:
   """
 
 agent implementer:
-  model: gpt-5.2
+  model: opus
   prompt: """
     You implement a planned parity gap in TypeScript with:
     - smallest correct change
@@ -53,7 +53,7 @@ agent implementer:
   """
 
 agent release_manager:
-  model: haiku
+  model: opus
   prompt: """
     You coordinate:
     - branch creation

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -61,7 +61,15 @@ vi.mock('@openhands/agent-sdk-ts', () => {
   }
 
   class AgentContext {
-    constructor(_params?: unknown) {}
+    static lastParams: any = null;
+
+    constructor(params?: any) {
+      AgentContext.lastParams = params ?? null;
+    }
+
+    static __getLastParams() {
+      return AgentContext.lastParams;
+    }
   }
 
   class SecretRegistry {
@@ -114,6 +122,7 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     AgentContext,
     Conversation,
     SecretRegistry,
+    loadSkillsFromDir: vi.fn(() => ({ repoSkills: new Map(), knowledgeSkills: new Map(), agentSkills: new Map() })),
     isBashCommand: vi.fn((event: any) => event?.type === 'BashCommand'),
     isBashOutput: vi.fn((event: any) => event?.type === 'BashOutput'),
     isBashExit: vi.fn((event: any) => event?.type === 'BashExit'),
@@ -123,6 +132,8 @@ vi.mock('@openhands/agent-sdk-ts', () => {
     isTextContent: vi.fn((content: any) => content?.type === 'text'),
     __getLastConversation: () => lastConversation,
     TerminalTool: vi.fn(() => new StubTool('terminal')),
+    __getLastAgentContextParams: () => AgentContext.__getLastParams(),
+
     FileEditorTool: vi.fn(() => new StubTool('file_editor')),
     TaskTrackerTool: vi.fn(() => new StubTool('task_tracker')),
     GlobTool: vi.fn(() => new StubTool('glob')),
@@ -900,8 +911,14 @@ describe('Settings and modes', () => {
     await extension.activate(mockContext);
     await resolveChatView(mockContext);
 
-    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+    const sdk = await import('@openhands/agent-sdk-ts');
+    const conv = sdk.__getLastConversation?.();
     expect(conv?.mode).toBe('local');
+
+    const agentContextParams = sdk.__getLastAgentContextParams?.();
+    expect(agentContextParams).toBeTruthy();
+    expect(agentContextParams?.loadUserSkills).toBe(true);
+    expect(sdk.loadSkillsFromDir).toHaveBeenCalledWith(path.join('/test/workspace', '.openhands', 'skills'));
   });
 
   it('streams BashEvents into the OpenHands terminal log in local mode', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,6 +39,7 @@ import {
   SecretRegistry,
   listProfiles,
   loadSkillsFromDir,
+  type Skill,
   type BashEvent,
   type Event,
   isBashCommand,
@@ -467,7 +468,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (desiredMode !== 'local' || !workspaceRoot) return undefined;
 
         const skillsDir = path.join(workspaceRoot, '.openhands', 'skills');
-        let skills: unknown[] = [];
+        let skills: Skill[] = [];
         try {
           const { repoSkills, knowledgeSkills, agentSkills } = loadSkillsFromDir(skillsDir);
           skills = [...repoSkills.values(), ...knowledgeSkills.values(), ...agentSkills.values()];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,6 +38,7 @@ import {
   type ConversationInstance,
   SecretRegistry,
   listProfiles,
+  loadSkillsFromDir,
   type BashEvent,
   type Event,
   isBashCommand,
@@ -462,10 +463,23 @@ export function activate(context: vscode.ExtensionContext) {
           : undefined;
       conversationStoreRoot = persistenceDir;
 
-      const agentContext =
-        desiredMode === 'local'
-          ? new AgentContext({ loadUserSkills: true })
-          : undefined;
+      const agentContext = (() => {
+        if (desiredMode !== 'local' || !workspaceRoot) return undefined;
+
+        const skillsDir = path.join(workspaceRoot, '.openhands', 'skills');
+        let skills: unknown[] = [];
+        try {
+          const { repoSkills, knowledgeSkills, agentSkills } = loadSkillsFromDir(skillsDir);
+          skills = [...repoSkills.values(), ...knowledgeSkills.values(), ...agentSkills.values()];
+        } catch (err) {
+          outputChannel?.appendLine(`[skills] Failed to load project skills from ${skillsDir}: ${renderError(err)}`);
+        }
+
+        return new AgentContext({
+          skills,
+          loadUserSkills: true,
+        });
+      })();
       localAgentContext = desiredMode === 'local' ? agentContext : undefined;
       if (desiredMode === 'local') {
         syncActiveEditorSystemMessageSuffix(vscode.window.activeTextEditor);


### PR DESCRIPTION
### Context
This PR adds an OpenProse program specification describing the workflow to keep `packages/agent-sdk-ts` aligned with the behavior and APIs of the upstream Python SDK (`OpenHands/software-agent-sdk`).

### What changed
- Added `docs/programs/agent-sdk-ts-upstream-parity.prose`: a multi-phase OpenProse program covering:
  1) updating the parity doc (`packages/agent-sdk-ts/docs/python-parity.md`)
  2) designing TS-idiomatic architecture for parity gaps
  3) slicing + implementing gaps as small PRs (with tests)

### Why
Issue #1 requests a program spec in OpenProse that can drive ongoing parity work between the TS SDK (used by OpenHands-Tab) and the Python reference SDK.

Fixes #1


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/acb054c640194c819ff9994dddd3b90a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenProse skill and enabled automatic discovery/loading of workspace skills.

* **Documentation**
  * Added comprehensive OpenProse language reference, VM/execution guide, design patterns, and antipatterns.
  * Added a TypeScript–Python agent SDK parity workflow document.

* **Tests**
  * Enhanced tests to verify skill-loading behavior and agent context propagation.

* **Chores**
  * Adjusted repository ignore rules and guidance for local runtime data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->