### PR TITLE
oh-tab-arr: Prefer workspace root from active editor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
+import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import {
   createOutputLogger,
   normalizeOutputVerbosity,
@@ -443,7 +444,7 @@ export function activate(context: vscode.ExtensionContext) {
       }
     }
 
-    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceRoot = resolvePreferredWorkspaceRoot();
     (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = workspaceRoot;
 
     const desiredMode: 'local' | 'remote' = settings.serverUrl ? 'remote' : 'local';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -445,7 +445,6 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     const workspaceRoot = resolvePreferredWorkspaceRoot();
-    (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = workspaceRoot;
 
     const desiredMode: 'local' | 'remote' = settings.serverUrl ? 'remote' : 'local';
     const savedIdKey = desiredMode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';

--- a/src/shared/__tests__/workspaceRoot.test.ts
+++ b/src/shared/__tests__/workspaceRoot.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { getEffectiveWorkspaceRoot, resolvePreferredWorkspaceRoot } from '../workspaceRoot';
+
+describe('workspaceRoot helpers', () => {
+  beforeEach(() => {
+    (vscode as any).__resetMocks?.();
+    delete (globalThis as any).vscodeWorkspaceRoot;
+  });
+
+  it('falls back to workspaceFolders[0] when no active editor', () => {
+    (vscode.window as any).activeTextEditor = undefined;
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }, { uri: { fsPath: '/test/workspace-b' } }];
+
+    expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-a');
+  });
+
+  it('prefers the workspace folder containing the active editor', () => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }, { uri: { fsPath: '/test/workspace-b' } }];
+    (vscode.workspace as any).getWorkspaceFolder = vi.fn((uri: { fsPath: string }) => {
+      if (uri.fsPath.startsWith('/test/workspace-b/')) return { uri: { fsPath: '/test/workspace-b' } };
+      if (uri.fsPath.startsWith('/test/workspace-a/')) return { uri: { fsPath: '/test/workspace-a' } };
+      return undefined;
+    });
+    (vscode.window as any).activeTextEditor = { document: { uri: { fsPath: '/test/workspace-b/src/a.ts' } } };
+
+    expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-b');
+  });
+
+  it('uses globalThis.vscodeWorkspaceRoot when set', () => {
+    (globalThis as any).vscodeWorkspaceRoot = '/from/global';
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }];
+
+    expect(getEffectiveWorkspaceRoot()).toBe('/from/global');
+  });
+});
+

--- a/src/shared/__tests__/workspaceRoot.test.ts
+++ b/src/shared/__tests__/workspaceRoot.test.ts
@@ -5,7 +5,6 @@ import { getEffectiveWorkspaceRoot, resolvePreferredWorkspaceRoot } from '../wor
 describe('workspaceRoot helpers', () => {
   beforeEach(() => {
     (vscode as any).__resetMocks?.();
-    delete (globalThis as any).vscodeWorkspaceRoot;
   });
 
   it('falls back to workspaceFolders[0] when no active editor', () => {
@@ -13,6 +12,7 @@ describe('workspaceRoot helpers', () => {
     (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }, { uri: { fsPath: '/test/workspace-b' } }];
 
     expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-a');
+    expect(getEffectiveWorkspaceRoot()).toBe('/test/workspace-a');
   });
 
   it('prefers the workspace folder containing the active editor', () => {
@@ -25,13 +25,15 @@ describe('workspaceRoot helpers', () => {
     (vscode.window as any).activeTextEditor = { document: { uri: { fsPath: '/test/workspace-b/src/a.ts' } } };
 
     expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-b');
+    expect(getEffectiveWorkspaceRoot()).toBe('/test/workspace-b');
   });
 
-  it('uses globalThis.vscodeWorkspaceRoot when set', () => {
-    (globalThis as any).vscodeWorkspaceRoot = '/from/global';
-    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }];
+  it('falls back to workspaceFolders[0] when active editor is outside all workspace folders', () => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }, { uri: { fsPath: '/test/workspace-b' } }];
+    (vscode.workspace as any).getWorkspaceFolder = vi.fn(() => undefined);
+    (vscode.window as any).activeTextEditor = { document: { uri: { fsPath: '/not/in/workspace/file.ts' } } };
 
-    expect(getEffectiveWorkspaceRoot()).toBe('/from/global');
+    expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-a');
+    expect(getEffectiveWorkspaceRoot()).toBe('/test/workspace-a');
   });
 });
-

--- a/src/shared/workspaceRoot.ts
+++ b/src/shared/workspaceRoot.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+export const resolvePreferredWorkspaceRoot = (): string | undefined => {
+  const activeUri = vscode.window.activeTextEditor?.document?.uri;
+  const getWorkspaceFolder = (vscode.workspace as unknown as { getWorkspaceFolder?: (uri: vscode.Uri) => { uri?: vscode.Uri } | undefined })
+    .getWorkspaceFolder;
+
+  if (activeUri && typeof getWorkspaceFolder === 'function') {
+    try {
+      const folder = getWorkspaceFolder(activeUri);
+      const fsPath = folder?.uri?.fsPath;
+      if (typeof fsPath === 'string' && fsPath.trim().length > 0) return fsPath;
+    } catch {
+      // ignore and fall back
+    }
+  }
+
+  const first = vscode.workspace.workspaceFolders?.[0]?.uri?.fsPath;
+  return typeof first === 'string' && first.trim().length > 0 ? first : undefined;
+};
+
+export const getEffectiveWorkspaceRoot = (): string | undefined => {
+  const globalRoot = (globalThis as { vscodeWorkspaceRoot?: unknown }).vscodeWorkspaceRoot;
+  if (typeof globalRoot === 'string' && globalRoot.trim().length > 0) return globalRoot;
+  return resolvePreferredWorkspaceRoot();
+};
+

