### PR TITLE
oh-tab-voc.5.3: token storage SecretStorage semantics

### DIFF
--- a/src/auth/__tests__/tokenStorage.test.ts
+++ b/src/auth/__tests__/tokenStorage.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { createTokenStorage, type SecretStorageLike } from '../tokenStorage';
+
+function createInMemorySecretStorage(initial?: Record<string, string>): SecretStorageLike {
+  const store = new Map<string, string>(Object.entries(initial ?? {}));
+  return {
+    async get(key: string) {
+      return store.has(key) ? (store.get(key) as string) : undefined;
+    },
+    async store(key: string, value: string) {
+      store.set(key, value);
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+  };
+}
+
+describe('token storage (SecretStorage semantics)', () => {
+  it('missing key: get returns undefined; has=false', async () => {
+    const storage = createTokenStorage(createInMemorySecretStorage());
+    await expect(storage.get('missing')).resolves.toBeUndefined();
+    await expect(storage.has('missing')).resolves.toBe(false);
+  });
+
+  it('get trims surrounding whitespace', async () => {
+    const storage = createTokenStorage(createInMemorySecretStorage());
+    await storage.store('k', '  sk-test \n');
+    await expect(storage.get('k')).resolves.toBe('sk-test');
+  });
+
+  it('empty/whitespace values are treated as set (has=true) and get returns empty string after trim', async () => {
+    const storage = createTokenStorage(createInMemorySecretStorage());
+    await storage.store('empty', '');
+    await storage.store('ws', '   \n\t');
+
+    await expect(storage.has('empty')).resolves.toBe(true);
+    await expect(storage.get('empty')).resolves.toBe('');
+
+    await expect(storage.has('ws')).resolves.toBe(true);
+    await expect(storage.get('ws')).resolves.toBe('');
+  });
+
+  it('store overwrites existing value', async () => {
+    const storage = createTokenStorage(createInMemorySecretStorage());
+    await storage.store('k', 'a');
+    await storage.store('k', 'b');
+    await expect(storage.get('k')).resolves.toBe('b');
+  });
+
+  it('delete removes key and returns whether it existed', async () => {
+    const storage = createTokenStorage(createInMemorySecretStorage({ k: 'v' }));
+    await expect(storage.delete('k')).resolves.toBe(true);
+    await expect(storage.has('k')).resolves.toBe(false);
+    await expect(storage.delete('k')).resolves.toBe(false);
+  });
+});
+

--- a/src/auth/tokenStorage.ts
+++ b/src/auth/tokenStorage.ts
@@ -1,0 +1,39 @@
+export type SecretStorageLike = {
+  get: (key: string) => Promise<string | undefined>;
+  store: (key: string, value: string) => Promise<void>;
+  delete: (key: string) => Promise<void>;
+};
+
+export type TokenStorage = {
+  get: (key: string) => Promise<string | undefined>;
+  has: (key: string) => Promise<boolean>;
+  store: (key: string, value: string) => Promise<void>;
+  delete: (key: string) => Promise<boolean>;
+};
+
+export function createTokenStorage(secrets: SecretStorageLike): TokenStorage {
+  return {
+    async get(key: string): Promise<string | undefined> {
+      const raw = await secrets.get(key);
+      if (raw === undefined) return undefined;
+      return raw.trim();
+    },
+
+    async has(key: string): Promise<boolean> {
+      const raw = await secrets.get(key);
+      return raw !== undefined;
+    },
+
+    async store(key: string, value: string): Promise<void> {
+      await secrets.store(key, value.trim());
+    },
+
+    async delete(key: string): Promise<boolean> {
+      const raw = await secrets.get(key);
+      const existed = raw !== undefined;
+      await secrets.delete(key);
+      return existed;
+    },
+  };
+}
+


### PR DESCRIPTION
### Bead

oh-tab-voc.5.3: Port CLI token_storage tests (SecretStorage semantics)
Status: open
Priority: P2
Type: task
Created: 2026-01-15 09:29
Updated: 2026-01-15 11:23

Description:
Port relevant scenarios from OpenHands-CLI `tests/auth/test_token_storage.py`, adapted to VS Code SecretStorage (no filesystem perms).

Note: current SecretRegistry + secret-marker UX treats whitespace-only/empty-string values as unset. Before porting “empty string counts as set” semantics, coordinate with `oh-tab-secret-storage-semantics` and adjust expectations if needed.

Acceptance Criteria:
- Port scenarios from `OpenHands-CLI/tests/auth/test_token_storage.py` using VS Code SecretStorage.
- Parity semantics:
  - Missing key => get returns null/undefined; has=false
  - If SecretStorage key exists but stored value is empty/whitespace => get returns "" (after trim) and has=true
  - get trims surrounding whitespace (e.g. "  sk-... 
" -> "sk-...")
  - store overwrites existing value
  - delete removes key (and ideally returns whether it existed)

Labels: [auth storage tests]

Depends on (1):
  → oh-tab-voc.5: Device-flow auth: port OpenHands-CLI auth tests to TypeScript (full suite) [P1]

### What
- Add `createTokenStorage()` helper for VS Code `SecretStorage`-like backends.
- Add unit tests covering the CLI-parity semantics (including the “empty/whitespace counts as set” behavior).

### Notes
- This helper intentionally treats stored empty/whitespace values as *present* (has=true) to match the bead, even though some existing secret-marker UX treats empty/whitespace as unset.

### Testing
- `npx vitest run src/auth/__tests__/tokenStorage.test.ts`
