### PR TITLE
E2E: ensure argv.json setup across suites (oh-tab-e2e-argv)

### DIFF
--- a/tests/e2e/agentSdkEvents.test.ts
+++ b/tests/e2e/agentSdkEvents.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-sdk-${Date.now()}`);
 
@@ -17,6 +17,8 @@ describe('OpenHands-Tab Agent-SDK Events E2E', function () {
 
     // Point to the suite directory (not a specific file)
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 function getDefaultAgentSdkDir(): string {
   return path.join(os.homedir(), 'repos', 'agent-sdk');
@@ -199,6 +199,8 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
       const extensionTestsPath = path.resolve(__dirname, './suite');
       const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-server-${Date.now()}`);
+
+      await ensureVsCodeArgvJson(userDataDir);
 
       await runTests({
         vscodeExecutablePath,

--- a/tests/e2e/confirmation.test.ts
+++ b/tests/e2e/confirmation.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-confirmation-${Date.now()}`);
 
@@ -14,6 +14,8 @@ describe('OpenHands-Tab Confirmation E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/diagnostics.test.ts
+++ b/tests/e2e/diagnostics.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-${Date.now()}`);
 
@@ -16,6 +16,8 @@ describe('OpenHands-Tab diagnostics', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/errorHandling.test.ts
+++ b/tests/e2e/errorHandling.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-errors-${Date.now()}`);
 
@@ -14,6 +14,8 @@ describe('OpenHands-Tab Error Handling E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/halNegative.test.ts
+++ b/tests/e2e/halNegative.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `oh-tab-hal-negative-${Date.now().toString(36)}`);
 
@@ -15,8 +14,7 @@ describe('OpenHands-Tab HAL negative cases E2E', function () {
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
 
-    await fs.mkdir(path.join(userDataDir, '.vscode'), { recursive: true });
-    await fs.writeFile(path.join(userDataDir, '.vscode', 'argv.json'), '{}\n', 'utf8');
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,
@@ -44,4 +42,3 @@ describe('OpenHands-Tab HAL negative cases E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/history.test.ts
+++ b/tests/e2e/history.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-history-${Date.now()}`);
 
@@ -14,6 +14,8 @@ describe('OpenHands-Tab History E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/messaging.test.ts
+++ b/tests/e2e/messaging.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-messaging-${Date.now()}`);
 
@@ -14,6 +14,8 @@ describe('OpenHands-Tab Messaging E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/open.test.ts
+++ b/tests/e2e/open.test.ts
@@ -3,7 +3,7 @@ import { runTests, resolveCliPathFromVSCodeExecutablePath } from '@vscode/test-e
 import * as cp from 'child_process';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-${Date.now()}`);
 
@@ -19,6 +19,8 @@ describe('OpenHands-Tab E2E', function () {
 
     // Log VS Code version via CLI (best-effort)
     cp.spawnSync(cliPath, ['--version'], { stdio: 'inherit', cwd: path.dirname(cliPath) });
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/serverSelection.test.ts
+++ b/tests/e2e/serverSelection.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-server-${Date.now()}`);
 
@@ -14,6 +14,8 @@ describe('OpenHands-Tab Server Selection E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-settings-${Date.now()}`);
 
@@ -14,6 +14,8 @@ describe('OpenHands-Tab Settings E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/terminalLog.test.ts
+++ b/tests/e2e/terminalLog.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-terminal-${Date.now()}`);
 
@@ -13,6 +13,8 @@ describe('OpenHands-Tab Terminal Log E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/terminalProgress.test.ts
+++ b/tests/e2e/terminalProgress.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-terminal-progress-${Date.now()}`);
 
@@ -13,6 +13,8 @@ describe('OpenHands-Tab Terminal Progress E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,

--- a/tests/e2e/uiFlows.test.ts
+++ b/tests/e2e/uiFlows.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
 import * as os from 'os';
-import { downloadVSCodeWithRetry } from './testHelpers';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
 const userDataDir = path.join(os.tmpdir(), `vscode-test-ui-flows-${Date.now()}`);
 
@@ -13,6 +13,8 @@ describe('OpenHands-Tab UI Flows E2E', function () {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
     const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
     const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
 
     await runTests({
       vscodeExecutablePath,
@@ -35,4 +37,3 @@ describe('OpenHands-Tab UI Flows E2E', function () {
     assert.ok(true);
   });
 });
-


### PR DESCRIPTION
### Summary
- Standardize E2E runners to call `ensureVsCodeArgvJson(userDataDir)` before launching VS Code.

### Testing
- `npx mocha tests/e2e/out/diagnostics.test.js`

### Bead

oh-tab-e2e-argv: E2E: ensure argv.json created for all suites
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 11:57
Updated: 2026-01-15 11:57

Description:
Some E2E tests call `ensureVsCodeArgvJson(userDataDir)` but others do not (e.g., messaging/history/errorHandling/serverSelection/terminal*). Standardizing this across all E2E runners should reduce VS Code launch flakiness and config drift.

Acceptance Criteria:
- Update all `tests/e2e/*.test.ts` that use `--user-data-dir` to call `ensureVsCodeArgvJson(userDataDir)` before `runTests()`
- Keep behavior identical otherwise (no new settings)
- E2E still passes locally/CI

Labels: [e2e tech-debt]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved E2E test setup reliability by introducing a standardized initialization step for VS Code configuration across all test suites. Replaced manual setup code with a consolidated helper, reducing setup complexity and potential inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->