### PR TITLE
oh-tab-voc.5.2: auth http client tests

### DIFF
--- a/src/auth/__tests__/httpClient.test.ts
+++ b/src/auth/__tests__/httpClient.test.ts
@@ -26,12 +26,20 @@ describe('AuthHttpClient', () => {
       raiseForStatus: false,
     });
 
+    await client.requestJson({
+      method: 'POST',
+      endpoint: 'oauth/device/token',
+      json: { hello: 'world' },
+      raiseForStatus: false,
+    });
+
     expect(out.ok).toBe(true);
     expect(out.status).toBe(200);
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(calls[0]?.url).toBe('https://example.com/v1/oauth/device/token');
     expect(calls[0]?.init.headers?.['content-type']).toBe('application/json');
     expect(calls[0]?.init.body).toBe(JSON.stringify({ hello: 'world' }));
+    expect(calls[1]?.url).toBe('https://example.com/v1/oauth/device/token');
   });
 
   it('supports form_data bodies', async () => {
@@ -53,8 +61,29 @@ describe('AuthHttpClient', () => {
   it('extracts JSON error details and throws AuthHttpStatusError by default', async () => {
     const fetch: HttpFetchLike = async () => jsonResponse(401, { detail: 'Unauthorized' });
     const client = new AuthHttpClient({ baseUrl: 'https://example.com/api', fetch });
-    await expect(client.requestJson({ method: 'GET', endpoint: 'me' })).rejects.toBeInstanceOf(AuthHttpStatusError);
-    await expect(client.requestJson({ method: 'GET', endpoint: 'me' })).rejects.toThrow('HTTP 401: Unauthorized');
+
+    try {
+      await client.requestJson({ method: 'GET', endpoint: 'me' });
+      throw new Error('Expected AuthHttpStatusError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthHttpStatusError);
+      expect(err).toMatchObject({ status: 401, detail: 'Unauthorized' });
+      expect(err instanceof Error ? err.message : String(err)).toBe('HTTP 401: Unauthorized');
+    }
+  });
+
+  it('falls back to status code string when JSON lacks detail', async () => {
+    const fetch: HttpFetchLike = async () => jsonResponse(400, { error: 'bad_request' });
+    const client = new AuthHttpClient({ baseUrl: 'https://example.com/api', fetch });
+
+    try {
+      await client.requestJson({ method: 'GET', endpoint: 'me' });
+      throw new Error('Expected AuthHttpStatusError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthHttpStatusError);
+      expect(err).toMatchObject({ status: 400, detail: '400' });
+      expect(err instanceof Error ? err.message : String(err)).toBe('HTTP 400: 400');
+    }
   });
 
   it('does not throw on non-2xx when raiseForStatus=false', async () => {
@@ -72,4 +101,3 @@ describe('AuthHttpClient', () => {
     await expect(client.requestJson({ method: 'GET', endpoint: 'me' })).rejects.toBeInstanceOf(AuthHttpNetworkError);
   });
 });
-

--- a/src/auth/__tests__/httpClient.test.ts
+++ b/src/auth/__tests__/httpClient.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { AuthHttpClient, AuthHttpNetworkError, AuthHttpStatusError, type HttpFetchLike, type HttpResponseLike } from '../httpClient';
+
+function jsonResponse(status: number, json: unknown): HttpResponseLike {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => json,
+    text: async () => JSON.stringify(json),
+  };
+}
+
+describe('AuthHttpClient', () => {
+  it('joins endpoints under a base path and strips trailing slashes', async () => {
+    const calls: Array<{ url: string; init: { method: string; headers?: Record<string, string>; body?: string } }> = [];
+    const fetch: HttpFetchLike = async (url, init) => {
+      calls.push({ url, init });
+      return jsonResponse(200, { ok: true });
+    };
+
+    const client = new AuthHttpClient({ baseUrl: 'https://example.com/v1/', fetch });
+    const out = await client.requestJson({
+      method: 'POST',
+      endpoint: '/oauth/device/token',
+      json: { hello: 'world' },
+      raiseForStatus: false,
+    });
+
+    expect(out.ok).toBe(true);
+    expect(out.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('https://example.com/v1/oauth/device/token');
+    expect(calls[0]?.init.headers?.['content-type']).toBe('application/json');
+    expect(calls[0]?.init.body).toBe(JSON.stringify({ hello: 'world' }));
+  });
+
+  it('supports form_data bodies', async () => {
+    const fetch: HttpFetchLike = async (_url, init) => {
+      expect(init.headers?.['content-type']).toBe('application/x-www-form-urlencoded');
+      expect(init.body).toContain('a=1');
+      expect(init.body).toContain('b=two');
+      return jsonResponse(200, { ok: true });
+    };
+
+    const client = new AuthHttpClient({ baseUrl: 'https://example.com', fetch });
+    await client.requestJson({
+      method: 'POST',
+      endpoint: 'oauth/form',
+      formData: { a: '1', b: 'two' },
+    });
+  });
+
+  it('extracts JSON error details and throws AuthHttpStatusError by default', async () => {
+    const fetch: HttpFetchLike = async () => jsonResponse(401, { detail: 'Unauthorized' });
+    const client = new AuthHttpClient({ baseUrl: 'https://example.com/api', fetch });
+    await expect(client.requestJson({ method: 'GET', endpoint: 'me' })).rejects.toBeInstanceOf(AuthHttpStatusError);
+    await expect(client.requestJson({ method: 'GET', endpoint: 'me' })).rejects.toThrow('HTTP 401: Unauthorized');
+  });
+
+  it('does not throw on non-2xx when raiseForStatus=false', async () => {
+    const fetch: HttpFetchLike = async () => jsonResponse(400, { detail: 'nope' });
+    const client = new AuthHttpClient({ baseUrl: 'https://example.com/api', fetch });
+    const out = await client.requestJson({ method: 'GET', endpoint: 'me', raiseForStatus: false });
+    expect(out).toEqual({ ok: false, status: 400, data: { detail: 'nope' } });
+  });
+
+  it('maps network failures to AuthHttpNetworkError', async () => {
+    const fetch: HttpFetchLike = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const client = new AuthHttpClient({ baseUrl: 'https://example.com/api', fetch });
+    await expect(client.requestJson({ method: 'GET', endpoint: 'me' })).rejects.toBeInstanceOf(AuthHttpNetworkError);
+  });
+});
+

--- a/src/auth/httpClient.ts
+++ b/src/auth/httpClient.ts
@@ -45,18 +45,12 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function extractErrorDetail(data: unknown): string | undefined {
-  if (!isRecord(data)) return undefined;
+function extractErrorDetail(data: unknown, status: number): string {
+  // Match OpenHands-CLI BaseHttpClient semantics: prefer explicit `detail`, otherwise fall back to the status code string.
+  if (!isRecord(data)) return `HTTP ${status}`;
   const detail = data.detail;
   if (typeof detail === 'string' && detail.trim()) return detail.trim();
-
-  const errorDescription = data.error_description;
-  if (typeof errorDescription === 'string' && errorDescription.trim()) return errorDescription.trim();
-
-  const error = data.error;
-  if (typeof error === 'string' && error.trim()) return error.trim();
-
-  return undefined;
+  return String(status);
 }
 
 function joinEndpoint(baseUrl: string, endpoint: string): string {
@@ -120,18 +114,18 @@ export class AuthHttpClient {
     } catch {
       const text = await res.text().catch(() => '');
       if (raiseForStatus && !res.ok) {
-        throw new AuthHttpStatusError(`Unexpected response from server: ${res.status}`, { status: res.status, bodyText: text });
+        const detail = `HTTP ${res.status}`;
+        throw new AuthHttpStatusError(`HTTP ${res.status}: ${detail}`, { status: res.status, bodyText: text, detail });
       }
       throw new AuthHttpProtocolError('Response was not valid JSON');
     }
 
     if (raiseForStatus && !res.ok) {
-      const detail = extractErrorDetail(json);
-      const message = `HTTP ${res.status}${detail ? `: ${detail}` : ''}`;
+      const detail = extractErrorDetail(json, res.status);
+      const message = `HTTP ${res.status}: ${detail}`;
       throw new AuthHttpStatusError(message, { status: res.status, bodyText: JSON.stringify(json), detail });
     }
 
     return { ok: res.ok, status: res.status, data: json as T };
   }
 }
-

--- a/src/auth/httpClient.ts
+++ b/src/auth/httpClient.ts
@@ -1,0 +1,137 @@
+import { normalizeHttpBaseUrl } from './url';
+
+export type HttpResponseLike = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+  text: () => Promise<string>;
+};
+
+export type HttpFetchLike = (url: string, init: {
+  method: string;
+  headers?: Record<string, string>;
+  body?: string;
+}) => Promise<HttpResponseLike>;
+
+export type AuthHttpJsonResponse<T = unknown> = {
+  ok: boolean;
+  status: number;
+  data: T;
+};
+
+export class AuthHttpProtocolError extends Error {
+  override name = 'AuthHttpProtocolError';
+}
+
+export class AuthHttpNetworkError extends Error {
+  override name = 'AuthHttpNetworkError';
+}
+
+export class AuthHttpStatusError extends Error {
+  override name = 'AuthHttpStatusError';
+  readonly status: number;
+  readonly bodyText: string;
+  readonly detail?: string;
+
+  constructor(message: string, params: { status: number; bodyText: string; detail?: string }) {
+    super(message);
+    this.status = params.status;
+    this.bodyText = params.bodyText;
+    this.detail = params.detail;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function extractErrorDetail(data: unknown): string | undefined {
+  if (!isRecord(data)) return undefined;
+  const detail = data.detail;
+  if (typeof detail === 'string' && detail.trim()) return detail.trim();
+
+  const errorDescription = data.error_description;
+  if (typeof errorDescription === 'string' && errorDescription.trim()) return errorDescription.trim();
+
+  const error = data.error;
+  if (typeof error === 'string' && error.trim()) return error.trim();
+
+  return undefined;
+}
+
+function joinEndpoint(baseUrl: string, endpoint: string): string {
+  const trimmed = typeof endpoint === 'string' ? endpoint.trim() : '';
+  if (!trimmed) return baseUrl;
+  if (/^https?:\/\//i.test(trimmed)) return trimmed;
+
+  const base = new URL(baseUrl);
+  const basePath = base.pathname.endsWith('/') ? base.pathname : `${base.pathname}/`;
+  const withoutLeadingSlashes = trimmed.replace(/^\/+/, '');
+  return new URL(withoutLeadingSlashes, `${base.origin}${basePath}`).toString();
+}
+
+export class AuthHttpClient {
+  readonly baseUrl: string;
+  private readonly fetch: HttpFetchLike;
+
+  constructor(options: { baseUrl: string; fetch: HttpFetchLike }) {
+    const normalized = normalizeHttpBaseUrl(options.baseUrl);
+    if (!normalized.ok) throw new AuthHttpProtocolError(normalized.error);
+    this.baseUrl = normalized.url;
+    this.fetch = options.fetch;
+  }
+
+  async requestJson<T = unknown>(options: {
+    method: string;
+    endpoint: string;
+    json?: unknown;
+    formData?: Record<string, string>;
+    headers?: Record<string, string>;
+    raiseForStatus?: boolean;
+  }): Promise<AuthHttpJsonResponse<T>> {
+    const raiseForStatus = options.raiseForStatus !== false;
+    const url = joinEndpoint(this.baseUrl, options.endpoint);
+
+    if (options.json !== undefined && options.formData) {
+      throw new AuthHttpProtocolError('Expected either json or formData, not both');
+    }
+
+    const headers: Record<string, string> = { ...(options.headers ?? {}) };
+    let body: string | undefined;
+
+    if (options.formData) {
+      headers['content-type'] = headers['content-type'] ?? 'application/x-www-form-urlencoded';
+      body = new URLSearchParams(options.formData).toString();
+    } else if (options.json !== undefined) {
+      headers['content-type'] = headers['content-type'] ?? 'application/json';
+      body = JSON.stringify(options.json);
+    }
+
+    let res: HttpResponseLike;
+    try {
+      res = await this.fetch(url, { method: options.method, headers, body });
+    } catch (err) {
+      throw new AuthHttpNetworkError(`Request failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+
+    let json: unknown;
+    try {
+      json = await res.json();
+    } catch {
+      const text = await res.text().catch(() => '');
+      if (raiseForStatus && !res.ok) {
+        throw new AuthHttpStatusError(`Unexpected response from server: ${res.status}`, { status: res.status, bodyText: text });
+      }
+      throw new AuthHttpProtocolError('Response was not valid JSON');
+    }
+
+    if (raiseForStatus && !res.ok) {
+      const detail = extractErrorDetail(json);
+      const message = `HTTP ${res.status}${detail ? `: ${detail}` : ''}`;
+      throw new AuthHttpStatusError(message, { status: res.status, bodyText: JSON.stringify(json), detail });
+    }
+
+    return { ok: res.ok, status: res.status, data: json as T };
+  }
+}
+


### PR DESCRIPTION
Implements `oh-tab-voc.5.2`.

- Adds `src/auth/httpClient.ts` with URL join + JSON/form helpers and typed errors.
- Adds Vitest coverage for base URL normalization, endpoint join, JSON error detail extraction, status/network error mapping, raiseForStatus=false, and form_data bodies.
