### PR TITLE
Add LOC counting and markdown output to token counter script

### DIFF
--- a/scripts/count_tokens.py
+++ b/scripts/count_tokens.py
@@ -31,9 +31,84 @@ def count_tokens_in_file(filepath, encoding):
         return 0
 
 
+def count_lines_in_file(filepath):
+    """Count lines of code in a single file."""
+    try:
+        content = filepath.read_text(errors='ignore')
+        return len(content.splitlines())
+    except OSError as e:
+        print(f"⚠️  Error reading {filepath}: {e}", file=sys.stderr)
+        return 0
+
+
 def format_number(num):
     """Format number with commas."""
     return f"{num:,}"
+
+
+def print_markdown_results(base_path, total_tokens, total_lines, file_count,
+                          tokens_by_extension, lines_by_extension, files_by_extension):
+    """Print results in markdown format."""
+    print(f"\n## Token and Line Count: `{base_path}`\n")
+    print(f"- **Total tokens:** {format_number(total_tokens)}")
+    print(f"- **Total lines:** {format_number(total_lines)}")
+    print(f"- **Total files:** {format_number(file_count)}\n")
+
+    # Context window comparison
+    print("### Context Windows\n")
+    context_windows = {
+        "200K context": 200_000,
+        "128K context": 128_000,
+        "100K context": 100_000,
+    }
+    for name, size in context_windows.items():
+        print(f"- {name}: {total_tokens/size:.1f}x")
+
+    # By file type
+    if tokens_by_extension:
+        print("\n### By File Type\n")
+        print("| Extension | Tokens | Lines | Files | % Tokens |")
+        print("|-----------|--------|-------|-------|----------|")
+        for ext in sorted(tokens_by_extension.keys(), key=lambda x: tokens_by_extension[x], reverse=True):
+            tokens = tokens_by_extension[ext]
+            lines = lines_by_extension[ext]
+            files = files_by_extension[ext]
+            pct = (tokens / total_tokens * 100) if total_tokens > 0 else 0
+            print(f"| `{ext}` | {format_number(tokens)} | {format_number(lines)} | {files} | {pct:.1f}% |")
+    print()
+
+
+def print_text_results(base_path, total_tokens, total_lines, file_count,
+                      tokens_by_extension, lines_by_extension, files_by_extension):
+    """Print results in text format."""
+    print("=" * 60)
+    print("📊 RESULTS")
+    print("=" * 60)
+    print(f"Total tokens:  {format_number(total_tokens)}")
+    print(f"Total lines:   {format_number(total_lines)}")
+    print(f"Total files:   {format_number(file_count)}")
+
+    # Context window comparison
+    print("\nContext windows (tiktoken estimate):")
+    context_windows = {
+        "200K context": 200_000,
+        "128K context": 128_000,
+        "100K context": 100_000,
+    }
+    for name, size in context_windows.items():
+        print(f"  - {name + ':':<20} {total_tokens/size:.1f}x")
+
+    if tokens_by_extension:
+        print("\n📁 By file type:")
+        print("-" * 60)
+        for ext in sorted(tokens_by_extension.keys(), key=lambda x: tokens_by_extension[x], reverse=True):
+            tokens = tokens_by_extension[ext]
+            lines = lines_by_extension[ext]
+            files = files_by_extension[ext]
+            pct = (tokens / total_tokens * 100) if total_tokens > 0 else 0
+            print(f"  {ext:8s}  {format_number(tokens):>12s} tokens  {format_number(lines):>10s} lines  ({files:>4d} files)  {pct:5.1f}%")
+
+    print("=" * 60)
 
 
 def main():
@@ -46,6 +121,8 @@ def main():
     parser.add_argument('--ignore-dirs', nargs='+',
                        default=['node_modules', 'dist', 'out', 'build', '.git', 'media', '.openhands', '__pycache__', 'venv', '.venv'],
                        help='Directory names to ignore (default: common build/cache dirs)')
