### PR TITLE
Estimate total cost via models.dev pricing (oh-tab-2la)

### DIFF
--- a/docs/models-dev-pricing.md
+++ b/docs/models-dev-pricing.md
@@ -1,0 +1,37 @@
+# models.dev pricing ingestion
+
+This repo uses [models.dev](https://models.dev) as a best-effort source of per-model pricing metadata so we can estimate conversation cost when the underlying LLM provider does not return explicit cost values.
+
+## Data source
+
+- Endpoint: `https://models.dev/api.json`
+- Source repo: `sst/models.dev` (MIT-licensed)
+- Units: `cost.input` / `cost.output` are USD per **1M tokens**
+
+## Mapping rules
+
+We map `@openhands/agent-sdk-ts` `LLMProvider` → models.dev provider id:
+
+- `openai` → `openai`
+- `anthropic` → `anthropic`
+- `gemini` → `google`
+- `openrouter` → `openrouter`
+- `litellm_proxy` → (no stable mapping; skip)
+
+Model IDs are matched case-insensitively within the provider’s `models` map.
+
+## Caching + failure modes
+
+The SDK caches the full `api.json` response under `~/.openhands/cache/` using:
+
+- a TTL (24h), and
+- `ETag` conditional requests (`If-None-Match`) when refreshing.
+
+If fetch/parse fails, the SDK falls back to the most recent cached copy; if none exists, pricing is treated as unknown.
+
+## Runtime behavior
+
+For local conversations, when an LLM profile does not explicitly specify both `inputCostPerToken` and `outputCostPerToken`, the SDK will (best-effort) look up pricing via models.dev and apply the derived **per-token** rates for that session only (no auto-persist back to the profile file).
+
+Once rates are present, `Metrics` computes `accumulatedCost` from token usage, and the webview displays the conversation’s `Total cost`.
+

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevApiCache.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevApiCache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+describe('getModelsDevApi', () => {
+  it('retries after an initial fetch failure when no disk cache exists', async () => {
+    const previousHome = process.env.HOME;
+    const tempHome = fs.mkdtempSync(path.join(os.tmpdir(), 'models-dev-home-'));
+    process.env.HOME = tempHome;
+
+    try {
+      let calls = 0;
+      vi.stubGlobal('fetch', vi.fn(async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('network down');
+        return {
+          status: 200,
+          ok: true,
+          headers: {
+            get: (key: string) => (key.toLowerCase() === 'etag' ? '"etag"' : null),
+          },
+          json: async () => ({
+            openai: {
+              models: {
+                'gpt-5': { cost: { input: 1.25, output: 10 } },
+              },
+            },
+          }),
+        } as unknown;
+      }));
+
+      vi.resetModules();
+      const { getModelsDevApi } = await import('../modelsDevPricing');
+
+      const first = await getModelsDevApi();
+      expect(Object.keys(first)).toHaveLength(0);
+
+      const second = await getModelsDevApi();
+      expect((fetch as unknown as { mock: { calls: unknown[] } }).mock.calls).toHaveLength(2);
+      expect(Object.keys(second)).toContain('openai');
+    } finally {
+      vi.unstubAllGlobals();
+      vi.resetModules();
+      process.env.HOME = previousHome;
+    }
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevPricing.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevPricing.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { extractModelsDevTokenPricing, getModelsDevProviderId } from '../modelsDevPricing';
+
+describe('modelsDevPricing', () => {
+  describe('getModelsDevProviderId', () => {
+    it('maps known providers to models.dev ids', () => {
+      expect(getModelsDevProviderId('openai')).toBe('openai');
+      expect(getModelsDevProviderId('anthropic')).toBe('anthropic');
+      expect(getModelsDevProviderId('gemini')).toBe('google');
+      expect(getModelsDevProviderId('openrouter')).toBe('openrouter');
+    });
+
+    it('returns null for providers without stable mapping', () => {
+      expect(getModelsDevProviderId('litellm_proxy')).toBeNull();
+    });
+  });
+
+  describe('extractModelsDevTokenPricing', () => {
+    it('converts USD per 1M tokens into per-token rates', () => {
+      const api = {
+        openai: {
+          models: {
+            'gpt-5': { cost: { input: 1.25, output: 10 } },
+          },
+        },
+      };
+      const pricing = extractModelsDevTokenPricing({
+        api,
+        providerId: 'openai',
+        modelId: 'gpt-5',
+      });
+      expect(pricing).toEqual({
+        inputCostPerToken: 1.25 / 1_000_000,
+        outputCostPerToken: 10 / 1_000_000,
+        source: 'models.dev',
+      });
+    });
+
+    it('is case-insensitive on model ids', () => {
+      const api = {
+        openai: {
+          models: {
+            'gpt-5': { cost: { input: 1.25, output: 10 } },
+          },
+        },
+      };
+      const pricing = extractModelsDevTokenPricing({
+        api,
+        providerId: 'openai',
+        modelId: 'GPT-5',
+      });
+      expect(pricing?.inputCostPerToken).toBeCloseTo(1.25 / 1_000_000);
+      expect(pricing?.outputCostPerToken).toBeCloseTo(10 / 1_000_000);
+    });
+
+    it('returns null when costs are missing or zero', () => {
+      const api = {
+        openai: {
+          models: {
+            a: { cost: { input: 0, output: 10 } },
+            b: { cost: { input: 1, output: 0 } },
+            c: { cost: { input: null, output: 10 } },
+            d: {},
+          },
+        },
+      };
+
+      expect(extractModelsDevTokenPricing({ api, providerId: 'openai', modelId: 'a' })).toBeNull();
+      expect(extractModelsDevTokenPricing({ api, providerId: 'openai', modelId: 'b' })).toBeNull();
+      expect(extractModelsDevTokenPricing({ api, providerId: 'openai', modelId: 'c' })).toBeNull();
+      expect(extractModelsDevTokenPricing({ api, providerId: 'openai', modelId: 'd' })).toBeNull();
+      expect(extractModelsDevTokenPricing({ api, providerId: 'openai', modelId: 'missing' })).toBeNull();
+    });
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -12,6 +12,7 @@ import type { SecretRegistry } from '../runtime/SecretRegistry';
 import { LLMRegistry, TrackedLLMClient, llmRegistryKeyToString, toLLMRegistryKey } from './registry';
 import { Metrics } from './metrics';
 import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl } from './provider';
+import { lookupModelsDevTokenPricing } from './modelsDevPricing';
 
 export interface LLMFactoryOptions {
   secrets?: SecretRegistry;
@@ -68,7 +69,38 @@ export class LLMFactory {
     })();
     config = normalizeGenerationParamsForModel(config);
 
+    const normalizeUrl = (value: string | null | undefined): string | undefined => {
+      const trimmed = typeof value === 'string' ? value.trim() : '';
+      if (!trimmed) return undefined;
+      return trimmed.replace(/\/+$/, '');
+    };
+
     const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
+
+    if (
+      (config.inputCostPerToken === null || config.inputCostPerToken === undefined)
+      && (config.outputCostPerToken === null || config.outputCostPerToken === undefined)
+    ) {
+      const normalizedBaseUrl = normalizeUrl(config.baseUrl);
+      const normalizedDefaultBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS[provider]);
+      const baseUrlMatchesProviderDefault =
+        !normalizedBaseUrl || normalizedBaseUrl === normalizedDefaultBaseUrl;
+
+      if (baseUrlMatchesProviderDefault) {
+        try {
+          const pricing = await lookupModelsDevTokenPricing({ provider, model: config.model });
+          if (pricing) {
+            config = {
+              ...config,
+              inputCostPerToken: pricing.inputCostPerToken,
+              outputCostPerToken: pricing.outputCostPerToken,
+            };
+          }
+        } catch {
+          // Best-effort only: ignore pricing lookup errors.
+        }
+      }
+    }
 
     const inlineApiKey =
       typeof config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(config.apiKey)
@@ -101,11 +133,6 @@ export class LLMFactory {
 
     const normalizedModel = config.model.toLowerCase();
     const openaiApiMode = provider === 'openai' ? config.openaiApiMode ?? undefined : undefined;
-    const normalizeUrl = (value: string | null | undefined): string | undefined => {
-      const trimmed = typeof value === 'string' ? value.trim() : '';
-      if (!trimmed) return undefined;
-      return trimmed.replace(/\/+$/, '');
-    };
     const normalizedBaseUrl = normalizeUrl(config.baseUrl);
     const normalizedDefaultOpenAIBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS.openai);
     const baseUrlSupportsResponses = !normalizedBaseUrl || normalizedBaseUrl === normalizedDefaultOpenAIBaseUrl;

--- a/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
@@ -1,0 +1,195 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { LLMProvider } from './types';
+
+export const MODELS_DEV_API_URL = 'https://models.dev/api.json';
+
+type ModelsDevCost = {
+  input?: unknown;
+  output?: unknown;
+};
+
+type ModelsDevModel = {
+  cost?: ModelsDevCost;
+};
+
+type ModelsDevProvider = {
+  models?: Record<string, ModelsDevModel>;
+};
+
+type ModelsDevApi = Record<string, ModelsDevProvider>;
+
+export type ModelsDevTokenPricing = {
+  inputCostPerToken: number;
+  outputCostPerToken: number;
+  source: 'models.dev';
+};
+
+const MODELS_DEV_CACHE_DIR = path.join(os.homedir(), '.openhands', 'cache');
+const MODELS_DEV_CACHE_PATH = path.join(MODELS_DEV_CACHE_DIR, 'models.dev.api.json');
+const MODELS_DEV_META_PATH = path.join(MODELS_DEV_CACHE_DIR, 'models.dev.api.meta.json');
+const MODELS_DEV_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const MODELS_DEV_FETCH_TIMEOUT_MS = 8000;
+
+type ModelsDevCacheMeta = {
+  etag?: string;
+  fetchedAtMs?: number;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const isModelsDevModelMap = (value: unknown): value is Record<string, ModelsDevModel> =>
+  isRecord(value);
+
+const asFiniteNumber = (value: unknown): number | null => {
+  const num = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  return Number.isFinite(num) ? num : null;
+};
+
+const safeReadJsonFile = (filePath: string): unknown => {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+const safeWriteJsonFile = (filePath: string, value: unknown): void => {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(value), 'utf8');
+  } catch {
+    // Best-effort cache: ignore write errors.
+  }
+};
+
+const loadCachedApi = (): ModelsDevApi | null => {
+  const raw = safeReadJsonFile(MODELS_DEV_CACHE_PATH);
+  return isRecord(raw) ? (raw as unknown as ModelsDevApi) : null;
+};
+
+const loadCacheMeta = (): ModelsDevCacheMeta | null => {
+  const raw = safeReadJsonFile(MODELS_DEV_META_PATH);
+  if (!isRecord(raw)) return null;
+  const etag = typeof raw.etag === 'string' ? raw.etag : undefined;
+  const fetchedAtMs = asFiniteNumber(raw.fetchedAtMs);
+  return { etag, fetchedAtMs: fetchedAtMs === null ? undefined : fetchedAtMs };
+};
+
+const isCacheFresh = (meta: ModelsDevCacheMeta | null): boolean => {
+  if (!meta?.fetchedAtMs) return false;
+  return Date.now() - meta.fetchedAtMs < MODELS_DEV_CACHE_TTL_MS;
+};
+
+let cachedApiPromise: Promise<ModelsDevApi> | null = null;
+
+export const getModelsDevProviderId = (provider: LLMProvider): string | null => {
+  switch (provider) {
+    case 'openai':
+      return 'openai';
+    case 'anthropic':
+      return 'anthropic';
+    case 'gemini':
+      return 'google';
+    case 'openrouter':
+      return 'openrouter';
+    case 'litellm_proxy':
+      return null;
+    default:
+      return null;
+  }
+};
+
+export const extractModelsDevTokenPricing = (params: {
+  api: ModelsDevApi;
+  providerId: string;
+  modelId: string;
+}): ModelsDevTokenPricing | null => {
+  const { api, providerId, modelId } = params;
+  const provider = api[providerId];
+  const models = provider?.models;
+  if (!models || !isModelsDevModelMap(models)) return null;
+
+  const direct = models[modelId];
+  const model = (() => {
+    if (direct) return direct;
+    const target = modelId.toLowerCase();
+    const entry = Object.entries(models).find(([key]) => key.toLowerCase() === target);
+    return entry ? entry[1] : undefined;
+  })();
+  if (!model) return null;
+
+  const costRaw = model.cost;
+  if (!costRaw || !isRecord(costRaw)) return null;
+
+  // models.dev cost fields are USD per 1M tokens.
+  const inputPerMillion = asFiniteNumber(costRaw.input);
+  const outputPerMillion = asFiniteNumber(costRaw.output);
+  if (inputPerMillion === null || outputPerMillion === null) return null;
+  if (inputPerMillion <= 0 || outputPerMillion <= 0) return null;
+
+  return {
+    inputCostPerToken: inputPerMillion / 1_000_000,
+    outputCostPerToken: outputPerMillion / 1_000_000,
+    source: 'models.dev',
+  };
+};
+
+export const getModelsDevApi = async (): Promise<ModelsDevApi> => {
+  if (cachedApiPromise) return cachedApiPromise;
+  cachedApiPromise = (async () => {
+    const meta = loadCacheMeta();
+    const cached = loadCachedApi();
+    if (cached && isCacheFresh(meta)) return cached;
+
+    const headers: Record<string, string> = {};
+    if (meta?.etag) headers['If-None-Match'] = meta.etag;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), MODELS_DEV_FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(MODELS_DEV_API_URL, { headers, signal: controller.signal });
+      if (response.status === 304 && cached) {
+        safeWriteJsonFile(MODELS_DEV_META_PATH, { ...meta, fetchedAtMs: Date.now() });
+        return cached;
+      }
+      if (!response.ok) {
+        return cached ?? {};
+      }
+
+      const json = (await response.json()) as unknown;
+      if (!isRecord(json)) return cached ?? {};
+
+      safeWriteJsonFile(MODELS_DEV_CACHE_PATH, json);
+      safeWriteJsonFile(MODELS_DEV_META_PATH, {
+        etag: response.headers.get('etag') ?? undefined,
+        fetchedAtMs: Date.now(),
+      });
+
+      return json as unknown as ModelsDevApi;
+    } catch {
+      return cached ?? {};
+    } finally {
+      clearTimeout(timer);
+    }
+  })();
+
+  return cachedApiPromise;
+};
+
+export const lookupModelsDevTokenPricing = async (params: {
+  provider: LLMProvider;
+  model: string;
+}): Promise<ModelsDevTokenPricing | null> => {
+  const providerId = getModelsDevProviderId(params.provider);
+  if (!providerId) return null;
+  const modelId = params.model.trim();
+  if (!modelId) return null;
+
+  const api = await getModelsDevApi();
+  return extractModelsDevTokenPricing({ api, providerId, modelId });
+};

--- a/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
@@ -84,7 +84,9 @@ const isCacheFresh = (meta: ModelsDevCacheMeta | null): boolean => {
   return Date.now() - meta.fetchedAtMs < MODELS_DEV_CACHE_TTL_MS;
 };
 
-let cachedApiPromise: Promise<ModelsDevApi> | null = null;
+// De-dupe concurrent refreshes, but do not permanently memoize results in memory.
+// We want disk TTL + ETag logic to remain effective even for long-running sessions.
+let inflightFetch: Promise<ModelsDevApi> | null = null;
 
 export const getModelsDevProviderId = (provider: LLMProvider): string | null => {
   switch (provider) {
@@ -139,14 +141,13 @@ export const extractModelsDevTokenPricing = (params: {
 };
 
 export const getModelsDevApi = async (): Promise<ModelsDevApi> => {
-  if (cachedApiPromise) return cachedApiPromise;
-
   const meta = loadCacheMeta();
   const cached = loadCachedApi();
   if (cached && isCacheFresh(meta)) return cached;
 
-  cachedApiPromise = (async () => {
+  if (inflightFetch) return inflightFetch;
 
+  inflightFetch = (async () => {
     const headers: Record<string, string> = {};
     if (meta?.etag) headers['If-None-Match'] = meta.etag;
 
@@ -177,15 +178,11 @@ export const getModelsDevApi = async (): Promise<ModelsDevApi> => {
       return cached ?? {};
     } finally {
       clearTimeout(timer);
+      inflightFetch = null;
     }
   })();
 
-  const api = await cachedApiPromise;
-  if (!cached && Object.keys(api).length === 0) {
-    // Avoid permanently memoizing an empty response when we had neither a network fetch nor a disk cache.
-    cachedApiPromise = null;
-  }
-  return api;
+  return inflightFetch;
 };
 
 export const lookupModelsDevTokenPricing = async (params: {

--- a/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
@@ -140,10 +140,12 @@ export const extractModelsDevTokenPricing = (params: {
 
 export const getModelsDevApi = async (): Promise<ModelsDevApi> => {
   if (cachedApiPromise) return cachedApiPromise;
+
+  const meta = loadCacheMeta();
+  const cached = loadCachedApi();
+  if (cached && isCacheFresh(meta)) return cached;
+
   cachedApiPromise = (async () => {
-    const meta = loadCacheMeta();
-    const cached = loadCachedApi();
-    if (cached && isCacheFresh(meta)) return cached;
 
     const headers: Record<string, string> = {};
     if (meta?.etag) headers['If-None-Match'] = meta.etag;
@@ -178,7 +180,12 @@ export const getModelsDevApi = async (): Promise<ModelsDevApi> => {
     }
   })();
 
-  return cachedApiPromise;
+  const api = await cachedApiPromise;
+  if (!cached && Object.keys(api).length === 0) {
+    // Avoid permanently memoizing an empty response when we had neither a network fetch nor a disk cache.
+    cachedApiPromise = null;
+  }
+  return api;
 };
 
 export const lookupModelsDevTokenPricing = async (params: {

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -51,7 +51,8 @@ describe('App toolbar interactions', () => {
 
     const totalsRow = await screen.findByTestId('header-totals-row');
     expect(totalsRow).toHaveTextContent('Context:');
-    expect(totalsRow).not.toHaveTextContent('Total cost:');
+    expect(totalsRow).toHaveTextContent('Total cost:');
+    expect(totalsRow).toHaveTextContent('—');
 
     await act(async () => {
       window.dispatchEvent(
@@ -74,7 +75,8 @@ describe('App toolbar interactions', () => {
     });
 
     expect(totalsRow).toHaveTextContent('Context: 10 tokens');
-    expect(totalsRow).not.toHaveTextContent('Total cost:');
+    expect(totalsRow).toHaveTextContent('Total cost:');
+    expect(totalsRow).toHaveTextContent('—');
 
     await act(async () => {
       window.dispatchEvent(
@@ -146,8 +148,9 @@ describe('App toolbar interactions', () => {
     });
 
     expect(totalsRow).toHaveTextContent('Context: 12 tokens');
-    expect(totalsRow).not.toHaveTextContent('Total cost:');
-    expect(totalsRow).not.toHaveTextContent('—');
+    expect(totalsRow).toHaveTextContent('Total cost:');
+    expect(totalsRow).toHaveTextContent('—');
+    expect(totalsRow).not.toHaveTextContent('$0.0123');
   });
 
   it('uses the main agent usage bucket for context tokens (not sum across usages)', async () => {

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -250,14 +250,12 @@ export function Header({
           <span>tokens</span>
         </div>
 
-        {totals.costIsKnown && (
-          <div className="flex items-center gap-1.5">
-            <span>Total cost:</span>{' '}
-            <span className="font-mono text-stone-300">
-              {formatCost(totals.totalCost)}
-            </span>
-          </div>
-        )}
+        <div className="flex items-center gap-1.5">
+          <span>Total cost:</span>{' '}
+          <span className="font-mono text-stone-300">
+            {totals.costIsKnown ? formatCost(totals.totalCost) : '—'}
+          </span>
+        </div>
       </div>
     </header>
   );


### PR DESCRIPTION
### Summary
- Add best-effort models.dev pricing lookup (cached) to hydrate `inputCostPerToken`/`outputCostPerToken` at runtime when missing.
- Show `Total cost: —` in the ConversationView header when pricing/cost is unknown (avoids misleading `$0.0000`).

### Testing
- `npx vitest run packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevPricing.test.ts src/webview-src/__tests__/App.toolbar.test.tsx`

### Notes
- Pricing lookup only applies when the profile base URL matches the provider default (or is unset), to avoid applying OpenAI pricing to arbitrary OpenAI-compatible endpoints.
- See `docs/models-dev-pricing.md` for endpoint/units/mapping/caching details.

### Bead

oh-tab-2la: Investigate models.dev pricing + estimate total run cost in ConversationView
Status: open
Priority: P2
Type: task
Created: 2026-01-15 01:02
Updated: 2026-01-15 01:02

Description:
We want to display accurate-ish total run cost to the user in the ConversationView header row (left: "Context: X tokens"; right: "Total cost").

Today we can only compute cost when the provider returns explicit pricing/usage cost info. In many cases the provider response doesn’t include cost, and sometimes not even a per-model price. So we can’t estimate cost even if we know prompt/completion token counts.

Idea: models.dev appears to maintain a database of models and providers, including essential per-model pricing (input/output token prices) per provider. We should investigate the best way to consume that data and use it to estimate cost during a session.

Target behavior:
- Source per-token pricing for (provider, model) from models.dev.
- Store/carry those pricing values during a session in the same place we store model + temperature + max tokens, ideally via LLM Profiles (so the active profile knows its pricing).
- Use token usage (prompt/completion) to compute accumulated total cost for the conversation run and display it in ConversationView.
- Handle missing pricing gracefully (display “—” or “unknown” without breaking UI).

Open questions for investigation:
- Does models.dev expose a stable machine-readable endpoint (JSON) and licensing/usage terms we can rely on?
- How do we map our provider IDs + model IDs to models.dev’s naming?
- Caching strategy: vendor a snapshot in-repo vs fetch at runtime; update cadence.
- Units/formatting: per-1M tokens vs per-1K tokens; currency.

Acceptance Criteria:
- Document the chosen ingestion approach for models.dev pricing (endpoint/format, mapping rules, caching strategy, and failure modes).
- Implement storing pricing metadata with the active LLM Profile (or clearly justify an alternative location).
- ConversationView shows an accumulated total cost based on token usage * pricing when pricing is known.
- If pricing is unknown/unavailable, ConversationView cost UI degrades gracefully (no incorrect $0.00).
- Basic sanity test or manual repro steps recorded in the issue comments.

Labels: [ConversationView context-window investigation llm profiles ui ux webview]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic pricing lookup: The system now fetches token pricing from models.dev for supported providers when input/output costs are not specified
  * Enhanced cost display: Total cost is now always shown in the header with a placeholder when pricing information is unavailable

* **Documentation**
  * Added documentation describing how pricing data is sourced, cached, and applied

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->