### PR TITLE
Fix SSE framing in OpenAI tool-calls mock server (oh-tab-e2e-openai-sse)

### DIFF
--- a/tests/e2e/suite/helpers/openAiToolCallsServer.ts
+++ b/tests/e2e/suite/helpers/openAiToolCallsServer.ts
@@ -76,17 +76,17 @@ function sendOpenAiToolCallsSse(res: http.ServerResponse, toolCalls: Array<{ id:
           },
         },
       ],
-    })}\n`,
+    })}\n\n`,
   );
 
   res.write(
     `data: ${JSON.stringify({
       choices: [{ delta: {}, finish_reason: 'tool_calls' }],
       usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
+    })}\n\n`,
   );
 
-  res.write('data: [DONE]\n');
+  res.write('data: [DONE]\n\n');
   res.end();
 }
 
@@ -178,4 +178,3 @@ export async function startOpenAiToolCallsMockServer(
     },
   };
 }
-


### PR DESCRIPTION
### Summary
- Fix `tests/e2e/suite/helpers/openAiToolCallsServer.ts` to emit valid SSE framing (`\n\n` per event).

### Testing
- `npx tsc -p tests/e2e/tsconfig.suite.json`
- `HOME="$(mktemp -d -t oh-tab-e2e-home.XXXXXX)" npx mocha tests/e2e/out/oracleUnset.test.js`

### Bead

oh-tab-e2e-openai-sse: E2E: OpenAI tool-calls mock server uses valid SSE framing
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 11:11
Updated: 2026-01-15 11:11

Description:
 writes SSE chunks terminated with  instead of the required blank line . This can make streaming consumers hang or parse inconsistently and is a likely source of E2E flakiness.

Acceptance Criteria:
- Update  so each SSE event ends with a blank line (e.g., , including the  line)\n- Confirm at least one existing E2E that uses this helper still passes (or add a minimal E2E/fixture assertion if none cover it).

Labels: [e2e tech-debt]

