### PR TITLE
oh-tab-1zt: Hide env info blocks in ConversationView

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -124,6 +124,38 @@ describe('Agent-SDK event rendering', () => {
     expect(screen.queryByText('User')).toBeNull();
   });
 
+  it('does not render <environment information> blocks in the message timeline', async () => {
+    render(<App />);
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: [
+              'do you see the opened file?',
+              '',
+              '<environment information>',
+              'Active editor: README.md',
+              'Open editors:',
+              '- README.md',
+              '</environment information>',
+            ].join('\n'),
+          },
+        ],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText('do you see the opened file?')).toBeInTheDocument();
+    expect(screen.queryByText(/<environment information>/i)).toBeNull();
+    expect(screen.queryByText(/active editor:/i)).toBeNull();
+    expect(screen.queryByText(/open editors:/i)).toBeNull();
+  });
+
   it('renders agent error events', async () => {
     render(<App />);
     const ev: AgentErrorEvent = {

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -6,6 +6,7 @@ import {
   EventContainer,
   MarkdownMessage,
   openWorkspaceFile,
+  stripEnvironmentInformationBlocks,
   USER_ACCENT_COLOR,
   withAlpha,
 } from './shared';
@@ -21,6 +22,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const isAgent = message.role === 'assistant';
 
   const rawText = message.content.filter(isTextContent).map((c) => c.text).join('\n');
+  const sanitizedText = stripEnvironmentInformationBlocks(rawText);
   const CONTEXT_HEADER = 'User has selected the following files for you to read:';
   function parseContextBlock(text: string): { main: string; files: string[] } {
     const idx = text.lastIndexOf(CONTEXT_HEADER);
@@ -31,7 +33,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
     const files = after.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
     return { main: before, files };
   }
-  const { main: withoutContext, files: contextFiles } = parseContextBlock(rawText);
+  const { main: withoutContext, files: contextFiles } = parseContextBlock(sanitizedText);
 
   const ATTACHMENT_BEGIN_LINE_RE = /^-{5,}\s*BEGIN ATTACHMENT:\s*(.*?)\s*-{5,}\s*$/;
   const ATTACHMENT_END_LINE_RE = /^-{5,}\s*END ATTACHMENT:\s*(.*?)\s*-{5,}\s*$/;

--- a/src/webview-src/components/eventBlocks/StreamingMessageBlock.tsx
+++ b/src/webview-src/components/eventBlocks/StreamingMessageBlock.tsx
@@ -1,4 +1,4 @@
-import { AGENT_ACCENT_COLOR, withAlpha } from './shared';
+import { AGENT_ACCENT_COLOR, stripEnvironmentInformationBlocks, withAlpha } from './shared';
 
 /**
  * Renders live streaming content while agent is generating response.
@@ -6,6 +6,7 @@ import { AGENT_ACCENT_COLOR, withAlpha } from './shared';
  */
 export function StreamingMessageBlock({ content }: { content: string }) {
   const accentColor = AGENT_ACCENT_COLOR;
+  const textContent = stripEnvironmentInformationBlocks(content);
 
   return (
     <div
@@ -42,7 +43,7 @@ export function StreamingMessageBlock({ content }: { content: string }) {
           </div>
 
           <div className="text-sm leading-relaxed whitespace-pre-wrap break-words text-stone-200">
-            {content}
+            {textContent}
             <span
               className="inline-block w-0.5 h-4 ml-0.5 rounded-sm animate-pulse"
               style={{ backgroundColor: accentColor }}
@@ -53,4 +54,3 @@ export function StreamingMessageBlock({ content }: { content: string }) {
     </div>
   );
 }
-

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -75,6 +75,19 @@ export const openMarkdownLink = (href: string) => {
   postMessage({ type: 'openMarkdownLink', href });
 };
 
+export const stripEnvironmentInformationBlocks = (text: string): string => {
+  const raw = typeof text === 'string' ? text : '';
+  if (!raw) return raw;
+
+  const withoutBlocks = raw.replace(
+    /(?:\r?\n){0,2}<environment information>[\s\S]*?<\/environment information>(?:\r?\n){0,2}/gi,
+    '\n\n',
+  );
+
+  // Keep formatting stable after stripping.
+  return withoutBlocks.replace(/\n{3,}/g, '\n\n').trimEnd();
+};
+
 function MarkdownLink({
   href,
   children,


### PR DESCRIPTION
### Summary
Strips `<environment information>…</environment information>` blocks from message rendering in the webview timeline (UI only; the LLM still receives the metadata).

### Bead
```text

oh-tab-1zt: Hide environment info from Webview in ConversationView
Status: closed
Priority: P2
Type: bug
Created: 2026-01-14 09:49
Updated: 2026-01-15 05:52

Description:
Problem:
Environment information is being displayed in the ConversationView webview alongside the user's message, e.g.:

"do you see the opened file?

<environment information> Active editor: README.md Open editors: - README.md </environment information>
"

This is surprising and should not be visible to the user.

Scope:
- Continue sending environment info to the LLM (for context) but do not render it in the webview message timeline.

Repro:
1. Open the OpenHands Tab extension.
2. Start a conversation and send a message while an editor is open.
3. Observe the user message rendered in the webview includes the <environment information> block.

Notes:
- For now, suppress rendering in the webview only. Keep the payload for the LLM unchanged.
- Adjust ConversationView message rendering to strip or hide this metadata.

Acceptance Criteria:
- Environment info blocks are never rendered in ConversationView (for both user and agent messages).
- Environment info still reaches the LLM unchanged.
- Existing conversations no longer show the environment block after reload.
- Add a simple unit/e2e assertion to prevent regressions (optional if infra exists).

Labels: [ConversationView vscode webview]

```

### Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
