### PR TITLE
Remove globalThis workspaceRoot fallback (oh-tab-zko)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -154,7 +154,10 @@ export class RemoteConversation extends EventEmitter {
 
     this.serverUrl = normalizeRemoteServerUrl(options.serverUrl);
     this.settings = options.settings;
-    this.workspaceRoot = options.workspaceRoot ?? (globalThis as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot ?? process.cwd();
+    const normalizedWorkspaceRoot = typeof options.workspaceRoot === 'string' && options.workspaceRoot.trim()
+      ? options.workspaceRoot.trim()
+      : undefined;
+    this.workspaceRoot = normalizedWorkspaceRoot ?? process.cwd();
     this.hasToolsOption = Object.prototype.hasOwnProperty.call(options, 'tools');
     this.tools = options.tools;
     this.includeDefaultTools = options.includeDefaultTools;

--- a/packages/agent-sdk-ts/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { OpenHandsSettings } from '../../types/settings';
+import { RemoteConversation } from '../RemoteConversation';
+
+const makeSettings = (): OpenHandsSettings => ({
+  llm: {},
+  agent: {},
+  conversation: {},
+  confirmation: {},
+  secrets: {},
+});
+
+describe('RemoteConversation workspaceRoot', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (globalThis as unknown as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot;
+  });
+
+  it('defaults to process.cwd() and ignores globalThis.vscodeWorkspaceRoot', () => {
+    (globalThis as unknown as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = '/should-not-use';
+    vi.spyOn(process, 'cwd').mockReturnValue('/cwd');
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: makeSettings(),
+    });
+
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/cwd');
+  });
+
+  it('uses an explicit workspaceRoot when provided (trimmed)', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/cwd');
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: makeSettings(),
+      workspaceRoot: ' /explicit ',
+    });
+
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/explicit');
+  });
+
+  it('treats empty workspaceRoot as unset', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/cwd');
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: makeSettings(),
+      workspaceRoot: '   ',
+    });
+
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/cwd');
+  });
+});
+


### PR DESCRIPTION
### Summary
- Stop using `globalThis.vscodeWorkspaceRoot` as a workspaceRoot fallback in `RemoteConversation`.
- Normalize `workspaceRoot` (trim; empty => unset) and default to `process.cwd()`.

### Testing
- `npx vitest run packages/agent-sdk-ts/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts`

### Bead

oh-tab-zko: agent-sdk-ts: Remove globalThis workspaceRoot fallback
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 07:41
Updated: 2026-01-15 07:41

Description:
Problem
- packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts currently uses a globalThis.vscodeWorkspaceRoot fallback when setting its workspaceRoot.
- This introduces a hidden global dependency and can reintroduce stale workspaceRoot behavior in multi-root contexts.

Goal
- Remove reliance on globalThis.vscodeWorkspaceRoot in the SDK and ensure workspaceRoot is always explicit (constructor option) or uses a clearly defined default (process.cwd()) only.

Notes
- After PR #778 merges, extension host should no longer set the global; this bead finishes cleaning up remaining usage.

Acceptance Criteria:
- RemoteConversation no longer references globalThis.vscodeWorkspaceRoot.
- Call sites that need a workspaceRoot pass it explicitly.
- Unit tests cover explicit workspaceRoot vs default behavior.

Labels: [agent-sdk-ts tech-debt workspace]

