### PR TITLE
Add more test coverage to agent-sdk-ts

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/mcp.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/mcp.test.ts
@@ -13,6 +13,7 @@ describe('MCP config', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -233,17 +234,14 @@ describe('MCP config', () => {
         mcpServers: {
           testServer: {
             command: 'node',
-            cwd: '${SKILL_ROOT}/scripts',
+            cwd: path.join('${SKILL_ROOT}', 'scripts'),
           },
         },
       };
       fs.writeFileSync(mcpPath, JSON.stringify(config));
 
       const result = loadMcpConfig(mcpPath, { skillRoot: tempDir });
-      // The implementation replaces ${SKILL_ROOT} with the skillRoot path and keeps /scripts
-      // On Windows tempDir uses backslashes, but the /scripts portion stays as forward slash
-      const expected = tempDir + '/scripts';
-      expect(result.mcpServers.testServer.cwd).toBe(expected);
+      expect(result.mcpServers.testServer.cwd).toBe(path.join(tempDir, 'scripts'));
     });
 
     it('expands environment variables', () => {
@@ -262,8 +260,6 @@ describe('MCP config', () => {
 
       const result = loadMcpConfig(mcpPath);
       expect(result.mcpServers.testServer.command).toBe(testValue);
-
-      vi.unstubAllEnvs();
     });
 
     it('uses default value when variable is undefined', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/mcp.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/mcp.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { findMcpConfig, loadMcpConfig, validateMcpConfigObject } from '../mcp';
+import { SkillValidationError } from '../exceptions';
+
+describe('MCP config', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('findMcpConfig', () => {
+    it('returns path when .mcp.json exists', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      fs.writeFileSync(mcpPath, '{}');
+
+      const result = findMcpConfig(tempDir);
+      expect(result).toBe(mcpPath);
+    });
+
+    it('returns null when .mcp.json does not exist', () => {
+      const result = findMcpConfig(tempDir);
+      expect(result).toBe(null);
+    });
+
+    it('returns null when .mcp.json is a directory', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      fs.mkdirSync(mcpPath);
+
+      const result = findMcpConfig(tempDir);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe('validateMcpConfigObject', () => {
+    it('validates correct config with command', () => {
+      const config = {
+        mcpServers: {
+          testServer: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      };
+
+      const result = validateMcpConfigObject(config);
+      expect(result.mcpServers.testServer.command).toBe('node');
+      expect(result.mcpServers.testServer.args).toEqual(['server.js']);
+    });
+
+    it('validates config with url (http server)', () => {
+      const config = {
+        mcpServers: {
+          httpServer: {
+            url: 'http://localhost:8080',
+            headers: { 'Authorization': 'Bearer token' },
+          },
+        },
+      };
+
+      const result = validateMcpConfigObject(config);
+      expect(result.mcpServers.httpServer.url).toBe('http://localhost:8080');
+      expect(result.mcpServers.httpServer.headers).toEqual({ 'Authorization': 'Bearer token' });
+    });
+
+    it('validates config with type and cwd', () => {
+      const config = {
+        mcpServers: {
+          myServer: {
+            type: 'stdio',
+            command: 'python',
+            args: ['server.py'],
+            cwd: '/path/to/dir',
+          },
+        },
+      };
+
+      const result = validateMcpConfigObject(config);
+      expect(result.mcpServers.myServer.type).toBe('stdio');
+      expect(result.mcpServers.myServer.cwd).toBe('/path/to/dir');
+    });
+
+    it('validates config with env', () => {
+      const config = {
+        mcpServers: {
+          myServer: {
+            command: 'python',
+            env: { 'MY_VAR': 'value' },
+          },
+        },
+      };
+
+      const result = validateMcpConfigObject(config);
+      expect(result.mcpServers.myServer.env).toEqual({ 'MY_VAR': 'value' });
+    });
+
+    it('throws for non-object config', () => {
+      expect(() => validateMcpConfigObject(null)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject('string')).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject([])).toThrow(SkillValidationError);
+    });
+
+    it('throws for missing mcpServers key', () => {
+      const config = { otherKey: {} };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("missing required key 'mcpServers'");
+    });
+
+    it('throws when mcpServers is not an object', () => {
+      const config = { mcpServers: 'not-an-object' };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("'mcpServers' must be an object");
+    });
+
+    it('throws for server missing both command and url', () => {
+      const config = {
+        mcpServers: {
+          badServer: { args: ['test'] },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("expected 'command' (stdio) or 'url' (http/sse)");
+    });
+
+    it('throws when args is not a string array', () => {
+      const config = {
+        mcpServers: {
+          badServer: {
+            command: 'node',
+            args: [1, 2, 3],
+          },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("'args' must be a string[]");
+    });
+
+    it('throws when env is not a string record', () => {
+      const config = {
+        mcpServers: {
+          badServer: {
+            command: 'node',
+            env: { key: 123 },
+          },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("'env' must be a record<string,string>");
+    });
+
+    it('throws when headers is not a string record', () => {
+      const config = {
+        mcpServers: {
+          badServer: {
+            url: 'http://localhost',
+            headers: { key: 123 },
+          },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("'headers' must be a record<string,string>");
+    });
+
+    it('throws when cwd is not a string', () => {
+      const config = {
+        mcpServers: {
+          badServer: {
+            command: 'node',
+            cwd: 123,
+          },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow("'cwd' must be a string");
+    });
+
+    it('throws for empty server name', () => {
+      const config = {
+        mcpServers: {
+          '': { command: 'node' },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow('contains an empty key');
+    });
+
+    it('throws for whitespace-only server name', () => {
+      const config = {
+        mcpServers: {
+          '   ': { command: 'node' },
+        },
+      };
+      expect(() => validateMcpConfigObject(config)).toThrow(SkillValidationError);
+      expect(() => validateMcpConfigObject(config)).toThrow('contains an empty key');
+    });
+  });
+
+  describe('loadMcpConfig', () => {
+    it('loads and parses a valid .mcp.json file', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      const config = {
+        mcpServers: {
+          testServer: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      };
+      fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+      const result = loadMcpConfig(mcpPath);
+      expect(result.mcpServers.testServer.command).toBe('node');
+    });
+
+    it('throws for invalid JSON', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      fs.writeFileSync(mcpPath, '{invalid json}');
+
+      expect(() => loadMcpConfig(mcpPath)).toThrow(SkillValidationError);
+      expect(() => loadMcpConfig(mcpPath)).toThrow('Invalid JSON');
+    });
+
+    it('expands ${SKILL_ROOT} variable when skillRoot is provided', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      const config = {
+        mcpServers: {
+          testServer: {
+            command: 'node',
+            cwd: '${SKILL_ROOT}/scripts',
+          },
+        },
+      };
+      fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+      const result = loadMcpConfig(mcpPath, { skillRoot: tempDir });
+      expect(result.mcpServers.testServer.cwd).toBe(`${tempDir}/scripts`);
+    });
+
+    it('expands environment variables', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      const testValue = 'test-value-' + Date.now();
+      process.env.MCP_TEST_VAR = testValue;
+
+      const config = {
+        mcpServers: {
+          testServer: {
+            command: '${MCP_TEST_VAR}',
+          },
+        },
+      };
+      fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+      const result = loadMcpConfig(mcpPath);
+      expect(result.mcpServers.testServer.command).toBe(testValue);
+
+      delete process.env.MCP_TEST_VAR;
+    });
+
+    it('uses default value when variable is undefined', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      const config = {
+        mcpServers: {
+          testServer: {
+            command: '${UNDEFINED_VAR:-default_command}',
+          },
+        },
+      };
+      fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+      const result = loadMcpConfig(mcpPath);
+      expect(result.mcpServers.testServer.command).toBe('default_command');
+    });
+
+    it('keeps undefined variable placeholder when no default', () => {
+      const mcpPath = path.join(tempDir, '.mcp.json');
+      const config = {
+        mcpServers: {
+          testServer: {
+            command: '${DEFINITELY_UNDEFINED_VAR_12345}',
+          },
+        },
+      };
+      fs.writeFileSync(mcpPath, JSON.stringify(config));
+
+      const result = loadMcpConfig(mcpPath);
+      expect(result.mcpServers.testServer.command).toBe('${DEFINITELY_UNDEFINED_VAR_12345}');
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/mcp.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/mcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
@@ -240,13 +240,16 @@ describe('MCP config', () => {
       fs.writeFileSync(mcpPath, JSON.stringify(config));
 
       const result = loadMcpConfig(mcpPath, { skillRoot: tempDir });
-      expect(result.mcpServers.testServer.cwd).toBe(`${tempDir}/scripts`);
+      // The implementation replaces ${SKILL_ROOT} with the skillRoot path and keeps /scripts
+      // On Windows tempDir uses backslashes, but the /scripts portion stays as forward slash
+      const expected = tempDir + '/scripts';
+      expect(result.mcpServers.testServer.cwd).toBe(expected);
     });
 
     it('expands environment variables', () => {
       const mcpPath = path.join(tempDir, '.mcp.json');
-      const testValue = 'test-value-' + Date.now();
-      process.env.MCP_TEST_VAR = testValue;
+      const testValue = 'test-value-deterministic';
+      vi.stubEnv('MCP_TEST_VAR', testValue);
 
       const config = {
         mcpServers: {
@@ -260,7 +263,7 @@ describe('MCP config', () => {
       const result = loadMcpConfig(mcpPath);
       expect(result.mcpServers.testServer.command).toBe(testValue);
 
-      delete process.env.MCP_TEST_VAR;
+      vi.unstubAllEnvs();
     });
 
     it('uses default value when variable is undefined', () => {

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/resources.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/resources.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { discoverSkillResources, hasSkillResources } from '../resources';
+
+describe('Skill resources', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-resources-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('discoverSkillResources', () => {
+    it('returns empty arrays when no resource directories exist', () => {
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.skillRoot).toBe(tempDir);
+      expect(resources.scripts).toEqual([]);
+      expect(resources.references).toEqual([]);
+      expect(resources.assets).toEqual([]);
+    });
+
+    it('discovers files in scripts directory', () => {
+      const scriptsDir = path.join(tempDir, 'scripts');
+      fs.mkdirSync(scriptsDir);
+      fs.writeFileSync(path.join(scriptsDir, 'build.sh'), '#!/bin/bash');
+      fs.writeFileSync(path.join(scriptsDir, 'test.sh'), '#!/bin/bash');
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.scripts).toContain('build.sh');
+      expect(resources.scripts).toContain('test.sh');
+      expect(resources.scripts).toHaveLength(2);
+    });
+
+    it('discovers files in references directory', () => {
+      const refsDir = path.join(tempDir, 'references');
+      fs.mkdirSync(refsDir);
+      fs.writeFileSync(path.join(refsDir, 'api-docs.md'), '# API');
+      fs.writeFileSync(path.join(refsDir, 'style-guide.md'), '# Style');
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.references).toContain('api-docs.md');
+      expect(resources.references).toContain('style-guide.md');
+    });
+
+    it('discovers files in assets directory', () => {
+      const assetsDir = path.join(tempDir, 'assets');
+      fs.mkdirSync(assetsDir);
+      fs.writeFileSync(path.join(assetsDir, 'logo.png'), 'image data');
+      fs.writeFileSync(path.join(assetsDir, 'config.json'), '{}');
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.assets).toContain('logo.png');
+      expect(resources.assets).toContain('config.json');
+    });
+
+    it('discovers files recursively in subdirectories', () => {
+      const scriptsDir = path.join(tempDir, 'scripts');
+      const subDir = path.join(scriptsDir, 'utils');
+      fs.mkdirSync(subDir, { recursive: true });
+      fs.writeFileSync(path.join(scriptsDir, 'main.sh'), '#!/bin/bash');
+      fs.writeFileSync(path.join(subDir, 'helper.sh'), '#!/bin/bash');
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.scripts).toContain('main.sh');
+      expect(resources.scripts).toContain(path.join('utils', 'helper.sh'));
+    });
+
+    it('returns sorted file lists', () => {
+      const scriptsDir = path.join(tempDir, 'scripts');
+      fs.mkdirSync(scriptsDir);
+      fs.writeFileSync(path.join(scriptsDir, 'z-script.sh'), '');
+      fs.writeFileSync(path.join(scriptsDir, 'a-script.sh'), '');
+      fs.writeFileSync(path.join(scriptsDir, 'm-script.sh'), '');
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.scripts).toEqual(['a-script.sh', 'm-script.sh', 'z-script.sh']);
+    });
+
+    it('ignores symlinks in resource directories', () => {
+      const scriptsDir = path.join(tempDir, 'scripts');
+      fs.mkdirSync(scriptsDir);
+      fs.writeFileSync(path.join(scriptsDir, 'real.sh'), '#!/bin/bash');
+      fs.symlinkSync(path.join(scriptsDir, 'real.sh'), path.join(scriptsDir, 'link.sh'));
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.scripts).toContain('real.sh');
+      expect(resources.scripts).not.toContain('link.sh');
+    });
+
+    it('ignores symlinked resource directories', () => {
+      const realDir = path.join(tempDir, 'real-scripts');
+      fs.mkdirSync(realDir);
+      fs.writeFileSync(path.join(realDir, 'test.sh'), '#!/bin/bash');
+      fs.symlinkSync(realDir, path.join(tempDir, 'scripts'));
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.scripts).toEqual([]);
+    });
+
+    it('resolves relative paths', () => {
+      const scriptsDir = path.join(tempDir, 'scripts');
+      fs.mkdirSync(scriptsDir);
+      fs.writeFileSync(path.join(scriptsDir, 'test.sh'), '');
+
+      const cwd = process.cwd();
+      const relativePath = path.relative(cwd, tempDir);
+
+      const resources = discoverSkillResources(relativePath);
+      expect(resources.skillRoot).toBe(path.resolve(relativePath));
+      expect(resources.scripts).toContain('test.sh');
+    });
+
+    it('handles multiple resource directories', () => {
+      // Create all directories
+      fs.mkdirSync(path.join(tempDir, 'scripts'));
+      fs.mkdirSync(path.join(tempDir, 'references'));
+      fs.mkdirSync(path.join(tempDir, 'assets'));
+
+      // Add files to each
+      fs.writeFileSync(path.join(tempDir, 'scripts', 'build.sh'), '');
+      fs.writeFileSync(path.join(tempDir, 'references', 'docs.md'), '');
+      fs.writeFileSync(path.join(tempDir, 'assets', 'icon.png'), '');
+
+      const resources = discoverSkillResources(tempDir);
+      expect(resources.scripts).toContain('build.sh');
+      expect(resources.references).toContain('docs.md');
+      expect(resources.assets).toContain('icon.png');
+    });
+  });
+
+  describe('hasSkillResources', () => {
+    it('returns false when all resource arrays are empty', () => {
+      const resources = {
+        skillRoot: tempDir,
+        scripts: [],
+        references: [],
+        assets: [],
+      };
+      expect(hasSkillResources(resources)).toBe(false);
+    });
+
+    it('returns true when scripts is non-empty', () => {
+      const resources = {
+        skillRoot: tempDir,
+        scripts: ['test.sh'],
+        references: [],
+        assets: [],
+      };
+      expect(hasSkillResources(resources)).toBe(true);
+    });
+
+    it('returns true when references is non-empty', () => {
+      const resources = {
+        skillRoot: tempDir,
+        scripts: [],
+        references: ['docs.md'],
+        assets: [],
+      };
+      expect(hasSkillResources(resources)).toBe(true);
+    });
+
+    it('returns true when assets is non-empty', () => {
+      const resources = {
+        skillRoot: tempDir,
+        scripts: [],
+        references: [],
+        assets: ['icon.png'],
+      };
+      expect(hasSkillResources(resources)).toBe(true);
+    });
+
+    it('returns true when multiple resource types are present', () => {
+      const resources = {
+        skillRoot: tempDir,
+        scripts: ['build.sh'],
+        references: ['docs.md'],
+        assets: ['icon.png'],
+      };
+      expect(hasSkillResources(resources)).toBe(true);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/resources.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/resources.test.ts
@@ -4,6 +4,22 @@ import * as path from 'path';
 import * as os from 'os';
 import { discoverSkillResources, hasSkillResources } from '../resources';
 
+// Check if symlinks are supported (may fail on Windows without developer mode)
+function canCreateSymlinks(): boolean {
+  if (process.platform !== 'win32') return true;
+  try {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-probe-'));
+    const target = path.join(tmp, 't');
+    const link = path.join(tmp, 'l');
+    fs.writeFileSync(target, 'x');
+    fs.symlinkSync(target, link);
+    fs.rmSync(tmp, { recursive: true, force: true });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 describe('Skill resources', () => {
   let tempDir: string;
 
@@ -81,7 +97,7 @@ describe('Skill resources', () => {
       expect(resources.scripts).toEqual(['a-script.sh', 'm-script.sh', 'z-script.sh']);
     });
 
-    it('ignores symlinks in resource directories', () => {
+    it.skipIf(!canCreateSymlinks())('ignores symlinks in resource directories', () => {
       const scriptsDir = path.join(tempDir, 'scripts');
       fs.mkdirSync(scriptsDir);
       fs.writeFileSync(path.join(scriptsDir, 'real.sh'), '#!/bin/bash');
@@ -92,7 +108,7 @@ describe('Skill resources', () => {
       expect(resources.scripts).not.toContain('link.sh');
     });
 
-    it('ignores symlinked resource directories', () => {
+    it.skipIf(!canCreateSymlinks())('ignores symlinked resource directories', () => {
       const realDir = path.join(tempDir, 'real-scripts');
       fs.mkdirSync(realDir);
       fs.writeFileSync(path.join(realDir, 'test.sh'), '#!/bin/bash');

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/resources.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/resources.test.ts
@@ -4,21 +4,23 @@ import * as path from 'path';
 import * as os from 'os';
 import { discoverSkillResources, hasSkillResources } from '../resources';
 
-// Check if symlinks are supported (may fail on Windows without developer mode)
-function canCreateSymlinks(): boolean {
-  if (process.platform !== 'win32') return true;
+const supportsSymlinks = (): boolean => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-test-'));
+  const target = path.join(root, 'target.txt');
+  const link = path.join(root, 'link.txt');
+  fs.writeFileSync(target, 'test');
+
   try {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-probe-'));
-    const target = path.join(tmp, 't');
-    const link = path.join(tmp, 'l');
-    fs.writeFileSync(target, 'x');
     fs.symlinkSync(target, link);
-    fs.rmSync(tmp, { recursive: true, force: true });
     return true;
   } catch {
     return false;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
   }
-}
+};
+
+const symlinksSupported = supportsSymlinks();
 
 describe('Skill resources', () => {
   let tempDir: string;
@@ -97,7 +99,7 @@ describe('Skill resources', () => {
       expect(resources.scripts).toEqual(['a-script.sh', 'm-script.sh', 'z-script.sh']);
     });
 
-    it.skipIf(!canCreateSymlinks())('ignores symlinks in resource directories', () => {
+    it.skipIf(!symlinksSupported)('ignores symlinks in resource directories', () => {
       const scriptsDir = path.join(tempDir, 'scripts');
       fs.mkdirSync(scriptsDir);
       fs.writeFileSync(path.join(scriptsDir, 'real.sh'), '#!/bin/bash');
@@ -108,7 +110,7 @@ describe('Skill resources', () => {
       expect(resources.scripts).not.toContain('link.sh');
     });
 
-    it.skipIf(!canCreateSymlinks())('ignores symlinked resource directories', () => {
+    it.skipIf(!symlinksSupported)('ignores symlinked resource directories', () => {
       const realDir = path.join(tempDir, 'real-scripts');
       fs.mkdirSync(realDir);
       fs.writeFileSync(path.join(realDir, 'test.sh'), '#!/bin/bash');

--- a/packages/agent-sdk-ts/src/sdk/conversation/__tests__/stuckDetector.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/__tests__/stuckDetector.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from 'vitest';
+import { StuckDetector } from '../stuckDetector';
+import type { ActionEvent, Event, MessageEvent, ObservationEvent, AgentErrorEvent, Condensation } from '../../types';
+
+const createUserMessage = (): MessageEvent => ({
+  kind: 'MessageEvent',
+  source: 'user',
+  llm_message: { role: 'user', content: [{ type: 'text', text: 'test' }] },
+});
+
+const createAgentMessage = (): MessageEvent => ({
+  kind: 'MessageEvent',
+  source: 'agent',
+  llm_message: { role: 'assistant', content: [{ type: 'text', text: 'response' }] },
+});
+
+const createActionEvent = (thought = 'test thought', toolName = 'test_tool'): ActionEvent => ({
+  kind: 'ActionEvent',
+  source: 'agent',
+  thought: [{ type: 'text', text: thought }],
+  action: { test: true },
+  tool_name: toolName,
+  tool_call_id: 'call_123',
+  tool_call: {
+    id: 'call_123',
+    type: 'function',
+    function: { name: toolName, arguments: '{}' },
+  },
+  llm_response_id: 'resp_123',
+});
+
+const createObservationEvent = (output = 'test output', toolName = 'test_tool'): ObservationEvent => ({
+  kind: 'ObservationEvent',
+  source: 'environment',
+  observation: { output },
+  tool_name: toolName,
+  tool_call_id: 'call_123',
+  action_id: 'action_123',
+});
+
+const createAgentErrorEvent = (error = 'test error', toolName = 'test_tool'): AgentErrorEvent => ({
+  kind: 'AgentErrorEvent',
+  source: 'agent',
+  error,
+  tool_name: toolName,
+  tool_call_id: 'call_123',
+});
+
+const createCondensation = (): Condensation => ({
+  kind: 'Condensation',
+  source: 'environment',
+  forgotten_event_ids: ['event_1', 'event_2'],
+});
+
+describe('StuckDetector', () => {
+  describe('constructor', () => {
+    it('uses default thresholds when none provided', () => {
+      const detector = new StuckDetector();
+      expect(detector.thresholds.actionObservation).toBe(4);
+      expect(detector.thresholds.actionError).toBe(3);
+      expect(detector.thresholds.monologue).toBe(3);
+      expect(detector.thresholds.alternatingPattern).toBe(6);
+    });
+
+    it('applies custom thresholds', () => {
+      const detector = new StuckDetector({
+        actionObservation: 5,
+        actionError: 4,
+        monologue: 2,
+        alternatingPattern: 8,
+      });
+      expect(detector.thresholds.actionObservation).toBe(5);
+      expect(detector.thresholds.actionError).toBe(4);
+      expect(detector.thresholds.monologue).toBe(2);
+      expect(detector.thresholds.alternatingPattern).toBe(8);
+    });
+
+    it('clamps threshold values to minimum of 1', () => {
+      const detector = new StuckDetector({
+        actionObservation: 0,
+        actionError: -5,
+      });
+      expect(detector.thresholds.actionObservation).toBe(1);
+      expect(detector.thresholds.actionError).toBe(1);
+    });
+
+    it('uses fallback for non-number values', () => {
+      const detector = new StuckDetector({
+        actionObservation: 'invalid' as unknown as number,
+        actionError: NaN,
+      });
+      expect(detector.thresholds.actionObservation).toBe(4); // default
+      expect(detector.thresholds.actionError).toBe(3); // default
+    });
+  });
+
+  describe('detect', () => {
+    it('returns not stuck when no user message exists', () => {
+      const detector = new StuckDetector();
+      const events: Event[] = [
+        createActionEvent(),
+        createObservationEvent(),
+      ];
+      const result = detector.detect(events);
+      expect(result.stuck).toBe(false);
+    });
+
+    it('returns not stuck when events after user message are fewer than min threshold', () => {
+      const detector = new StuckDetector();
+      const events: Event[] = [
+        createUserMessage(),
+        createActionEvent(),
+      ];
+      const result = detector.detect(events);
+      expect(result.stuck).toBe(false);
+    });
+
+    describe('repeating action/observation loop', () => {
+      it('detects repeated identical action/observation pairs', () => {
+        const detector = new StuckDetector({ actionObservation: 3 });
+        const events: Event[] = [
+          createUserMessage(),
+          createActionEvent('same thought', 'same_tool'),
+          createObservationEvent('same output', 'same_tool'),
+          createActionEvent('same thought', 'same_tool'),
+          createObservationEvent('same output', 'same_tool'),
+          createActionEvent('same thought', 'same_tool'),
+          createObservationEvent('same output', 'same_tool'),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(true);
+        expect(result.reason).toBe('Action/observation loop detected');
+      });
+
+      it('does not detect loop when actions differ', () => {
+        const detector = new StuckDetector({ actionObservation: 3 });
+        const events: Event[] = [
+          createUserMessage(),
+          createActionEvent('thought 1', 'tool_1'),
+          createObservationEvent('output', 'tool_1'),
+          createActionEvent('thought 2', 'tool_2'),
+          createObservationEvent('output', 'tool_2'),
+          createActionEvent('thought 3', 'tool_3'),
+          createObservationEvent('output', 'tool_3'),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(false);
+      });
+    });
+
+    describe('repeating action/error loop', () => {
+      it('detects repeated actions followed by errors', () => {
+        const detector = new StuckDetector({ actionError: 2 });
+        const events: Event[] = [
+          createUserMessage(),
+          createActionEvent('same thought', 'same_tool'),
+          createAgentErrorEvent('error 1', 'same_tool'),
+          createActionEvent('same thought', 'same_tool'),
+          createAgentErrorEvent('error 2', 'same_tool'),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(true);
+        expect(result.reason).toBe('Action/error loop detected');
+      });
+    });
+
+    describe('agent monologue detection', () => {
+      it('detects agent sending multiple consecutive messages', () => {
+        const detector = new StuckDetector({ monologue: 3 });
+        const events: Event[] = [
+          createUserMessage(),
+          createAgentMessage(),
+          createAgentMessage(),
+          createAgentMessage(),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(true);
+        expect(result.reason).toBe('Agent monologue detected');
+      });
+
+      it('skips condensation events in monologue check', () => {
+        const detector = new StuckDetector({ monologue: 3 });
+        const events: Event[] = [
+          createUserMessage(),
+          createAgentMessage(),
+          createCondensation(),
+          createAgentMessage(),
+          createCondensation(),
+          createAgentMessage(),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(true);
+        expect(result.reason).toBe('Agent monologue detected');
+      });
+
+      it('does not detect monologue when count is below threshold', () => {
+        const detector = new StuckDetector({ monologue: 3 });
+        const events: Event[] = [
+          createUserMessage(),
+          createAgentMessage(),
+          createAgentMessage(),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(false);
+      });
+    });
+
+    describe('alternating action/observation pattern', () => {
+      it('detects alternating pattern when threshold is met', () => {
+        const detector = new StuckDetector({ alternatingPattern: 4 });
+        const events: Event[] = [
+          createUserMessage(),
+          createActionEvent('thought A', 'tool_a'),
+          createObservationEvent('output A', 'tool_a'),
+          createActionEvent('thought B', 'tool_b'),
+          createObservationEvent('output B', 'tool_b'),
+          createActionEvent('thought A', 'tool_a'),
+          createObservationEvent('output A', 'tool_a'),
+          createActionEvent('thought B', 'tool_b'),
+          createObservationEvent('output B', 'tool_b'),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(true);
+        expect(result.reason).toBe('Alternating action/observation loop detected');
+      });
+
+      it('does not detect alternating pattern when insufficient events', () => {
+        const detector = new StuckDetector({ alternatingPattern: 6 });
+        const events: Event[] = [
+          createUserMessage(),
+          createActionEvent('thought A', 'tool_a'),
+          createObservationEvent('output A', 'tool_a'),
+        ];
+        const result = detector.detect(events);
+        expect(result.stuck).toBe(false);
+      });
+    });
+
+    it('returns not stuck when patterns do not match any detection', () => {
+      const detector = new StuckDetector();
+      const events: Event[] = [
+        createUserMessage(),
+        createActionEvent('thought 1', 'tool_1'),
+        createObservationEvent('output 1', 'tool_1'),
+        createActionEvent('thought 2', 'tool_2'),
+        createObservationEvent('output 2', 'tool_2'),
+      ];
+      const result = detector.detect(events);
+      expect(result.stuck).toBe(false);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/credentials.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/credentials.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { LLMCredentialProvider } from '../credentials';
+import { SecretRegistry } from '../../runtime/SecretRegistry';
+
+describe('LLMCredentialProvider', () => {
+  describe('constructor', () => {
+    it('creates instance with default registry', () => {
+      const provider = new LLMCredentialProvider();
+      // Should not throw
+      expect(provider).toBeDefined();
+    });
+
+    it('creates instance with custom registry', () => {
+      const registry = new SecretRegistry();
+      const provider = new LLMCredentialProvider(registry);
+      expect(provider).toBeDefined();
+    });
+  });
+
+  describe('getApiKey', () => {
+    it('returns undefined when no keys are registered', async () => {
+      const registry = new SecretRegistry();
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey();
+      expect(key).toBe(undefined);
+    });
+
+    it('returns key from openhands.llmApiKey', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('openhands.llmApiKey', 'my-api-key');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey();
+      expect(key).toBe('my-api-key');
+    });
+
+    it('returns key from LLM_API_KEY fallback', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('LLM_API_KEY', 'fallback-key');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey();
+      expect(key).toBe('fallback-key');
+    });
+
+    it('prefers openhands.llmApiKey over LLM_API_KEY', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('openhands.llmApiKey', 'primary-key');
+      await registry.set('LLM_API_KEY', 'fallback-key');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey();
+      expect(key).toBe('primary-key');
+    });
+
+    it('uses preferred key as string when provided', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('custom.apiKey', 'custom-value');
+      await registry.set('openhands.llmApiKey', 'default-value');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey('custom.apiKey');
+      expect(key).toBe('custom-value');
+    });
+
+    it('uses preferred keys as array when provided', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('custom.second', 'second-value');
+      await registry.set('openhands.llmApiKey', 'default-value');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey(['custom.first', 'custom.second']);
+      expect(key).toBe('second-value');
+    });
+
+    it('falls back to defaults when preferred keys not found', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('openhands.llmApiKey', 'default-value');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey(['nonexistent.key']);
+      expect(key).toBe('default-value');
+    });
+
+    it('respects priority order of preferred keys', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('first.key', 'first-value');
+      await registry.set('second.key', 'second-value');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey(['first.key', 'second.key']);
+      expect(key).toBe('first-value');
+    });
+
+    it('returns first available key in order', async () => {
+      const registry = new SecretRegistry();
+      await registry.set('second.key', 'second-value');
+      const provider = new LLMCredentialProvider(registry);
+
+      const key = await provider.getApiKey(['first.key', 'second.key', 'third.key']);
+      expect(key).toBe('second-value');
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/errorMapping.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/errorMapping.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest';
+import { classifyLlmErrorCode } from '../errorMapping';
+
+describe('classifyLlmErrorCode', () => {
+  describe('network errors', () => {
+    const networkCodes = [
+      'ECONNREFUSED',
+      'ECONNRESET',
+      'EHOSTUNREACH',
+      'ENETUNREACH',
+      'ENOTFOUND',
+      'EAI_AGAIN',
+      'ETIMEDOUT',
+      'UND_ERR_CONNECT_TIMEOUT',
+      'UND_ERR_SOCKET',
+    ];
+
+    networkCodes.forEach((code) => {
+      it(`classifies ${code} as llm_network_error`, () => {
+        const error = new Error('Network failure');
+        (error as Error & { code: string }).code = code;
+        expect(classifyLlmErrorCode({ error })).toBe('llm_network_error');
+      });
+    });
+
+    it('detects error code in cause', () => {
+      const cause = { code: 'ECONNREFUSED' };
+      const error = { message: 'fetch failed', cause };
+      expect(classifyLlmErrorCode({ error })).toBe('llm_network_error');
+    });
+  });
+
+  describe('abort/timeout errors', () => {
+    it('classifies AbortError by name', () => {
+      const error = new Error('Aborted');
+      error.name = 'AbortError';
+      expect(classifyLlmErrorCode({ error })).toBe('llm_timeout');
+    });
+
+    it('classifies error message containing "aborted"', () => {
+      const error = new Error('The request was aborted');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_timeout');
+    });
+
+    it('classifies error message containing "aborterror"', () => {
+      const error = new Error('AbortError: operation cancelled');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_timeout');
+    });
+  });
+
+  describe('HTTP status errors from message', () => {
+    it('classifies 401 as llm_auth', () => {
+      const error = new Error('LLM request failed (401): Unauthorized');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_auth');
+    });
+
+    it('classifies 403 as llm_auth', () => {
+      const error = new Error('Anthropic request failed (403): Forbidden');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_auth');
+    });
+
+    it('classifies 429 as llm_rate_limit', () => {
+      const error = new Error('LLM request failed (429): Too Many Requests');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_rate_limit');
+    });
+
+    it('classifies 408 as llm_timeout', () => {
+      const error = new Error('LLM request failed (408): Request Timeout');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_timeout');
+    });
+
+    it('classifies 504 as llm_timeout', () => {
+      const error = new Error('LLM request failed (504): Gateway Timeout');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_timeout');
+    });
+
+    it('classifies 500 as llm_service_unavailable', () => {
+      const error = new Error('LLM request failed (500): Internal Server Error');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_service_unavailable');
+    });
+
+    it('classifies 502 as llm_service_unavailable', () => {
+      const error = new Error('LLM request failed (502): Bad Gateway');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_service_unavailable');
+    });
+
+    it('classifies 503 as llm_service_unavailable', () => {
+      const error = new Error('LLM request failed (503): Service Unavailable');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_service_unavailable');
+    });
+
+    it('classifies 400 as llm_bad_request', () => {
+      const error = new Error('LLM request failed (400): Bad Request');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_bad_request');
+    });
+
+    it('classifies 422 as llm_bad_request', () => {
+      const error = new Error('LLM request failed (422): Unprocessable Entity');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_bad_request');
+    });
+
+    it('handles HTTP prefix in status format', () => {
+      const error = new Error('LLM request failed (HTTP 400): Bad Request');
+      expect(classifyLlmErrorCode({ error })).toBe('llm_bad_request');
+    });
+  });
+
+  describe('context limit errors', () => {
+    it('classifies context limit error for anthropic', () => {
+      // Context limit detection is done via isContextLimitError
+      // which checks for specific patterns
+      const error = new Error('prompt is too long');
+      expect(classifyLlmErrorCode({ provider: 'anthropic', error })).toBe('llm_context_limit');
+    });
+
+    it('classifies context limit error for openai', () => {
+      const error = new Error('maximum context length');
+      expect(classifyLlmErrorCode({ provider: 'openai', error })).toBe('llm_context_limit');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns undefined for unclassified error', () => {
+      const error = new Error('Unknown error');
+      expect(classifyLlmErrorCode({ error })).toBe(undefined);
+    });
+
+    it('handles string errors', () => {
+      const error = 'LLM request failed (500): Server Error';
+      expect(classifyLlmErrorCode({ error })).toBe('llm_service_unavailable');
+    });
+
+    it('handles non-Error objects', () => {
+      const error = { message: 'LLM request failed (429): Rate limited' };
+      expect(classifyLlmErrorCode({ error })).toBe('llm_rate_limit');
+    });
+
+    it('handles null provider', () => {
+      const error = new Error('LLM request failed (400): Bad Request');
+      expect(classifyLlmErrorCode({ provider: null, error })).toBe('llm_bad_request');
+    });
+
+    it('handles undefined provider', () => {
+      const error = new Error('LLM request failed (400): Bad Request');
+      expect(classifyLlmErrorCode({ provider: undefined, error })).toBe('llm_bad_request');
+    });
+
+    it('handles empty error message', () => {
+      const error = new Error('');
+      expect(classifyLlmErrorCode({ error })).toBe(undefined);
+    });
+
+    it('handles objects that stringify to error-like text', () => {
+      const error = { customField: true };
+      expect(classifyLlmErrorCode({ error })).toBe(undefined);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/provider.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/provider.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl } from '../provider';
+
+describe('provider', () => {
+  describe('DEFAULT_PROVIDER_BASE_URLS', () => {
+    it('has OpenAI URL', () => {
+      expect(DEFAULT_PROVIDER_BASE_URLS.openai).toBe('https://api.openai.com/v1');
+    });
+
+    it('has Anthropic URL', () => {
+      expect(DEFAULT_PROVIDER_BASE_URLS.anthropic).toBe('https://api.anthropic.com/v1');
+    });
+
+    it('has Gemini URL', () => {
+      expect(DEFAULT_PROVIDER_BASE_URLS.gemini).toBe('https://generativelanguage.googleapis.com/v1beta');
+    });
+
+    it('has OpenRouter URL', () => {
+      expect(DEFAULT_PROVIDER_BASE_URLS.openrouter).toBe('https://openrouter.ai/api/v1');
+    });
+
+    it('has LiteLLM proxy URL', () => {
+      expect(DEFAULT_PROVIDER_BASE_URLS.litellm_proxy).toBe('http://localhost:4000');
+    });
+  });
+
+  describe('detectProviderFromBaseUrl', () => {
+    it('detects anthropic from anthropic.com URL', () => {
+      expect(detectProviderFromBaseUrl('https://api.anthropic.com/v1')).toBe('anthropic');
+      expect(detectProviderFromBaseUrl('https://ANTHROPIC.COM/api')).toBe('anthropic');
+    });
+
+    it('detects openrouter from openrouter.ai URL', () => {
+      expect(detectProviderFromBaseUrl('https://openrouter.ai/api/v1')).toBe('openrouter');
+      expect(detectProviderFromBaseUrl('https://OPENROUTER.AI/api')).toBe('openrouter');
+    });
+
+    it('detects litellm_proxy from litellm URL', () => {
+      expect(detectProviderFromBaseUrl('http://localhost:4000/litellm')).toBe('litellm_proxy');
+      expect(detectProviderFromBaseUrl('http://my-llm-proxy.internal')).toBe('litellm_proxy');
+    });
+
+    it('detects gemini from generativelanguage.googleapis.com URL', () => {
+      expect(detectProviderFromBaseUrl('https://generativelanguage.googleapis.com/v1beta')).toBe('gemini');
+    });
+
+    it('detects gemini from ai.google.dev URL', () => {
+      expect(detectProviderFromBaseUrl('https://ai.google.dev/v1')).toBe('gemini');
+    });
+
+    it('defaults to openai for unknown URLs', () => {
+      expect(detectProviderFromBaseUrl('https://api.custom.com/v1')).toBe('openai');
+      expect(detectProviderFromBaseUrl('http://localhost:8080')).toBe('openai');
+    });
+
+    it('defaults to openai for undefined', () => {
+      expect(detectProviderFromBaseUrl(undefined)).toBe('openai');
+    });
+
+    it('defaults to openai for null', () => {
+      expect(detectProviderFromBaseUrl(null)).toBe('openai');
+    });
+
+    it('defaults to openai for empty string', () => {
+      expect(detectProviderFromBaseUrl('')).toBe('openai');
+    });
+
+    it('is case-insensitive', () => {
+      expect(detectProviderFromBaseUrl('HTTPS://API.ANTHROPIC.COM/V1')).toBe('anthropic');
+      expect(detectProviderFromBaseUrl('https://GENERATIVELANGUAGE.GOOGLEAPIS.COM/v1beta')).toBe('gemini');
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/AsyncLock.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/AsyncLock.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { AsyncLock } from '../AsyncLock';
+
+describe('AsyncLock', () => {
+  it('executes a single function and returns its result', async () => {
+    const lock = new AsyncLock();
+    const result = await lock.acquire(async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it('executes functions sequentially', async () => {
+    const lock = new AsyncLock();
+    const order: number[] = [];
+
+    const p1 = lock.acquire(async () => {
+      await delay(20);
+      order.push(1);
+      return 'first';
+    });
+
+    const p2 = lock.acquire(async () => {
+      order.push(2);
+      return 'second';
+    });
+
+    const p3 = lock.acquire(async () => {
+      order.push(3);
+      return 'third';
+    });
+
+    const results = await Promise.all([p1, p2, p3]);
+    expect(results).toEqual(['first', 'second', 'third']);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('releases lock even when function throws', async () => {
+    const lock = new AsyncLock();
+    const order: string[] = [];
+
+    const p1 = lock.acquire(async () => {
+      order.push('first-start');
+      throw new Error('First failed');
+    }).catch(() => {
+      order.push('first-caught');
+      return 'first-error';
+    });
+
+    const p2 = lock.acquire(async () => {
+      order.push('second-start');
+      return 'second-success';
+    });
+
+    const results = await Promise.all([p1, p2]);
+
+    expect(results[0]).toBe('first-error');
+    expect(results[1]).toBe('second-success');
+    expect(order).toEqual(['first-start', 'first-caught', 'second-start']);
+  });
+
+  it('handles nested acquire calls from different locks', async () => {
+    const lock1 = new AsyncLock();
+    const lock2 = new AsyncLock();
+    const order: string[] = [];
+
+    const result = await lock1.acquire(async () => {
+      order.push('lock1-start');
+      const innerResult = await lock2.acquire(async () => {
+        order.push('lock2');
+        return 'inner';
+      });
+      order.push('lock1-end');
+      return `outer-${innerResult}`;
+    });
+
+    expect(result).toBe('outer-inner');
+    expect(order).toEqual(['lock1-start', 'lock2', 'lock1-end']);
+  });
+
+  it('maintains proper queue ordering under concurrent stress', async () => {
+    const lock = new AsyncLock();
+    const results: number[] = [];
+    const count = 10;
+
+    const promises = Array.from({ length: count }, (_, i) =>
+      lock.acquire(async () => {
+        await delay(Math.random() * 5);
+        results.push(i);
+        return i;
+      })
+    );
+
+    const returned = await Promise.all(promises);
+
+    // Results should be in order they were queued
+    expect(results).toEqual(Array.from({ length: count }, (_, i) => i));
+    expect(returned).toEqual(Array.from({ length: count }, (_, i) => i));
+  });
+
+  it('supports returning different types', async () => {
+    const lock = new AsyncLock();
+
+    const str = await lock.acquire(async () => 'hello');
+    const num = await lock.acquire(async () => 123);
+    const obj = await lock.acquire(async () => ({ foo: 'bar' }));
+    const arr = await lock.acquire(async () => [1, 2, 3]);
+    const nul = await lock.acquire(async () => null);
+
+    expect(str).toBe('hello');
+    expect(num).toBe(123);
+    expect(obj).toEqual({ foo: 'bar' });
+    expect(arr).toEqual([1, 2, 3]);
+    expect(nul).toBe(null);
+  });
+
+  it('propagates errors correctly', async () => {
+    const lock = new AsyncLock();
+
+    await expect(lock.acquire(async () => {
+      throw new Error('Test error');
+    })).rejects.toThrow('Test error');
+  });
+
+  it('handles synchronously resolving functions', async () => {
+    const lock = new AsyncLock();
+    const order: number[] = [];
+
+    const p1 = lock.acquire(async () => {
+      order.push(1);
+      return 1;
+    });
+
+    const p2 = lock.acquire(async () => {
+      order.push(2);
+      return 2;
+    });
+
+    await Promise.all([p1, p2]);
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('handles void returning functions', async () => {
+    const lock = new AsyncLock();
+    const sideEffect = vi.fn();
+
+    await lock.acquire(async () => {
+      sideEffect('called');
+    });
+
+    expect(sideEffect).toHaveBeenCalledWith('called');
+  });
+});
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/ConversationState.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/ConversationState.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ConversationState, type AgentState } from '../ConversationState';
+import { EventLog } from '../EventLog';
+import type { ConversationPersistence } from '../persistence';
+import type { ConversationStateUpdateEvent, Event } from '../../types';
+
+const createMockPersistence = (): ConversationPersistence => ({
+  appendEvent: vi.fn(),
+  readEvents: vi.fn().mockReturnValue([]),
+  readLlmConfig: vi.fn().mockReturnValue(null),
+  writeLlmConfig: vi.fn(),
+  readState: vi.fn().mockReturnValue(null),
+  writeState: vi.fn(),
+});
+
+describe('ConversationState', () => {
+  describe('constructor', () => {
+    it('initializes with default state', () => {
+      const state = new ConversationState();
+      const snapshot = state.snapshot;
+      expect(snapshot.status).toBe('idle');
+      expect(snapshot.iteration).toBe(0);
+      expect(snapshot.values).toEqual({});
+    });
+
+    it('initializes with provided initial state', () => {
+      const initialState: AgentState = {
+        status: 'running',
+        iteration: 5,
+        values: { foo: 'bar' },
+      };
+      const state = new ConversationState({ initialState });
+      const snapshot = state.snapshot;
+      expect(snapshot.status).toBe('running');
+      expect(snapshot.iteration).toBe(5);
+      expect(snapshot.values).toEqual({ foo: 'bar' });
+    });
+
+    it('accepts custom eventLog', () => {
+      const eventLog = new EventLog();
+      const state = new ConversationState({ eventLog });
+      // Should not throw
+      state.incrementIteration();
+    });
+
+    it('accepts persistence adapter', () => {
+      const persistence = createMockPersistence();
+      const state = new ConversationState({ persistence });
+      state.incrementIteration();
+      expect(persistence.writeState).toHaveBeenCalled();
+    });
+  });
+
+  describe('snapshot', () => {
+    it('returns a copy of the state', () => {
+      const state = new ConversationState({
+        initialState: { status: 'running', iteration: 1, values: { a: 1 } },
+      });
+      const snapshot1 = state.snapshot;
+      const snapshot2 = state.snapshot;
+
+      // Should be equal but not same reference
+      expect(snapshot1).toEqual(snapshot2);
+      expect(snapshot1).not.toBe(snapshot2);
+      expect(snapshot1.values).not.toBe(snapshot2.values);
+    });
+
+    it('does not allow external mutation of internal state', () => {
+      const state = new ConversationState();
+      const snapshot = state.snapshot;
+      snapshot.status = 'mutated';
+      snapshot.values.hacked = true;
+
+      expect(state.snapshot.status).toBe('idle');
+      expect(state.snapshot.values).toEqual({});
+    });
+  });
+
+  describe('incrementIteration', () => {
+    it('increments iteration by 1', () => {
+      const state = new ConversationState();
+      expect(state.snapshot.iteration).toBe(0);
+
+      const result = state.incrementIteration();
+      expect(result.iteration).toBe(1);
+      expect(state.snapshot.iteration).toBe(1);
+    });
+
+    it('emits ConversationStateUpdateEvent', () => {
+      const eventLog = new EventLog();
+      const state = new ConversationState({ eventLog });
+      state.incrementIteration();
+
+      const events = eventLog.list();
+      expect(events).toHaveLength(1);
+      expect(events[0].kind).toBe('ConversationStateUpdateEvent');
+      expect((events[0] as ConversationStateUpdateEvent).iteration).toBe(1);
+    });
+
+    it('persists state', () => {
+      const persistence = createMockPersistence();
+      const state = new ConversationState({ persistence });
+      state.incrementIteration();
+      expect(persistence.writeState).toHaveBeenCalledWith(expect.objectContaining({ iteration: 1 }));
+    });
+  });
+
+  describe('setStatus', () => {
+    it('updates status', () => {
+      const state = new ConversationState();
+      const result = state.setStatus('running');
+      expect(result.status).toBe('running');
+      expect(state.snapshot.status).toBe('running');
+    });
+
+    it('emits ConversationStateUpdateEvent', () => {
+      const eventLog = new EventLog();
+      const state = new ConversationState({ eventLog });
+      state.setStatus('paused');
+
+      const events = eventLog.list();
+      expect(events).toHaveLength(1);
+      expect((events[0] as ConversationStateUpdateEvent).agent_status).toBe('paused');
+    });
+  });
+
+  describe('setValue', () => {
+    it('sets a value in the values map', () => {
+      const state = new ConversationState();
+      const result = state.setValue('myKey', 'myValue');
+      expect(result.values.myKey).toBe('myValue');
+    });
+
+    it('handles different value types', () => {
+      const state = new ConversationState();
+      state.setValue('string', 'hello');
+      state.setValue('number', 42);
+      state.setValue('object', { nested: true });
+      state.setValue('array', [1, 2, 3]);
+      state.setValue('null', null);
+
+      const snapshot = state.snapshot;
+      expect(snapshot.values.string).toBe('hello');
+      expect(snapshot.values.number).toBe(42);
+      expect(snapshot.values.object).toEqual({ nested: true });
+      expect(snapshot.values.array).toEqual([1, 2, 3]);
+      expect(snapshot.values.null).toBeNull();
+    });
+
+    it('emits ConversationStateUpdateEvent with key/value', () => {
+      const eventLog = new EventLog();
+      const state = new ConversationState({ eventLog });
+      state.setValue('testKey', 'testValue');
+
+      const events = eventLog.list();
+      const event = events[0] as ConversationStateUpdateEvent;
+      expect(event.key).toBe('testKey');
+      expect(event.value).toBe('testValue');
+    });
+
+    it('can skip persistence when persist=false', () => {
+      const persistence = createMockPersistence();
+      const state = new ConversationState({ persistence });
+      state.setValue('key', 'value', false);
+      expect(persistence.writeState).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('restore', () => {
+    it('restores state from snapshot', () => {
+      const state = new ConversationState();
+      state.incrementIteration();
+      state.setStatus('running');
+
+      const newState: AgentState = {
+        status: 'idle',
+        iteration: 100,
+        values: { restored: true },
+      };
+
+      const result = state.restore(newState);
+      expect(result.status).toBe('idle');
+      expect(result.iteration).toBe(100);
+      expect(result.values).toEqual({ restored: true });
+    });
+
+    it('creates a copy of the restored values', () => {
+      const state = new ConversationState();
+      const externalState: AgentState = {
+        status: 'idle',
+        iteration: 0,
+        values: { external: true },
+      };
+
+      state.restore(externalState);
+      externalState.values.external = false;
+      externalState.status = 'mutated';
+
+      expect(state.snapshot.values.external).toBe(true);
+      expect(state.snapshot.status).toBe('idle');
+    });
+  });
+
+  describe('loadEvents', () => {
+    it('rebuilds state from ConversationStateUpdateEvents', () => {
+      const state = new ConversationState();
+      const events: Event[] = [
+        {
+          kind: 'ConversationStateUpdateEvent',
+          source: 'agent',
+          iteration: 5,
+        },
+        {
+          kind: 'ConversationStateUpdateEvent',
+          source: 'agent',
+          agent_status: 'running',
+        },
+        {
+          kind: 'ConversationStateUpdateEvent',
+          source: 'agent',
+          key: 'customKey',
+          value: 'customValue',
+        },
+      ];
+
+      const result = state.loadEvents(events);
+      expect(result.iteration).toBe(5);
+      expect(result.status).toBe('running');
+      expect(result.values.customKey).toBe('customValue');
+    });
+
+    it('ignores non-ConversationStateUpdateEvents', () => {
+      const state = new ConversationState();
+      const events: Event[] = [
+        {
+          kind: 'MessageEvent',
+          source: 'user',
+          llm_message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+        },
+        {
+          kind: 'ConversationStateUpdateEvent',
+          source: 'agent',
+          iteration: 10,
+        },
+      ];
+
+      const result = state.loadEvents(events);
+      expect(result.iteration).toBe(10);
+    });
+
+    it('resets state before loading', () => {
+      const state = new ConversationState({
+        initialState: { status: 'running', iteration: 100, values: { old: true } },
+      });
+
+      const events: Event[] = [
+        {
+          kind: 'ConversationStateUpdateEvent',
+          source: 'agent',
+          iteration: 1,
+        },
+      ];
+
+      const result = state.loadEvents(events);
+      expect(result.iteration).toBe(1);
+      expect(result.status).toBe('idle');
+      expect(result.values).not.toHaveProperty('old');
+    });
+  });
+
+  describe('attachEventLog', () => {
+    it('replaces the event log', () => {
+      const oldLog = new EventLog();
+      const newLog = new EventLog();
+      const state = new ConversationState({ eventLog: oldLog });
+
+      state.attachEventLog(newLog);
+      state.incrementIteration();
+
+      expect(oldLog.list()).toHaveLength(0);
+      expect(newLog.list()).toHaveLength(1);
+    });
+  });
+
+  describe('attachPersistence', () => {
+    it('replaces the persistence adapter', () => {
+      const oldPersistence = createMockPersistence();
+      const newPersistence = createMockPersistence();
+      const state = new ConversationState({ persistence: oldPersistence });
+
+      state.attachPersistence(newPersistence);
+      state.incrementIteration();
+
+      expect(oldPersistence.writeState).not.toHaveBeenCalled();
+      expect(newPersistence.writeState).toHaveBeenCalled();
+    });
+  });
+
+  describe('persistSnapshot', () => {
+    it('writes current state to persistence', () => {
+      const persistence = createMockPersistence();
+      const state = new ConversationState({ persistence });
+      state.incrementIteration();
+      vi.clearAllMocks();
+
+      state.persistSnapshot();
+      expect(persistence.writeState).toHaveBeenCalledWith(
+        expect.objectContaining({ iteration: 1 })
+      );
+    });
+
+    it('does nothing when no persistence attached', () => {
+      const state = new ConversationState();
+      // Should not throw
+      state.persistSnapshot();
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/ConversationState.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/ConversationState.test.ts
@@ -5,6 +5,7 @@ import type { ConversationPersistence } from '../persistence';
 import type { ConversationStateUpdateEvent, Event } from '../../types';
 
 const createMockPersistence = (): ConversationPersistence => ({
+  conversationId: 'test-conversation-id',
   appendEvent: vi.fn(),
   readEvents: vi.fn().mockReturnValue([]),
   readLlmConfig: vi.fn().mockReturnValue(null),

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/EventLog.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/EventLog.test.ts
@@ -4,6 +4,7 @@ import type { ConversationPersistence } from '../persistence';
 import type { Event, MessageEvent, ActionEvent, ConversationStateUpdateEvent } from '../../types';
 
 const createMockPersistence = (): ConversationPersistence => ({
+  conversationId: 'test-conversation-id',
   appendEvent: vi.fn(),
   readEvents: vi.fn().mockReturnValue([]),
   readLlmConfig: vi.fn().mockReturnValue(null),

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/EventLog.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/EventLog.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, vi } from 'vitest';
+import { EventLog } from '../EventLog';
+import type { ConversationPersistence } from '../persistence';
+import type { Event, MessageEvent, ActionEvent, ConversationStateUpdateEvent } from '../../types';
+
+const createMockPersistence = (): ConversationPersistence => ({
+  appendEvent: vi.fn(),
+  readEvents: vi.fn().mockReturnValue([]),
+  readLlmConfig: vi.fn().mockReturnValue(null),
+  writeLlmConfig: vi.fn(),
+  readState: vi.fn().mockReturnValue(null),
+  writeState: vi.fn(),
+});
+
+const createMessageEvent = (source: 'user' | 'agent' = 'user'): MessageEvent => ({
+  kind: 'MessageEvent',
+  source,
+  llm_message: { role: source === 'user' ? 'user' : 'assistant', content: [{ type: 'text', text: 'test' }] },
+});
+
+const createActionEvent = (): ActionEvent => ({
+  kind: 'ActionEvent',
+  source: 'agent',
+  thought: [{ type: 'text', text: 'thinking' }],
+  action: { test: true },
+  tool_name: 'test_tool',
+  tool_call_id: 'call_123',
+  tool_call: {
+    id: 'call_123',
+    type: 'function',
+    function: { name: 'test_tool', arguments: '{}' },
+  },
+  llm_response_id: 'resp_123',
+});
+
+describe('EventLog', () => {
+  describe('constructor', () => {
+    it('initializes with empty events', () => {
+      const log = new EventLog();
+      expect(log.list()).toEqual([]);
+    });
+
+    it('initializes with seed events', () => {
+      const seedEvents: Event[] = [createMessageEvent()];
+      const log = new EventLog({ events: seedEvents });
+      const events = log.list();
+      expect(events).toHaveLength(1);
+      expect(events[0].kind).toBe('MessageEvent');
+    });
+
+    it('normalizes seed events with id and timestamp', () => {
+      const seedEvent = createMessageEvent();
+      const log = new EventLog({ events: [seedEvent] });
+      const events = log.list();
+      expect(events[0].id).toBeDefined();
+      expect(events[0].timestamp).toBeDefined();
+    });
+
+    it('preserves existing id and timestamp on seed events', () => {
+      const seedEvent: MessageEvent = {
+        ...createMessageEvent(),
+        id: 'existing_id',
+        timestamp: '2024-01-01T00:00:00Z',
+      };
+      const log = new EventLog({ events: [seedEvent] });
+      const events = log.list();
+      expect(events[0].id).toBe('existing_id');
+      expect(events[0].timestamp).toBe('2024-01-01T00:00:00Z');
+    });
+
+    it('accepts persistence adapter', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+      // Should not throw
+      log.push(createMessageEvent());
+      expect(persistence.appendEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe('push', () => {
+    it('adds event to the log', () => {
+      const log = new EventLog();
+      const event = createMessageEvent();
+      log.push(event);
+      expect(log.list()).toHaveLength(1);
+    });
+
+    it('assigns id to event if missing', () => {
+      const log = new EventLog();
+      const event = createMessageEvent();
+      const pushed = log.push(event);
+      expect(pushed.id).toBeDefined();
+      expect(typeof pushed.id).toBe('string');
+    });
+
+    it('assigns timestamp to event if missing', () => {
+      const log = new EventLog();
+      const event = createMessageEvent();
+      const pushed = log.push(event);
+      expect(pushed.timestamp).toBeDefined();
+    });
+
+    it('preserves existing id and timestamp', () => {
+      const log = new EventLog();
+      const event: MessageEvent = {
+        ...createMessageEvent(),
+        id: 'custom_id',
+        timestamp: '2024-06-01T12:00:00Z',
+      };
+      const pushed = log.push(event);
+      expect(pushed.id).toBe('custom_id');
+      expect(pushed.timestamp).toBe('2024-06-01T12:00:00Z');
+    });
+
+    it('notifies listeners', () => {
+      const log = new EventLog();
+      const listener = vi.fn();
+      log.on(listener);
+
+      const event = createMessageEvent();
+      log.push(event);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(listener.mock.calls[0][0].kind).toBe('MessageEvent');
+    });
+
+    it('persists event to storage', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+      const event = createMessageEvent();
+      log.push(event);
+      expect(persistence.appendEvent).toHaveBeenCalled();
+    });
+
+    it('throws for invalid events', () => {
+      const log = new EventLog();
+      const invalidEvent = { notAnEvent: true } as unknown as Event;
+      expect(() => log.push(invalidEvent)).toThrow('Attempted to push invalid event');
+    });
+  });
+
+  describe('replay', () => {
+    it('adds multiple events to log', () => {
+      const log = new EventLog();
+      const events = [createMessageEvent(), createActionEvent()];
+      log.replay(events);
+      expect(log.list()).toHaveLength(2);
+    });
+
+    it('emits events to listeners by default', () => {
+      const log = new EventLog();
+      const listener = vi.fn();
+      log.on(listener);
+
+      log.replay([createMessageEvent(), createActionEvent()]);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips emitting when emit=false', () => {
+      const log = new EventLog();
+      const listener = vi.fn();
+      log.on(listener);
+
+      log.replay([createMessageEvent()], false);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not persist replayed events', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+      log.replay([createMessageEvent()]);
+      expect(persistence.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns normalized events', () => {
+      const log = new EventLog();
+      const event = createMessageEvent();
+      const replayed = log.replay([event]);
+      expect(replayed[0].id).toBeDefined();
+      expect(replayed[0].timestamp).toBeDefined();
+    });
+  });
+
+  describe('list', () => {
+    it('returns a copy of events', () => {
+      const log = new EventLog();
+      log.push(createMessageEvent());
+      const list1 = log.list();
+      const list2 = log.list();
+      expect(list1).toEqual(list2);
+      expect(list1).not.toBe(list2);
+    });
+
+    it('returns events in order they were added', () => {
+      const log = new EventLog();
+      const event1 = createMessageEvent('user');
+      const event2 = createActionEvent();
+      const event3 = createMessageEvent('agent');
+
+      log.push(event1);
+      log.push(event2);
+      log.push(event3);
+
+      const events = log.list();
+      expect(events[0].kind).toBe('MessageEvent');
+      expect((events[0] as MessageEvent).source).toBe('user');
+      expect(events[1].kind).toBe('ActionEvent');
+      expect(events[2].kind).toBe('MessageEvent');
+      expect((events[2] as MessageEvent).source).toBe('agent');
+    });
+  });
+
+  describe('on', () => {
+    it('adds listener and returns unsubscribe function', () => {
+      const log = new EventLog();
+      const listener = vi.fn();
+      const unsubscribe = log.on(listener);
+
+      log.push(createMessageEvent());
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      log.push(createMessageEvent());
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports multiple listeners', () => {
+      const log = new EventLog();
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+
+      log.on(listener1);
+      log.on(listener2);
+
+      log.push(createMessageEvent());
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('attachPersistence', () => {
+    it('replaces persistence adapter', () => {
+      const oldPersistence = createMockPersistence();
+      const newPersistence = createMockPersistence();
+      const log = new EventLog({ persistence: oldPersistence });
+
+      log.attachPersistence(newPersistence);
+      log.push(createMessageEvent());
+
+      expect(oldPersistence.appendEvent).not.toHaveBeenCalled();
+      expect(newPersistence.appendEvent).toHaveBeenCalled();
+    });
+  });
+
+  describe('persistence filtering for ConversationStateUpdateEvent', () => {
+    it('does not persist llm_stream state updates', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+
+      const streamEvent: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        source: 'agent',
+        key: 'llm_stream',
+        value: { partial: 'text' },
+      };
+      log.push(streamEvent);
+
+      expect(persistence.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not persist llm_tool_call state updates', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+
+      const toolCallEvent: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        source: 'agent',
+        key: 'llm_tool_call',
+        value: { name: 'test' },
+      };
+      log.push(toolCallEvent);
+
+      expect(persistence.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('persists other ConversationStateUpdateEvent types', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+
+      const iterationEvent: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        source: 'agent',
+        iteration: 5,
+      };
+      log.push(iterationEvent);
+
+      expect(persistence.appendEvent).toHaveBeenCalled();
+    });
+
+    it('persists ConversationStateUpdateEvent with other keys', () => {
+      const persistence = createMockPersistence();
+      const log = new EventLog({ persistence });
+
+      const customEvent: ConversationStateUpdateEvent = {
+        kind: 'ConversationStateUpdateEvent',
+        source: 'agent',
+        key: 'custom_key',
+        value: 'custom_value',
+      };
+      log.push(customEvent);
+
+      expect(persistence.appendEvent).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
@@ -127,22 +127,35 @@ describe('SecretMasker', () => {
       expect(result).toBe('secret: ***');
     });
 
-    it('reuses cached computation when secrets are unchanged', () => {
-      // The masker caches the computed secret values based on a signature.
-      // When secrets don't change, it returns cached values instead of recomputing.
-      // We verify this by checking the same values are returned (via cache hit).
-      const secrets = ['cached_secret_1234'];
+    it('caches secret values for performance', () => {
+      process.env = {};
+      const getConfiguredSecrets = vi.fn(() => ['cached_secret_1234']);
       const masker = new SecretMasker({
-        getConfiguredSecrets: () => secrets,
+        getConfiguredSecrets,
         getRegisteredSecrets: () => [],
       });
 
-      // Both calls should return the same masked result
-      const result1 = masker.maskText('test cached_secret_1234');
-      const result2 = masker.maskText('test cached_secret_1234 again');
+      const addSpy = vi.spyOn(Set.prototype, 'add');
+      try {
+        const result1 = masker.maskText('test cached_secret_1234');
+        const addCallsAfterFirst = addSpy.mock.calls.length;
+        expect(addCallsAfterFirst).toBeGreaterThan(0);
+        expect(result1).toBe('test ***');
 
-      expect(result1).toBe('test ***');
-      expect(result2).toBe('test *** again');
+        const result2 = masker.maskText('test cached_secret_1234 again');
+        expect(addSpy.mock.calls.length).toBe(addCallsAfterFirst);
+        expect(result2).toBe('test *** again');
+
+        const result3 = masker.maskText('test cached_secret_1234 one more time');
+        expect(addSpy.mock.calls.length).toBe(addCallsAfterFirst);
+        expect(result3).toBe('test *** one more time');
+
+        // Secrets are fetched each time to compute the cache signature,
+        // but expensive masking list computation is cached for the same signature.
+        expect(getConfiguredSecrets).toHaveBeenCalledTimes(3);
+      } finally {
+        addSpy.mockRestore();
+      }
     });
 
     it('invalidates cache when secrets change', () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SecretMasker } from '../secretMasker';
 
 describe('SecretMasker', () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { SecretMasker } from '../secretMasker';
 
 describe('SecretMasker', () => {
@@ -127,18 +127,22 @@ describe('SecretMasker', () => {
       expect(result).toBe('secret: ***');
     });
 
-    it('caches secret values for performance', () => {
-      const getConfiguredSecrets = vi.fn(() => ['cached_secret_1234']);
+    it('reuses cached computation when secrets are unchanged', () => {
+      // The masker caches the computed secret values based on a signature.
+      // When secrets don't change, it returns cached values instead of recomputing.
+      // We verify this by checking the same values are returned (via cache hit).
+      const secrets = ['cached_secret_1234'];
       const masker = new SecretMasker({
-        getConfiguredSecrets,
+        getConfiguredSecrets: () => secrets,
         getRegisteredSecrets: () => [],
       });
 
-      masker.maskText('test cached_secret_1234');
-      masker.maskText('test cached_secret_1234 again');
+      // Both calls should return the same masked result
+      const result1 = masker.maskText('test cached_secret_1234');
+      const result2 = masker.maskText('test cached_secret_1234 again');
 
-      // Should only compute once due to caching
-      expect(getConfiguredSecrets).toHaveBeenCalled();
+      expect(result1).toBe('test ***');
+      expect(result2).toBe('test *** again');
     });
 
     it('invalidates cache when secrets change', () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/secretMasker.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SecretMasker } from '../secretMasker';
+
+describe('SecretMasker', () => {
+  let originalEnv: typeof process.env;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('maskText', () => {
+    it('masks configured secrets', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['supersecretkey123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('API key: supersecretkey123');
+      expect(result).toBe('API key: ***');
+    });
+
+    it('masks registered secrets', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => ['registered_secret_value'],
+      });
+
+      const result = masker.maskText('Token: registered_secret_value');
+      expect(result).toBe('Token: ***');
+    });
+
+    it('masks multiple occurrences of the same secret', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['mysecret12'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('First: mysecret12, Second: mysecret12');
+      expect(result).toBe('First: ***, Second: ***');
+    });
+
+    it('masks multiple different secrets', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['secret_one', 'secret_two'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('A: secret_one, B: secret_two');
+      expect(result).toBe('A: ***, B: ***');
+    });
+
+    it('masks longer secrets first (priority order)', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['short123', 'longsecret123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('longsecret123');
+      expect(result).toBe('***');
+    });
+
+    it('ignores secrets shorter than 8 characters', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['short'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('value: short');
+      expect(result).toBe('value: short');
+    });
+
+    it('expands env var names to their values', () => {
+      process.env.TEST_SECRET_KEY = 'env_secret_value_12345';
+
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['TEST_SECRET_KEY'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('The value is env_secret_value_12345');
+      expect(result).toBe('The value is ***');
+    });
+
+    it('masks env vars with sensitive-looking names', () => {
+      process.env.MY_API_KEY = 'api_key_from_env_123';
+
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('Key: api_key_from_env_123');
+      expect(result).toBe('Key: ***');
+    });
+
+    it('trims whitespace from configured secrets', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['  trimmed_secret_123  '],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('secret: trimmed_secret_123');
+      expect(result).toBe('secret: ***');
+    });
+
+    it('ignores empty/whitespace-only configured secrets', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['', '   ', 'valid_secret_123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('secret: valid_secret_123');
+      expect(result).toBe('secret: ***');
+    });
+
+    it('filters out non-string configured secrets', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [123, null, undefined, 'string_secret_123'] as unknown[],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskText('secret: string_secret_123');
+      expect(result).toBe('secret: ***');
+    });
+
+    it('caches secret values for performance', () => {
+      const getConfiguredSecrets = vi.fn(() => ['cached_secret_1234']);
+      const masker = new SecretMasker({
+        getConfiguredSecrets,
+        getRegisteredSecrets: () => [],
+      });
+
+      masker.maskText('test cached_secret_1234');
+      masker.maskText('test cached_secret_1234 again');
+
+      // Should only compute once due to caching
+      expect(getConfiguredSecrets).toHaveBeenCalled();
+    });
+
+    it('invalidates cache when secrets change', () => {
+      let secrets = ['first_secret_1234'];
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => secrets,
+        getRegisteredSecrets: () => [],
+      });
+
+      expect(masker.maskText('first_secret_1234')).toBe('***');
+
+      secrets = ['second_secret_5678'];
+      expect(masker.maskText('second_secret_5678')).toBe('***');
+    });
+  });
+
+  describe('maskUnknown', () => {
+    it('masks strings', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['secret_value_123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskUnknown('Contains secret_value_123');
+      expect(result).toBe('Contains ***');
+    });
+
+    it('masks strings in arrays', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['array_secret_123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskUnknown(['normal', 'array_secret_123', 'text']);
+      expect(result).toEqual(['normal', '***', 'text']);
+    });
+
+    it('masks strings in objects', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['object_secret_123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskUnknown({
+        key: 'object_secret_123',
+        other: 'safe value',
+      });
+      expect(result).toEqual({
+        key: '***',
+        other: 'safe value',
+      });
+    });
+
+    it('masks nested structures', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => ['nested_secret_123'],
+        getRegisteredSecrets: () => [],
+      });
+
+      const result = masker.maskUnknown({
+        level1: {
+          level2: {
+            secret: 'nested_secret_123',
+          },
+        },
+      });
+      expect(result).toEqual({
+        level1: {
+          level2: {
+            secret: '***',
+          },
+        },
+      });
+    });
+
+    it('handles circular references', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => [],
+      });
+
+      const circular: Record<string, unknown> = { value: 'test' };
+      circular.self = circular;
+
+      const result = masker.maskUnknown(circular) as Record<string, unknown>;
+      expect(result.value).toBe('test');
+      expect(result.self).toBe('[Circular]');
+    });
+
+    it('handles circular arrays', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => [],
+      });
+
+      const arr: unknown[] = ['a', 'b'];
+      arr.push(arr);
+
+      const result = masker.maskUnknown(arr) as unknown[];
+      expect(result[0]).toBe('a');
+      expect(result[1]).toBe('b');
+      expect(result[2]).toBe('[Circular]');
+    });
+
+    it('returns primitives unchanged', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => [],
+      });
+
+      expect(masker.maskUnknown(123)).toBe(123);
+      expect(masker.maskUnknown(true)).toBe(true);
+      expect(masker.maskUnknown(null)).toBe(null);
+      expect(masker.maskUnknown(undefined)).toBe(undefined);
+    });
+
+    it('handles empty objects', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => [],
+      });
+
+      expect(masker.maskUnknown({})).toEqual({});
+    });
+
+    it('handles empty arrays', () => {
+      const masker = new SecretMasker({
+        getConfiguredSecrets: () => [],
+        getRegisteredSecrets: () => [],
+      });
+
+      expect(masker.maskUnknown([])).toEqual([]);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/settingsUtils.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/settingsUtils.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { toOptionalNonEmptyString, isSafeProfileId } from '../settingsUtils';
+
+describe('settingsUtils', () => {
+  describe('toOptionalNonEmptyString', () => {
+    it('returns undefined for undefined input', () => {
+      expect(toOptionalNonEmptyString(undefined)).toBe(undefined);
+    });
+
+    it('returns undefined for non-string input', () => {
+      expect(toOptionalNonEmptyString(123)).toBe(undefined);
+      expect(toOptionalNonEmptyString(null)).toBe(undefined);
+      expect(toOptionalNonEmptyString({})).toBe(undefined);
+      expect(toOptionalNonEmptyString([])).toBe(undefined);
+      expect(toOptionalNonEmptyString(true)).toBe(undefined);
+    });
+
+    it('returns undefined for empty string', () => {
+      expect(toOptionalNonEmptyString('')).toBe(undefined);
+    });
+
+    it('returns undefined for whitespace-only string', () => {
+      expect(toOptionalNonEmptyString('   ')).toBe(undefined);
+      expect(toOptionalNonEmptyString('\t')).toBe(undefined);
+      expect(toOptionalNonEmptyString('\n')).toBe(undefined);
+    });
+
+    it('returns trimmed string for valid input', () => {
+      expect(toOptionalNonEmptyString('  hello  ')).toBe('hello');
+      expect(toOptionalNonEmptyString('value')).toBe('value');
+    });
+
+    it('preserves internal whitespace', () => {
+      expect(toOptionalNonEmptyString('  hello world  ')).toBe('hello world');
+    });
+  });
+
+  describe('isSafeProfileId', () => {
+    it('returns true for valid profile IDs', () => {
+      expect(isSafeProfileId('default')).toBe(true);
+      expect(isSafeProfileId('my-profile')).toBe(true);
+      expect(isSafeProfileId('profile_1')).toBe(true);
+      expect(isSafeProfileId('Profile123')).toBe(true);
+    });
+
+    it('returns true for alphanumeric IDs', () => {
+      expect(isSafeProfileId('abc123')).toBe(true);
+      expect(isSafeProfileId('ABC123')).toBe(true);
+    });
+
+    it('returns true for IDs with allowed special chars', () => {
+      expect(isSafeProfileId('my-profile')).toBe(true);
+      expect(isSafeProfileId('my_profile')).toBe(true);
+    });
+
+    it('returns false for empty string', () => {
+      expect(isSafeProfileId('')).toBe(false);
+    });
+
+    it('returns false for IDs with invalid characters', () => {
+      expect(isSafeProfileId('profile/name')).toBe(false);
+      expect(isSafeProfileId('profile\\name')).toBe(false);
+      expect(isSafeProfileId('profile:name')).toBe(false);
+      expect(isSafeProfileId('../evil')).toBe(false);
+    });
+
+    it('returns false for IDs with spaces', () => {
+      expect(isSafeProfileId('my profile')).toBe(false);
+    });
+
+    it('allows IDs starting with dot', () => {
+      // The regex allows dots anywhere: /^[a-zA-Z0-9._-]+$/
+      expect(isSafeProfileId('.hidden')).toBe(true);
+    });
+
+    it('allows IDs with dots', () => {
+      expect(isSafeProfileId('profile.v2')).toBe(true);
+    });
+
+    it('allows long IDs', () => {
+      // No length limit in validation
+      const longId = 'a'.repeat(200);
+      expect(isSafeProfileId(longId)).toBe(true);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolResultTruncation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/toolResultTruncation.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CIRCULAR_REFERENCE_MARKER,
+  TOOL_MESSAGE_CLIP_MARKER,
+  TOOL_MESSAGE_MAX_CHARS,
+  deepTruncate,
+  truncateToolMessage,
+} from '../toolResultTruncation';
+
+describe('toolResultTruncation', () => {
+  describe('constants', () => {
+    it('has correct circular reference marker', () => {
+      expect(CIRCULAR_REFERENCE_MARKER).toBe('[Circular]');
+    });
+
+    it('has correct clip marker', () => {
+      expect(TOOL_MESSAGE_CLIP_MARKER).toBe('<response clipped>');
+    });
+
+    it('has correct max chars', () => {
+      expect(TOOL_MESSAGE_MAX_CHARS).toBe(8000);
+    });
+  });
+
+  describe('deepTruncate', () => {
+    it('returns primitives unchanged', () => {
+      expect(deepTruncate(123)).toBe(123);
+      expect(deepTruncate(true)).toBe(true);
+      expect(deepTruncate(null)).toBe(null);
+      expect(deepTruncate(undefined)).toBe(undefined);
+    });
+
+    it('truncates long strings', () => {
+      const longString = 'x'.repeat(20000);
+      const result = deepTruncate(longString) as string;
+      expect(result.length).toBeLessThan(longString.length);
+    });
+
+    it('handles short strings', () => {
+      expect(deepTruncate('short')).toBe('short');
+    });
+
+    it('truncates strings in arrays', () => {
+      const longString = 'y'.repeat(20000);
+      const result = deepTruncate(['short', longString]) as string[];
+      expect(result[0]).toBe('short');
+      expect(result[1].length).toBeLessThan(longString.length);
+    });
+
+    it('truncates strings in objects', () => {
+      const longString = 'z'.repeat(20000);
+      const result = deepTruncate({ key: longString }) as Record<string, string>;
+      expect(result.key.length).toBeLessThan(longString.length);
+    });
+
+    it('handles nested objects', () => {
+      const result = deepTruncate({
+        level1: {
+          level2: {
+            value: 'test',
+          },
+        },
+      }) as Record<string, Record<string, Record<string, string>>>;
+      expect(result.level1.level2.value).toBe('test');
+    });
+
+    it('handles Date objects', () => {
+      const date = new Date('2024-01-15T12:00:00Z');
+      const result = deepTruncate(date);
+      expect(result).toBe('2024-01-15T12:00:00.000Z');
+    });
+
+    it('handles invalid Date objects', () => {
+      const invalidDate = new Date('invalid');
+      const result = deepTruncate(invalidDate);
+      expect(result).toBe('Invalid Date');
+    });
+
+    it('handles circular references in objects', () => {
+      const obj: Record<string, unknown> = { value: 'test' };
+      obj.self = obj;
+      const result = deepTruncate(obj) as Record<string, unknown>;
+      expect(result.value).toBe('test');
+      expect(result.self).toBe(CIRCULAR_REFERENCE_MARKER);
+    });
+
+    it('handles circular references in arrays', () => {
+      const arr: unknown[] = ['a', 'b'];
+      arr.push(arr);
+      const result = deepTruncate(arr) as unknown[];
+      expect(result[0]).toBe('a');
+      expect(result[1]).toBe('b');
+      expect(result[2]).toBe(CIRCULAR_REFERENCE_MARKER);
+    });
+
+    it('handles empty objects', () => {
+      expect(deepTruncate({})).toEqual({});
+    });
+
+    it('handles empty arrays', () => {
+      expect(deepTruncate([])).toEqual([]);
+    });
+  });
+
+  describe('truncateToolMessage', () => {
+    it('returns short messages unchanged', () => {
+      const message = 'This is a short message';
+      expect(truncateToolMessage(message)).toBe(message);
+    });
+
+    it('returns messages at max length unchanged', () => {
+      const message = 'x'.repeat(TOOL_MESSAGE_MAX_CHARS);
+      expect(truncateToolMessage(message)).toBe(message);
+    });
+
+    it('truncates messages over max length', () => {
+      const message = 'y'.repeat(TOOL_MESSAGE_MAX_CHARS + 1000);
+      const result = truncateToolMessage(message);
+      expect(result.length).toBeLessThan(message.length);
+      expect(result).toContain(TOOL_MESSAGE_CLIP_MARKER);
+    });
+
+    it('preserves head and tail of long messages', () => {
+      const message = 'HEAD'.repeat(3000) + 'TAIL'.repeat(3000);
+      const result = truncateToolMessage(message);
+      expect(result.startsWith('HEAD')).toBe(true);
+      expect(result.endsWith('TAIL')).toBe(true);
+    });
+
+    it('respects custom maxChars', () => {
+      const message = 'x'.repeat(200);
+      const result = truncateToolMessage(message, 100);
+      expect(result.length).toBeLessThan(200);
+      expect(result).toContain(TOOL_MESSAGE_CLIP_MARKER);
+    });
+
+    it('handles edge case of very small maxChars', () => {
+      const message = 'x'.repeat(100);
+      const result = truncateToolMessage(message, 30);
+      expect(result).toContain(TOOL_MESSAGE_CLIP_MARKER);
+    });
+
+    it('contains clip marker with newlines', () => {
+      const message = 'x'.repeat(10000);
+      const result = truncateToolMessage(message);
+      expect(result).toContain(`\n${TOOL_MESSAGE_CLIP_MARKER}\n`);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/security/__tests__/analyzer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/__tests__/analyzer.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import { LLMSecurityAnalyzer } from '../analyzer';
+import type { ActionEvent, Event, SecurityRisk } from '../../types';
+
+const createActionEvent = (risk?: SecurityRisk): ActionEvent => ({
+  kind: 'ActionEvent',
+  source: 'agent',
+  thought: [{ type: 'text', text: 'test thought' }],
+  action: { test: true },
+  tool_name: 'test_tool',
+  tool_call_id: 'call_123',
+  tool_call: {
+    id: 'call_123',
+    type: 'function',
+    function: { name: 'test_tool', arguments: '{}' },
+  },
+  llm_response_id: 'resp_123',
+  security_risk: risk,
+});
+
+describe('LLMSecurityAnalyzer', () => {
+  describe('securityRisk', () => {
+    it('returns the security_risk from action event when present', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const action = createActionEvent('HIGH');
+      expect(analyzer.securityRisk(action)).toBe('HIGH');
+    });
+
+    it('returns UNKNOWN when security_risk is undefined', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const action = createActionEvent(undefined);
+      expect(analyzer.securityRisk(action)).toBe('UNKNOWN');
+    });
+
+    it('handles LOW risk level', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const action = createActionEvent('LOW');
+      expect(analyzer.securityRisk(action)).toBe('LOW');
+    });
+
+    it('handles MEDIUM risk level', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const action = createActionEvent('MEDIUM');
+      expect(analyzer.securityRisk(action)).toBe('MEDIUM');
+    });
+  });
+
+  describe('analyzeEvent', () => {
+    it('returns security risk for ActionEvent', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const action = createActionEvent('HIGH');
+      expect(analyzer.analyzeEvent(action)).toBe('HIGH');
+    });
+
+    it('returns null for non-ActionEvent', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const messageEvent: Event = {
+        kind: 'MessageEvent',
+        source: 'user',
+        llm_message: {
+          role: 'user',
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      };
+      expect(analyzer.analyzeEvent(messageEvent)).toBe(null);
+    });
+
+    it('returns null for ObservationEvent', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const observationEvent: Event = {
+        kind: 'ObservationEvent',
+        source: 'environment',
+        observation: { output: 'test' },
+        tool_name: 'test_tool',
+        tool_call_id: 'call_123',
+        action_id: 'action_123',
+      };
+      expect(analyzer.analyzeEvent(observationEvent)).toBe(null);
+    });
+  });
+
+  describe('analyzePendingActions', () => {
+    it('returns array of action/risk pairs', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const actions = [
+        createActionEvent('HIGH'),
+        createActionEvent('LOW'),
+        createActionEvent('MEDIUM'),
+      ];
+      const results = analyzer.analyzePendingActions(actions);
+
+      expect(results).toHaveLength(3);
+      expect(results[0]).toEqual({ action: actions[0], risk: 'HIGH' });
+      expect(results[1]).toEqual({ action: actions[1], risk: 'LOW' });
+      expect(results[2]).toEqual({ action: actions[2], risk: 'MEDIUM' });
+    });
+
+    it('returns UNKNOWN for actions without security_risk', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const actions = [createActionEvent(undefined)];
+      const results = analyzer.analyzePendingActions(actions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].risk).toBe('UNKNOWN');
+    });
+
+    it('returns empty array for empty input', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const results = analyzer.analyzePendingActions([]);
+      expect(results).toEqual([]);
+    });
+
+    it('returns HIGH risk when securityRisk throws', () => {
+      // Create a subclass that throws
+      class ThrowingAnalyzer extends LLMSecurityAnalyzer {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        override securityRisk(action: ActionEvent): SecurityRisk {
+          throw new Error('Unexpected error');
+        }
+      }
+
+      const analyzer = new ThrowingAnalyzer();
+      const actions = [createActionEvent('LOW')];
+      const results = analyzer.analyzePendingActions(actions);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].risk).toBe('HIGH');
+    });
+  });
+
+  describe('kind property', () => {
+    it('returns LLMSecurityAnalyzer', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      expect(analyzer.kind).toBe('LLMSecurityAnalyzer');
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/security/__tests__/confirmationPolicy.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/__tests__/confirmationPolicy.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  AlwaysConfirm,
+  NeverConfirm,
+  ConfirmRisky,
+  createConfirmationPolicyFromSettings,
+} from '../confirmationPolicy';
+
+describe('AlwaysConfirm', () => {
+  it('always returns true regardless of risk level', () => {
+    const policy = new AlwaysConfirm();
+    expect(policy.shouldConfirm('LOW')).toBe(true);
+    expect(policy.shouldConfirm('MEDIUM')).toBe(true);
+    expect(policy.shouldConfirm('HIGH')).toBe(true);
+    expect(policy.shouldConfirm('UNKNOWN')).toBe(true);
+    expect(policy.shouldConfirm()).toBe(true);
+  });
+
+  it('has kind AlwaysConfirm', () => {
+    const policy = new AlwaysConfirm();
+    expect(policy.kind).toBe('AlwaysConfirm');
+  });
+});
+
+describe('NeverConfirm', () => {
+  it('always returns false regardless of risk level', () => {
+    const policy = new NeverConfirm();
+    expect(policy.shouldConfirm('LOW')).toBe(false);
+    expect(policy.shouldConfirm('MEDIUM')).toBe(false);
+    expect(policy.shouldConfirm('HIGH')).toBe(false);
+    expect(policy.shouldConfirm('UNKNOWN')).toBe(false);
+    expect(policy.shouldConfirm()).toBe(false);
+  });
+
+  it('has kind NeverConfirm', () => {
+    const policy = new NeverConfirm();
+    expect(policy.kind).toBe('NeverConfirm');
+  });
+});
+
+describe('ConfirmRisky', () => {
+  describe('with default threshold (HIGH)', () => {
+    it('confirms only HIGH risk', () => {
+      const policy = new ConfirmRisky();
+      expect(policy.shouldConfirm('LOW')).toBe(false);
+      expect(policy.shouldConfirm('MEDIUM')).toBe(false);
+      expect(policy.shouldConfirm('HIGH')).toBe(true);
+    });
+
+    it('confirms UNKNOWN by default', () => {
+      const policy = new ConfirmRisky();
+      expect(policy.shouldConfirm('UNKNOWN')).toBe(true);
+      expect(policy.shouldConfirm()).toBe(true);
+    });
+  });
+
+  describe('with MEDIUM threshold', () => {
+    it('confirms MEDIUM and HIGH', () => {
+      const policy = new ConfirmRisky({ threshold: 'MEDIUM' });
+      expect(policy.shouldConfirm('LOW')).toBe(false);
+      expect(policy.shouldConfirm('MEDIUM')).toBe(true);
+      expect(policy.shouldConfirm('HIGH')).toBe(true);
+    });
+  });
+
+  describe('with LOW threshold', () => {
+    it('confirms LOW, MEDIUM, and HIGH', () => {
+      const policy = new ConfirmRisky({ threshold: 'LOW' });
+      expect(policy.shouldConfirm('LOW')).toBe(true);
+      expect(policy.shouldConfirm('MEDIUM')).toBe(true);
+      expect(policy.shouldConfirm('HIGH')).toBe(true);
+    });
+  });
+
+  describe('confirmUnknown option', () => {
+    it('does not confirm UNKNOWN when confirmUnknown is false', () => {
+      const policy = new ConfirmRisky({ confirmUnknown: false });
+      expect(policy.shouldConfirm('UNKNOWN')).toBe(false);
+      expect(policy.shouldConfirm()).toBe(false);
+    });
+
+    it('confirms UNKNOWN when confirmUnknown is true', () => {
+      const policy = new ConfirmRisky({ confirmUnknown: true });
+      expect(policy.shouldConfirm('UNKNOWN')).toBe(true);
+    });
+  });
+
+  it('has kind ConfirmRisky', () => {
+    const policy = new ConfirmRisky();
+    expect(policy.kind).toBe('ConfirmRisky');
+  });
+
+  it('exposes threshold and confirmUnknown properties', () => {
+    const policy = new ConfirmRisky({ threshold: 'MEDIUM', confirmUnknown: false });
+    expect(policy.threshold).toBe('MEDIUM');
+    expect(policy.confirmUnknown).toBe(false);
+  });
+});
+
+describe('createConfirmationPolicyFromSettings', () => {
+  it('returns NeverConfirm for undefined settings', () => {
+    const policy = createConfirmationPolicyFromSettings(undefined);
+    expect(policy.kind).toBe('NeverConfirm');
+  });
+
+  it('returns NeverConfirm for policy: never', () => {
+    const policy = createConfirmationPolicyFromSettings({ policy: 'never' });
+    expect(policy.kind).toBe('NeverConfirm');
+  });
+
+  it('returns AlwaysConfirm for policy: always', () => {
+    const policy = createConfirmationPolicyFromSettings({ policy: 'always' });
+    expect(policy.kind).toBe('AlwaysConfirm');
+  });
+
+  it('returns ConfirmRisky for policy: risky', () => {
+    const policy = createConfirmationPolicyFromSettings({ policy: 'risky' });
+    expect(policy.kind).toBe('ConfirmRisky');
+  });
+
+  it('applies riskyThreshold from settings', () => {
+    const policy = createConfirmationPolicyFromSettings({
+      policy: 'risky',
+      riskyThreshold: 'low',
+    }) as ConfirmRisky;
+    expect(policy.threshold).toBe('LOW');
+  });
+
+  it('applies uppercase riskyThreshold from settings', () => {
+    const policy = createConfirmationPolicyFromSettings({
+      policy: 'risky',
+      riskyThreshold: 'MEDIUM',
+    }) as ConfirmRisky;
+    expect(policy.threshold).toBe('MEDIUM');
+  });
+
+  it('applies confirmUnknown from settings', () => {
+    const policy = createConfirmationPolicyFromSettings({
+      policy: 'risky',
+      confirmUnknown: false,
+    }) as ConfirmRisky;
+    expect(policy.confirmUnknown).toBe(false);
+  });
+
+  it('defaults riskyThreshold to MEDIUM', () => {
+    const policy = createConfirmationPolicyFromSettings({
+      policy: 'risky',
+    }) as ConfirmRisky;
+    expect(policy.threshold).toBe('MEDIUM');
+  });
+
+  it('defaults confirmUnknown to true', () => {
+    const policy = createConfirmationPolicyFromSettings({
+      policy: 'risky',
+    }) as ConfirmRisky;
+    expect(policy.confirmUnknown).toBe(true);
+  });
+
+  it('returns NeverConfirm when policy is undefined', () => {
+    const policy = createConfirmationPolicyFromSettings({});
+    expect(policy.kind).toBe('NeverConfirm');
+  });
+});

--- a/packages/agent-sdk-ts/src/sdk/types/__tests__/typeGuards.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/__tests__/typeGuards.test.ts
@@ -1,0 +1,391 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isEvent,
+  isTextContent,
+  isImageContent,
+  isSystemPromptEvent,
+  isActionEvent,
+  isObservationEvent,
+  isUserRejectObservation,
+  isMessageEvent,
+  isAgentErrorEvent,
+  isConversationErrorEvent,
+  isPauseEvent,
+  isCondensation,
+  isConversationStateUpdateEvent,
+  isBashEvent,
+  isBashCommand,
+  isBashOutput,
+  isBashExit,
+  type Event,
+  type Content,
+  type BashEvent,
+} from '../index';
+
+describe('Content guards', () => {
+  describe('isTextContent', () => {
+    it('returns true for text content', () => {
+      const content: Content = { type: 'text', text: 'hello' };
+      expect(isTextContent(content)).toBe(true);
+    });
+
+    it('returns false for image content', () => {
+      const content: Content = { type: 'image', image_urls: ['url'] };
+      expect(isTextContent(content)).toBe(false);
+    });
+  });
+
+  describe('isImageContent', () => {
+    it('returns true for image content', () => {
+      const content: Content = { type: 'image', image_urls: ['url'] };
+      expect(isImageContent(content)).toBe(true);
+    });
+
+    it('returns false for text content', () => {
+      const content: Content = { type: 'text', text: 'hello' };
+      expect(isImageContent(content)).toBe(false);
+    });
+  });
+});
+
+describe('Event guards', () => {
+  describe('isEvent', () => {
+    it('returns true for valid SystemPromptEvent', () => {
+      const event = {
+        kind: 'SystemPromptEvent',
+        source: 'agent',
+        system_prompt: { type: 'text', text: 'prompt' },
+        tools: [],
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid ActionEvent', () => {
+      const event = {
+        kind: 'ActionEvent',
+        source: 'agent',
+        thought: [{ type: 'text', text: 'thinking' }],
+        action: {},
+        tool_name: 'test',
+        tool_call_id: 'id',
+        tool_call: { id: 'id', type: 'function', function: { name: 'test', arguments: '{}' } },
+        llm_response_id: 'resp',
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid ObservationEvent', () => {
+      const event = {
+        kind: 'ObservationEvent',
+        source: 'environment',
+        observation: {},
+        tool_name: 'test',
+        tool_call_id: 'id',
+        action_id: 'action',
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid MessageEvent', () => {
+      const event = {
+        kind: 'MessageEvent',
+        source: 'user',
+        llm_message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid AgentErrorEvent', () => {
+      const event = {
+        kind: 'AgentErrorEvent',
+        source: 'agent',
+        error: 'error message',
+        tool_name: 'test',
+        tool_call_id: 'id',
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid ConversationErrorEvent', () => {
+      const event = {
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        code: 'ERR_001',
+        detail: 'Error details',
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid PauseEvent', () => {
+      const event = {
+        kind: 'PauseEvent',
+        source: 'user',
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid Condensation', () => {
+      const event = {
+        kind: 'Condensation',
+        source: 'environment',
+        forgotten_event_ids: ['id1', 'id2'],
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid ConversationStateUpdateEvent', () => {
+      const event = {
+        kind: 'ConversationStateUpdateEvent',
+        source: 'agent',
+        iteration: 1,
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid UserRejectObservation', () => {
+      const event = {
+        kind: 'UserRejectObservation',
+        source: 'environment',
+        rejection_reason: 'User rejected',
+        tool_name: 'test',
+        tool_call_id: 'id',
+        action_id: 'action',
+      };
+      expect(isEvent(event)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isEvent(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isEvent(undefined)).toBe(false);
+    });
+
+    it('returns false for non-object', () => {
+      expect(isEvent('string')).toBe(false);
+    });
+
+    it('returns false for missing kind', () => {
+      expect(isEvent({ source: 'agent' })).toBe(false);
+    });
+
+    it('returns false for unknown kind', () => {
+      expect(isEvent({ kind: 'UnknownEvent' })).toBe(false);
+    });
+  });
+
+  describe('Event kind guards', () => {
+    const systemPromptEvent: Event = {
+      kind: 'SystemPromptEvent',
+      source: 'agent',
+      system_prompt: { type: 'text', text: 'prompt' },
+      tools: [],
+    };
+
+    const actionEvent: Event = {
+      kind: 'ActionEvent',
+      source: 'agent',
+      thought: [{ type: 'text', text: 'thinking' }],
+      action: {},
+      tool_name: 'test',
+      tool_call_id: 'id',
+      tool_call: { id: 'id', type: 'function', function: { name: 'test', arguments: '{}' } },
+      llm_response_id: 'resp',
+    };
+
+    const observationEvent: Event = {
+      kind: 'ObservationEvent',
+      source: 'environment',
+      observation: {},
+      tool_name: 'test',
+      tool_call_id: 'id',
+      action_id: 'action',
+    };
+
+    const messageEvent: Event = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    };
+
+    it('isSystemPromptEvent correctly identifies', () => {
+      expect(isSystemPromptEvent(systemPromptEvent)).toBe(true);
+      expect(isSystemPromptEvent(actionEvent)).toBe(false);
+    });
+
+    it('isActionEvent correctly identifies', () => {
+      expect(isActionEvent(actionEvent)).toBe(true);
+      expect(isActionEvent(messageEvent)).toBe(false);
+    });
+
+    it('isObservationEvent correctly identifies', () => {
+      expect(isObservationEvent(observationEvent)).toBe(true);
+      expect(isObservationEvent(actionEvent)).toBe(false);
+    });
+
+    it('isMessageEvent correctly identifies', () => {
+      expect(isMessageEvent(messageEvent)).toBe(true);
+      expect(isMessageEvent(actionEvent)).toBe(false);
+    });
+
+    it('isConversationStateUpdateEvent correctly identifies', () => {
+      const event: Event = { kind: 'ConversationStateUpdateEvent', source: 'agent' };
+      expect(isConversationStateUpdateEvent(event)).toBe(true);
+      expect(isConversationStateUpdateEvent(actionEvent)).toBe(false);
+    });
+
+    it('isPauseEvent correctly identifies', () => {
+      const event: Event = { kind: 'PauseEvent', source: 'user' };
+      expect(isPauseEvent(event)).toBe(true);
+      expect(isPauseEvent(actionEvent)).toBe(false);
+    });
+
+    it('isCondensation correctly identifies', () => {
+      const event: Event = {
+        kind: 'Condensation',
+        source: 'environment',
+        forgotten_event_ids: [],
+      };
+      expect(isCondensation(event)).toBe(true);
+      expect(isCondensation(actionEvent)).toBe(false);
+    });
+
+    it('isAgentErrorEvent correctly identifies', () => {
+      const event: Event = {
+        kind: 'AgentErrorEvent',
+        source: 'agent',
+        error: 'error',
+        tool_name: 'test',
+        tool_call_id: 'id',
+      };
+      expect(isAgentErrorEvent(event)).toBe(true);
+      expect(isAgentErrorEvent(actionEvent)).toBe(false);
+    });
+
+    it('isConversationErrorEvent correctly identifies', () => {
+      const event: Event = {
+        kind: 'ConversationErrorEvent',
+        source: 'agent',
+        detail: 'error',
+      };
+      expect(isConversationErrorEvent(event)).toBe(true);
+      expect(isConversationErrorEvent(actionEvent)).toBe(false);
+    });
+
+    it('isUserRejectObservation correctly identifies', () => {
+      const event: Event = {
+        kind: 'UserRejectObservation',
+        source: 'environment',
+        rejection_reason: 'rejected',
+        tool_name: 'test',
+        tool_call_id: 'id',
+        action_id: 'action',
+      };
+      expect(isUserRejectObservation(event)).toBe(true);
+      expect(isUserRejectObservation(actionEvent)).toBe(false);
+    });
+  });
+});
+
+describe('Bash event guards', () => {
+  describe('isBashEvent', () => {
+    it('returns true for valid BashCommand', () => {
+      const event = {
+        id: '1',
+        type: 'BashCommand',
+        timestamp: '2024-01-01T00:00:00Z',
+        command_id: 'cmd1',
+        order: 0,
+        command: 'ls -la',
+      };
+      expect(isBashEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid BashOutput', () => {
+      const event = {
+        id: '2',
+        type: 'BashOutput',
+        timestamp: '2024-01-01T00:00:00Z',
+        command_id: 'cmd1',
+        order: 1,
+        exit_code: 0,
+        stdout: 'output',
+        stderr: null,
+      };
+      expect(isBashEvent(event)).toBe(true);
+    });
+
+    it('returns true for valid BashExit', () => {
+      const event = {
+        id: '3',
+        type: 'BashExit',
+        timestamp: '2024-01-01T00:00:00Z',
+        command_id: 'cmd1',
+        order: 2,
+        exit_code: 0,
+      };
+      expect(isBashEvent(event)).toBe(true);
+    });
+
+    it('returns false for invalid object', () => {
+      expect(isBashEvent({})).toBe(false);
+      expect(isBashEvent(null)).toBe(false);
+      expect(isBashEvent('string')).toBe(false);
+    });
+
+    it('returns false for missing required fields', () => {
+      expect(isBashEvent({ type: 'BashCommand' })).toBe(false);
+      expect(isBashEvent({ type: 'BashCommand', command_id: 'id' })).toBe(false);
+    });
+  });
+
+  describe('Bash event kind guards', () => {
+    const bashCommand: BashEvent = {
+      id: '1',
+      type: 'BashCommand',
+      timestamp: '2024-01-01T00:00:00Z',
+      command_id: 'cmd1',
+      order: 0,
+      command: 'ls',
+    };
+
+    const bashOutput: BashEvent = {
+      id: '2',
+      type: 'BashOutput',
+      timestamp: '2024-01-01T00:00:00Z',
+      command_id: 'cmd1',
+      order: 1,
+      exit_code: 0,
+      stdout: 'output',
+      stderr: null,
+    };
+
+    const bashExit: BashEvent = {
+      id: '3',
+      type: 'BashExit',
+      timestamp: '2024-01-01T00:00:00Z',
+      command_id: 'cmd1',
+      order: 2,
+      exit_code: 0,
+    };
+
+    it('isBashCommand correctly identifies', () => {
+      expect(isBashCommand(bashCommand)).toBe(true);
+      expect(isBashCommand(bashOutput)).toBe(false);
+      expect(isBashCommand(bashExit)).toBe(false);
+    });
+
+    it('isBashOutput correctly identifies', () => {
+      expect(isBashOutput(bashOutput)).toBe(true);
+      expect(isBashOutput(bashCommand)).toBe(false);
+      expect(isBashOutput(bashExit)).toBe(false);
+    });
+
+    it('isBashExit correctly identifies', () => {
+      expect(isBashExit(bashExit)).toBe(true);
+      expect(isBashExit(bashCommand)).toBe(false);
+      expect(isBashExit(bashOutput)).toBe(false);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/tools/__tests__/searchUtils.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/searchUtils.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  shouldSkipSearchEntry,
+  listFilesRecursively,
+  normalizeSlashes,
+  normalizeGlobPattern,
+  expandHome,
+  planGlobWalk,
+  createGlobMatcher,
+} from '../searchUtils';
+
+describe('searchUtils', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-utils-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('shouldSkipSearchEntry', () => {
+    it('skips hidden files by default', () => {
+      expect(shouldSkipSearchEntry('.gitignore')).toBe(true);
+      expect(shouldSkipSearchEntry('.config')).toBe(true);
+    });
+
+    it('does not skip hidden files when includeHidden is true', () => {
+      expect(shouldSkipSearchEntry('.gitignore', { includeHidden: true })).toBe(false);
+    });
+
+    it('skips node_modules by default', () => {
+      expect(shouldSkipSearchEntry('node_modules')).toBe(true);
+    });
+
+    it('does not skip node_modules when includeNodeModules is true', () => {
+      expect(shouldSkipSearchEntry('node_modules', { includeNodeModules: true })).toBe(false);
+    });
+
+    it('does not skip regular files', () => {
+      expect(shouldSkipSearchEntry('file.txt')).toBe(false);
+      expect(shouldSkipSearchEntry('src')).toBe(false);
+    });
+  });
+
+  describe('listFilesRecursively', () => {
+    it('lists files in a directory', async () => {
+      fs.writeFileSync(path.join(tempDir, 'file1.txt'), 'content1');
+      fs.writeFileSync(path.join(tempDir, 'file2.txt'), 'content2');
+
+      const files = await listFilesRecursively(tempDir);
+      expect(files.map((f) => path.basename(f))).toContain('file1.txt');
+      expect(files.map((f) => path.basename(f))).toContain('file2.txt');
+    });
+
+    it('lists files recursively in subdirectories', async () => {
+      const subDir = path.join(tempDir, 'subdir');
+      fs.mkdirSync(subDir);
+      fs.writeFileSync(path.join(tempDir, 'root.txt'), '');
+      fs.writeFileSync(path.join(subDir, 'nested.txt'), '');
+
+      const files = await listFilesRecursively(tempDir);
+      expect(files.some((f) => f.endsWith('root.txt'))).toBe(true);
+      expect(files.some((f) => f.endsWith('nested.txt'))).toBe(true);
+    });
+
+    it('skips hidden files by default', async () => {
+      fs.writeFileSync(path.join(tempDir, '.hidden'), '');
+      fs.writeFileSync(path.join(tempDir, 'visible.txt'), '');
+
+      const files = await listFilesRecursively(tempDir);
+      expect(files.some((f) => f.endsWith('.hidden'))).toBe(false);
+      expect(files.some((f) => f.endsWith('visible.txt'))).toBe(true);
+    });
+
+    it('includes hidden files when includeHidden is true', async () => {
+      fs.writeFileSync(path.join(tempDir, '.hidden'), '');
+
+      const files = await listFilesRecursively(tempDir, { includeHidden: true });
+      expect(files.some((f) => f.endsWith('.hidden'))).toBe(true);
+    });
+
+    it('respects maxDepth option', async () => {
+      const level1 = path.join(tempDir, 'level1');
+      const level2 = path.join(level1, 'level2');
+      fs.mkdirSync(level2, { recursive: true });
+      fs.writeFileSync(path.join(tempDir, 'root.txt'), '');
+      fs.writeFileSync(path.join(level1, 'l1.txt'), '');
+      fs.writeFileSync(path.join(level2, 'l2.txt'), '');
+
+      const files = await listFilesRecursively(tempDir, { maxDepth: 0 });
+      expect(files.some((f) => f.endsWith('root.txt'))).toBe(true);
+      expect(files.some((f) => f.endsWith('l1.txt'))).toBe(false);
+    });
+  });
+
+  describe('normalizeSlashes', () => {
+    it('normalizes path separators to forward slashes', () => {
+      // normalizeSlashes splits by path.sep and joins with '/'
+      // On Unix (path.sep = '/'), forward slashes stay as forward slashes
+      // On Windows (path.sep = '\'), backslashes become forward slashes
+      const result = normalizeSlashes('path/to/file');
+      expect(result).toBe('path/to/file');
+    });
+
+    it('leaves forward slashes unchanged on Unix', () => {
+      expect(normalizeSlashes('path/to/file')).toBe('path/to/file');
+    });
+
+    it('handles nested paths', () => {
+      const result = normalizeSlashes('src/components/Button.tsx');
+      expect(result).toBe('src/components/Button.tsx');
+    });
+
+    it('handles empty string', () => {
+      expect(normalizeSlashes('')).toBe('');
+    });
+
+    it('handles single component path', () => {
+      expect(normalizeSlashes('file.txt')).toBe('file.txt');
+    });
+  });
+
+  describe('normalizeGlobPattern', () => {
+    it('returns **/* for empty pattern', () => {
+      expect(normalizeGlobPattern('')).toBe('**/*');
+    });
+
+    it('returns **/* for whitespace-only pattern', () => {
+      expect(normalizeGlobPattern('   ')).toBe('**/*');
+    });
+
+    it('trims whitespace from pattern', () => {
+      expect(normalizeGlobPattern('  *.ts  ')).toBe('*.ts');
+    });
+
+    it('normalizes slashes in pattern', () => {
+      const pattern = 'src\\**\\*.ts';
+      const result = normalizeGlobPattern(pattern);
+      // On Unix, backslashes may remain, but on Windows they get normalized
+      expect(result).toBeDefined();
+    });
+  });
+
+  describe('expandHome', () => {
+    it('expands ~ to home directory', () => {
+      expect(expandHome('~')).toBe(os.homedir());
+    });
+
+    it('expands ~/ prefix to home directory', () => {
+      const result = expandHome('~/documents');
+      expect(result).toBe(path.join(os.homedir(), 'documents'));
+    });
+
+    it('expands ~\\ prefix on Windows-style paths', () => {
+      const result = expandHome('~\\documents');
+      expect(result).toBe(path.join(os.homedir(), 'documents'));
+    });
+
+    it('does not expand ~ in the middle of path', () => {
+      expect(expandHome('/home/user~name')).toBe('/home/user~name');
+    });
+
+    it('returns absolute paths unchanged', () => {
+      expect(expandHome('/absolute/path')).toBe('/absolute/path');
+    });
+  });
+
+  describe('planGlobWalk', () => {
+    it('returns search root as walk root for wildcard patterns', () => {
+      const result = planGlobWalk('/search', '**/*.ts');
+      expect(result.walkRoot).toBe('/search');
+      expect(result.matcherPattern).toBe('**/*.ts');
+    });
+
+    it('optimizes walk root for static prefix', () => {
+      const result = planGlobWalk('/search', 'src/components/*.tsx');
+      expect(result.walkRoot).toBe(path.join('/search', 'src', 'components'));
+      expect(result.matcherPattern).toBe('*.tsx');
+    });
+
+    it('calculates maxDepth for non-globstar patterns', () => {
+      const result = planGlobWalk('/search', 'src/*.ts');
+      expect(result.walkRoot).toBe(path.join('/search', 'src'));
+      expect(result.maxDepth).toBe(0);
+    });
+
+    it('returns undefined maxDepth for globstar patterns', () => {
+      const result = planGlobWalk('/search', '**/*.ts');
+      expect(result.maxDepth).toBe(undefined);
+    });
+
+    it('handles patterns starting with glob', () => {
+      const result = planGlobWalk('/search', '*.ts');
+      expect(result.walkRoot).toBe('/search');
+      expect(result.matcherPattern).toBe('*.ts');
+    });
+
+    it('handles pattern with double globstar in middle', () => {
+      const result = planGlobWalk('/search', 'src/**/test/*.spec.ts');
+      expect(result.walkRoot).toBe(path.join('/search', 'src'));
+      expect(result.matcherPattern).toBe('**/test/*.spec.ts');
+    });
+  });
+
+  describe('createGlobMatcher', () => {
+    it('matches files based on pattern', () => {
+      const matcher = createGlobMatcher('*.ts');
+      expect(matcher('file.ts')).toBe(true);
+      expect(matcher('file.tsx')).toBe(false);
+      expect(matcher('file.js')).toBe(false);
+    });
+
+    it('matches glob star patterns', () => {
+      const matcher = createGlobMatcher('**/*.ts');
+      expect(matcher('file.ts')).toBe(true);
+      expect(matcher('src/file.ts')).toBe(true);
+      expect(matcher('src/nested/file.ts')).toBe(true);
+    });
+
+    it('matches dot files when dot option is enabled', () => {
+      const matcher = createGlobMatcher('**/*');
+      expect(matcher('.gitignore')).toBe(true);
+      expect(matcher('src/.config')).toBe(true);
+    });
+
+    it('matches brace expansion patterns', () => {
+      const matcher = createGlobMatcher('*.{ts,tsx}');
+      expect(matcher('file.ts')).toBe(true);
+      expect(matcher('file.tsx')).toBe(true);
+      expect(matcher('file.js')).toBe(false);
+    });
+
+    it('returns boolean', () => {
+      const matcher = createGlobMatcher('*.ts');
+      const result = matcher('test.ts');
+      expect(typeof result).toBe('boolean');
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/tools/__tests__/validation.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/validation.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest';
+import {
+  requireObject,
+  requireString,
+  optionalString,
+  requireBoolean,
+  optionalNumber,
+} from '../validation';
+
+describe('validation utilities', () => {
+  describe('requireObject', () => {
+    it('returns valid object', () => {
+      const obj = { foo: 'bar' };
+      expect(requireObject(obj, 'test')).toBe(obj);
+    });
+
+    it('returns empty object', () => {
+      const obj = {};
+      expect(requireObject(obj, 'test')).toBe(obj);
+    });
+
+    it('throws for null', () => {
+      expect(() => requireObject(null, 'field')).toThrow('field must be an object');
+    });
+
+    it('throws for undefined', () => {
+      expect(() => requireObject(undefined, 'field')).toThrow('field must be an object');
+    });
+
+    it('throws for string', () => {
+      expect(() => requireObject('string', 'field')).toThrow('field must be an object');
+    });
+
+    it('throws for number', () => {
+      expect(() => requireObject(123, 'field')).toThrow('field must be an object');
+    });
+
+    it('throws for boolean', () => {
+      expect(() => requireObject(true, 'field')).toThrow('field must be an object');
+    });
+
+    it('accepts arrays (which are objects)', () => {
+      const arr = [1, 2, 3];
+      expect(requireObject(arr, 'test')).toBe(arr);
+    });
+  });
+
+  describe('requireString', () => {
+    it('returns valid string', () => {
+      expect(requireString('hello', 'field')).toBe('hello');
+    });
+
+    it('returns string with content', () => {
+      expect(requireString('test value', 'field')).toBe('test value');
+    });
+
+    it('throws for empty string', () => {
+      expect(() => requireString('', 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for whitespace-only string', () => {
+      expect(() => requireString('   ', 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for null', () => {
+      expect(() => requireString(null, 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for undefined', () => {
+      expect(() => requireString(undefined, 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for number', () => {
+      expect(() => requireString(123, 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for object', () => {
+      expect(() => requireString({}, 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('returns string with leading/trailing whitespace', () => {
+      expect(requireString('  hello  ', 'field')).toBe('  hello  ');
+    });
+  });
+
+  describe('optionalString', () => {
+    it('returns undefined for undefined input', () => {
+      expect(optionalString(undefined, 'field')).toBe(undefined);
+    });
+
+    it('returns string for valid string', () => {
+      expect(optionalString('hello', 'field')).toBe('hello');
+    });
+
+    it('throws for empty string', () => {
+      expect(() => optionalString('', 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for whitespace-only string', () => {
+      expect(() => optionalString('   ', 'field')).toThrow('field must be a non-empty string');
+    });
+
+    it('throws for non-string non-undefined values', () => {
+      expect(() => optionalString(123, 'field')).toThrow('field must be a non-empty string');
+      expect(() => optionalString(null, 'field')).toThrow('field must be a non-empty string');
+      expect(() => optionalString({}, 'field')).toThrow('field must be a non-empty string');
+    });
+  });
+
+  describe('requireBoolean', () => {
+    it('returns true for true', () => {
+      expect(requireBoolean(true, 'field')).toBe(true);
+    });
+
+    it('returns false for false', () => {
+      expect(requireBoolean(false, 'field')).toBe(false);
+    });
+
+    it('throws for string', () => {
+      expect(() => requireBoolean('true', 'field')).toThrow('field must be a boolean');
+    });
+
+    it('throws for number', () => {
+      expect(() => requireBoolean(1, 'field')).toThrow('field must be a boolean');
+      expect(() => requireBoolean(0, 'field')).toThrow('field must be a boolean');
+    });
+
+    it('throws for null', () => {
+      expect(() => requireBoolean(null, 'field')).toThrow('field must be a boolean');
+    });
+
+    it('throws for undefined', () => {
+      expect(() => requireBoolean(undefined, 'field')).toThrow('field must be a boolean');
+    });
+
+    it('throws for object', () => {
+      expect(() => requireBoolean({}, 'field')).toThrow('field must be a boolean');
+    });
+  });
+
+  describe('optionalNumber', () => {
+    it('returns undefined for undefined input', () => {
+      expect(optionalNumber(undefined, 'field')).toBe(undefined);
+    });
+
+    it('returns number for valid number', () => {
+      expect(optionalNumber(42, 'field')).toBe(42);
+    });
+
+    it('returns 0 for zero', () => {
+      expect(optionalNumber(0, 'field')).toBe(0);
+    });
+
+    it('returns negative numbers', () => {
+      expect(optionalNumber(-5, 'field')).toBe(-5);
+    });
+
+    it('returns floating point numbers', () => {
+      expect(optionalNumber(3.14, 'field')).toBe(3.14);
+    });
+
+    it('throws for NaN', () => {
+      expect(() => optionalNumber(NaN, 'field')).toThrow('field must be a number');
+    });
+
+    it('throws for string', () => {
+      expect(() => optionalNumber('42', 'field')).toThrow('field must be a number');
+    });
+
+    it('throws for null', () => {
+      expect(() => optionalNumber(null, 'field')).toThrow('field must be a number');
+    });
+
+    it('throws for object', () => {
+      expect(() => optionalNumber({}, 'field')).toThrow('field must be a number');
+    });
+
+    it('returns Infinity', () => {
+      expect(optionalNumber(Infinity, 'field')).toBe(Infinity);
+    });
+
+    it('returns negative Infinity', () => {
+      expect(optionalNumber(-Infinity, 'field')).toBe(-Infinity);
+    });
+  });
+});

--- a/packages/agent-sdk-ts/src/tools/__tests__/zod-tool.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/zod-tool.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { ZodTool, booleanWithDefault } from '../zod-tool';
+import type { ToolContext } from '../types';
+
+// Create a concrete implementation of ZodTool for testing
+class TestTool extends ZodTool<{ message: string; count?: number }, string> {
+  readonly name = 'test_tool';
+  readonly description = 'A test tool for unit tests';
+  readonly schema = z.object({
+    message: z.string(),
+    count: z.number().optional(),
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async execute(args: { message: string; count?: number }, context: ToolContext): Promise<string> {
+    const count = args.count ?? 1;
+    return args.message.repeat(count);
+  }
+}
+
+// Tool with nested schema
+class NestedSchemaTool extends ZodTool<{ config: { enabled: boolean; options: string[] } }, void> {
+  readonly name = 'nested_tool';
+  readonly description = 'A tool with nested schema';
+  readonly schema = z.object({
+    config: z.object({
+      enabled: z.boolean(),
+      options: z.array(z.string()),
+    }),
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async execute(args: { config: { enabled: boolean; options: string[] } }, context: ToolContext): Promise<void> {
+    // Do nothing
+  }
+}
+
+// Tool with custom parameter schema
+class CustomParametersTool extends ZodTool<{ value: string }, string> {
+  readonly name = 'custom_params_tool';
+  readonly description = 'A tool with custom parameters';
+  readonly schema = z.object({ value: z.string() });
+  protected override readonly parameterSchema = {
+    type: 'object',
+    properties: {
+      value: { type: 'string', description: 'Custom description' },
+    },
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async execute(args: { value: string }, context: ToolContext): Promise<string> {
+    return args.value;
+  }
+}
+
+describe('ZodTool', () => {
+  describe('validate', () => {
+    it('validates correct input', () => {
+      const tool = new TestTool();
+      const result = tool.validate({ message: 'hello', count: 3 });
+      expect(result.message).toBe('hello');
+      expect(result.count).toBe(3);
+    });
+
+    it('validates input with optional fields missing', () => {
+      const tool = new TestTool();
+      const result = tool.validate({ message: 'hello' });
+      expect(result.message).toBe('hello');
+      expect(result.count).toBeUndefined();
+    });
+
+    it('throws for invalid input', () => {
+      const tool = new TestTool();
+      expect(() => tool.validate({ message: 123 })).toThrow();
+    });
+
+    it('throws for missing required fields', () => {
+      const tool = new TestTool();
+      expect(() => tool.validate({})).toThrow();
+    });
+
+    it('validates nested schema', () => {
+      const tool = new NestedSchemaTool();
+      const result = tool.validate({
+        config: {
+          enabled: true,
+          options: ['a', 'b'],
+        },
+      });
+      expect(result.config.enabled).toBe(true);
+      expect(result.config.options).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('execute', () => {
+    const mockContext: ToolContext = {
+      workspaceRoot: '/test',
+    };
+
+    it('executes tool with valid args', async () => {
+      const tool = new TestTool();
+      const result = await tool.execute({ message: 'hi' }, mockContext);
+      expect(result).toBe('hi');
+    });
+
+    it('executes tool with optional args', async () => {
+      const tool = new TestTool();
+      const result = await tool.execute({ message: 'x', count: 5 }, mockContext);
+      expect(result).toBe('xxxxx');
+    });
+  });
+
+  describe('parameters', () => {
+    it('generates JSON schema from Zod schema', () => {
+      const tool = new TestTool();
+      const params = tool.parameters;
+
+      expect(params.type).toBe('object');
+      expect(params.properties).toBeDefined();
+      expect((params.properties as Record<string, unknown>).message).toBeDefined();
+    });
+
+    it('uses custom parameter schema when provided', () => {
+      const tool = new CustomParametersTool();
+      const params = tool.parameters;
+
+      expect(params.type).toBe('object');
+      expect((params.properties as Record<string, { description?: string }>).value.description).toBe('Custom description');
+    });
+
+    it('handles nested schemas', () => {
+      const tool = new NestedSchemaTool();
+      const params = tool.parameters;
+
+      expect(params.type).toBe('object');
+      expect((params.properties as Record<string, unknown>).config).toBeDefined();
+    });
+  });
+
+  describe('getToolDefinition', () => {
+    it('returns LLM tool definition', () => {
+      const tool = new TestTool();
+      const def = tool.getToolDefinition();
+
+      expect(def.type).toBe('function');
+      expect(def.function.name).toBe('test_tool');
+      expect(def.function.description).toBe('A test tool for unit tests');
+      expect(def.function.parameters).toBeDefined();
+    });
+
+    it('includes parameters from schema', () => {
+      const tool = new TestTool();
+      const def = tool.getToolDefinition();
+
+      expect(def.function.parameters.type).toBe('object');
+      expect(def.function.parameters.properties).toBeDefined();
+    });
+  });
+});
+
+describe('booleanWithDefault', () => {
+  it('creates schema with default true', () => {
+    const schema = booleanWithDefault(true);
+    expect(schema.parse(undefined)).toBe(true);
+    expect(schema.parse(false)).toBe(false);
+    expect(schema.parse(true)).toBe(true);
+  });
+
+  it('creates schema with default false', () => {
+    const schema = booleanWithDefault(false);
+    expect(schema.parse(undefined)).toBe(false);
+    expect(schema.parse(true)).toBe(true);
+    expect(schema.parse(false)).toBe(false);
+  });
+
+  it('throws for non-boolean values', () => {
+    const schema = booleanWithDefault(true);
+    expect(() => schema.parse('true')).toThrow();
+    expect(() => schema.parse(1)).toThrow();
+    expect(() => schema.parse(null)).toThrow();
+  });
+});


### PR DESCRIPTION
Add 18 new test files covering previously untested SDK functionality:

- Security: analyzer, confirmationPolicy
- Conversation: stuckDetector
- Runtime: AsyncLock, ConversationState, EventLog, secretMasker, settingsUtils, toolResultTruncation
- Skills: mcp config, resources discovery
- LLM: errorMapping, credentials, provider
- Tools: validation, searchUtils, zod-tool
- Types: event and content type guards

Test count increased from ~562 to 953 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added broad test coverage across the SDK: MCP config and skill resource discovery, stuck detection, LLM credentials/error mapping/provider, and confirmation/security policies.
  * New suites for runtime primitives: AsyncLock, ConversationState, EventLog, SecretMasker, tool result truncation, and settings utilities.
  * Added tests for search utilities, validation helpers, Zod-based tools, type guards, and miscellaneous tooling utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->