### PR TITLE
e2e: assert default LLM profile seeding

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -567,6 +567,10 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     return { ok: true, provider, key, hasKey: true };
   });
 
+  const listProfiles = vscode.commands.registerCommand('openhands._listProfiles', () => {
+    return { profiles: llmProfilesStore.listProfiles() };
+  });
+
   const injectTerminalEvent = vscode.commands.registerCommand('openhands._injectTerminalEvent', (raw: unknown) => {
     if (!isBashEvent(raw)) {
       return { injected: false, error: 'Invalid BashEvent structure' };
@@ -600,6 +604,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     selectProfile,
     setProfileApiKey,
     setProviderApiKey,
+    listProfiles,
     injectTerminalEvent,
   ];
 }

--- a/tests/e2e/defaultProfilesSeeding.test.ts
+++ b/tests/e2e/defaultProfilesSeeding.test.ts
@@ -1,0 +1,49 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-default-profiles-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab default profiles seeding E2E', function () {
+  this.timeout(180000);
+
+  after(async () => {
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  });
+
+  it('seeds default LLM profiles on first install and does not overwrite existing defaults', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    // Isolate ~/.openhands/llm-profiles + VS Code argv settings for this suite.
+    await ensureVsCodeArgvJson(userDataDir);
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir',
+        userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'defaultProfilesSeeding',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/defaultProfilesSeeding.ts
+++ b/tests/e2e/suite/defaultProfilesSeeding.ts
@@ -1,0 +1,111 @@
+import * as assert from 'assert';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+
+const DEFAULT_PROFILE_IDS = [
+  'gemini-flash',
+  'gemini-flash-hal',
+  'gemini-flash-summarizer',
+  'gpt-5',
+  'gpt-5-mini',
+  'sonnet-45',
+] as const;
+
+type LlmProfilesResult = { profiles?: unknown } | undefined;
+
+const getProfilesDir = (): string => path.join(os.homedir(), '.openhands', 'llm-profiles');
+
+const readJson = async (filePath: string): Promise<Record<string, unknown>> => {
+  const raw = await fs.readFile(filePath, 'utf8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`Expected JSON object in ${filePath}`);
+  }
+  return parsed as Record<string, unknown>;
+};
+
+export async function run(): Promise<void> {
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<{ chat?: { hasView?: boolean; webviewReady?: boolean } }>(
+      'openhands._diagnostics',
+    );
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  // 1) Fresh install: default profiles should be seeded on disk.
+  const profilesDir = getProfilesDir();
+
+  await pollUntil(async () => {
+    try {
+      await fs.access(profilesDir);
+    } catch {
+      return false;
+    }
+
+    const exists = await Promise.all(
+      DEFAULT_PROFILE_IDS.map(async (id) => {
+        try {
+          await fs.access(path.join(profilesDir, `${id}.json`));
+          return true;
+        } catch {
+          return false;
+        }
+      }),
+    );
+    return exists.every(Boolean);
+  }, 15000);
+
+  for (const id of DEFAULT_PROFILE_IDS) {
+    const payload = await readJson(path.join(profilesDir, `${id}.json`));
+    assert.strictEqual(typeof payload.provider, 'string');
+    assert.strictEqual(typeof payload.model, 'string');
+    assert.strictEqual(typeof payload.baseUrl, 'string');
+    assert.strictEqual(payload.apiKey, undefined);
+    assert.strictEqual(payload.headers, undefined);
+  }
+
+  // 2) Source of truth for dropdown: host-side profile list.
+  const listed = await vscode.commands.executeCommand<LlmProfilesResult>('openhands._listProfiles');
+  const profilesRaw = listed && typeof listed === 'object' ? (listed as { profiles?: unknown }).profiles : undefined;
+  if (!Array.isArray(profilesRaw)) throw new Error(`Expected profiles array, got: ${JSON.stringify(listed)}`);
+  const profiles = profilesRaw.filter((id): id is string => typeof id === 'string');
+  for (const id of DEFAULT_PROFILE_IDS) {
+    assert.ok(profiles.includes(id), `Expected _listProfiles to include '${id}'`);
+  }
+
+  // 3) Non-destructive: user customizations to a default profile should not be overwritten.
+  const customizedId = 'sonnet-45';
+  const customizedPath = path.join(profilesDir, `${customizedId}.json`);
+  const before = await readJson(customizedPath);
+  const updated = { ...before, model: 'claude-e2e-custom', temperature: 0.123 };
+  await fs.writeFile(customizedPath, `${JSON.stringify(updated, null, 2)}\n`, 'utf8');
+
+  await vscode.commands.executeCommand('openhands._listProfiles');
+
+  const after = await readJson(customizedPath);
+  assert.strictEqual(after.model, 'claude-e2e-custom');
+  assert.strictEqual(after.temperature, 0.123);
+
+  // 4) Additive: missing default profiles should be recreated (simulates an upgrade adding defaults).
+  const missingId = 'gpt-5-mini';
+  const missingPath = path.join(profilesDir, `${missingId}.json`);
+  await fs.rm(missingPath, { force: true });
+  assert.rejects(() => fs.access(missingPath));
+
+  await vscode.commands.executeCommand('openhands._listProfiles');
+
+  await pollUntil(async () => {
+    try {
+      await fs.access(missingPath);
+      return true;
+    } catch {
+      return false;
+    }
+  }, 15000);
+}
+

--- a/tests/e2e/suite/defaultProfilesSeeding.ts
+++ b/tests/e2e/suite/defaultProfilesSeeding.ts
@@ -14,7 +14,7 @@ const DEFAULT_PROFILE_IDS = [
   'sonnet-45',
 ] as const;
 
-type LlmProfilesResult = { profiles?: unknown } | undefined;
+type LlmProfilesResult = { profiles?: string[] } | undefined;
 
 const getProfilesDir = (): string => path.join(os.homedir(), '.openhands', 'llm-profiles');
 
@@ -71,7 +71,7 @@ export async function run(): Promise<void> {
 
   // 2) Source of truth for dropdown: host-side profile list.
   const listed = await vscode.commands.executeCommand<LlmProfilesResult>('openhands._listProfiles');
-  const profilesRaw = listed && typeof listed === 'object' ? (listed as { profiles?: unknown }).profiles : undefined;
+  const profilesRaw = listed?.profiles;
   if (!Array.isArray(profilesRaw)) throw new Error(`Expected profiles array, got: ${JSON.stringify(listed)}`);
   const profiles = profilesRaw.filter((id): id is string => typeof id === 'string');
   for (const id of DEFAULT_PROFILE_IDS) {
@@ -95,7 +95,7 @@ export async function run(): Promise<void> {
   const missingId = 'gpt-5-mini';
   const missingPath = path.join(profilesDir, `${missingId}.json`);
   await fs.rm(missingPath, { force: true });
-  assert.rejects(() => fs.access(missingPath));
+  await assert.rejects(() => fs.access(missingPath));
 
   await vscode.commands.executeCommand('openhands._listProfiles');
 
@@ -108,4 +108,3 @@ export async function run(): Promise<void> {
     }
   }, 15000);
 }
-

--- a/tests/e2e/suite/defaultProfilesSeeding.ts
+++ b/tests/e2e/suite/defaultProfilesSeeding.ts
@@ -71,9 +71,8 @@ export async function run(): Promise<void> {
 
   // 2) Source of truth for dropdown: host-side profile list.
   const listed = await vscode.commands.executeCommand<LlmProfilesResult>('openhands._listProfiles');
-  const profilesRaw = listed?.profiles;
-  if (!Array.isArray(profilesRaw)) throw new Error(`Expected profiles array, got: ${JSON.stringify(listed)}`);
-  const profiles = profilesRaw.filter((id): id is string => typeof id === 'string');
+  const profiles = listed?.profiles;
+  if (!Array.isArray(profiles)) throw new Error(`Expected profiles array, got: ${JSON.stringify(listed)}`);
   for (const id of DEFAULT_PROFILE_IDS) {
     assert.ok(profiles.includes(id), `Expected _listProfiles to include '${id}'`);
   }

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -69,6 +69,11 @@ export async function run(): Promise<void> {
     return runDefaultProfileSelectionTest();
   }
 
+  if (testName === 'defaultProfilesSeeding') {
+    const { run: runDefaultProfilesSeedingTest } = await import('./defaultProfilesSeeding');
+    return runDefaultProfilesSeedingTest();
+  }
+
   if (testName === 'oracleUnset') {
     const { run: runOracleUnsetTest } = await import('./oracleUnset');
     return runOracleUnsetTest();


### PR DESCRIPTION
- Adds E2E coverage for default LLM profile seeding on fresh install.
- Verifies: defaults exist on disk, appear in host profiles list (dropdown source), do not overwrite user edits, and recreate missing defaults.

Test:
- `npm run e2e -- --grep "default profiles seeding"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end tests for default LLM profile initialization on first install.
  * Tests verify customized profiles persist correctly and validate profile recreation during upgrades.

* **Chores**
  * Added internal diagnostics command for profile listing support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->