+    parser.add_argument('--format', choices=['text', 'markdown'], default='text',
+                       help='Output format (default: text)')
 
     args = parser.parse_args()
 
@@ -64,16 +141,19 @@ def main():
         print(f"⚠️  Unknown model {args.model}, using cl100k_base encoding", file=sys.stderr)
         encoding = tiktoken.get_encoding("cl100k_base")
 
-    # Count tokens
+    # Count tokens and lines
     total_tokens = 0
+    total_lines = 0
     file_count = 0
     tokens_by_extension = defaultdict(int)
+    lines_by_extension = defaultdict(int)
     files_by_extension = defaultdict(int)
 
-    print(f"\n🔍 Analyzing: {base_path}")
-    print(f"📝 Extensions: {', '.join(args.extensions)}")
-    print(f"🤖 Tokenizer: {args.model}")
-    print(f"🚫 Ignoring: {', '.join(sorted(ignore_dirs))}\n")
+    if args.format != 'markdown':
+        print(f"\n🔍 Analyzing: {base_path}")
+        print(f"📝 Extensions: {', '.join(args.extensions)}")
+        print(f"🤖 Tokenizer: {args.model}")
+        print(f"🚫 Ignoring: {', '.join(sorted(ignore_dirs))}\n")
 
     for filepath in base_path.rglob('*'):
         # Skip files in ignored directories
@@ -82,38 +162,21 @@ def main():
 
         if filepath.is_file() and filepath.suffix in args.extensions:
             tokens = count_tokens_in_file(filepath, encoding)
+            lines = count_lines_in_file(filepath)
             total_tokens += tokens
+            total_lines += lines
             file_count += 1
             tokens_by_extension[filepath.suffix] += tokens
+            lines_by_extension[filepath.suffix] += lines
             files_by_extension[filepath.suffix] += 1
 
     # Results
-    print("=" * 60)
-    print("📊 RESULTS")
-    print("=" * 60)
-    print(f"Total tokens:  {format_number(total_tokens)}")
-    print(f"Total files:   {format_number(file_count)}")
-
-    # Context window comparison (using generic sizes, tokens estimated via tiktoken)
-    print("\nContext windows (tiktoken estimate):")
-    context_windows = {
-        "200K context": 200_000,
-        "128K context": 128_000,
-        "100K context": 100_000,
-    }
-    for name, size in context_windows.items():
-        print(f"  - {name + ':':<20} {total_tokens/size:.1f}x")
-
-    if tokens_by_extension:
-        print("\n📁 By file type:")
-        print("-" * 60)
-        for ext in sorted(tokens_by_extension.keys(), key=lambda x: tokens_by_extension[x], reverse=True):
-            tokens = tokens_by_extension[ext]
-            files = files_by_extension[ext]
-            pct = (tokens / total_tokens * 100) if total_tokens > 0 else 0
-            print(f"  {ext:8s}  {format_number(tokens):>12s} tokens  ({files:>4d} files)  {pct:5.1f}%")
-
-    print("=" * 60)
+    if args.format == 'markdown':
+        print_markdown_results(base_path, total_tokens, total_lines, file_count,
+                             tokens_by_extension, lines_by_extension, files_by_extension)
+    else:
+        print_text_results(base_path, total_tokens, total_lines, file_count,
+                         tokens_by_extension, lines_by_extension, files_by_extension)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Enhanced scripts/count_tokens.py with:
- count_lines_in_file() function to track lines of code
- print_markdown_results() for structured markdown output
- print_text_results() refactored from inline code
- --format flag to choose between text/markdown output
- Display both tokens and lines in all output formats

Results for current codebase:
- Extension (src/): 244K tokens, 28K lines
- SDK (packages/agent-sdk-ts/): 299K tokens, 35K lines
- Total project: 637K tokens, 74K lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--format` option to choose between text and markdown output formats for token count reports.

* **Refactor**
  * Enhanced token counting script to track and report line count statistics alongside token metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->