### PR TITLE
oh-tab-32i: Env info workspaceRoot follows active editor

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,7 +174,7 @@ function syncActiveEditorSystemMessageSuffix(editor: vscode.TextEditor | undefin
 
 function buildEnvironmentInfoSuffix(): string | null {
   try {
-    const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+    const workspaceRoot = resolvePreferredWorkspaceRoot();
     const activeEditorPath =
       (vscode.window.activeTextEditor?.document?.uri?.scheme === 'file' || vscode.window.activeTextEditor?.document?.uri?.scheme === 'vscode-remote')
         ? vscode.window.activeTextEditor.document.uri.fsPath


### PR DESCRIPTION
Fix env-info workspaceRoot selection so multi-root workspaces render workspace-relative paths for the active editor.

### Bead


oh-tab-32i: Env info: workspaceRoot should follow active editor
Status: open
Priority: P2
Type: bug
Created: 2026-01-15 08:28
Updated: 2026-01-15 08:28

Description:
Problem
- `buildEnvironmentInfoSuffix()` currently uses `vscode.workspace.workspaceFolders?.[0]` as `workspaceRoot`.
- In multi-root workspaces, if the active editor is in another folder, env-info treats it as outside the workspace and emits an absolute path (hurts UX + can leak long tmp paths in E2E).

Goal
- Make environment info workspaceRoot follow the active editor’s workspace folder (same strategy as `getEffectiveWorkspaceRoot()`), so `Active editor:` is workspace-relative when applicable.

Acceptance Criteria
- `buildEnvironmentInfoSuffix()` uses `getEffectiveWorkspaceRoot()` (or equivalent) instead of `workspaceFolders[0]`.
- Unit test added/updated under `src/shared/__tests__/environmentInformation.test.ts` or `src/shared/__tests__/workspaceRoot.test.ts` demonstrating active-editor-based root.
- E2E `oh-tab-tpq` passes once added.

Labels: [env-info multi-root workspace]

Blocks (1):
  ← oh-tab-tpq: E2E: multi-root workspaceRoot follows active editor [P2]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace root resolution mechanism for enhanced reliability and stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->