### PR TITLE
chore(release): v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenHands Tab",
   "publisher": "openhands",
   "icon": "media/icons/openhands-icon.png",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A VS Code extension to interact with OpenHands agents in a dedicated sidebar chat view",
   "license": "MIT",
   "workspaces": [


### PR DESCRIPTION
Bump extension version to 0.6.0.

After merge, tag `v0.6.0` to trigger the Release workflow (builds and attaches the VSIX).