### PR TITLE
docs: refresh agent-sdk-ts upstream parity .prose program

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -286,3 +286,12 @@ Pitfalls to avoid
 - [docs/agent-sdk-architecture.md](docs/agent-sdk-architecture.md) - SDK architecture
 - [docs/vscode_local_setup.md](docs/vscode_local_setup.md) - Local development setup
 - [packages/agent-sdk-ts/AGENTS.md](packages/agent-sdk-ts/AGENTS.md) - SDK-specific guidelines
+
+
+## OpenProse notes
+
+- OpenProse skill docs are vendored at `OpenHands-Tab/.openhands/skills/open-prose/`.
+- The agent-sdk-ts parity program lives at `docs/programs/agent-sdk-ts-upstream-parity.prose`.
+- Opening PRs via the OpenHands `create_pr` tool expects:
+  - `repo_name`, `source_branch`, `target_branch`, `title`, `body`
+

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -1,7 +1,8 @@
 # Program: Keep agent-sdk-ts aligned with upstream python Software Agent SDK
 # Repo: enyst/OpenHands-Tab
 # Upstream: OpenHands/software-agent-sdk
-# Issue: #1 Update agent-sdk-ts from upstream python agent-sdk behavior
+# Tracking: link PRs to the relevant open parity issue(s) in enyst/OpenHands-Tab.
+# (The parity work is typically tracked across multiple issues; examples at time of writing include #634, #658, #662, #663, #667, #570.)
 
 # Inputs
 input oh_tab_repo: "https://github.com/enyst/OpenHands-Tab.git"
@@ -105,7 +106,7 @@ loop until **all planned parity gaps are implemented or explicitly marked Not Pl
     prompt: "Pick the next highest-priority, unblocked PR slice. Return a PR plan object with: title, scope, acceptance_criteria, files_to_change, tests_to_add, risk_notes, and rollout_notes."
 
   session: implementor
-    prompt: "Implement the selected PR slice end-to-end: create a branch, implement changes, run tests/lint/typecheck, open a PR against enyst/OpenHands-Tab, and link it to issue #1. Keep the PR small and reviewable (one gap/cluster)."
+    prompt: "Implement the selected PR slice end-to-end: create a branch, implement changes, run tests/lint/typecheck, open a PR against enyst/OpenHands-Tab, and link it to the relevant parity tracking issue. Keep the PR small and reviewable (one gap/cluster)."
     context: next_pr
 
 # Completion

--- a/docs/programs/agent-sdk-ts-upstream-parity.prose
+++ b/docs/programs/agent-sdk-ts-upstream-parity.prose
@@ -113,4 +113,4 @@ loop until **all planned parity gaps are implemented or explicitly marked Not Pl
 session "Summarize parity status, open PR links, and remaining work"
   context: { ts_map, py_map }
 
-output results = "A set of PRs updating docs and implementing TS parity improvements, each linked to issue #1." 
+output results = "A set of PRs updating docs and implementing TS parity improvements, each linked to the relevant issue number." 


### PR DESCRIPTION
This updates `docs/programs/agent-sdk-ts-upstream-parity.prose` to remove the stale reference to issue 1 on enyst/open-prose and instead instruct linking PRs to the relevant open parity tracking issue(s).

No runtime behavior changes.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated user-facing prompts to reference parity tracking issues more generically.
  * Added OpenProse notes section with guidance on vendoring location, parity program path, and PR tool usage details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->