### PR TITLE
oh-tab-voc.5.1: Port device-flow polling tests

### DIFF
--- a/src/auth/__tests__/deviceFlow.test.ts
+++ b/src/auth/__tests__/deviceFlow.test.ts
@@ -3,8 +3,6 @@ import {
   DeviceFlowHttpError,
   DeviceFlowNetworkError,
   DeviceFlowProtocolError,
-  DeviceFlowTimeoutError,
-  DeviceFlowTokenError,
   pollDeviceToken,
   startDeviceAuthorization,
   type HttpClientLike,
@@ -73,9 +71,8 @@ describe('device flow client', () => {
       (url, init) => {
         expect(url).toBe('https://example.com/oauth/device/token');
         expect(init.headers?.['content-type']).toBe('application/x-www-form-urlencoded');
-        expect(init.body).toContain('grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code');
         expect(init.body).toContain('device_code=dev');
-        return jsonResponse(200, { error: 'authorization_pending' });
+        return jsonResponse(400, { error: 'authorization_pending' });
       },
       () => jsonResponse(200, { access_token: 'tok', token_type: 'bearer', expires_in: 123 }),
     ]);
@@ -99,9 +96,9 @@ describe('device flow client', () => {
     let now = 0;
     const sleepCalls: number[] = [];
     const http = createSequenceHttp([
-      () => jsonResponse(200, { error: 'authorization_pending' }),
-      () => jsonResponse(200, { error: 'slow_down' }),
-      () => jsonResponse(200, { error: 'authorization_pending' }),
+      () => jsonResponse(400, { error: 'authorization_pending' }),
+      () => jsonResponse(400, { error: 'slow_down' }),
+      () => jsonResponse(400, { error: 'authorization_pending' }),
       () => jsonResponse(200, { access_token: 'tok' }),
     ]);
 
@@ -117,8 +114,8 @@ describe('device flow client', () => {
       },
     });
     expect(out.accessToken).toBe('tok');
-    // first pending = 1000ms, slow_down increases by +5000 => 6000ms, then pending uses 6000ms
-    expect(sleepCalls).toEqual([1000, 6000, 6000]);
+    // first pending = 1000ms, slow_down doubles => 2000ms, then pending uses 2000ms
+    expect(sleepCalls).toEqual([1000, 2000, 2000]);
   });
 
   it('pollDeviceToken fails on expired_token', async () => {
@@ -133,7 +130,7 @@ describe('device flow client', () => {
       http,
       timeoutMs: 10_000,
       clock: { now: () => 0, sleep: async () => {} },
-    })).rejects.toBeInstanceOf(DeviceFlowTokenError);
+    })).rejects.toMatchObject({ name: 'DeviceFlowTokenError', error: 'expired_token' });
 
     await expect(pollDeviceToken({
       baseUrl: 'https://example.com',
@@ -142,7 +139,7 @@ describe('device flow client', () => {
       http: createSequenceHttp([() => jsonResponse(400, { error: 'expired_token' })]),
       timeoutMs: 10_000,
       clock: { now: () => 0, sleep: async () => {} },
-    })).rejects.toMatchObject({ error: 'expired_token' });
+    })).rejects.toThrow('Device code has expired');
   });
 
   it('pollDeviceToken fails on access_denied', async () => {
@@ -156,7 +153,7 @@ describe('device flow client', () => {
       http,
       timeoutMs: 10_000,
       clock: { now: () => 0, sleep: async () => {} },
-    })).rejects.toMatchObject({ error: 'access_denied' });
+    })).rejects.toThrow('User denied the authorization request.');
   });
 
   it('pollDeviceToken surfaces unknown errors', async () => {
@@ -220,7 +217,7 @@ describe('device flow client', () => {
     let calls = 0;
     const http: HttpClientLike = async () => {
       calls += 1;
-      return jsonResponse(200, { error: 'authorization_pending' });
+      return jsonResponse(400, { error: 'authorization_pending' });
     };
 
     await expect(pollDeviceToken({
@@ -230,8 +227,35 @@ describe('device flow client', () => {
       http,
       timeoutMs: 2500,
       clock: { now: () => now, sleep: async (ms) => { now += ms; } },
-    })).rejects.toBeInstanceOf(DeviceFlowTimeoutError);
+    })).rejects.toMatchObject({ name: 'DeviceFlowTimeoutError' });
     expect(calls).toBe(3);
   });
-});
 
