### PR TITLE
oh-tab-eqv: welcome prompts for missing API keys

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -35,6 +35,10 @@ export type UiStateSnapshot = {
   selectedContextFiles: string[];
   skillsCount: number;
   attachmentsCount: number;
+  hasWelcomeProviderKey: boolean;
+  hasWelcomeGeminiKey: boolean;
+  showWelcomeProviderKeyMessage: boolean;
+  showWelcomeGeminiKeyMessage: boolean;
 };
 
 const DEFAULT_UI_STATE: UiStateSnapshot = {
@@ -46,6 +50,10 @@ const DEFAULT_UI_STATE: UiStateSnapshot = {
   selectedContextFiles: [],
   skillsCount: 0,
   attachmentsCount: 0,
+  hasWelcomeProviderKey: false,
+  hasWelcomeGeminiKey: false,
+  showWelcomeProviderKeyMessage: false,
+  showWelcomeGeminiKeyMessage: false,
 };
 
 type EnsureConversationAndConnection = (options?: { uiJustCreated?: boolean; modeSwitched?: boolean }) => Promise<void>;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -340,6 +340,99 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
+  let lastWelcomeSecretStatus: { hasProviderKey: boolean; hasGeminiKey: boolean } | null = null;
+  let welcomeSecretStatusTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const computeWelcomeSecretStatus = async (): Promise<{ hasProviderKey: boolean; hasGeminiKey: boolean }> => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const settings = await settingsMgr.get();
+
+    const secretIsSet = async (key: string): Promise<boolean> => {
+      try {
+        const value = await context.secrets.get(key);
+        return typeof value === 'string' && value.trim().length > 0;
+      } catch {
+        return false;
+      }
+    };
+
+    const envIsSet = (key: string): boolean => {
+      const value = process.env[key];
+      return typeof value === 'string' && value.trim().length > 0;
+    };
+
+    const hasGeminiKey =
+      (await secretIsSet('GEMINI_API_KEY')) ||
+      envIsSet('GEMINI_API_KEY') ||
+      (settings.llm.provider === 'gemini' && typeof settings.secrets.llmApiKey === 'string' && settings.secrets.llmApiKey.trim().length > 0);
+
+    const hasGenericKey = typeof settings.secrets.llmApiKey === 'string' && settings.secrets.llmApiKey.trim().length > 0;
+
+    const providerStorageKeys = [
+      'OPENAI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'OPENROUTER_API_KEY',
+      'LITELLM_API_KEY',
+    ];
+
+    let hasAnyProviderStorageKey = false;
+    for (const key of providerStorageKeys) {
+      if (envIsSet(key) || await secretIsSet(key)) {
+        hasAnyProviderStorageKey = true;
+        break;
+      }
+    }
+
+    let hasAnyProfileKey = false;
+    try {
+      for (const profileId of listProfiles()) {
+        if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
+          hasAnyProfileKey = true;
+          break;
+        }
+      }
+    } catch {
+      hasAnyProfileKey = false;
+    }
+
+    const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
+    return { hasProviderKey, hasGeminiKey };
+  };
+
+  const postWelcomeSecretStatus = async (): Promise<void> => {
+    if (!chatView) return;
+    const status = await computeWelcomeSecretStatus();
+    if (
+      lastWelcomeSecretStatus &&
+      lastWelcomeSecretStatus.hasProviderKey === status.hasProviderKey &&
+      lastWelcomeSecretStatus.hasGeminiKey === status.hasGeminiKey
+    ) {
+      return;
+    }
+    lastWelcomeSecretStatus = status;
+    void chatView.webview.postMessage({ type: 'welcomeSecretStatus', ...status } satisfies HostToWebviewMessage);
+  };
+
+  const scheduleWelcomeSecretStatusUpdate = () => {
+    if (welcomeSecretStatusTimer) clearTimeout(welcomeSecretStatusTimer);
+    welcomeSecretStatusTimer = setTimeout(() => {
+      welcomeSecretStatusTimer = null;
+      void postWelcomeSecretStatus().catch((err: unknown) => {
+        outputChannel?.appendLine(`[welcome] Failed to compute secret status: ${renderError(err)}`);
+      });
+    }, 150);
+  };
+
+  // Watch SecretStorage so welcome-page onboarding prompts reflect current key state.
+  const secretsOnDidChange = (context.secrets as unknown as { onDidChange?: vscode.Event<{ key: string }> }).onDidChange;
+  if (typeof secretsOnDidChange === 'function') {
+    context.subscriptions.push(
+      secretsOnDidChange(() => {
+        scheduleWelcomeSecretStatusUpdate();
+      })
+    );
+  }
+
   // Enable dev bridge only for Development/Test extension modes or with user setting
   const mode = context.extensionMode;
   const extensionMode = vscode.ExtensionMode;

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -24,6 +24,7 @@ export type HostToWebviewMessage =
     mode: 'local' | 'remote';
     llmProfileLabel?: string | null;
   }
