### PR TITLE
oh-tab-kl3: Fix env info for remote editors

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -696,6 +696,43 @@ describe('Command handlers', () => {
     expect(message).toContain('</environment information>');
   });
 
+  it('includes vscode-remote editors in environment info suffix', async () => {
+    mockSettings.serverUrl = undefined as any;
+    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', '');
+
+    (vscode.window as any).activeTextEditor = {
+      selection: {
+        isEmpty: false,
+        start: { line: 3, character: 2 },
+        end: { line: 5, character: 10 },
+      },
+      document: {
+        languageId: 'markdown',
+        uri: {
+          scheme: 'vscode-remote',
+          fsPath: '/test/workspace/content/posts/ralph.md',
+          toString: () => 'vscode-remote://ssh-remote+devcontainer/test/workspace/content/posts/ralph.md',
+        },
+        getText: vi.fn(() => '# hello'),
+      },
+    };
+    (vscode.window as any).visibleTextEditors = [(vscode.window as any).activeTextEditor];
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace' } }];
+
+    await vscode.commands.executeCommand('openhands.explainSelection');
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const latestConversation = __getLastConversation();
+
+    expect(latestConversation.sendUserMessage).toHaveBeenCalled();
+    const message = (latestConversation.sendUserMessage as unknown as Mock).mock.calls[0]?.[0] as string;
+    expect(message).toContain('<environment information>');
+    expect(message).toContain('Active editor: ralph.md');
+    expect(message).toContain('Open editors:');
+    expect(message).toContain('- ralph.md');
+    expect(message).toContain('</environment information>');
+  });
+
   it('sends reconnect/pause/resume commands', async () => {
     await vscode.commands.executeCommand('openhands.reconnect');
     await vscode.commands.executeCommand('openhands.pauseCurrentRun');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -151,7 +151,7 @@ function renderError(err: unknown): string {
 function resolveActiveEditorFilePath(editor: vscode.TextEditor | undefined): string | undefined {
   if (!editor) return undefined;
   const uri = editor.document.uri;
-  if (uri.scheme !== 'file') return undefined;
+  if (uri.scheme !== 'file' && uri.scheme !== 'vscode-remote') return undefined;
   const fsPath = typeof uri.fsPath === 'string' ? uri.fsPath.trim() : '';
   return fsPath || undefined;
 }
@@ -175,11 +175,11 @@ function buildEnvironmentInfoSuffix(): string | null {
   try {
     const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
     const activeEditorPath =
-      vscode.window.activeTextEditor?.document?.uri?.scheme === 'file'
+      (vscode.window.activeTextEditor?.document?.uri?.scheme === 'file' || vscode.window.activeTextEditor?.document?.uri?.scheme === 'vscode-remote')
         ? vscode.window.activeTextEditor.document.uri.fsPath
         : null;
     const openEditorPaths = (vscode.window.visibleTextEditors ?? [])
-      .map((e) => (e?.document?.uri?.scheme === 'file' ? e.document.uri.fsPath : null))
+      .map((e) => ((e?.document?.uri?.scheme === 'file' || e?.document?.uri?.scheme === 'vscode-remote') ? e.document.uri.fsPath : null))
       .filter((p): p is string => typeof p === 'string' && p.length > 0);
     return formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths });
   } catch {

--- a/src/extension/explainSelectionCommand.ts
+++ b/src/extension/explainSelectionCommand.ts
@@ -64,11 +64,11 @@ export function registerExplainSelectionCommand(options: {
     if (getConversationMode() === 'local') {
       const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
       const activeEditorPath =
-        vscode.window.activeTextEditor?.document?.uri?.scheme === 'file'
+        (vscode.window.activeTextEditor?.document?.uri?.scheme === 'file' || vscode.window.activeTextEditor?.document?.uri?.scheme === 'vscode-remote')
           ? vscode.window.activeTextEditor.document.uri.fsPath
           : null;
       const openEditorPaths = (vscode.window.visibleTextEditors ?? [])
-        .map((e) => (e?.document?.uri?.scheme === 'file' ? e.document.uri.fsPath : null))
+        .map((e) => ((e?.document?.uri?.scheme === 'file' || e?.document?.uri?.scheme === 'vscode-remote') ? e.document.uri.fsPath : null))
         .filter((p): p is string => typeof p === 'string' && p.length > 0);
       finalPrompt += `\n\n${formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths })}`;
     }


### PR DESCRIPTION
### Summary
Treats `vscode-remote` text editors as file-backed for environment info, so Active/Open editors are reported correctly (including Markdown in remote workspaces).

### Bead
```text

oh-tab-kl3: Active editor reports 'none' even when Markdown file is open
Status: closed
Priority: P2
Type: bug
Created: 2026-01-15 01:14
Updated: 2026-01-15 05:56

Description:
In the user message suffix we sometimes attach:

<environment information>
Active editor: none
Open editors:
- none
</environment information>

But VS Code visibly has an editor open (e.g. screenshot shows a file like `content/posts/ralph.md` open). It looks like our active/open editor detection is failing when the active document is a Markdown file (or, more generally, non-code / non-TextDocument schemes).

We should recognize Markdown and other text files as valid editors for both:
- Active editor
- Open editors list

Possible causes to investigate:
- We filter by languageId or file extension (e.g. only code)
- We filter by URI scheme and accidentally exclude `file:` / include only workspace files
- We read `window.activeTextEditor` at a time when it is undefined (timing) and don’t fall back to visible editors
- We treat untitled/virtual documents incorrectly

Desired behavior:
- If a Markdown file is the active editor, environment info reports it as Active editor (path) and includes it in Open editors.
- If an editor is open but not a text editor (e.g. diff, settings UI), we should still report open file-backed editors where possible.

Acceptance Criteria:
- With a Markdown file focused (e.g. `content/posts/ralph.md`), the next user message’s <environment information> reports that file as `Active editor`.
- `Open editors` lists currently open file-backed editors including Markdown.
- No regression for code files: active/open editor detection still works for TS/JS/etc.
- If there truly is no active editor (no text editor focused), we still correctly report `none`.

Labels: [context extension local-mode prompt ui ux workspace]

```

### Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
