### PR TITLE
oh-tab-h99: Trigger condensation on context limit errors

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/agent.loop.test.ts
@@ -60,7 +60,9 @@ class CondensingLLM implements LLMClient {
     this.calls += 1;
 
     if (this.calls === 1) {
-      throw new Error('context_length_exceeded');
+      throw new Error(
+        'LLM request failed (400): litellm.ContextWindowExceededError: litellm.BadRequestError: AnthropicError - b\'{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 212624 tokens > 200000 maximum"},"request_id":"req_011CX7fivsByr5DdM7bEFA1K"}\'',
+      );
     }
 
     if (this.calls === 2) {
@@ -400,7 +402,7 @@ describe('Agent loop control', () => {
     }
 
     const agent = new Agent({
-      settings: baseSettings,
+      settings: { ...baseSettings, llm: { ...baseSettings.llm, provider: 'litellm_proxy' } },
       events: log,
       workspaceRoot: createWorkspaceRoot(),
       llmClient: llm,
@@ -412,7 +414,8 @@ describe('Agent loop control', () => {
     const condensation = log.list().find(isCondensation);
     expect(condensation).toBeTruthy();
     expect(condensation?.summary).toBe('SUMMARY');
-    expect(condensation?.forgotten_event_ids).toContain(seededMessageIds[4]);
+    expect(condensation?.forgotten_event_ids).not.toContain(seededMessageIds[0]);
+    expect(condensation?.forgotten_event_ids).toContain(seededMessageIds[1]);
 
     const retryRequest = [...llm.requests].reverse().find((req) => req.systemPrompt.includes('<CONVERSATION SUMMARY>'));
     expect(retryRequest).toBeTruthy();

--- a/packages/agent-sdk-ts/src/sdk/context/condenser/llmSummarizingCondenser.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/condenser/llmSummarizingCondenser.ts
@@ -32,7 +32,7 @@ export interface LLMSummarizingCondenserOptions {
   maxEventTokens?: number;
 }
 
-const DEFAULT_KEEP_FIRST = 4;
+const DEFAULT_KEEP_FIRST = 1;
 const DEFAULT_TARGET_FRACTION = 0.5;
 const DEFAULT_RESERVED_SUMMARY_TOKENS = 512;
 const DEFAULT_MAX_EVENT_TOKENS = 350;

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/contextLimit.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/contextLimit.test.ts
@@ -23,6 +23,23 @@ describe('isContextLimitError', () => {
     ).toBe(true);
   });
 
+  it('detects LiteLLM proxy prompt-too-long errors (Anthropic-style payload)', () => {
+    expect(
+      isContextLimitError(
+        'litellm_proxy',
+        new Error(
+          'LLM request failed (400): litellm.ContextWindowExceededError: litellm.BadRequestError: AnthropicError - b\'{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 212624 tokens > 200000 maximum"},"request_id":"req_011CX7fivsByr5DdM7bEFA1K"}\'',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('detects prompt-too-long when nested in an error cause', () => {
+    const cause = new Error('prompt is too long: 212624 tokens > 200000 maximum');
+    const error = { message: 'LLM request failed (400): Bad Request', cause };
+    expect(isContextLimitError('litellm_proxy', error)).toBe(true);
+  });
+
   it('detects Gemini token-limit errors', () => {
     expect(
       isContextLimitError(
@@ -75,4 +92,3 @@ describe('estimateRequestTokens / wouldExceedMaxInputTokens', () => {
     expect(wouldExceedMaxInputTokens({ request, maxInputTokens: 200 })).toBe(true);
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/llm/contextLimit.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/contextLimit.ts
@@ -1,14 +1,65 @@
 import type { ChatCompletionRequest, LLMProvider } from './types';
 import { reduceTextContent } from './types';
 
-const normalizeErrorText = (error: unknown): string => {
-  if (error instanceof Error) return error.message;
-  if (typeof error === 'string') return error;
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
+const collectErrorTextParts = (params: {
+  error: unknown;
+  depth: number;
+  seen: Set<unknown>;
+}): string[] => {
+  if (params.depth <= 0) return [];
+
+  const error = params.error;
+  if (error === null || error === undefined) return [];
+  if (typeof error === 'string') return [error];
+
+  if (typeof error === 'object') {
+    if (params.seen.has(error)) return [];
+    params.seen.add(error);
+
+    if (error instanceof Error) {
+      const parts: string[] = [];
+      if (error.message) parts.push(error.message);
+      const cause = (error as Error & { cause?: unknown }).cause;
+      if (cause && !params.seen.has(cause)) {
+        parts.push(...collectErrorTextParts({ error: cause, depth: params.depth - 1, seen: params.seen }));
+      }
+      return parts;
+    }
+
+    const maybe = error as { message?: unknown; cause?: unknown };
+    const parts: string[] = [];
+    if (typeof maybe.message === 'string' && maybe.message.trim()) parts.push(maybe.message);
+
+    if (maybe.cause && !params.seen.has(maybe.cause)) {
+      parts.push(...collectErrorTextParts({ error: maybe.cause, depth: params.depth - 1, seen: params.seen }));
+    }
+
+    try {
+      parts.push(JSON.stringify(error));
+    } catch {
+      // ignore stringify failures
+    }
+
+    if (!parts.length) parts.push(Object.prototype.toString.call(error));
+    return parts;
   }
+
+  if (typeof error === 'number' || typeof error === 'boolean' || typeof error === 'bigint') {
+    return [String(error)];
+  }
+  if (typeof error === 'symbol') {
+    return [error.description ? `Symbol(${error.description})` : 'Symbol()'];
+  }
+  if (typeof error === 'function') {
+    return [error.name ? `[function ${error.name}]` : '[function]'];
+  }
+
+  return [];
+};
+
+const normalizeErrorText = (error: unknown): string => {
+  const seen = new Set<unknown>();
+  return collectErrorTextParts({ error, depth: 6, seen }).join('\n');
 };
 
 const containsAny = (haystack: string, needles: string[]): boolean =>
@@ -24,30 +75,55 @@ export const isContextLimitError = (provider: LLMProvider | undefined, error: un
   const text = normalizeErrorText(error).toLowerCase();
   if (!text) return false;
 
+  const genericNeedles = [
+    'context_length_exceeded',
+    'maximum context length',
+    'prompt is too long',
+    'token limit',
+    'exceeds the maximum number of tokens',
+    'reduce the length',
+    'context window exceeded',
+    'contextwindowexceedederror',
+  ];
+
   // Provider-specific hints first (most reliable).
   switch (provider) {
     case 'openai':
     case 'openrouter':
     case 'litellm_proxy': {
-      return containsAny(text, [
+      if (
+        containsAny(text, [
         'context_length_exceeded',
         'maximum context length',
         "this model's maximum context length",
         'too many tokens',
         'reduce the length of the messages',
         'tokens in the prompt',
-      ]);
+        // LiteLLM proxy can wrap Anthropic-style errors (e.g. "prompt is too long: X tokens > Y maximum").
+        'prompt is too long',
+        'contextwindowexceedederror',
+      ])
+      ) {
+        return true;
+      }
+      break;
     }
     case 'anthropic': {
-      return containsAny(text, [
+      if (
+        containsAny(text, [
         'prompt is too long',
         'prompt too long',
         'context length exceeded',
         'tokens exceeded',
-      ]);
+      ])
+      ) {
+        return true;
+      }
+      break;
     }
     case 'gemini': {
-      return containsAny(text, [
+      if (
+        containsAny(text, [
         'prompttokencount',
         'candidatestokencount',
         'exceeds the maximum',
@@ -55,21 +131,18 @@ export const isContextLimitError = (provider: LLMProvider | undefined, error: un
         'input token',
         'token limit',
         'context length',
-      ]);
+      ])
+      ) {
+        return true;
+      }
+      break;
     }
     default:
       break;
   }
 
   // Generic fallback heuristics.
-  return containsAny(text, [
-    'context_length_exceeded',
-    'maximum context length',
-    'prompt is too long',
-    'token limit',
-    'exceeds the maximum number of tokens',
-    'reduce the length',
-  ]);
+  return containsAny(text, genericNeedles);
 };
 
 const estimateTokens = (text: string): number => {


### PR DESCRIPTION
### Summary
- Makes context-window exceeded errors trigger condensation + retry more reliably, including LiteLLM-proxy-wrapped Anthropic-style "prompt is too long" errors.
- Aligns condenser defaults with the intended keep-first semantics.

### Bead
```text

oh-tab-h99: Conversation Error: llm_bad_request (LiteLLM ContextWindowExceededError)
Status: closed
Priority: P1
Type: bug
Created: 2026-01-14 18:34
Updated: 2026-01-15 05:49

Description:
Observed error in a conversation:

Conversation Error
Code: llm_bad_request
LLM request failed (400): litellm.ContextWindowExceededError: litellm.BadRequestError: AnthropicError - b'{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 212624 tokens > 200000 maximum"},"request_id":"req_011CX7fivsByr5DdM7bEFA1K"}'. Received Model Group=claude-opus-4-5
Available Model Group Fallbacks=None
Error doing the fallback: litellm.ContextWindowExceededError: litellm.BadRequestError: AnthropicError - b'{"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 212624 tokens > 200000 maximum"},"request_id":"req_011CX7fivsByr5DdM7bEFA1K"}' LiteLLM Retried: 3 times

Hypothesis
- We likely already have some condensation-triggering logic on context-length errors, but this particular error shape from a LiteLLM proxy (wrapped as ContextWindowExceededError/BadRequestError with AnthropicError payload) did not trigger it.

Desired behavior
- When we detect a provider-reported context window exceeded / prompt-too-long error, automatically run condensation (or equivalent history truncation) and retry the request.
- Avoid infinite retry loops; cap condensation + retry attempts and surface a clear error if still failing.

Implementation notes
- Add/extend a single classification helper near the LLM client/request wrapper that inspects exceptions (including nested causes/strings) and detects context-window exceeded cases.
- Ensure the fix is robust to LiteLLM wrapper exceptions and Anthropic-style payload messages like "prompt is too long: X tokens > Y maximum".

Notes:
## Implementation Reference

1. **agent-sdk-ts is a transpilation of python agent-sdk** — the TypeScript SDK at ~/repos/agent-sdk-ts is essentially a port of the Python original at ~/repos/agent-sdk. Use the Python version as the authoritative reference for behavior.

2. **Condensation behavior should match LLMSummarizingCondenser** from the Python SDK:
   - Core behavior: summarize older context, prepend the summary at the beginning
   - No need for abstract classes or elaborate inheritance — just the main behavior
   - **Critical**: set `keep_first=2` — this preserves:
     - Position 0: system prompt
     - Position 1: first user message
   - The very first assistant message (position 2) must be the first one summarized
   - **Why this matters**: thinking models will fail if the first assistant message is preserved raw (they expect their first response to come after user input, not to be fed back)

3. **Verify keep_first semantics**: confirm that keep_first=2 means "keep system prompt + first user message untouched" and that summarization starts from the first assistant response onward.

Acceptance Criteria:
- Investigate the codebase first to confirm whether context-window error handling/condensation logic already exists; if it does, extend it rather than duplicating.
- Add detection for LiteLLM ContextWindowExceededError (and/or AnthropicError invalid_request_error prompt-too-long message) so condensation triggers.
- Add a regression test or harness-level repro if there is an existing test pattern for LLM error classification.
- Verify that after condensation the request retries and succeeds (or fails with a clear message if the prompt remains too large).

Labels: [condensation context-window litellm llm reliability]

```

### Testing
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run typecheck`
- `npm test -w @openhands/agent-sdk-ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context limit error detection to handle LiteLLM proxy errors and nested error causes more reliably.
  * Enhanced error message parsing to better identify prompt-too-long errors across various error formats.

* **Behavior Changes**
  * Adjusted conversation history condensation to be more aggressive, preserving fewer initial events during summarization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->