+  | { type: 'welcomeSecretStatus'; hasProviderKey: boolean; hasGeminiKey: boolean }
   | { type: 'error'; error: string }
   | { type: 'statusMessage'; level: 'info' | 'warn' | 'error'; message: string; autoDismiss?: boolean; autoDismissDelay?: number }
   | { type: 'llmProfilesUpdated'; profiles: string[]; activeProfileId: string | null }
@@ -78,6 +79,7 @@ export type WebviewToHostMessage =
   | { type: 'webviewReady'; conversationId?: string; lastSeenSeq?: number }
   | { type: 'openSettingsPage' }
   | { type: 'openSettings' }
+  | { type: 'openSettingsSecrets' }
   | { type: 'requestWorkspaceFiles' }
   | { type: 'requestSkills' }
   | { type: 'requestTools' }
@@ -125,6 +127,10 @@ export type WebviewToHostMessage =
     selectedContextFiles: string[];
     skillsCount: number;
     attachmentsCount: number;
+    hasWelcomeProviderKey: boolean;
+    hasWelcomeGeminiKey: boolean;
+    showWelcomeProviderKeyMessage: boolean;
+    showWelcomeGeminiKeyMessage: boolean;
   }
   | {
     type: 'halStateResponse';

--- a/src/webview-src/__tests__/welcomePrompts.test.ts
+++ b/src/webview-src/__tests__/welcomePrompts.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getWelcomePromptFlags } from '../components/app/welcomePrompts';
+
+describe('welcome prompts display logic', () => {
+  it('shows both messages when no provider key and no gemini key', () => {
+    const flags = getWelcomePromptFlags({ hasProviderKey: false, hasGeminiKey: false });
+    expect(flags.showProviderKeyMessage).toBe(true);
+    expect(flags.showGeminiKeyMessage).toBe(true);
+  });
+
+  it('hides provider-key message but shows gemini message when provider key exists but gemini missing', () => {
+    const flags = getWelcomePromptFlags({ hasProviderKey: true, hasGeminiKey: false });
+    expect(flags.showProviderKeyMessage).toBe(false);
+    expect(flags.showGeminiKeyMessage).toBe(true);
+  });
+
+  it('hides both messages when gemini key is set', () => {
+    const flags = getWelcomePromptFlags({ hasProviderKey: true, hasGeminiKey: true });
+    expect(flags.showProviderKeyMessage).toBe(false);
+    expect(flags.showGeminiKeyMessage).toBe(false);
+  });
+
+  it('treats gemini key as a provider key (never show provider-key message when gemini is set)', () => {
+    const flags = getWelcomePromptFlags({ hasProviderKey: false, hasGeminiKey: true });
+    expect(flags.showProviderKeyMessage).toBe(false);
+    expect(flags.showGeminiKeyMessage).toBe(false);
+  });
+});
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -18,6 +18,7 @@ import { useLlmProfilesRequests } from './app/useLlmProfilesRequests';
 import { useWebviewReady } from './app/useWebviewReady';
 import { ConversationPane } from './app/ConversationPane';
 import { ConversationInputDock } from './app/ConversationInputDock';
