### PR TITLE
build(extension): bundle extension host with esbuild; shrink VSIX

### DIFF
--- a/.github/workflows/build-vsix.yml
+++ b/.github/workflows/build-vsix.yml
@@ -132,3 +132,21 @@ jobs:
             }
 
             await github.rest.issues.createComment({ owner, repo, issue_number, body });
+
+
+      - name: Guard: ensure VSIX excludes heavy/debug assets
+        run: |
+          VSIX_FILE="${{ steps.package.outputs.vsix_file }}"
+          unzip -l "$VSIX_FILE" > vsix.list
+          echo "Inspecting VSIX contents..."
+          # Fail if screenshots, audio, or source maps are present
+          if grep -E "extension/media/screenshots/|\.wav$|\.mp3$|\.ogg$|\.map$" vsix.list; then
+            echo "Found disallowed assets in VSIX (screenshots/audio/maps)." >&2
+            exit 1
+          fi
+          # Optional: ensure only dist/ and media/ exist under extension/
+          if ! grep -E "^\s+extension/(dist/|media/|package\.json|readme\.md|LICENSE\.txt|extension\.vsixmanifest|\[Content_Types\]\.xml)" -q vsix.list; then
+            echo "VSIX contains unexpected top-level paths under extension/. Review .vscodeignore." >&2
+            # Not fatal yet; comment next line to enforce strictly
+            # exit 1
+          fi

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -37,6 +37,27 @@ media/webview-src/**
 # Scripts and misc tooling
 scripts/**
 
+esbuild.webview.mjs
+esbuild.extension.mjs
+
+# Exclude installed packages — extension host is bundled
+node_modules/**
+
+# Dev-only config and metadata
+.gitignore
+.lintstagedrc.cjs
+.eslintignore
+eslint.config.js
+opencode.json
+*.mcp.json
+*.mjs.map
+AGENTS.md
+CLAUDE.md
+
+# TypeScript configs and tailwind config (not needed at runtime)
+tsconfig*.json
+tailwind.config.js
+
 # Audio assets safeguard (we do not currently ship any)
 **/*.wav
 **/*.mp3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,9 @@
 # OpenHands-Tab for AI Agents
+# Agent Notes / Conventions
+
+- Always use real newlines in commit messages, PR/issue descriptions, and comments. Never paste literal \n sequences. Keep messages readable as rendered Markdown.
+
+
 
 Essential information for working with this codebase.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,4 @@
 # OpenHands-Tab for AI Agents
-# Agent Notes / Conventions
-
-- Always use real newlines in commit messages, PR/issue descriptions, and comments. Never paste literal \n sequences. Keep messages readable as rendered Markdown.
-
-
 
 Essential information for working with this codebase.
 
@@ -300,3 +295,8 @@ Pitfalls to avoid
 - Opening PRs via the OpenHands `create_pr` tool expects:
   - `repo_name`, `source_branch`, `target_branch`, `title`, `body`
 
+
+
+## Notes & Conventions
+
+- Use real newlines in commit messages, PR/issue descriptions, and comments. Avoid literal `\n` sequences; write readable Markdown.

--- a/esbuild.extension.mjs
+++ b/esbuild.extension.mjs
@@ -1,0 +1,21 @@
+import esbuild from 'esbuild';
+
+await esbuild.build({
+  entryPoints: ['src/extension.ts'],
+  outfile: 'dist/extension.js',
+  bundle: true,
+  platform: 'node',
+  target: 'node20',
+  format: 'cjs',
+  sourcemap: true,
+  minify: true,
+  external: [
+    'vscode',
+    // Optional native perf deps used by ws; keep external to avoid resolution/bundling
+    'utf-8-validate',
+    'bufferutil',
+  ],
+  define: {
+    'process.env.NODE_ENV': '"production"',
+  },
+});

--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
   "scripts": {
     "build": "npm run build -w @openhands/agent-sdk-ts && npm run compile",
     "build:tailwind": "tailwindcss -i ./src/webview-src/tailwind.css -o ./src/webview-src/tailwind.gen.css --minify",
-    "compile": "tsc -p . && npm run build:tailwind && npm run build:webview",
+    "compile": "node esbuild.extension.mjs && npm run build:tailwind && npm run build:webview",
     "watch": "tsc -w -p . & npx tailwindcss -i ./src/webview-src/tailwind.css -o ./src/webview-src/tailwind.gen.css --watch & node --watch esbuild.webview.mjs",
     "vscode:prepublish": "npm run build",
     "package": "node scripts/run-vsce-package.cjs",


### PR DESCRIPTION
This PR bundles the extension host with esbuild and tightens packaging to dramatically reduce the VSIX size.

What’s included
- Add esbuild.extension.mjs to bundle src/extension.ts → dist/extension.js
  - platform: node, format: cjs, target: node20
  - external: ['vscode', 'utf-8-validate', 'bufferutil']
  - minify + sourcemap (maps excluded from VSIX)
- Update compile script to run esbuild for the extension host
- Update .vscodeignore to exclude node_modules and dev-only configs (esbuild scripts, tsconfig, tailwind, eslint, lint-staged, *.mcp.json, etc.)
- Keep only built dist/ and media/ assets in the VSIX
- Webview bundle already minified in prior PR

Size/results
- Before bundling: ~4.04 MB VSIX (after .vscodeignore + webview minify)
- After bundling: ~0.49 MB VSIX
- Files in VSIX: 83 (dist + media only)
- Verified no audio/screenshots/source maps included

Why externalize
- 'vscode' is provided by VS Code at runtime and must not be bundled
- 'utf-8-validate' and 'bufferutil' are optional native perf deps used by ws; keeping them external avoids bundling/resolve warnings

Compatibility
- engines.vscode remains ^1.104.0. Bundling does not narrow supported versions; compatibility is governed by engines.vscode.
- Target Node 20 aligns with VS Code host runtime.

Test plan
- npm run package → verify openhands-tab-*.vsix ~500 KB
- unzip -l openhands-tab-*.vsix → check only dist/ + media/ present
- code --extensionDevelopmentPath=. (Dev Host) → extension loads and functions normally
- Optional: vsce ls --tree to further inspect packaged files

Follow-ups (optional, separate PRs)
- Add CI check to fail if screenshots/audio/maps sneak into the VSIX
- Make a dev vs prod build for the extension host (e.g., sourcemap only in dev)
- Consider tree-shaking minor leftovers if any
