### PR TITLE
add working directory context to tool descriptions

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -852,18 +852,36 @@ export class Agent extends EventEmitter {
   }
 
   private getToolDefinitions(): LLMToolDefinition[] {
+    const workspaceRoot = this.workspace.root;
     const definitions: LLMToolDefinition[] = Array.from(this.tools.values()).map((tool): LLMToolDefinition => {
+      // Get base definition
+      let baseDef: LLMToolDefinition;
       if (typeof tool.getToolDefinition === 'function') {
-        return tool.getToolDefinition();
+        baseDef = tool.getToolDefinition();
+      } else {
+        const definition: LLMToolDefinition['function'] = { name: tool.name };
+        if (tool.description) {
+          definition.description = tool.description;
+        }
+        if (tool.parameters) {
+          definition.parameters = tool.parameters;
+        }
+        baseDef = { type: 'function', function: definition };
       }
-      const definition: LLMToolDefinition['function'] = { name: tool.name };
-      if (tool.description) {
-        definition.description = tool.description;
+
+      // Enhance description with workspace context if tool supports it
+      if (typeof tool.getEnhancedDescription === 'function') {
+        const enhancedDescription = tool.getEnhancedDescription(workspaceRoot);
+        return {
+          ...baseDef,
+          function: {
+            ...baseDef.function,
+            description: enhancedDescription,
+          },
+        };
       }
-      if (tool.parameters) {
-        definition.parameters = tool.parameters;
-      }
-      return { type: 'function', function: definition };
+
+      return baseDef;
     });
 
     if (!this.shouldIncludeSecurityRiskAssessment()) return definitions;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -872,13 +872,15 @@ export class Agent extends EventEmitter {
       // Enhance description with workspace context if tool supports it
       if (typeof tool.getEnhancedDescription === 'function') {
         const enhancedDescription = tool.getEnhancedDescription(workspaceRoot);
-        return {
-          ...baseDef,
-          function: {
-            ...baseDef.function,
-            description: enhancedDescription,
-          },
-        };
+        if (typeof enhancedDescription === 'string' && enhancedDescription.trim().length > 0) {
+          return {
+            ...baseDef,
+            function: {
+              ...baseDef.function,
+              description: enhancedDescription,
+            },
+          };
+        }
       }
 
       return baseDef;

--- a/packages/agent-sdk-ts/src/sdk/types/tools.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/tools.ts
@@ -18,4 +18,9 @@ export interface ToolDefinition<TArgs, TResult> {
   validate(input: unknown): TArgs;
   execute(args: TArgs, context: ToolContext): Promise<TResult>;
   getToolDefinition?: () => LLMToolDefinition;
+  /**
+   * Returns an enhanced description with context-specific information (e.g., working directory).
+   * If not implemented, the static description is used.
+   */
+  getEnhancedDescription?: (workspaceRoot: string) => string;
 }

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -167,6 +167,14 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
   private undoBytesTotal = 0;
   private readonly maxOutputChars: number;
 
+  override getEnhancedDescription(workspaceRoot: string): string {
+    return (
+      `${TOOL_DESCRIPTION}\n\n` +
+      `Your current working directory is: ${workspaceRoot}\n` +
+      `When exploring project structure, start with this directory instead of the root filesystem.`
+    );
+  }
+
   constructor(options: { maxOutputChars?: number } = {}) {
     super();
     const configured = options.maxOutputChars;

--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -168,11 +168,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
   private readonly maxOutputChars: number;
 
   override getEnhancedDescription(workspaceRoot: string): string {
-    return (
-      `${TOOL_DESCRIPTION}\n\n` +
-      `Your current working directory is: ${workspaceRoot}\n` +
-      `When exploring project structure, start with this directory instead of the root filesystem.`
-    );
+    return `${TOOL_DESCRIPTION}\n\nYour current working directory is: ${workspaceRoot}\nWhen exploring project structure, start with this directory instead of the root filesystem.`;
   }
 
   constructor(options: { maxOutputChars?: number } = {}) {

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -117,11 +117,7 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
   readonly schema = globArgsSchema;
 
   override getEnhancedDescription(workspaceRoot: string): string {
-    return (
-      `${TOOL_DESCRIPTION}\n\n` +
-      `Your current working directory is: ${workspaceRoot}\n` +
-      `When searching for files, patterns are relative to this directory.`
-    );
+    return `${TOOL_DESCRIPTION}\n\nYour current working directory is: ${workspaceRoot}\nWhen searching for files, patterns are relative to this directory.`;
   }
 
   async execute(args: z.infer<typeof globArgsSchema>, context: ToolContext): Promise<GlobResult> {

--- a/packages/agent-sdk-ts/src/tools/GlobTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GlobTool.ts
@@ -116,6 +116,14 @@ export class GlobTool extends ZodTool<z.infer<typeof globArgsSchema>, GlobResult
   readonly description = TOOL_DESCRIPTION;
   readonly schema = globArgsSchema;
 
+  override getEnhancedDescription(workspaceRoot: string): string {
+    return (
+      `${TOOL_DESCRIPTION}\n\n` +
+      `Your current working directory is: ${workspaceRoot}\n` +
+      `When searching for files, patterns are relative to this directory.`
+    );
+  }
+
   async execute(args: z.infer<typeof globArgsSchema>, context: ToolContext): Promise<GlobResult> {
     const resolved = await resolveSearchRootAndPattern(args, context);
 

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -58,11 +58,7 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
   readonly schema = grepArgsSchema;
 
   override getEnhancedDescription(workspaceRoot: string): string {
-    return (
-      `${TOOL_DESCRIPTION}\n\n` +
-      `Your current working directory is: ${workspaceRoot}\n` +
-      `When searching for content, searches are performed in this directory.`
-    );
+    return `${TOOL_DESCRIPTION}\n\nYour current working directory is: ${workspaceRoot}\nWhen searching for content, searches are performed in this directory.`;
   }
 
   async execute(args: z.infer<typeof grepArgsSchema>, context: ToolContext): Promise<GrepResult> {

--- a/packages/agent-sdk-ts/src/tools/GrepTool.ts
+++ b/packages/agent-sdk-ts/src/tools/GrepTool.ts
@@ -57,6 +57,14 @@ export class GrepTool extends ZodTool<z.infer<typeof grepArgsSchema>, GrepResult
   readonly description = TOOL_DESCRIPTION;
   readonly schema = grepArgsSchema;
 
+  override getEnhancedDescription(workspaceRoot: string): string {
+    return (
+      `${TOOL_DESCRIPTION}\n\n` +
+      `Your current working directory is: ${workspaceRoot}\n` +
+      `When searching for content, searches are performed in this directory.`
+    );
+  }
+
   async execute(args: z.infer<typeof grepArgsSchema>, context: ToolContext): Promise<GrepResult> {
     let searchRoot: string;
     try {

--- a/packages/agent-sdk-ts/src/tools/zod-tool.ts
+++ b/packages/agent-sdk-ts/src/tools/zod-tool.ts
@@ -52,6 +52,15 @@ export abstract class ZodTool<TArgs, TResult> implements ToolDefinition<TArgs, T
       },
     };
   }
+
+  /**
+   * Returns an enhanced description with context-specific information.
+   * Override in subclasses to add workspace-specific context (e.g., working directory).
+   * Default implementation returns the static description.
+   */
+  getEnhancedDescription(_workspaceRoot: string): string {
+    return this.description;
+  }
 }
 
 export const booleanWithDefault = (defaultValue: boolean) => z.boolean().optional().default(defaultValue);


### PR DESCRIPTION
Align tool descriptions with Python SDK by adding workspace root context:

- Add getEnhancedDescription() method to ToolDefinition interface
- Implement default in ZodTool base class
- Override in GlobTool, GrepTool, FileEditorTool to include:
  - Current working directory path
  - Context-specific guidance for searches

This matches the Python SDK behavior where tool descriptions are dynamically enhanced with workspace info to help the LLM understand the file system context.

Refs: upstream OpenHands/software-agent-sdk parity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool descriptions are now context-aware: tools can supply enhanced descriptions that include the workspace root (current working directory) so guidance is tailored to your project.
  * When a tool lacks a static definition, its parameters are incorporated into the generated definition to improve discoverability and help text consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->