### PR TITLE
agent-sdk-ts: match Python tool error messages (no truncation)

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -1085,6 +1085,19 @@ interface ToolExecutor {
 - Tool handlers now expose zod schemas to validate inputs and surface JSON schemas for LLM tool definitions (`src/tools/zod-tool.ts`).
 - `Agent` injects tool descriptions into the system prompt so models see name + description context alongside function metadata.
 
+
+### Tool output truncation and error messages
+
+The SDK keeps tool output readable for the model by truncating **tool result** text before it is sent back to the LLM:
+
+- Shared truncation utility: `src/sdk/runtime/toolResultTruncation.ts`
+- Marker: `<response clipped>`
+- Limit: 8,000 characters (head + tail)
+
+For **tool error** messages, the SDK aims to match Python behavior: `AgentErrorEvent` is converted into a `role="tool"` message whose text content is the raw error string (no JSON encoding, no truncation).
+
+- Source: `src/sdk/runtime/toolCallErrorEvents.ts`
+
 ### TerminalTool
 
 **File**: `src/tools/TerminalTool.ts`

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -10,6 +10,31 @@ This document is the living output for Beads issue `oh-tab-0rq`.
 - Python reference SDK: `~/repos/agent-sdk` ([OpenHands/software-agent-sdk](https://github.com/OpenHands/software-agent-sdk)).
 - Focus: VS Code local-mode parity and remote conversation working correctly (no agent-server implementation in TS).
 
+## How to re-run this audit
+
+1. Clone both repos:
+
+   - This repo: `enyst/OpenHands-Tab` (folder: `packages/agent-sdk-ts`)
+   - Upstream: `OpenHands/software-agent-sdk`
+
+2. Record the upstream ref/commit you audited against in this doc.
+
+   - Last audited against upstream commit: `6a004a1d53d30fe09d9812753a57c69ec0a32036` (2026-01-14)
+
+3. Compare the wire-format and runtime behavior (not just types):
+
+   - Events → LLM messages: Python `openhands-sdk/openhands/sdk/event/llm_convertible/*` vs TS `packages/agent-sdk-ts/src/sdk/runtime/*`
+   - Tool schemas + validation: Python `openhands-sdk/openhands/sdk/tool/*` vs TS `packages/agent-sdk-ts/src/sdk/tools/*`
+   - Conversation persistence + resume: Python `openhands-sdk/openhands/sdk/conversation/*` vs TS `packages/agent-sdk-ts/src/sdk/conversation/*`
+
+4. Run TS SDK unit tests before/after changes:
+
+   ```bash
+   npm install
+   npm test -w @openhands/agent-sdk-ts
+   ```
+
+
 ## Module structure overview
 
 Quick reference for module-level parity between Python and TypeScript SDKs.
@@ -118,13 +143,15 @@ Quick reference for module-level parity between Python and TypeScript SDKs.
 | **ask_oracle** | ✗ Not in Python | Delegates to oracle LLM | TS only |
 | **browser (HTTP)** | ✗ Not in Python | Simple HTTP fetch | TS only |
 
-## Current parity snapshot (2026-01-13)
+## Current parity snapshot (2026-01-14)
 
 ### Tool error messages (MessageEvent with role="tool")
-- Python: `events_to_messages` converts `AgentErrorEvent` to a tool Message with plain text error content. No JSON encoding.
-- TypeScript: `createToolCallErrorEvents` emits a tool MessageEvent with plain text error content (not JSON).
-- Truncation: TS caps error text at 4096 chars and appends " (truncated)"; Python does not enforce a 4096 cap in conversion.
-- **Status**: Content format aligned (plain text); truncation policy diverges.
+- Python: `AgentErrorEvent.to_llm_message()` emits a `role="tool"` message with plain text `error` content (no JSON encoding, no truncation).
+  - Source: `openhands-sdk/openhands/sdk/event/llm_convertible/observation.py`
+- TypeScript: `createToolCallErrorEvents()` emits a `MessageEvent` with `role="tool"` and plain text `error` content (no JSON encoding, no truncation).
+  - Source: `packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts`
+- Note: non-error tool outputs are still truncated for LLM safety (shared `<response clipped>` marker) via `packages/agent-sdk-ts/src/sdk/runtime/toolResultTruncation.ts`.
+- **Status**: Aligned.
 
 ### Tool-call argument redaction
 - Python: Secrets masking via `SecretRegistry.mask_secrets_in_output` for tool observations.

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts
@@ -19,7 +19,7 @@ describe('toolCallErrorEvents truncation and normalization', () => {
     expect(text).toBe(messy);
   });
 
-  it('clips long tool error messages for LLM using the shared tool-message clip marker', () => {
+  it('does not clip long tool error messages (python parity)', () => {
     const toolCall = makeToolCall('t2', 'echo');
     const longBase = 'A'.repeat(10_000);
     const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, longBase);
@@ -28,7 +28,6 @@ describe('toolCallErrorEvents truncation and normalization', () => {
     expect(err).toBe(longBase);
 
     const toolErr = (toolMessageEvent.llm_message.content[0] as { type: 'text'; text: string }).text;
-    expect(toolErr.length).toBeLessThanOrEqual(8000);
-    expect(toolErr).toContain('<response clipped>');
+    expect(toolErr).toBe(longBase);
   });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/toolCallErrorEvents.ts
@@ -21,7 +21,11 @@ export const createToolCallErrorEvents = (
   error: string,
 ): { agentErrorEvent: AgentErrorEvent; toolMessageEvent: MessageEvent } => {
   const rawMessage = normalizeErrorMessage(error);
-  const message = truncateToolMessage(rawMessage);
+
+  // IMPORTANT (python parity): AgentErrorEvent -> tool MessageEvent content must be the
+  // raw error string (no JSON encoding, no truncation).
+  const message = rawMessage;
+
   const toolName = toolCall.function.name;
   const toolCallId = toolCall.id;
 


### PR DESCRIPTION
This PR aligns `AgentErrorEvent` → `role="tool"` message behavior with the upstream Python SDK.

Changes:
- Stop truncating tool error messages in `createToolCallErrorEvents` (raw text, no JSON encoding, no truncation).
- Update TS parity doc to include rerun methodology and reflect the now-aligned behavior.
- Document tool-result truncation vs tool-error behavior in `docs/agent-sdk-architecture.md`.

Upstream reference:
- `openhands-sdk/openhands/sdk/event/llm_convertible/observation.py` (`AgentErrorEvent.to_llm_message`)

Tests:
- `npm test -w @openhands/agent-sdk-ts`

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)