+  it('startDeviceAuthorization throws on non-2xx', async () => {
+    const http = createSequenceHttp([
+      () => jsonResponse(500, { message: 'nope' }),
+    ]);
+    await expect(startDeviceAuthorization({ baseUrl: 'https://example.com', http })).rejects.toBeInstanceOf(DeviceFlowHttpError);
+  });
+
+  it('startDeviceAuthorization throws on network error', async () => {
+    const http: HttpClientLike = async () => {
+      throw new Error('offline');
+    };
+    await expect(startDeviceAuthorization({ baseUrl: 'https://example.com', http })).rejects.toBeInstanceOf(DeviceFlowNetworkError);
+  });
+
+  it('startDeviceAuthorization throws on invalid JSON', async () => {
+    const http = createSequenceHttp([
+      () => invalidJsonResponse(200, 'not json'),
+    ]);
+    await expect(startDeviceAuthorization({ baseUrl: 'https://example.com', http })).rejects.toBeInstanceOf(DeviceFlowProtocolError);
+  });
+
+  it('startDeviceAuthorization throws when required fields are missing', async () => {
+    const http = createSequenceHttp([
+      () => jsonResponse(200, { device_code: 'dev' }),
+    ]);
+    await expect(startDeviceAuthorization({ baseUrl: 'https://example.com', http })).rejects.toBeInstanceOf(DeviceFlowProtocolError);
+  });
+});

