### PR TITLE
oh-tab-gvc: E2E watched-file notes via extended_content

### DIFF
--- a/tests/e2e/gvc.test.ts
+++ b/tests/e2e/gvc.test.ts
@@ -1,0 +1,43 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-gvc-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab watched-file notes E2E', function () {
+  this.timeout(180000);
+
+  it('queues watched-file notes into next LLM request extended_content', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'gvc',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+        OPENAI_API_KEY: 'e2e-openai-key',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/gvc.ts
+++ b/tests/e2e/suite/gvc.ts
@@ -1,0 +1,154 @@
+import * as vscode from 'vscode';
+import * as os from 'os';
+import * as path from 'path';
+import { pollUntil } from './pollUntil';
+import { startMockLlmServer } from './mockLlmServer';
+import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
+
+type DiagnosticsInfo = {
+  chat?: { hasView?: boolean; webviewReady?: boolean };
+  conversationId?: string | null;
+  mode?: 'local' | 'remote';
+};
+
+function extractUserMessageTexts(json: unknown): string[] {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) return [];
+  const obj = json as Record<string, unknown>;
+  const messages = obj.messages;
+  if (!Array.isArray(messages)) return [];
+
+  return messages.flatMap((m) => {
+    if (!m || typeof m !== 'object' || Array.isArray(m)) return [];
+    const msg = m as Record<string, unknown>;
+    if (msg.role !== 'user') return [];
+
+    const content = msg.content;
+    if (typeof content === 'string') return [content];
+    if (!Array.isArray(content)) return [];
+
+    const parts = content.flatMap((p) => {
+      if (!p || typeof p !== 'object' || Array.isArray(p)) return [];
+      const part = p as Record<string, unknown>;
+      const text = part.text;
+      return typeof text === 'string' ? [text] : [];
+    });
+    return parts.length ? [parts.join('')] : [];
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForWebviewReady(timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let last: DiagnosticsInfo | undefined;
+
+  while (Date.now() < deadline) {
+    last = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    if (last?.chat?.hasView && last.chat.webviewReady) return;
+    await sleep(200);
+  }
+
+  throw new Error(`Timed out waiting for chat webview readiness. diagnostics=${JSON.stringify(last)}`);
+}
+
+export async function run(): Promise<void> {
+  const mock = await startMockLlmServer();
+
+  let tempUri: vscode.Uri | undefined;
+
+  try {
+    await vscode.commands.executeCommand('openhands.open');
+    await waitForWebviewReady(30000);
+
+    // Force local mode + short runs for E2E.
+    const cfg = vscode.workspace.getConfiguration();
+    await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.conversation.maxIterations', 5, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.confirmation.policy', 'never', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.agent.enableSecurityAnalyzer', false, vscode.ConfigurationTarget.Global);
+
+    // Create a profile that points at the mock server.
+    const v1BaseUrl = `${mock.baseUrl}/v1`;
+    const profileId = 'e2e-gvc-openai';
+    await vscode.commands.executeCommand('openhands._setProviderApiKey', { provider: 'openai', apiKey: 'sk-e2e-openai' });
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId,
+      profile: {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        baseUrl: v1BaseUrl,
+        openaiApiMode: 'chat_completions',
+      },
+    });
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId });
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+
+    await pollUntil(async () => {
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+      return diag?.mode === 'local' && typeof diag?.conversationId === 'string' && diag.conversationId.length > 0;
+    }, 30000);
+
+    const filePath = path.join(os.tmpdir(), `e2e-gvc-${Date.now().toString(36)}.txt`);
+    tempUri = vscode.Uri.file(filePath);
+    await vscode.workspace.fs.writeFile(tempUri, Buffer.from('initial\n'));
+
+    const doc = await vscode.workspace.openTextDocument(tempUri);
+    await vscode.window.showTextDocument(doc, { preview: false });
+
+    // Ensure no prior traffic makes assertions flaky.
+    mock.reset();
+
+    // Mark as agent-edited, then save a user edit to queue a watched-file note.
+    await vscode.commands.executeCommand('openhands._testMarkAgentEditedFile', { fsPath: filePath });
+
+    const editor = vscode.window.activeTextEditor;
+    if (!editor) throw new Error('Expected an active editor');
+    const end = doc.lineAt(doc.lineCount - 1).range.end;
+    await editor.edit((edit) => {
+      edit.insert(end, `user edit ${Date.now().toString(36)}\n`);
+    });
+    await doc.save();
+
+    // The save should only queue a note; it must not trigger an LLM request by itself.
+    await sleep(500);
+    if (mock.requests.length !== 0) {
+      throw new Error(`Expected no LLM requests after save, but saw ${mock.requests.length}`);
+    }
+
+    // First send should include the queued note via extended_content.
+    const first = await sendAndWaitForRequestPath({
+      text: 'E2E gvc step 1',
+      expectedPath: '/v1/chat/completions',
+      getRequests: () => mock.requests,
+    });
+    const firstUsers = extractUserMessageTexts(first.json);
+    const hasNote = firstUsers.some((t) => t.includes('Environment note: user edited file:') && t.includes(filePath));
+    if (!hasNote) {
+      throw new Error(`Expected first request to contain queued watched-file note. userTexts=${JSON.stringify(firstUsers)}`);
+    }
+
+    // Second send should not include stale notes (queue drained).
+    const second = await sendAndWaitForRequestPath({
+      text: 'E2E gvc step 2',
+      expectedPath: '/v1/chat/completions',
+      getRequests: () => mock.requests,
+    });
+    const secondUsers = extractUserMessageTexts(second.json);
+    const noteCount = secondUsers.filter((t) => t.includes('Environment note: user edited file:')).length;
+    if (noteCount !== 1) {
+      throw new Error(`Expected note to appear exactly once in conversation history. userTexts=${JSON.stringify(secondUsers)}`);
+    }
+  } finally {
+    if (tempUri) {
+      try {
+        await vscode.workspace.fs.delete(tempUri, { useTrash: false });
+      } catch {
+        // ignore
+      }
+    }
+    await mock.close();
+  }
+}

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -99,6 +99,11 @@ export async function run(): Promise<void> {
     return runWelcomeTest();
   }
 
