### PR TITLE
oh-tab-0ph.2: E2E context-length condensation + retry

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/retryPolicy.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/retryPolicy.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LLMStreamer } from '../../runtime';
+import { OpenAICompatibleClient, OpenAIResponsesClient } from '../index';
+import type { ChatCompletionRequest, LLMConfiguration, RetryOptions } from '../types';
+
+const encoder = new TextEncoder();
+
+const createStreamResponse = (payload: string, status = 200): Response =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(payload));
+        controller.close();
+      },
+    }),
+    { status, headers: { 'content-type': 'text/event-stream' } },
+  );
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LLM HTTP retry policies', () => {
+  const request: ChatCompletionRequest = {
+    systemPrompt: 'you are a test harness',
+    messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }],
+  };
+
+  it('OpenAICompatibleClient does not retry on non-retryable HTTP statuses', async () => {
+    const baseConfig: LLMConfiguration = { model: 'gpt-4o-mini', provider: 'openai', baseUrl: 'http://localhost:4000' };
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response('{"error":{"code":"context_length_exceeded"}}', { status: 400 }));
+
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    await expect(streamer.runChat(request)).rejects.toThrow(/LLM request failed \(400\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('OpenAIResponsesClient does not retry on non-retryable HTTP statuses', async () => {
+    const baseConfig: LLMConfiguration = { model: 'gpt-4o-mini', provider: 'openai', baseUrl: 'http://localhost:4000' };
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response('{"error":{"code":"context_length_exceeded"}}', { status: 400 }));
+
+    const client = new OpenAIResponsesClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    await expect(streamer.runChat(request)).rejects.toThrow(/LLM request failed \(400\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('OpenAICompatibleClient still retries on retryable statuses', async () => {
+    const baseConfig: LLMConfiguration = { model: 'gpt-4o-mini', provider: 'openai', baseUrl: 'http://localhost:4000' };
+    const retry: RetryOptions = { maxRetries: 1, baseDelayMs: 0, maxDelayMs: 0, retryOn: (status) => status === 503 };
+
+    const sse = [
+      'data: {"choices":[{"delta":{"content":[{"type":"text","text":"OK"}]}}]}',
+      'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}',
+      'data: [DONE]',
+    ].join('\n');
+
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response('overloaded', { status: 503 }))
+      .mockResolvedValueOnce(createStreamResponse(sse));
+
+    const client = new OpenAICompatibleClient(baseConfig, 'test-key', retry);
+    const streamer = new LLMStreamer(client);
+
+    const result = await streamer.runChat(request);
+    expect(result.message.role).toBe('assistant');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -5,6 +5,16 @@ import { supportsThinkingBlocks } from './providerQuirks';
 
 const decoder = new TextDecoder();
 
+class NonRetryableHttpStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'NonRetryableHttpStatusError';
+    this.status = status;
+  }
+}
+
 const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
   ...(base ?? {}),
   ...(overrides ?? {}),
@@ -374,11 +384,14 @@ export class OpenAICompatibleClient implements LLMClient {
           }
 
           const message = await response.text();
-          throw new Error(`LLM request failed (${response.status}): ${message}`);
+          throw new NonRetryableHttpStatusError(response.status, `LLM request failed (${response.status}): ${message}`);
         }
 
         return response;
       } catch (error) {
+        if (error instanceof NonRetryableHttpStatusError) {
+          throw error;
+        }
         lastError = error as Error;
         if (attempt >= this.retry.maxRetries) break;
         await delay(delayMs);

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -3,6 +3,16 @@ import type { Message, ResponsesReasoningItem, ToolCall } from '../types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 import { DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions } from './types';
 
+class NonRetryableHttpStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'NonRetryableHttpStatusError';
+    this.status = status;
+  }
+}
+
 const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
   ...(base ?? {}),
   ...(overrides ?? {}),
@@ -388,7 +398,7 @@ export class OpenAIResponsesClient implements LLMClient {
             continue;
           }
           const message = await response.text();
-          throw new Error(`LLM request failed (${response.status}): ${message}`);
+          throw new NonRetryableHttpStatusError(response.status, `LLM request failed (${response.status}): ${message}`);
         }
 
         const json = await response.json() as unknown;
@@ -397,6 +407,9 @@ export class OpenAIResponsesClient implements LLMClient {
         }
         return json as OpenAIResponsesResponse;
       } catch (error) {
+        if (error instanceof NonRetryableHttpStatusError) {
+          throw error;
+        }
         lastError = error as Error;
         if (attempt >= this.retry.maxRetries) break;
         await delay(delayMs);

--- a/tests/e2e/contextLimitRetry.test.ts
+++ b/tests/e2e/contextLimitRetry.test.ts
@@ -1,0 +1,43 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as os from 'os';
+import * as path from 'path';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `oh-tab-0ph2-${Date.now().toString(36)}`);
+
+describe('OpenHands-Tab context-limit condensation + retry E2E', function () {
+  this.timeout(180000);
+
+  it('condenses and retries after context_length_exceeded', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--use-inmemory-secretstorage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'contextLimitRetry',
+        HOME: userDataDir,
+        USERPROFILE: userDataDir,
+        OPENAI_API_KEY: 'e2e-openai-key',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/contextLimitRetry.ts
+++ b/tests/e2e/suite/contextLimitRetry.ts
@@ -1,0 +1,210 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import { startMockLlmServer } from './mockLlmServer';
+import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
+
+type DiagnosticsInfo = {
+  chat?: { hasView?: boolean; webviewReady?: boolean };
+  conversationId?: string | null;
+  mode?: 'local' | 'remote';
+};
+
+type ErrorInfo = { seq?: number } | null;
+
+type RenderedEventsInfo = {
+  eventTypes?: string[];
+};
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForWebviewReady(timeoutMs: number): Promise<void> {
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag.chat.webviewReady);
+  }, timeoutMs);
+}
+
+function isCondensationRequest(json: unknown): boolean {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) return false;
+  const obj = json as Record<string, unknown>;
+  const messages = obj.messages;
+  if (!Array.isArray(messages) || messages.length < 1) return false;
+  const first = messages[0];
+  if (!first || typeof first !== 'object' || Array.isArray(first)) return false;
+  const msg = first as Record<string, unknown>;
+  if (msg.role !== 'system') return false;
+  return msg.content === 'You summarize conversation history for an interactive agent.';
+}
+
+function buildOpenAiChatCompletionsSseResponse(text: string) {
+  return {
+    type: 'sse' as const,
+    status: 200,
+    events: [
+      { data: { choices: [{ delta: { content: [{ type: 'text', text }] } }] } },
+      {
+        data: {
+          choices: [{ delta: {}, finish_reason: 'stop' }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
+        },
+      },
+      { data: '[DONE]' },
+    ],
+  };
+}
+
+export async function run(): Promise<void> {
+  const mock = await startMockLlmServer();
+
+  try {
+    await vscode.commands.executeCommand('openhands.open');
+    await waitForWebviewReady(30000);
+
+    // Force local mode + short runs for E2E.
+    const cfg = vscode.workspace.getConfiguration();
+    await cfg.update('openhands.serverUrl', '', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.conversation.maxIterations', 50, vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.confirmation.policy', 'never', vscode.ConfigurationTarget.Global);
+    await cfg.update('openhands.agent.enableSecurityAnalyzer', false, vscode.ConfigurationTarget.Global);
+
+    // Create a profile that points at the mock server.
+    const v1BaseUrl = `${mock.baseUrl}/v1`;
+    const profileId = 'e2e-context-limit-retry-openai';
+    await vscode.commands.executeCommand('openhands._setProviderApiKey', { provider: 'openai', apiKey: 'sk-e2e-openai' });
+    await vscode.commands.executeCommand('openhands._createProfile', {
+      profileId,
+      profile: {
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        baseUrl: v1BaseUrl,
+        openaiApiMode: 'chat_completions',
+      },
+    });
+    await vscode.commands.executeCommand('openhands._selectProfile', { profileId });
+    await vscode.commands.executeCommand('openhands.reconnect');
+    await vscode.commands.executeCommand('openhands.startNewConversation');
+
+    await pollUntil(async () => {
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+      return diag?.mode === 'local' && typeof diag?.conversationId === 'string' && diag.conversationId.length > 0;
+    }, 30000);
+
+    // Ensure no prior traffic makes assertions flaky.
+    mock.reset();
+
+    // Seed conversation history through real LLM turns (ensures the Agent's event log has ids).
+    // Make assistant responses long so the condensation prompt hits its per-event preview cap.
+    const longAssistant = `seed-assistant ${'y'.repeat(2_000)}`;
+    mock.setScript({
+      path: '/v1/chat/completions',
+      responses: Array.from({ length: 30 }, () => buildOpenAiChatCompletionsSseResponse(longAssistant)),
+    });
+
+    for (let i = 0; i < 10; i += 1) {
+      const userText = `seed-user-${i} ` + 'x'.repeat(2_000);
+      await sendAndWaitForRequestPath({
+        text: userText,
+        expectedPath: '/v1/chat/completions',
+        getRequests: () => mock.requests,
+      });
+    }
+
+    // Step 2: first request fails with context_length_exceeded, then we should condense + retry.
+    mock.setScript({
+      path: '/v1/chat/completions',
+      responses: [
+        { type: 'json', status: 400, body: { error: { code: 'context_length_exceeded' } } },
+      ],
+    });
+
+    const beforeReqCount = mock.requests.length;
+    const beforeRendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+    const beforeCondensations = (beforeRendered?.eventTypes ?? []).filter((t) => t === 'Condensation').length;
+    const beforeError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+    const beforeErrorSeq = typeof beforeError?.seq === 'number' ? beforeError.seq : -1;
+
+    const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+      action: 'sendMessage',
+      payload: { text: 'E2E context-limit retry step 2' },
+    });
+    if (!send?.sent) throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+
+    try {
+      await pollUntil(async () => {
+        const newRequests = mock.requests.slice(beforeReqCount);
+        const mainReqs = newRequests.filter(
+          (r) => r.path === '/v1/chat/completions' && !isCondensationRequest(r.json),
+        );
+        if (mainReqs.length < 2) return false;
+
+        const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+        const condensationCount = (rendered?.eventTypes ?? []).filter((t) => t === 'Condensation').length;
+        const hasCondensation = condensationCount > beforeCondensations;
+        if (!hasCondensation) return false;
+
+        const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+        const afterErrorSeq = typeof afterError?.seq === 'number' ? afterError.seq : -1;
+        return !(afterError && afterErrorSeq > beforeErrorSeq);
+      }, 60000, 250);
+    } catch (err) {
+      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
+      const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
+      const recent = mock.requests
+        .slice(beforeReqCount)
+        .map((r) => ({ path: r.path, isCondensation: isCondensationRequest(r.json) }))
+        .slice(-25);
+      throw new Error(
+        `Timed out waiting for context-limit condensation + retry.\n` +
+        `- diag: ${JSON.stringify(diag)}\n` +
+        `- lastError: ${JSON.stringify(lastError)}\n` +
+        `- renderedEvents: ${JSON.stringify(rendered)}\n` +
+        `- recentRequestsSinceSend: ${JSON.stringify(recent)}\n` +
+        `- original: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const newRequests = mock.requests.slice(beforeReqCount);
+    const mainIndices: number[] = [];
+    let condenseIndex = -1;
+    for (let i = 0; i < newRequests.length; i += 1) {
+      const req = newRequests[i];
+      if (req.path === '/v1/chat/completions' && !isCondensationRequest(req.json)) {
+        mainIndices.push(i);
+      }
+      if (condenseIndex === -1 && isCondensationRequest(req.json)) {
+        condenseIndex = i;
+      }
+    }
+
+    if (mainIndices.length !== 2) {
+      throw new Error(`Expected exactly 2 non-condensation requests (fail + retry), got ${mainIndices.length}`);
+    }
+    if (condenseIndex < 0) {
+      throw new Error('Expected at least 1 condensation LLM request, but none was recorded');
+    }
+    if (!(mainIndices[0] < condenseIndex && condenseIndex < mainIndices[1])) {
+      throw new Error(
+        `Expected condensation request to occur between the two main requests; main=${JSON.stringify(mainIndices)} condense=${condenseIndex}`,
+      );
+    }
+
+    // Guard against runaway retries.
+    await sleep(1000);
+    const afterRequests = mock.requests.slice(beforeReqCount);
+    const finalMainCount = afterRequests.filter(
+      (r) => r.path === '/v1/chat/completions' && !isCondensationRequest(r.json),
+    ).length;
+    if (finalMainCount !== 2) {
+      throw new Error(`Expected no extra non-condensation chat requests after completion (still 2), got ${finalMainCount}`);
+    }
+  } finally {
+    await mock.close();
+  }
+}

--- a/tests/e2e/suite/contextLimitRetry.ts
+++ b/tests/e2e/suite/contextLimitRetry.ts
@@ -138,10 +138,12 @@ export async function run(): Promise<void> {
     try {
       await pollUntil(async () => {
         const newRequests = mock.requests.slice(beforeReqCount);
-        const mainReqs = newRequests.filter(
-          (r) => r.path === '/v1/chat/completions' && !isCondensationRequest(r.json),
-        );
+        const chatReqs = newRequests.filter((r) => r.path === '/v1/chat/completions');
+        const mainReqs = chatReqs.filter((r) => !isCondensationRequest(r.json));
+        const condenseReqs = chatReqs.filter((r) => isCondensationRequest(r.json));
         if (mainReqs.length < 2) return false;
+        if (condenseReqs.length < 1) return false;
+        if (chatReqs.length < 3) return false;
 
         const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
         const condensationCount = (rendered?.eventTypes ?? []).filter((t) => t === 'Condensation').length;
@@ -171,6 +173,11 @@ export async function run(): Promise<void> {
     }
 
     const newRequests = mock.requests.slice(beforeReqCount);
+    const newChatReqs = newRequests.filter((r) => r.path === '/v1/chat/completions');
+    if (newChatReqs.length !== 3) {
+      throw new Error(`Expected exactly 3 chat completions requests after triggering send, got ${newChatReqs.length}`);
+    }
+
     const mainIndices: number[] = [];
     let condenseIndex = -1;
     for (let i = 0; i < newRequests.length; i += 1) {
@@ -186,6 +193,10 @@ export async function run(): Promise<void> {
     if (mainIndices.length !== 2) {
       throw new Error(`Expected exactly 2 non-condensation requests (fail + retry), got ${mainIndices.length}`);
     }
+    const condenseCount = newRequests.filter((r) => isCondensationRequest(r.json)).length;
+    if (condenseCount !== 1) {
+      throw new Error(`Expected exactly 1 condensation request, got ${condenseCount}`);
+    }
     if (condenseIndex < 0) {
       throw new Error('Expected at least 1 condensation LLM request, but none was recorded');
     }
@@ -198,11 +209,9 @@ export async function run(): Promise<void> {
     // Guard against runaway retries.
     await sleep(1000);
     const afterRequests = mock.requests.slice(beforeReqCount);
-    const finalMainCount = afterRequests.filter(
-      (r) => r.path === '/v1/chat/completions' && !isCondensationRequest(r.json),
-    ).length;
-    if (finalMainCount !== 2) {
-      throw new Error(`Expected no extra non-condensation chat requests after completion (still 2), got ${finalMainCount}`);
+    const finalChatReqs = afterRequests.filter((r) => r.path === '/v1/chat/completions');
+    if (finalChatReqs.length !== 3) {
+      throw new Error(`Expected no extra chat requests after completion (still 3), got ${finalChatReqs.length}`);
     }
   } finally {
     await mock.close();

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -109,6 +109,11 @@ export async function run(): Promise<void> {
     return runTpqTest();
   }
 
+  if (testName === 'contextLimitRetry') {
+    const { run: runContextLimitRetryTest } = await import('./contextLimitRetry');
+    return runContextLimitRetryTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness


### PR DESCRIPTION
### Bead

oh-tab-0ph.2: E2E: context_length_exceeded triggers condensation + single retry
Status: open
Priority: P2
Type: task
Created: 2026-01-15 09:30
Updated: 2026-01-15 11:13

Description:
Add an E2E suite that uses the scripted mock server to force one context-length failure followed by success, validating the condensation+retry path end-to-end (extension host ↔ SDK ↔ LLM transport).

Acceptance Criteria:
- Exactly 3 requests to the expected LLM path for the triggering send: (1) initial failure with context_length_exceeded, (2) condensation summary call, (3) retry success
- A Condensation event is emitted/rendered (visible via openhands._queryRenderedEvents)
- No unhandled error event in openhands._queryLastError after the successful retry

Labels: [condensation e2e]

Depends on (1):
  → oh-tab-0ph: E2E: context-limit error triggers condensation + retry [P2]

### What
- Add E2E suite `contextLimitRetry` that forces a `context_length_exceeded` then asserts condensation + single retry.
- Fix `OpenAICompatibleClient` / `OpenAIResponsesClient` retry logic so non-retryable HTTP statuses (e.g. 400) don't get silently retried (lets the Agent-level condensation policy handle context-limit errors).
- Add unit coverage for the retry policy.

### Testing
- `npx vitest run packages/agent-sdk-ts/src/sdk/llm/__tests__/retryPolicy.test.ts`
- `node -e "require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })" && npx tsc -p tests/e2e/tsconfig.suite.json && npx tsc -p tsconfig.e2e.json && npx mocha tests/e2e/out/contextLimitRetry.test.js`