--- a/src/shared/workspaceRoot.ts
+++ b/src/shared/workspaceRoot.ts
@@ -20,8 +20,5 @@ export const resolvePreferredWorkspaceRoot = (): string | undefined => {
 };
 
 export const getEffectiveWorkspaceRoot = (): string | undefined => {
-  const globalRoot = (globalThis as { vscodeWorkspaceRoot?: unknown }).vscodeWorkspaceRoot;
-  if (typeof globalRoot === 'string' && globalRoot.trim().length > 0) return globalRoot;
   return resolvePreferredWorkspaceRoot();
 };
-

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -17,7 +17,8 @@ import { MAX_PASTED_IMAGE_BYTES } from '../../shared/pasteLimits';
 import { normalizeServerUrl } from '../../shared/serverUrls';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS, type HostToWebviewMessage, type WebviewToHostMessage } from '../../shared/webviewMessages';
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
-// import removed: environment info is provided via AgentContext.userMessageSuffix
+// Environment info is provided via AgentContext.userMessageSuffix (extension host).
+import { getEffectiveWorkspaceRoot } from '../../shared/workspaceRoot';
 import { getConversationHistoryList, persistConversationTitle } from './conversationHistory';
 import { showWorkspaceDiff } from './diffDocuments';
 import { resolveGitHeadDiffContents } from './gitHeadDiff';
@@ -538,7 +539,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           break;
         }
 
-        const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+        const wsRoot = getEffectiveWorkspaceRoot();
         if (!wsRoot) {
           void vscode.window.showErrorMessage('Cannot open link: no workspace folder is open.');
           break;
@@ -579,7 +580,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           let newContent = message.newContent;
 
           if (message.preferGitHead === true) {
-            const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+            const wsRoot = getEffectiveWorkspaceRoot();
             const { resolvedPath } = resolveWorkspaceFilePath(p);
             const resolved = await resolveGitHeadDiffContents({
               workspaceRoot: wsRoot,

--- a/src/webview/host/workspacePaths.ts
+++ b/src/webview/host/workspacePaths.ts
@@ -1,9 +1,9 @@
-import * as vscode from 'vscode';
 import * as path from 'path';
+import { getEffectiveWorkspaceRoot } from '../../shared/workspaceRoot';
 
 export function resolveWorkspaceFilePath(inputPath: string): { resolvedPath: string; displayPath: string } {
   const isAbs = path.isAbsolute(inputPath);
-  const wsRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  const wsRoot = getEffectiveWorkspaceRoot();
 
   let resolvedPath: string;
   if (!isAbs && wsRoot) {
@@ -25,4 +25,3 @@ export function resolveWorkspaceFilePath(inputPath: string): { resolvedPath: str
   const displayPath = rel && !rel.startsWith('..') && !path.isAbsolute(rel) ? rel : resolvedPath;
   return { resolvedPath, displayPath };
 }
-


### PR DESCRIPTION
### Summary
Selects `workspaceRoot` based on the active editor’s workspace folder in multi-root workspaces, with a safe fallback to `workspaceFolders[0]`.

### Bead
```text

oh-tab-arr: Select workspaceRoot based on active editor file (multi-root workspaces)
Status: closed
Priority: P2
Type: bug
Created: 2026-01-14 19:51
Updated: 2026-01-15 06:01

Description:
GitHub issue: https://github.com/enyst/OpenHands-Tab/issues/764

Problem
- Today `workspaceRoot` is taken from `vscode.workspace.workspaceFolders?.[0]`.
- This breaks multi-root workspaces and can cause project-scoped features (e.g. loading `.openhands/skills`, git context, workspace-relative actions) to use the wrong root.

Proposed behavior
1. If there is an active text editor, resolve the workspace folder that contains that file (`vscode.workspace.getWorkspaceFolder(editor.document.uri)`) and use that folder as `workspaceRoot`.
2. If there is no active editor, or the file is not inside any workspace folder, fall back to the existing behavior: `workspaceFolders?.[0]`.

Notes
- No behavior change in single-root workspaces.
- Ensure this applies to local-mode workspace-root-scoped behavior (skills loading, git context, tools that rely on root).


Acceptance Criteria:
- In multi-root workspaces, local-mode uses the workspace folder containing the active file for skill loading and other workspace-root-scoped behavior.
- No behavior change in single-root workspaces.
- Fallback unchanged when no editor is active or the active file is outside all workspace folders.
- Add/adjust tests if there is an established pattern (unit and/or e2e) for workspace root selection logic.

Labels: [extension local-mode multi-root skills workspace]

Depends on (1):
  → oh-tab-2gy: Investigation: Switch conversation workspace folder mid-stream; PRD update [P3]

```

### Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced workspace root resolution to intelligently prioritize the workspace folder containing your active editor, with fallback to the first workspace folder when necessary.

* **Tests**
  * Added comprehensive test coverage for workspace root detection logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->