+  if (testName === 'gvc') {
+    const { run: runGvcTest } = await import('./gvc');
+    return runGvcTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness


### PR DESCRIPTION
Adds an E2E suite that verifies queued watched-file notes are included in the next outbound LLM request via `extended_content`, and are not re-added on subsequent sends.

### Bead


oh-tab-gvc: E2E: watched-file notes reach LLM via extended_content
Status: open
Priority: P2
Type: task
Created: 2026-01-15 06:25
Updated: 2026-01-15 07:59

Description:
Problem
- `oh-tab-rq3` changes subtle behavior (queued watched-file notes routed via `extended_content`). Unit tests help, but this is easy to break at integration boundaries (extension host ↔ SDK ↔ webview action send).

Goal
- Add an E2E test that proves watched-file notes reach the LLM in the *next* user message via `extended_content`.

Proposed test strategy
- Start OpenHands in local mode with a mock LLM server.
- Inject an `ObservationEvent` with `tool_name='file_editor'` and `observation.command` != 'view' for a temp file path to mark it as agent-edited (existing listener behavior).
- Modify and save that temp file using VS Code APIs to trigger the note pipeline.
- Send a real user message and inspect the outbound LLM request JSON.
- Assert the request includes `Environment note: user edited file:` text (as part of the user message content due to `extended_content` merge), and that the note does *not* trigger a separate LLM request.

Notes
- Reuse existing E2E helpers; keep test hermetic.

Acceptance Criteria:
- New E2E suite verifies watched-file note appears in the next outbound LLM request.
- Test verifies queue drains after a successful send (second send contains no stale note).
- `npm run e2e` remains green.

Labels: [e2e extended-context tests]

Depends on (2):
  → oh-tab-5vt: E2E helper: internal command to mark file as agent-edited for fileEditNoteTracker [P2]
  → oh-tab-rq3: Queue watched-file environment notes into next user message extended context [P2]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for watched file notes functionality, ensuring file changes are properly queued and included in LLM requests.
  * Expanded test coverage for the OpenHands integration with mock LLM server verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->