--- a/src/auth/__tests__/deviceFlow.test.ts
+++ b/src/auth/__tests__/deviceFlow.test.ts
@@ -3,6 +3,7 @@ import {
   DeviceFlowHttpError,
   DeviceFlowNetworkError,
   DeviceFlowProtocolError,
+  DeviceFlowTokenError,
   pollDeviceToken,
   startDeviceAuthorization,
   type HttpClientLike,
@@ -160,19 +161,27 @@ describe('device flow client', () => {
     const http = createSequenceHttp([
       () => jsonResponse(400, { error: 'something_else', error_description: 'nope' }),
     ]);
-    await expect(pollDeviceToken({
-      baseUrl: 'https://example.com',
-      deviceCode: 'dev',
-      pollIntervalMs: 1000,
-      http,
-      timeoutMs: 10_000,
-      clock: { now: () => 0, sleep: async () => {} },
-    })).rejects.toMatchObject({ error: 'something_else' });
+
+    try {
+      await pollDeviceToken({
+        baseUrl: 'https://example.com',
+        deviceCode: 'dev',
+        pollIntervalMs: 1000,
+        http,
+        timeoutMs: 10_000,
+        clock: { now: () => 0, sleep: async () => {} },
+      });
+      throw new Error('Expected pollDeviceToken to fail');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DeviceFlowTokenError);
+      expect(err).toMatchObject({ error: 'something_else' });
+      expect(err instanceof Error ? err.message : String(err)).toMatch(/Authorization error:/);
+    }
   });
 
   it('pollDeviceToken throws on invalid JSON', async () => {
     const http = createSequenceHttp([
-      () => invalidJsonResponse(200, 'not json'),
+      () => invalidJsonResponse(500, 'Internal Server Error'),
     ]);
     await expect(pollDeviceToken({
       baseUrl: 'https://example.com',
@@ -181,7 +190,7 @@ describe('device flow client', () => {
       http,
       timeoutMs: 10_000,
       clock: { now: () => 0, sleep: async () => {} },
-    })).rejects.toBeInstanceOf(DeviceFlowProtocolError);
+    })).rejects.toThrow('Unexpected response from server: 500');
   });
 
   it('pollDeviceToken throws on non-2xx without error', async () => {

--- a/src/auth/__tests__/deviceFlow.test.ts
+++ b/src/auth/__tests__/deviceFlow.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DeviceFlowHttpError,
+  DeviceFlowNetworkError,
+  DeviceFlowProtocolError,
+  DeviceFlowTimeoutError,
+  DeviceFlowTokenError,
+  pollDeviceToken,
+  startDeviceAuthorization,
+  type HttpClientLike,
+  type HttpResponseLike,
+} from '../deviceFlow';
+
+function jsonResponse(status: number, json: unknown): HttpResponseLike {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => json,
+    text: async () => JSON.stringify(json),
+  };
+}
+
+function invalidJsonResponse(status: number, text: string): HttpResponseLike {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => {
+      throw new Error('invalid json');
+    },
+    text: async () => text,
+  };
+}
+
+function createSequenceHttp(steps: Array<(url: string, init: { body?: string; headers?: Record<string, string> }) => HttpResponseLike>): HttpClientLike {
+  let i = 0;
+  return async (url, init) => {
+    const step = steps[i];
+    if (!step) throw new Error(`Unexpected request #${i + 1}: ${url}`);
+    i += 1;
+    return step(url, init);
+  };
+}
+
+describe('device flow client', () => {
+  it('startDeviceAuthorization builds verificationUriComplete when absent', async () => {
+    const http = createSequenceHttp([
+      (url, init) => {
+        expect(url).toBe('https://example.com/oauth/device/authorize');
+        expect(init.headers?.['content-type']).toBe('application/json');
+        expect(init.body).toBe('{}');
+        return jsonResponse(200, {
+          device_code: 'dev',
+          user_code: 'ABC-123',
+          verification_uri: 'https://example.com/verify?foo=bar',
+          interval: 1,
+        });
+      },
+    ]);
+
+    const auth = await startDeviceAuthorization({ baseUrl: 'https://example.com', http });
+    expect(auth.deviceCode).toBe('dev');
+    expect(auth.userCode).toBe('ABC-123');
+    expect(auth.intervalMs).toBe(1000);
+    expect(auth.verificationUriComplete).toContain('https://example.com/verify');
+    expect(new URL(auth.verificationUriComplete).searchParams.get('user_code')).toBe('ABC-123');
+    expect(new URL(auth.verificationUriComplete).searchParams.get('foo')).toBe('bar');
+  });
+
+  it('pollDeviceToken retries on authorization_pending until success', async () => {
+    let now = 0;
+    const sleepCalls: number[] = [];
+    const http = createSequenceHttp([
+      (url, init) => {
+        expect(url).toBe('https://example.com/oauth/device/token');
+        expect(init.headers?.['content-type']).toBe('application/x-www-form-urlencoded');
+        expect(init.body).toContain('grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code');
+        expect(init.body).toContain('device_code=dev');
+        return jsonResponse(200, { error: 'authorization_pending' });
+      },
+      () => jsonResponse(200, { access_token: 'tok', token_type: 'bearer', expires_in: 123 }),
+    ]);
+
+    const out = await pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: {
+        now: () => now,
+        sleep: async (ms) => { sleepCalls.push(ms); now += ms; },
+      },
+    });
+    expect(out).toEqual({ accessToken: 'tok', tokenType: 'bearer', expiresInSeconds: 123 });
+    expect(sleepCalls).toEqual([1000]);
+  });
+
+  it('pollDeviceToken increases interval on slow_down', async () => {
+    let now = 0;
+    const sleepCalls: number[] = [];
+    const http = createSequenceHttp([
+      () => jsonResponse(200, { error: 'authorization_pending' }),
+      () => jsonResponse(200, { error: 'slow_down' }),
+      () => jsonResponse(200, { error: 'authorization_pending' }),
+      () => jsonResponse(200, { access_token: 'tok' }),
+    ]);
+
+    const out = await pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 60_000,
+      clock: {
+        now: () => now,
+        sleep: async (ms) => { sleepCalls.push(ms); now += ms; },
+      },
+    });
+    expect(out.accessToken).toBe('tok');
+    // first pending = 1000ms, slow_down increases by +5000 => 6000ms, then pending uses 6000ms
+    expect(sleepCalls).toEqual([1000, 6000, 6000]);
+  });
+
+  it('pollDeviceToken fails on expired_token', async () => {
+    const http = createSequenceHttp([
+      () => jsonResponse(400, { error: 'expired_token', error_description: 'expired' }),
+    ]);
+
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toBeInstanceOf(DeviceFlowTokenError);
+
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http: createSequenceHttp([() => jsonResponse(400, { error: 'expired_token' })]),
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toMatchObject({ error: 'expired_token' });
+  });
+
+  it('pollDeviceToken fails on access_denied', async () => {
+    const http = createSequenceHttp([
+      () => jsonResponse(400, { error: 'access_denied' }),
+    ]);
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toMatchObject({ error: 'access_denied' });
+  });
+
+  it('pollDeviceToken surfaces unknown errors', async () => {
+    const http = createSequenceHttp([
+      () => jsonResponse(400, { error: 'something_else', error_description: 'nope' }),
+    ]);
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toMatchObject({ error: 'something_else' });
+  });
+
+  it('pollDeviceToken throws on invalid JSON', async () => {
+    const http = createSequenceHttp([
+      () => invalidJsonResponse(200, 'not json'),
+    ]);
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toBeInstanceOf(DeviceFlowProtocolError);
+  });
+
+  it('pollDeviceToken throws on non-2xx without error', async () => {
+    const http = createSequenceHttp([
+      () => jsonResponse(500, { message: 'oops' }),
+    ]);
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toBeInstanceOf(DeviceFlowHttpError);
+  });
+
+  it('pollDeviceToken surfaces network errors', async () => {
+    const http: HttpClientLike = async () => {
+      throw new Error('network down');
+    };
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 10_000,
+      clock: { now: () => 0, sleep: async () => {} },
+    })).rejects.toBeInstanceOf(DeviceFlowNetworkError);
+  });
+
+  it('pollDeviceToken enforces timeout', async () => {
+    let now = 0;
+    let calls = 0;
+    const http: HttpClientLike = async () => {
+      calls += 1;
+      return jsonResponse(200, { error: 'authorization_pending' });
+    };
+
+    await expect(pollDeviceToken({
+      baseUrl: 'https://example.com',
+      deviceCode: 'dev',
+      pollIntervalMs: 1000,
+      http,
+      timeoutMs: 2500,
+      clock: { now: () => now, sleep: async (ms) => { now += ms; } },
+    })).rejects.toBeInstanceOf(DeviceFlowTimeoutError);
+    expect(calls).toBe(3);
+  });
+});
+