+import { getWelcomePromptFlags, type WelcomeSecretStatus } from './app/welcomePrompts';
 
 // Component imports
 import { Header } from './Header';
@@ -62,6 +63,7 @@ export function App() {
   const [showHistory, setShowHistory] = useState(false);
   const [showLlmProfiles, setShowLlmProfiles] = useState(false);
   const [llmProfilesOpenRequest, setLlmProfilesOpenRequest] = useState<LlmProfilesViewOpenRequest | null>(null);
+  const [welcomeSecretStatus, setWelcomeSecretStatus] = useState<WelcomeSecretStatus>({ hasProviderKey: false, hasGeminiKey: false });
 
   // Context picker state
   const [showContextPicker, setShowContextPicker] = useState(false);
@@ -109,6 +111,10 @@ export function App() {
     selectedContextFiles: [] as string[],
     skillsCount: 0,
     attachmentsCount: 0,
+    hasWelcomeProviderKey: false,
+    hasWelcomeGeminiKey: false,
+    showWelcomeProviderKeyMessage: true,
+    showWelcomeGeminiKeyMessage: true,
   });
 
   // Post message helper
@@ -135,6 +141,7 @@ export function App() {
 
   // Keep a snapshot for E2E state queries without re-registering message listeners on every keystroke.
   useEffect(() => {
+    const welcome = getWelcomePromptFlags(welcomeSecretStatus);
     uiStateRef.current = {
       input,
       showContextPicker,
@@ -144,8 +151,12 @@ export function App() {
       selectedContextFiles: selectedContextFiles.slice(),
       skillsCount: skills.length,
       attachmentsCount: attachments.length,
+      hasWelcomeProviderKey: welcome.hasProviderKey,
+      hasWelcomeGeminiKey: welcome.hasGeminiKey,
+      showWelcomeProviderKeyMessage: welcome.showProviderKeyMessage,
+      showWelcomeGeminiKeyMessage: welcome.showGeminiKeyMessage,
     };
-  }, [attachments.length, input, selectedContextFiles, showContextPicker, showHistory, showSkillsPopover, skills.length, workspaceFiles.length]);
+  }, [attachments.length, input, selectedContextFiles, showContextPicker, showHistory, showSkillsPopover, skills.length, welcomeSecretStatus, workspaceFiles.length]);
 
   const handleApprove = useCallback(() => {
     if (isSubmitting) return;
@@ -308,6 +319,7 @@ export function App() {
     setStreamingContent,
     setTools,
     setWorkspaceFiles,
+    setWelcomeSecretStatus,
     showStatusMessage,
     currentServerUrlRef,
     conversationIdRef,
@@ -697,6 +709,8 @@ export function App() {
           streamingContent={streamingContent}
           skills={skills}
           endRef={endRef}
+          welcomeSecretStatus={welcomeSecretStatus}
+          onOpenSecretsSettings={() => postMessage({ type: 'openSettingsSecrets' })}
         />
 
         {/* HAL overlay (Phase 0: bundled flow replaces confirmation UI) */}

--- a/src/webview-src/components/app/ConversationPane.tsx
+++ b/src/webview-src/components/app/ConversationPane.tsx
@@ -2,16 +2,20 @@ import type { RefObject } from 'react';
 import type { Event } from '@openhands/agent-sdk-ts';
 import { StreamingMessageBlock } from '../EventBlock';
 import { RenderedEventBlock } from './RenderedEventBlock';
+import { getWelcomePromptFlags, type WelcomeSecretStatus } from './welcomePrompts';
 
 type ConversationPaneProps = {
   events: Array<{ id: number; event: Event }>;
   streamingContent: string | null;
   skills: { label: string; path: string }[];
   endRef: RefObject<HTMLDivElement | null>;
+  welcomeSecretStatus: WelcomeSecretStatus;
+  onOpenSecretsSettings: () => void;
 };
 
-export function ConversationPane({ events, streamingContent, skills, endRef }: ConversationPaneProps) {
+export function ConversationPane({ events, streamingContent, skills, endRef, welcomeSecretStatus, onOpenSecretsSettings }: ConversationPaneProps) {
   const isEmptyConversation = events.length === 0 && streamingContent === null;
+  const welcome = getWelcomePromptFlags(welcomeSecretStatus);
 
   return (
     <div className="flex-1 overflow-y-auto px-4 py-4">
@@ -26,6 +30,45 @@ export function ConversationPane({ events, streamingContent, skills, endRef }: C
             <span className="codicon codicon-lightbulb text-brand-400" />
             <span>Type a message below to get started</span>
           </div>
+
+          {(welcome.showProviderKeyMessage || welcome.showGeminiKeyMessage) && (
+            <div className="mt-6 w-full max-w-lg text-left space-y-2">
+              {welcome.showProviderKeyMessage && (
+                <div className="flex items-start gap-2 text-sm text-stone-300 bg-black/20 border border-white/[0.04] rounded-lg p-3">
+                  <span className="codicon codicon-key text-brand-400 mt-0.5" />
+                  <div>
+                    Please set{' '}
+                    <button
+                      type="button"
+                      onClick={onOpenSecretsSettings}
+                      className="underline underline-offset-2 hover:text-stone-100 transition-colors"
+                    >
+                      an API key
+                    </button>{' '}
+                    for a provider to start.
+                  </div>
+                </div>
+              )}
+
+              {welcome.showGeminiKeyMessage && (
+                <div className="flex items-start gap-2 text-sm text-stone-300 bg-black/20 border border-white/[0.04] rounded-lg p-3">
+                  <span className="codicon codicon-star-full text-brand-400 mt-0.5" />
+                  <div>
+                    Please set a{' '}
+                    <button
+                      type="button"
+                      onClick={onOpenSecretsSettings}
+                      className="underline underline-offset-2 hover:text-stone-100 transition-colors"
+                    >
+                      Gemini (AI Studio) key
+                    </button>{' '}
+                    for a better experience. OpenHands-Tab will use a Gemini 2.5 Flash profile for tool summarization,
+                    remote teleport and other features.
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       ) : (
         <>
@@ -41,4 +84,3 @@ export function ConversationPane({ events, streamingContent, skills, endRef }: C
     </div>
   );
 }
-

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -9,6 +9,7 @@ import type { PendingLlmProfilesRequest } from './llmProfilesRequests';
 import type { StatusBannerState } from './useStatusMessages';
 import { isHalDecision, type HalDecision, type HalStateSnapshot } from '../../../shared/halTypes';
 import type { ConversationTotals } from './conversationTotals';
+import type { WelcomeSecretStatus } from './welcomePrompts';
 
 type WebviewPersistedState = {
   conversationId?: string;
@@ -34,6 +35,10 @@ type UiStateSnapshot = {
   selectedContextFiles: string[];
   skillsCount: number;
   attachmentsCount: number;
+  hasWelcomeProviderKey: boolean;
+  hasWelcomeGeminiKey: boolean;
+  showWelcomeProviderKeyMessage: boolean;
+  showWelcomeGeminiKeyMessage: boolean;
 };
 
 type ShowStatusMessage = (
@@ -93,6 +98,7 @@ export type HostMessageHandlerOptions = {
   setStreamingContent: Dispatch<SetStateAction<string | null>>;
   setTools: Dispatch<SetStateAction<{ id: string; label: string; description?: string; isDefault?: boolean }[]>>;
   setWorkspaceFiles: Dispatch<SetStateAction<string[]>>;
+  setWelcomeSecretStatus: Dispatch<SetStateAction<WelcomeSecretStatus>>;
   showStatusMessage: ShowStatusMessage;
   currentServerUrlRef: RefObject<string | undefined>;
   conversationIdRef: RefObject<string | undefined>;
@@ -154,6 +160,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     setStreamingContent,
     setTools,
     setWorkspaceFiles,
+    setWelcomeSecretStatus,
     showStatusMessage,
     currentServerUrlRef,
     conversationIdRef,
@@ -179,13 +186,14 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
         serverLabel?: string;
         mode?: 'local' | 'remote';
         llmProfileLabel?: string | null;
+        hasProviderKey?: unknown;
+        hasGeminiKey?: unknown;
         profiles?: string[];
         activeProfileId?: string | null;
         profileId?: unknown;
         profile?: unknown;
         hasKey?: unknown;
         hasProfileKey?: unknown;
-        hasProviderKey?: unknown;
         providerKeyName?: unknown;
         hal?: Partial<HalSettingsSnapshot> & { [k: string]: unknown };
         event?: unknown;
@@ -244,6 +252,12 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
             }
           }
           break;
+        case 'welcomeSecretStatus': {
+          const hasProviderKey = payload.hasProviderKey === true;
+          const hasGeminiKey = payload.hasGeminiKey === true;
+          setWelcomeSecretStatus({ hasProviderKey, hasGeminiKey });
+          break;
+        }
         case 'statusMessage': {
           const level = payload.level;
           const message = payload.message;

--- a/src/webview-src/components/app/welcomePrompts.ts
+++ b/src/webview-src/components/app/welcomePrompts.ts
@@ -1,0 +1,19 @@
+export type WelcomeSecretStatus = { hasProviderKey: boolean; hasGeminiKey: boolean };
+
+export function getWelcomePromptFlags(status: WelcomeSecretStatus | null | undefined): {
+  hasProviderKey: boolean;
+  hasGeminiKey: boolean;
+  showProviderKeyMessage: boolean;
+  showGeminiKeyMessage: boolean;
+} {
+  const hasGeminiKey = status?.hasGeminiKey === true;
+  // Treat Gemini as a valid "provider key" even if callers provide inconsistent flags.
+  const hasProviderKey = (status?.hasProviderKey === true) || hasGeminiKey;
+
+  return {
+    hasProviderKey,
+    hasGeminiKey,
+    showProviderKeyMessage: !hasProviderKey,
+    showGeminiKeyMessage: !hasGeminiKey,
+  };
+}

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -192,6 +192,10 @@ export type CreateWebviewMessageHandlerDeps = {
       selectedContextFiles: string[];
       skillsCount: number;
       attachmentsCount: number;
+      hasWelcomeProviderKey: boolean;
+      hasWelcomeGeminiKey: boolean;
+      showWelcomeProviderKeyMessage: boolean;
+      showWelcomeGeminiKeyMessage: boolean;
     }
   ) => void;
   onHalStateResponse: (
@@ -438,6 +442,58 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           hal: initSettings.hal,
         });
 
+        // Welcome page: communicate whether API keys are present so the UI can show onboarding prompts.
+        void (async () => {
+          const secretIsSet = async (key: string): Promise<boolean> => {
+            try {
+              const value = await context.secrets.get(key);
+              return typeof value === 'string' && value.trim().length > 0;
+            } catch {
+              return false;
+            }
+          };
+
+          const envIsSet = (key: string): boolean => {
+            const value = process.env[key];
+            return typeof value === 'string' && value.trim().length > 0;
+          };
+
+          const hasGeminiKey = (await secretIsSet('GEMINI_API_KEY'))
+            || envIsSet('GEMINI_API_KEY')
+            || (initSettings.llm.provider === 'gemini' && typeof initSettings.secrets.llmApiKey === 'string' && initSettings.secrets.llmApiKey.trim().length > 0);
+
+          const hasGenericKey = typeof initSettings.secrets.llmApiKey === 'string' && initSettings.secrets.llmApiKey.trim().length > 0;
+
+          const providerStorageKeys = [
+            'OPENAI_API_KEY',
+            'ANTHROPIC_API_KEY',
+            'OPENROUTER_API_KEY',
+            'LITELLM_API_KEY',
+          ];
+          let hasAnyProviderStorageKey = false;
+          for (const key of providerStorageKeys) {
+            if (envIsSet(key) || await secretIsSet(key)) {
+              hasAnyProviderStorageKey = true;
+              break;
+            }
+          }
+
+          let hasAnyProfileKey = false;
+          try {
+            for (const profileId of listAvailableLlmProfiles()) {
+              if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
+                hasAnyProfileKey = true;
+                break;
+              }
+            }
+          } catch {
+            hasAnyProfileKey = false;
+          }
+
+          const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
+          void host.postMessage({ type: 'welcomeSecretStatus', hasProviderKey, hasGeminiKey });
+        })();
+
         deps.flushConversationEventBacklog({
           postMessage: host.postMessage,
           clientConversationId: message.conversationId,
@@ -449,6 +505,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       case 'openSettingsPage':
       case 'openSettings':
         await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
+        break;
+      case 'openSettingsSecrets':
+        await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab openhands.secrets');
         break;
       case 'requestWorkspaceFiles': {
         const files = await listWorkspaceFiles();
@@ -1361,6 +1420,10 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           selectedContextFiles: message.selectedContextFiles,
           skillsCount: message.skillsCount,
           attachmentsCount: message.attachmentsCount,
+          hasWelcomeProviderKey: message.hasWelcomeProviderKey,
+          hasWelcomeGeminiKey: message.hasWelcomeGeminiKey,
+          showWelcomeProviderKeyMessage: message.showWelcomeProviderKeyMessage,
+          showWelcomeGeminiKeyMessage: message.showWelcomeGeminiKeyMessage,
         });
         break;
       case 'halStateResponse':

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -94,6 +94,11 @@ export async function run(): Promise<void> {
     return runTerminalProgressTest();
   }
 
+  if (testName === 'welcome') {
+    const { run: runWelcomeTest } = await import('./welcome');
+    return runWelcomeTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness

--- a/tests/e2e/suite/welcome.ts
+++ b/tests/e2e/suite/welcome.ts
@@ -1,0 +1,72 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+
+type UiStateSnapshot = {
+  showWelcomeProviderKeyMessage?: boolean;
+  showWelcomeGeminiKeyMessage?: boolean;
+  hasWelcomeProviderKey?: boolean;
+  hasWelcomeGeminiKey?: boolean;
+};
+
+async function getUiState(): Promise<UiStateSnapshot> {
+  return (await vscode.commands.executeCommand('openhands._queryUiState')) as UiStateSnapshot;
+}
+
+async function waitForWelcomeMessages(options: {
+  showProvider: boolean;
+  showGemini: boolean;
+  timeoutMs?: number;
+}): Promise<UiStateSnapshot> {
+  const { showProvider, showGemini, timeoutMs = 15000 } = options;
+
+  await pollUntil(async () => {
+    const state = await getUiState();
+    return state.showWelcomeProviderKeyMessage === showProvider
+      && state.showWelcomeGeminiKeyMessage === showGemini;
+  }, timeoutMs, 200);
+
+  return await getUiState();
+}
+
+async function setProviderKey(provider: string, apiKey: string): Promise<void> {
+  await vscode.commands.executeCommand('openhands._setProviderApiKey', { provider, apiKey });
+}
+
+export async function run(): Promise<void> {
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+
+  // Ensure a deterministic baseline: no stored provider keys.
+  await setProviderKey('openai', '');
+  await setProviderKey('anthropic', '');
+  await setProviderKey('openrouter', '');
+  await setProviderKey('litellm_proxy', '');
+  await setProviderKey('gemini', '');
+
+  const initial = await waitForWelcomeMessages({ showProvider: true, showGemini: true });
+  if (initial.hasWelcomeProviderKey !== false || initial.hasWelcomeGeminiKey !== false) {
+    throw new Error(`Expected no keys initially but got: ${JSON.stringify(initial)}`);
+  }
+
+  // Gemini key alone should be sufficient (hide both messages).
+  await setProviderKey('gemini', 'e2e-gemini-key');
+  const geminiOnly = await waitForWelcomeMessages({ showProvider: false, showGemini: false });
+  if (geminiOnly.hasWelcomeGeminiKey !== true) {
+    throw new Error(`Expected hasWelcomeGeminiKey=true but got: ${JSON.stringify(geminiOnly)}`);
+  }
+
+  // Non-Gemini key should hide provider prompt but still show Gemini recommendation.
+  await setProviderKey('gemini', '');
+  await setProviderKey('openai', 'e2e-openai-key');
+  const openaiOnly = await waitForWelcomeMessages({ showProvider: false, showGemini: true });
+  if (openaiOnly.hasWelcomeProviderKey !== true || openaiOnly.hasWelcomeGeminiKey !== false) {
+    throw new Error(`Expected provider-only keys but got: ${JSON.stringify(openaiOnly)}`);
+  }
+}
+

--- a/tests/e2e/welcome.test.ts
+++ b/tests/e2e/welcome.test.ts
@@ -1,0 +1,47 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-welcome-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab welcome missing-key prompts E2E', function () {
+  this.timeout(180000);
+
+  it('shows/hides prompts as keys change', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'welcome',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+        OPENAI_API_KEY: '',
+        ANTHROPIC_API_KEY: '',
+        OPENROUTER_API_KEY: '',
+        LITELLM_API_KEY: '',
+        GEMINI_API_KEY: '',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+


### PR DESCRIPTION
Implements welcome-page prompts for missing API keys and keeps them in sync with SecretStorage changes.

- Webview shows 0–2 onboarding rows on the empty conversation welcome screen.
- Clicking the links opens Settings scoped to the extension Secrets section.
- Host posts live key-presence updates so prompts reappear if keys are deleted.
- Adds unit + E2E coverage for the display matrix.

Tests:
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run e2e`

### Bead

oh-tab-eqv: Welcome page: prompt user to set API keys when missing
Status: open
Priority: P2
Type: feature
Created: 2026-01-15 05:29
Updated: 2026-01-15 05:29

Description:
When the extension is freshly installed and the user hasn't configured API keys, the Welcome page should guide them to set up credentials.

## Current behavior
The Welcome page shows a generic greeting but doesn't indicate that API keys are needed.

## Desired behavior

### Two conditional messages on the Welcome page:

1. **Primary provider key missing**: Display a row saying:
   > Please set [an API key](link-to-settings-secrets) for a provider to start.

2. **Gemini key missing**: Display a row saying:
   > Please set a [Gemini (AI Studio) key](link-to-settings-secrets) for a better experience. OpenHands-Tab will use a Gemini 2.5 Flash profile for tool summarization, remote teleport and other features.

### Display logic:

| Has Provider Key | Has Gemini Key | Show Message 1 | Show Message 2 |
|------------------|----------------|----------------|----------------|
| No               | No             | Yes            | Yes            |
| Yes (non-Gemini) | No             | No             | Yes            |
| No               | Yes            | No             | No             |
| Yes              | Yes            | No             | No             |

Key points:
- If user sets ONLY a Gemini key (no other provider), that's sufficient — use Gemini models for all LLM-requiring features, show neither message
- Messages should reappear if user deletes the key(s) from VSCode secrets (not just initialization state)
- Links from "an API key" and "Gemini (AI Studio) key" should navigate directly to Settings → Secrets section

## Implementation notes
- Need to watch for secret storage changes, not just check on init
- Consider a lightweight state/context that tracks key presence
- Gemini key presence should enable Gemini 2.5 Flash as default for internal features

Acceptance Criteria:
- [ ] Welcome page shows message 1 when no provider API key is set
- [ ] Welcome page shows message 2 when no Gemini key is set (but another provider key exists)
- [ ] Neither message shown when Gemini key is set (even if it's the only key)
- [ ] Messages reappear if user deletes keys from VSCode secrets
- [ ] Links in messages navigate to Settings → Secrets section
- [ ] Unit tests for the display logic (all 4 state combinations)
- [ ] E2E test: fresh install shows both messages
- [ ] E2E test: setting Gemini key hides both messages
- [ ] E2E test: setting non-Gemini key hides message 1, keeps message 2

Labels: [onboarding settings ux webview]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Welcome prompts now guide users through API key setup (Provider and Gemini/AI Studio keys) based on current configuration
  * Automatic detection determines which prompts to display when keys are missing
  * One-click access to settings for managing API keys

* **Tests**
  * Added comprehensive end-to-end tests for the welcome onboarding experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->