### PR TITLE
oh-tab-mey: Auto-pause when OpenHands view hidden

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -399,8 +399,13 @@ function createMockWebviewView() {
       view._disposeHandler = handler;
       return { dispose: vi.fn() };
     }),
+    onDidChangeVisibility: vi.fn((handler: Function) => {
+      view._visibilityHandler = handler;
+      return { dispose: vi.fn() };
+    }),
     _messageHandler: null as Function | null,
     _disposeHandler: null as Function | null,
+    _visibilityHandler: null as Function | null,
   };
 
   return view;
@@ -461,6 +466,36 @@ describe('Chat view behavior', () => {
 
     const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
     expect(conv?.restoreConversation).not.toHaveBeenCalled();
+  });
+
+  it('auto-pauses when the chat view becomes hidden (and avoids spamming)', async () => {
+    const view = await resolveChatView(mockContext);
+    expect(view).toBeTruthy();
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const conv = __getLastConversation();
+    expect(conv).toBeTruthy();
+
+    (conv.pause as Mock).mockClear();
+
+    // Hide -> pause once
+    view.visible = false;
+    view._visibilityHandler?.();
+    expect(conv.pause).toHaveBeenCalledTimes(1);
+
+    // Still hidden -> do not pause again
+    view._visibilityHandler?.();
+    expect(conv.pause).toHaveBeenCalledTimes(1);
+
+    // Show -> no pause
+    view.visible = true;
+    view._visibilityHandler?.();
+    expect(conv.pause).toHaveBeenCalledTimes(1);
+
+    // Hide again -> pause again
+    view.visible = false;
+    view._visibilityHandler?.();
+    expect(conv.pause).toHaveBeenCalledTimes(2);
   });
 
   it('refreshes the active conversation when LLM settings change', async () => {

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -498,6 +498,24 @@ describe('Chat view behavior', () => {
     expect(conv.pause).toHaveBeenCalledTimes(2);
   });
 
+  it('does not double-pause when the chat view is hidden then disposed', async () => {
+    const view = await resolveChatView(mockContext);
+    expect(view).toBeTruthy();
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const conv = __getLastConversation();
+    expect(conv).toBeTruthy();
+
+    (conv.pause as Mock).mockClear();
+
+    view.visible = false;
+    view._visibilityHandler?.();
+    expect(conv.pause).toHaveBeenCalledTimes(1);
+
+    view._disposeHandler?.();
+    expect(conv.pause).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes the active conversation when LLM settings change', async () => {
     const view = await resolveChatView(mockContext);
     expect(view).toBeTruthy();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -242,6 +242,8 @@ export function activate(context: vscode.ExtensionContext) {
     getGitHeadDiffSummaryForFile,
   });
 
+  let lastChatViewVisibility: boolean | undefined;
+
   const chatViewProvider = new OpenHandsChatViewProvider(context, {
     createMessageHandler: (view) =>
       createWebviewMessageHandler({
@@ -291,15 +293,39 @@ export function activate(context: vscode.ExtensionContext) {
     onResolved: (view) => {
       chatView = view;
       chatWebviewReady = false;
+      lastChatViewVisibility = Boolean(view.visible);
       void ensureConversationAndConnection({ uiJustCreated: true }).catch((err: unknown) => {
         outputChannel?.appendLine(`[error] ensureConversationAndConnection failed: ${renderError(err)}`);
       });
     },
+    onVisibilityChange: (_view, visible) => {
+      const isVisible = Boolean(visible);
+      if (lastChatViewVisibility === isVisible) return;
+      lastChatViewVisibility = isVisible;
+
+      if (!isVisible) {
+        void (async () => {
+          try {
+            await conversation?.pause();
+          } catch (err) {
+            outputChannel?.appendLine(`[pause] Failed to auto-pause when chat view was hidden: ${renderError(err)}`);
+          }
+        })();
+      }
+    },
     onDisposed: () => {
+      void (async () => {
+        try {
+          await conversation?.pause();
+        } catch (err) {
+          outputChannel?.appendLine(`[pause] Failed to auto-pause when chat view was disposed: ${renderError(err)}`);
+        }
+      })();
       chatView = undefined;
       chatWebviewReady = false;
       chatLastConversationId = undefined;
       chatLastSeenSeq = undefined;
+      lastChatViewVisibility = undefined;
     },
   });
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -314,13 +314,16 @@ export function activate(context: vscode.ExtensionContext) {
       }
     },
     onDisposed: () => {
-      void (async () => {
-        try {
-          await conversation?.pause();
-        } catch (err) {
-          outputChannel?.appendLine(`[pause] Failed to auto-pause when chat view was disposed: ${renderError(err)}`);
-        }
-      })();
+      const shouldPauseOnDispose = lastChatViewVisibility !== false;
+      if (shouldPauseOnDispose) {
+        void (async () => {
+          try {
+            await conversation?.pause();
+          } catch (err) {
+            outputChannel?.appendLine(`[pause] Failed to auto-pause when chat view was disposed: ${renderError(err)}`);
+          }
+        })();
+      }
       chatView = undefined;
       chatWebviewReady = false;
       chatLastConversationId = undefined;

--- a/src/sidebar/OpenHandsChatViewProvider.ts
+++ b/src/sidebar/OpenHandsChatViewProvider.ts
@@ -4,6 +4,7 @@ import { getWebviewHtml } from '../webview/getWebviewHtml';
 export type OpenHandsChatViewHandlers = {
   createMessageHandler: (view: vscode.WebviewView) => (msg: unknown) => void;
   onResolved: (view: vscode.WebviewView) => void;
+  onVisibilityChange?: (view: vscode.WebviewView, visible: boolean) => void;
   onDisposed: () => void;
 };
 
@@ -45,6 +46,14 @@ export class OpenHandsChatViewProvider implements vscode.WebviewViewProvider {
         this.handlers.onDisposed();
       })
     );
+
+    const onDidChangeVisibility = (webviewView as unknown as { onDidChangeVisibility?: (listener: () => void) => vscode.Disposable })
+      .onDidChangeVisibility;
+    if (typeof onDidChangeVisibility === 'function') {
+      this.viewDisposables.push(onDidChangeVisibility(() => {
+        this.handlers.onVisibilityChange?.(webviewView, Boolean(webviewView.visible));
+      }));
+    }
 
     this.handlers.onResolved(webviewView);
   }


### PR DESCRIPTION
### Summary
Auto-pauses the active agent run when the OpenHands chat view becomes hidden or is disposed.

### Bead
```text

oh-tab-mey: Pause agent when OpenHands webview is not visible
Status: closed
Priority: P2
Type: task
Created: 2026-01-14 18:50
Updated: 2026-01-15 06:05

Description:
When the user navigates away from the OpenHands webview (i.e., closes the OpenHands view completely, or switches the same view container to another extension/view so OpenHands is no longer visible), automatically PAUSE the agent.

Notes
- We already have a pause event. Use it (do not invent a new mechanism).
- This should trigger when OpenHands is not actively visible, including:
  - Webview disposed/closed.
  - Webview/view becomes hidden due to the user switching to a different view in the same location.

Implementation guidance
- Hook into the VS Code view/webview visibility lifecycle (`onDidChangeViewState` / visibility events for the webview container / view provider) and emit the existing pause event.
- Avoid pausing for transient cases where OpenHands is still visible (e.g., internal UI state changes).

Acceptance Criteria
- When OpenHands becomes not visible (hidden or disposed), the agent receives the existing pause event and transitions to paused.
- No regression: pausing does not spam repeated pause events on minor UI events.
- Confirm in codebase that the pause event is already handled by the agent/conversation runtime; re-use that path.
- Add/adjust a unit test or e2e test if there is an established pattern for visibility-driven events.

Labels: [agent extension pause ux webview]

```

### Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat automatically pauses when the chat view is hidden
  * Chat automatically pauses on extension disposal if the view was visible

* **Bug Fixes**
  * Prevents double-pausing scenarios when chat view is hidden then disposed

* **Tests**
  * Added tests for visibility-based auto-pause behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->