--- a/src/auth/deviceFlow.ts
+++ b/src/auth/deviceFlow.ts
@@ -210,7 +210,10 @@ export async function pollDeviceToken(options: {
       json = await res.json();
     } catch {
       const text = await res.text().catch(() => '');
-      throw new DeviceFlowProtocolError(`Device token response was not valid JSON (status ${res.status}): ${text}`);
+      if (res.status !== 200) {
+        throw new DeviceFlowProtocolError(`Unexpected response from server: ${res.status}`);
+      }
+      throw new DeviceFlowProtocolError(`Device token response was not valid JSON: ${text}`);
     }
 
     const obj = parseJsonRecord(json, 'Device token response') as DeviceTokenResponse;
@@ -244,8 +247,8 @@ export async function pollDeviceToken(options: {
     }
 
     if (error) {
-      const message = errorDescription ? `${error}: ${errorDescription}` : error;
-      throw new DeviceFlowTokenError(message, { error, errorDescription });
+      const suffix = errorDescription ? ` - ${errorDescription}` : '';
+      throw new DeviceFlowTokenError(`Authorization error: ${error}${suffix}`, { error, errorDescription });
     }
 
     if (!res.ok) {

--- a/src/auth/deviceFlow.ts
+++ b/src/auth/deviceFlow.ts
@@ -1,0 +1,248 @@
+import { buildVerificationUriComplete } from './url';
+
+export type HttpResponseLike = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+export type HttpClientLike = (url: string, init: {
+  method: 'POST';
+  headers?: Record<string, string>;
+  body?: string;
+  signal?: AbortSignalLike;
+}) => Promise<HttpResponseLike>;
+
+export type AbortSignalLike = { aborted?: boolean };
+
+export type Clock = {
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+};
+
+const DEFAULT_CLOCK: Clock = {
+  now: () => Date.now(),
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+};
+
+export type DeviceAuthorization = {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string;
+  verificationUriComplete: string;
+  intervalMs: number;
+};
+
+export type DeviceToken = {
+  accessToken: string;
+  tokenType?: string;
+  expiresInSeconds?: number;
+};
+
+type DeviceAuthorizationResponse = {
+  device_code?: unknown;
+  user_code?: unknown;
+  verification_uri?: unknown;
+  verification_uri_complete?: unknown;
+  interval?: unknown;
+};
+
+type DeviceTokenResponse = {
+  access_token?: unknown;
+  token_type?: unknown;
+  expires_in?: unknown;
+  error?: unknown;
+  error_description?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function parseJsonRecord(value: unknown, context: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new DeviceFlowProtocolError(`${context}: expected JSON object`);
+  return value;
+}
+
+function clampPollIntervalMs(value: number): number {
+  if (!Number.isFinite(value)) return 5000;
+  return Math.max(1000, Math.trunc(value));
+}
+
+export class DeviceFlowProtocolError extends Error {
+  override name = 'DeviceFlowProtocolError';
+}
+
+export class DeviceFlowHttpError extends Error {
+  override name = 'DeviceFlowHttpError';
+  readonly status: number;
+  readonly bodyText: string;
+
+  constructor(message: string, params: { status: number; bodyText: string }) {
+    super(message);
+    this.status = params.status;
+    this.bodyText = params.bodyText;
+  }
+}
+
+export class DeviceFlowNetworkError extends Error {
+  override name = 'DeviceFlowNetworkError';
+}
+
+export class DeviceFlowTimeoutError extends Error {
+  override name = 'DeviceFlowTimeoutError';
+}
+
+export class DeviceFlowCancelledError extends Error {
+  override name = 'DeviceFlowCancelledError';
+}
+
+export class DeviceFlowTokenError extends Error {
+  override name = 'DeviceFlowTokenError';
+  readonly error: string;
+  readonly errorDescription?: string;
+
+  constructor(message: string, params: { error: string; errorDescription?: string }) {
+    super(message);
+    this.error = params.error;
+    this.errorDescription = params.errorDescription;
+  }
+}
+
+export async function startDeviceAuthorization(options: {
+  baseUrl: string;
+  http: HttpClientLike;
+  authorizePath?: string;
+  signal?: AbortSignalLike;
+}): Promise<DeviceAuthorization> {
+  const authorizePath = options.authorizePath ?? '/oauth/device/authorize';
+  const url = new URL(authorizePath, options.baseUrl).toString();
+
+  let res: HttpResponseLike;
+  try {
+    res = await options.http(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+      signal: options.signal,
+    });
+  } catch (err) {
+    throw new DeviceFlowNetworkError(`Device authorization request failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new DeviceFlowHttpError('Device authorization request failed', { status: res.status, bodyText: text });
+  }
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch {
+    throw new DeviceFlowProtocolError('Device authorization response was not valid JSON');
+  }
+
+  const obj = parseJsonRecord(json, 'Device authorization response');
+  const data = obj as DeviceAuthorizationResponse;
+
+  const deviceCode = typeof data.device_code === 'string' ? data.device_code.trim() : '';
+  const userCode = typeof data.user_code === 'string' ? data.user_code.trim() : '';
+  const verificationUri = typeof data.verification_uri === 'string' ? data.verification_uri.trim() : '';
+  const verificationUriCompleteRaw = typeof data.verification_uri_complete === 'string' ? data.verification_uri_complete.trim() : '';
+  if (!deviceCode || !userCode || !verificationUri) {
+    throw new DeviceFlowProtocolError('Device authorization response missing required fields');
+  }
+
+  const intervalSeconds = typeof data.interval === 'number' && Number.isFinite(data.interval) ? Math.trunc(data.interval) : 5;
+  const intervalMs = clampPollIntervalMs(intervalSeconds * 1000);
+
+  const verificationUriComplete = verificationUriCompleteRaw || buildVerificationUriComplete(verificationUri, userCode);
+
+  return { deviceCode, userCode, verificationUri, verificationUriComplete, intervalMs };
+}
+
+export async function pollDeviceToken(options: {
+  baseUrl: string;
+  deviceCode: string;
+  pollIntervalMs: number;
+  http: HttpClientLike;
+  tokenPath?: string;
+  timeoutMs?: number;
+  signal?: AbortSignalLike;
+  clock?: Clock;
+}): Promise<DeviceToken> {
+  const tokenPath = options.tokenPath ?? '/oauth/device/token';
+  const url = new URL(tokenPath, options.baseUrl).toString();
+  const timeoutMs = typeof options.timeoutMs === 'number' && Number.isFinite(options.timeoutMs) ? Math.max(0, options.timeoutMs) : 10 * 60_000;
+  const clock = options.clock ?? DEFAULT_CLOCK;
+
+  const deviceCode = typeof options.deviceCode === 'string' ? options.deviceCode.trim() : '';
+  if (!deviceCode) throw new DeviceFlowProtocolError('deviceCode is required');
+
+  const startedAt = clock.now();
+  let pollIntervalMs = clampPollIntervalMs(options.pollIntervalMs);
+
+  const body = new URLSearchParams({
+    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+    device_code: deviceCode,
+  }).toString();
+
+  while (true) {
+    if (options.signal?.aborted) throw new DeviceFlowCancelledError('Device flow cancelled');
+    if (clock.now() - startedAt > timeoutMs) throw new DeviceFlowTimeoutError('Device flow timed out');
+
+    let res: HttpResponseLike;
+    try {
+      res = await options.http(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body,
+        signal: options.signal,
+      });
+    } catch (err) {
+      throw new DeviceFlowNetworkError(`Device token request failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    let json: unknown;
+    try {
+      json = await res.json();
+    } catch {
+      const text = await res.text().catch(() => '');
+      throw new DeviceFlowProtocolError(`Device token response was not valid JSON (status ${res.status}): ${text}`);
+    }
+
+    const obj = parseJsonRecord(json, 'Device token response') as DeviceTokenResponse;
+    const accessToken = typeof obj.access_token === 'string' ? obj.access_token.trim() : '';
+    if (accessToken) {
+      const tokenType = typeof obj.token_type === 'string' ? obj.token_type : undefined;
+      const expiresInSeconds = typeof obj.expires_in === 'number' && Number.isFinite(obj.expires_in) ? Math.trunc(obj.expires_in) : undefined;
+      return { accessToken, tokenType, expiresInSeconds };
+    }
+
+    const error = typeof obj.error === 'string' ? obj.error : '';
+    const errorDescription = typeof obj.error_description === 'string' ? obj.error_description : undefined;
+
+    if (error === 'authorization_pending') {
+      await clock.sleep(pollIntervalMs);
+      continue;
+    }
+
+    if (error === 'slow_down') {
+      pollIntervalMs = clampPollIntervalMs(pollIntervalMs + 5000);
+      await clock.sleep(pollIntervalMs);
+      continue;
+    }
+
+    if (error) {
+      const message = errorDescription ? `${error}: ${errorDescription}` : error;
+      throw new DeviceFlowTokenError(message, { error, errorDescription });
+    }
+
+    if (!res.ok) {
+      throw new DeviceFlowHttpError('Device token request failed', { status: res.status, bodyText: JSON.stringify(obj) });
+    }
+
+    throw new DeviceFlowProtocolError('Device token response missing access_token and error');
+  }
+}

--- a/src/auth/deviceFlow.ts
+++ b/src/auth/deviceFlow.ts
@@ -70,6 +70,8 @@ function clampPollIntervalMs(value: number): number {
   return Math.max(1000, Math.trunc(value));
 }
 
+const MAX_SLOW_DOWN_INTERVAL_MS = 30_000;
+
 export class DeviceFlowProtocolError extends Error {
   override name = 'DeviceFlowProtocolError';
 }
@@ -184,13 +186,12 @@ export async function pollDeviceToken(options: {
   let pollIntervalMs = clampPollIntervalMs(options.pollIntervalMs);
 
   const body = new URLSearchParams({
-    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
     device_code: deviceCode,
   }).toString();
 
   while (true) {
     if (options.signal?.aborted) throw new DeviceFlowCancelledError('Device flow cancelled');
-    if (clock.now() - startedAt > timeoutMs) throw new DeviceFlowTimeoutError('Device flow timed out');
+    if (clock.now() - startedAt > timeoutMs) throw new DeviceFlowTimeoutError('Timeout waiting for user authorization (device flow)');
 
     let res: HttpResponseLike;
     try {
@@ -229,9 +230,17 @@ export async function pollDeviceToken(options: {
     }
 
     if (error === 'slow_down') {
-      pollIntervalMs = clampPollIntervalMs(pollIntervalMs + 5000);
+      pollIntervalMs = Math.min(clampPollIntervalMs(pollIntervalMs * 2), MAX_SLOW_DOWN_INTERVAL_MS);
       await clock.sleep(pollIntervalMs);
       continue;
+    }
+
+    if (error === 'expired_token') {
+      throw new DeviceFlowTokenError('Device code has expired. Please restart the device authorization flow.', { error, errorDescription });
+    }
+
+    if (error === 'access_denied') {
+      throw new DeviceFlowTokenError('User denied the authorization request.', { error, errorDescription });
     }
 
     if (error) {


### PR DESCRIPTION
Ports the core device-flow polling state machine scenarios into Vitest (no placeholders) and introduces a small pure TS `src/auth/deviceFlow.ts` implementation so the tests are executable and green.

### Bead


oh-tab-voc.5.1: Port CLI device_flow tests (polling states + timeout)
Status: open
Priority: P1
Type: task
Created: 2026-01-15 09:29
Updated: 2026-01-15 09:29

Description:
Port the core scenarios from OpenHands-CLI `tests/auth/test_device_flow.py` into Vitest, focusing on the pure device-flow client behaviors (start flow + poll states + timeout + error mapping).

Acceptance
- Tests cover: success, authorization_pending, slow_down backoff, expired_token, access_denied, unknown error, invalid JSON / unexpected status, network error, timeout.
- No `it.todo` placeholders; executable assertions only.

Labels: [auth device-flow tests]

Depends on (1):
  → oh-tab-voc.5: Device-flow auth: port OpenHands-CLI auth tests to TypeScript (full suite) [P1]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Device Flow authentication support with comprehensive error handling for protocol, HTTP, network, and timeout scenarios. Includes request cancellation and configurable polling intervals.

* **Tests**
  * Added extensive test suite for Device Flow authentication, covering authorization initiation, token polling, error cases, and network resilience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->