### PR TITLE
chore/vscodeignore reduce vsix size

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -30,6 +30,7 @@ media/screenshots/**
 .claude/**
 .codex/**
 .beads/**
+.openhands/**
 
 # Scripts and misc tooling
 scripts/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -21,6 +21,8 @@ src/webview-src/**
 
 # Screenshots and heavy media not needed at runtime
 media/screenshots/**
+# Exclude transpiled, unbundled webview sources — we ship media/webview.js instead
+media/webview-src/**
 
 # Dot-directories not needed in VSIX
 .vscode/**

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,24 +4,35 @@
 .env
 .env.*
 
-# Tests and docs (compiled code is shipped under dist/ and media/)
-src/**/__tests__/**
-tests/**
+# Exclude sources, tests, docs (ship compiled dist/ and media/ only)
+src/**
+packages/**
+ tests/**
 docs/**
 logs/**
 *.log
 
-# Source maps (keep if you need them for marketplace debugging)
+# Exclude TypeScript sources and source maps
+**/*.ts
 **/*.map
 
-# Webview sources (only ship compiled assets under media/)
+# Webview sources (compiled bundle lives in media/)
 src/webview-src/**
 
 # Screenshots and heavy media not needed at runtime
 media/screenshots/**
 
-# Beads and local tooling
+# Dot-directories not needed in VSIX
+.vscode/**
+.vscode-dev/**
+.github/**
+.husky/**
+.claude/**
+.codex/**
 .beads/**
+
+# Scripts and misc tooling
+scripts/**
 
 # Audio assets safeguard (we do not currently ship any)
 **/*.wav

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,35 @@
+# Exclude development-only and large assets from the VSIX
+
+# Node and build caches
+node_modules/**
+!node_modules/.bin/**
+
+# Tests and docs
+src/**/__tests__/**
+tests/**
+docs/**
+logs/**
+*.log
+
+# Source maps (keep if you need them for marketplace debugging)
+**/*.map
+
+# Webview sources (only ship compiled assets under media/)
+src/webview-src/**
+
+# Screenshots and heavy media not needed at runtime
+media/screenshots/**
+
+# Unused top-level artifacts
+.eslintrc*
+*.config.*
+.esbuild*
+*.tsbuildinfo
+
+# Beads and local tooling
+.beads/**
+
+# Also exclude any audio by extension just to be safe
+**/*.wav
+**/*.mp3
+**/*.ogg

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,10 +1,10 @@
 # Exclude development-only and large assets from the VSIX
 
-# Node and build caches
-node_modules/**
-!node_modules/.bin/**
+# Do not include env files
+.env
+.env.*
 
-# Tests and docs
+# Tests and docs (compiled code is shipped under dist/ and media/)
 src/**/__tests__/**
 tests/**
 docs/**
@@ -20,16 +20,10 @@ src/webview-src/**
 # Screenshots and heavy media not needed at runtime
 media/screenshots/**
 
-# Unused top-level artifacts
-.eslintrc*
-*.config.*
-.esbuild*
-*.tsbuildinfo
-
 # Beads and local tooling
 .beads/**
 
-# Also exclude any audio by extension just to be safe
+# Audio assets safeguard (we do not currently ship any)
 **/*.wav
 **/*.mp3
 **/*.ogg

--- a/esbuild.webview.mjs
+++ b/esbuild.webview.mjs
@@ -5,6 +5,7 @@ await esbuild.build({
   outdir: 'media',
   bundle: true,
   sourcemap: true,
+  minify: true,
   format: 'esm',
   jsx: 'automatic',
   loader: { '.css': 'css', '.png': 'file' },

--- a/package.json
+++ b/package.json
@@ -517,31 +517,8 @@
     "dev:vscode": "bash scripts/dev-vscode.sh",
     "prepare": "husky"
   },
-  "files": [
-    "dist/**",
-    "media/**/*.js",
-    "media/**/*.css",
-    "media/**/*.ttf",
-    "media/**/*.png",
-    "media/**/*.svg",
-    "media/**/*.wav",
-    "node_modules/@openhands/agent-sdk-ts/dist/**",
-    "node_modules/@openhands/agent-sdk-ts/package.json",
-    "node_modules/argparse/**",
-    "node_modules/esprima/**",
-    "node_modules/front-matter/**",
-    "node_modules/js-yaml/**",
-    "node_modules/picomatch/**",
-    "node_modules/sprintf-js/**",
-    "node_modules/ws/**",
-    "node_modules/zod/**",
-    "node_modules/zod-to-json-schema/dist/cjs/**",
-    "node_modules/zod-to-json-schema/dist/types/**",
-    "node_modules/zod-to-json-schema/package.json",
-    "package.json",
-    "README.md",
-    "LICENSE"
-  ],
+  // Use .vscodeignore to control VSIX contents
+
   "bundledDependencies": [
     "ws"
   ],

--- a/package.json
+++ b/package.json
@@ -517,8 +517,6 @@
     "dev:vscode": "bash scripts/dev-vscode.sh",
     "prepare": "husky"
   },
-  // Use .vscodeignore to control VSIX contents
-
   "bundledDependencies": [
     "ws"
   ],


### PR DESCRIPTION
- **chore: add .vscodeignore to reduce VSIX size\n\n- Exclude tests, docs, screenshots, source maps, and webview source\n- Exclude audio extensions as a safeguard\n- Keep only built assets under media/ and extension dist/\n\nCo-authored-by: openhands <openhands@all-hands.dev>**
- **build: switch to .vscodeignore strategy for VSIX contents\n\n- Remove package.json files[] to avoid vsce conflict\n- Rely on .vscodeignore for exclusions\n\nCo-authored-by: openhands <openhands@all-hands.dev>**
- **fix: package.json JSON validity after files[] removal comment\n\nCo-authored-by: openhands <openhands@all-hands.dev>**
- **chore: add .vscodeignore and drop files[] to reduce VSIX and exclude secrets\n\n- Exclude tests/docs/screenshots/webview source/audio\n- Exclude .env files to prevent vsce secret warnings\n\nCo-authored-by: openhands <openhands@all-hands.dev>**
- **chore: aggressively exclude sources and heavy assets from VSIX via .vscodeignore\n\n- Exclude src/, packages/, scripts/, dot-dirs, TypeScript, maps\n- Keep only compiled dist/ and media/ bundles\n- Exclude screenshots and audio\n\nCo-authored-by: openhands <openhands@all-hands.dev>**
- **chore: exclude .openhands/ from VSIX to avoid large log payloads\n\nCo-authored-by: openhands <openhands@all-hands.dev>**
- **chore(vscodeignore): exclude heavy media, webview sources, and maps from VSIX**
- **build(webview): enable esbuild minify for media/webview.js**
