### PR TITLE
oh-tab-5vt: E2E helper to mark agent-edited files

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -68,6 +68,7 @@ type RegisterDiagnosticsCommandsDeps = {
   pendingHalStateRequests: Map<string, (info: HalStateSnapshot) => void>;
   ensureConversationAndConnection: EnsureConversationAndConnection;
   secretRegistry: SecretRegistry;
+  trackAgentEditedFile: (fsPath: string) => void;
   getConversation: () => ConversationInstance | undefined;
   getConversationMode: () => 'local' | 'remote';
   getTerminal: () => vscode.Terminal | undefined;
@@ -584,6 +585,16 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     }
   });
 
+  const testMarkAgentEditedFile = vscode.commands.registerCommand('openhands._testMarkAgentEditedFile', (raw: unknown) => {
+    const fsPathRaw = (raw as { fsPath?: unknown } | undefined)?.fsPath;
+    const fsPath = typeof fsPathRaw === 'string' ? fsPathRaw.trim() : '';
+    if (!fsPath) throw new Error('fsPath is required');
+
+    if (deps.getConversationMode() !== 'local') return { ok: true };
+    deps.trackAgentEditedFile(fsPath);
+    return { ok: true };
+  });
+
   return [
     diag,
     serversGet,
@@ -606,5 +617,6 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     setProviderApiKey,
     listProfiles,
     injectTerminalEvent,
+    testMarkAgentEditedFile,
   ];
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -661,6 +661,7 @@ export function activate(context: vscode.ExtensionContext) {
     pendingHalStateRequests,
     ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
     secretRegistry: secrets,
+    trackAgentEditedFile: fileEditNoteTracker.trackAgentEditedFile,
     getConversation: () => conversation,
     getConversationMode: () => conversationMode,
     getTerminal: () => terminal,


### PR DESCRIPTION
Adds a deterministic E2E helper command to mark a file path as agent-edited so tests can exercise the watched-file note pipeline.

- New internal command: `openhands._testMarkAgentEditedFile({ fsPath })`
- Validates input; no-ops in remote mode

Tests:
- `npm run typecheck`

### Bead

oh-tab-5vt: E2E helper: internal command to mark file as agent-edited for fileEditNoteTracker
Status: open
Priority: P2
Type: task
Created: 2026-01-15 06:45
Updated: 2026-01-15 07:59

Description:
Problem
- File edit note behavior depends on fileEditNoteTracker.agentEditedFiles which is populated via attachConversationListeners when a real file_editor ObservationEvent occurs.
- E2E tests cannot reliably trigger that path today; openhands._sendTestEvent bypasses attachConversationListeners and won’t call trackAgentEditedFile.

Goal
- Add a deterministic, test-only way to mark a file path as agent-edited so E2E can cover watched-file note pipeline end-to-end.

Proposed approach
- Add an internal command (dev/test only) like `openhands._testMarkAgentEditedFile` (or similar) that takes `{ fsPath: string }` and calls `fileEditNoteTracker.trackAgentEditedFile(fsPath)`.
- Keep it namespaced under `openhands._` and return a small `{ ok: true }` payload.

Notes
- This unblocks `oh-tab-gvc` E2E for queued watched-file notes -> next user message extended_content.

Acceptance Criteria:
- New internal command exists and is usable from E2E suite code.
- Command validates input and is no-op when conversation not local.
- `oh-tab-gvc` (or another E2E) uses it to assert watched-file note reaches next LLM request.

Labels: [dev e2e extension tests]

Blocks (1):
  ← oh-tab-gvc: E2E: watched-file notes reach LLM via extended_content [P2]

