### PR TITLE
oh-tab-h55.1: AgentSkills fields parity

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/agentSkillsFields.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/agentSkillsFields.test.ts
@@ -1,0 +1,152 @@
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { Skill, SkillValidationError } from '../skill';
+
+describe('AgentSkills frontmatter fields parity', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = join(tmpdir(), `skill-fields-test-${Date.now()}`);
+    mkdirSync(tempDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('parses license, compatibility, metadata, and allowed-tools', () => {
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const skillPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: Example skill
+license: MIT
+compatibility: openhands>=1.0
+metadata:
+  version: "1.0"
+  build: 123
+allowed-tools: "A B"
+---
+
+Hello.`,
+    );
+
+    const skill = Skill.load({ path: skillPath });
+    expect(skill.name).toBe('my-skill');
+    expect(skill.description).toBe('Example skill');
+    expect(skill.license).toBe('MIT');
+    expect(skill.compatibility).toBe('openhands>=1.0');
+    expect(skill.metadata).toEqual({ version: '1.0', build: '123' });
+    expect(skill.allowedTools).toEqual(['A', 'B']);
+  });
+
+  it('accepts allowed_tools underscore alias', () => {
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const skillPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: Example skill
+allowed_tools:
+  - tool_a
+  - tool_b
+---
+
+Hello.`,
+    );
+
+    const skill = Skill.load({ path: skillPath });
+    expect(skill.allowedTools).toEqual(['tool_a', 'tool_b']);
+  });
+
+  it('validates metadata is a dictionary and stringifies values', () => {
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const skillPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: Example skill
+metadata: string
+---
+
+Hello.`,
+    );
+
+    expect(() => Skill.load({ path: skillPath })).toThrowError(SkillValidationError);
+    expect(() => Skill.load({ path: skillPath })).toThrow(/metadata must be a dictionary/);
+  });
+
+  it('validates allowed-tools type', () => {
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const skillPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: Example skill
+allowed-tools: 123
+---
+
+Hello.`,
+    );
+
+    expect(() => Skill.load({ path: skillPath })).toThrowError(SkillValidationError);
+    expect(() => Skill.load({ path: skillPath })).toThrow(/allowed-tools must be/);
+  });
+
+  it('enforces description max length (<= 1024)', () => {
+    const ok = 'a'.repeat(1024);
+    const bad = 'a'.repeat(1025);
+
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const okPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      okPath,
+      `---
+description: ${ok}
+---
+
+Hello.`,
+    );
+    expect(() => Skill.load({ path: okPath })).not.toThrow();
+
+    const badPath = join(skillRoot, 'SKILL_BAD.md');
+    writeFileSync(
+      badPath,
+      `---
+description: ${bad}
+---
+
+Hello.`,
+    );
+    expect(() => Skill.load({ path: badPath })).toThrowError(SkillValidationError);
+    expect(() => Skill.load({ path: badPath })).toThrow(/1024 characters/);
+  });
+
+  it('validates description type', () => {
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const skillPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: 123
+---
+
+Hello.`,
+    );
+
+    expect(() => Skill.load({ path: skillPath })).toThrowError(SkillValidationError);
+    expect(() => Skill.load({ path: skillPath })).toThrow(/description must be a string/);
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -88,6 +88,10 @@ export class Skill {
   inputs: InputMetadata[];
   isAgentSkillsFormat: boolean;
   description: string | null;
+  license: string | null;
+  compatibility: string | null;
+  metadata: Record<string, string> | null;
+  allowedTools: string[] | null;
   mcpTools: McpConfig | null;
   resources: SkillResources | null;
 
@@ -108,6 +112,10 @@ export class Skill {
     inputs?: InputMetadata[];
     isAgentSkillsFormat?: boolean;
     description?: string | null;
+    license?: string | null;
+    compatibility?: string | null;
+    metadata?: Record<string, string> | null;
+    allowedTools?: string[] | null;
     mcpTools?: McpConfig | null;
     resources?: SkillResources | null;
   }) {
@@ -118,6 +126,10 @@ export class Skill {
     this.inputs = params.inputs ?? [];
     this.isAgentSkillsFormat = params.isAgentSkillsFormat ?? false;
     this.description = params.description ?? null;
+    this.license = params.license ?? null;
+    this.compatibility = params.compatibility ?? null;
+    this.metadata = params.metadata ?? null;
+    this.allowedTools = params.allowedTools ?? null;
     this.mcpTools = params.mcpTools ?? null;
     this.resources = params.resources ?? null;
 
@@ -210,7 +222,55 @@ export class Skill {
       }
     }
 
-    const description = typeof metadata.description === 'string' ? metadata.description : null;
+    const rawDescription = metadata.description;
+    if (rawDescription !== undefined && rawDescription !== null && typeof rawDescription !== 'string') {
+      throw new SkillValidationError('description must be a string');
+    }
+    const description = typeof rawDescription === 'string' ? rawDescription : null;
+    if (typeof description === 'string' && description.length > 1024) {
+      throw new SkillValidationError(`description must be <= 1024 characters (got ${description.length})`);
+    }
+
+    const rawLicense = metadata.license;
+    if (rawLicense !== undefined && rawLicense !== null && typeof rawLicense !== 'string') {
+      throw new SkillValidationError('license must be a string');
+    }
+    const license = typeof rawLicense === 'string' ? rawLicense.trim() : null;
+
+    const rawCompatibility = metadata.compatibility;
+    if (rawCompatibility !== undefined && rawCompatibility !== null && typeof rawCompatibility !== 'string') {
+      throw new SkillValidationError('compatibility must be a string');
+    }
+    const compatibility = typeof rawCompatibility === 'string' ? rawCompatibility.trim() : null;
+
+    const rawMetadata = metadata.metadata;
+    if (rawMetadata !== undefined && rawMetadata !== null) {
+      if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+        throw new SkillValidationError('metadata must be a dictionary');
+      }
+    }
+    const skillMetadata =
+      rawMetadata && typeof rawMetadata === 'object' && !Array.isArray(rawMetadata)
+        ? Object.fromEntries(
+            Object.entries(rawMetadata as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+          )
+        : null;
+
+    const allowedToolsRaw = metadata['allowed-tools'] ?? metadata.allowed_tools;
+    if (allowedToolsRaw !== undefined && allowedToolsRaw !== null) {
+      if (typeof allowedToolsRaw !== 'string' && !Array.isArray(allowedToolsRaw)) {
+        throw new SkillValidationError('allowed-tools must be a string or list of strings');
+      }
+      if (Array.isArray(allowedToolsRaw) && !allowedToolsRaw.every((t) => typeof t === 'string')) {
+        throw new SkillValidationError('allowed-tools must be a string or list of strings');
+      }
+    }
+    const allowedTools =
+      typeof allowedToolsRaw === 'string'
+        ? allowedToolsRaw.split(/\s+/).map((t) => t.trim()).filter(Boolean)
+        : Array.isArray(allowedToolsRaw)
+          ? allowedToolsRaw.map((t) => t.trim()).filter(Boolean)
+          : null;
 
     // For AgentSkills-format SKILL.md, load .mcp.json + discover resources (Python parity).
     let mcpTools: McpConfig | null = null;
@@ -275,6 +335,10 @@ export class Skill {
         source: filePath,
         isAgentSkillsFormat: isSkillMd,
         description,
+        license,
+        compatibility,
+        metadata: skillMetadata,
+        allowedTools,
         mcpTools,
         resources,
         trigger: { type: 'task', triggers: keywords },
@@ -287,6 +351,10 @@ export class Skill {
         source: filePath,
         isAgentSkillsFormat: isSkillMd,
         description,
+        license,
+        compatibility,
+        metadata: skillMetadata,
+        allowedTools,
         mcpTools,
         resources,
         trigger: { type: 'keyword', keywords },
@@ -299,6 +367,10 @@ export class Skill {
         source: filePath,
         isAgentSkillsFormat: isSkillMd,
         description,
+        license,
+        compatibility,
+        metadata: skillMetadata,
+        allowedTools,
         mcpTools,
         resources,
         trigger: null,


### PR DESCRIPTION
### Bead

oh-tab-h55.1: AgentSkills parity: support license/compatibility/metadata/allowed-tools + description length
Status: open
Priority: P2
Type: task
Created: 2026-01-15 09:22
Updated: 2026-01-15 09:22

Description:
Problem
- Python SDK Skill model supports AgentSkills standard fields and validators (license, compatibility, metadata dict[str,str], allowed-tools parsing + description length max 1024).
- agent-sdk-ts Skill currently parses `description` but does not enforce 1024-char limit, and does not model/parse the other standard fields.

Goal
- Add these AgentSkills fields + validation to agent-sdk-ts Skill parsing to match Python behavior.

Acceptance Criteria
- In `packages/agent-sdk-ts/src/sdk/context/skills/skill.ts`:
  - Parse frontmatter fields: `license`, `compatibility`, `metadata` (dict), `allowed-tools` (space-delimited string or list) and accept underscore alias `allowed_tools`.
  - Enforce `description` length <= 1024 (throw SkillValidationError when exceeded).
  - Validate `metadata` is an object/dictionary; coerce values to strings (Python behavior).
  - Validate `allowed-tools` type; parse string->split or list->stringify.
- Add Vitest tests ported from Python.
- Existing tests remain green.

Labels: [agent-sdk-ts parity skills]

Depends on (1):
  → oh-tab-h55: Verify AgentSkill format parity with Python SDK [P2]

### What
- Extend `Skill.load()` to parse AgentSkills fields and enforce validators.
- Add Vitest coverage for these fields/validators.

### Testing
- `npx vitest run packages/agent-sdk-ts/src/sdk/context/skills/__tests__/agentSkillsFields.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills now support extended metadata fields including license information, compatibility details, custom metadata dictionaries, and allowed tools configuration for enhanced documentation and control.
  * Skill descriptions now enforce a maximum length requirement for consistency.

* **Tests**
  * Added comprehensive test suite validating skill metadata parsing, type validation, and constraint enforcement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->