### PR TITLE
Stop retrying 400s for Anthropic/Gemini (oh-tab-llm-retry-nonretryable-others)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/retryPolicy.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/retryPolicy.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { LLMStreamer } from '../../runtime';
-import { OpenAICompatibleClient, OpenAIResponsesClient } from '../index';
+import { AnthropicClient, GeminiClient, OpenAICompatibleClient, OpenAIResponsesClient } from '../index';
 import type { ChatCompletionRequest, LLMConfiguration, RetryOptions } from '../types';
 
 const encoder = new TextEncoder();
@@ -52,6 +52,32 @@ describe('LLM HTTP retry policies', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('AnthropicClient does not retry on non-retryable HTTP statuses', async () => {
+    const baseConfig: LLMConfiguration = { model: 'claude-3-5-sonnet', provider: 'anthropic', baseUrl: 'http://localhost:4000' };
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response('bad request', { status: 400 }));
+
+    const client = new AnthropicClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    await expect(streamer.runChat(request)).rejects.toThrow(/Anthropic request failed \(400\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('GeminiClient does not retry on non-retryable HTTP statuses', async () => {
+    const baseConfig: LLMConfiguration = { model: 'gemini-3', provider: 'gemini', baseUrl: 'http://localhost:4000' };
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response('bad request', { status: 400 }));
+
+    const client = new GeminiClient(baseConfig, 'test-key');
+    const streamer = new LLMStreamer(client);
+
+    await expect(streamer.runChat(request)).rejects.toThrow(/LLM request failed \(HTTP 400\)/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it('OpenAICompatibleClient still retries on retryable statuses', async () => {
     const baseConfig: LLMConfiguration = { model: 'gpt-4o-mini', provider: 'openai', baseUrl: 'http://localhost:4000' };
     const retry: RetryOptions = { maxRetries: 1, baseDelayMs: 0, maxDelayMs: 0, retryOn: (status) => status === 503 };
@@ -75,4 +101,3 @@ describe('LLM HTTP retry policies', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -4,6 +4,16 @@ import { getAnthropicThinkingBudget } from './providerQuirks';
 
 const decoder = new TextDecoder();
 
+class NonRetryableHttpStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'NonRetryableHttpStatusError';
+    this.status = status;
+  }
+}
+
 // Anthropic content block types
 type AnthropicThinkingBlock = {
   type: 'thinking';
@@ -372,11 +382,14 @@ export class AnthropicClient implements LLMClient {
           }
 
           const message = await response.text();
-          throw new Error(`Anthropic request failed (${response.status}): ${message}`);
+          throw new NonRetryableHttpStatusError(response.status, `Anthropic request failed (${response.status}): ${message}`);
         }
 
         return response;
       } catch (error) {
+        if (error instanceof NonRetryableHttpStatusError) {
+          throw error;
+        }
         lastError = error as Error;
         if (attempt >= this.retry.maxRetries) break;
         await delay(delayMs);

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -23,6 +23,16 @@ const decoder = new TextDecoder();
 
 const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
+class NonRetryableHttpStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'NonRetryableHttpStatusError';
+    this.status = status;
+  }
+}
+
 type GeminiRole = 'user' | 'model';
 
 type GeminiPart =
@@ -393,11 +403,14 @@ export class GeminiClient implements LLMClient {
             continue;
           }
           const detail = await response.text().catch(() => '');
-          throw new Error(`LLM request failed (HTTP ${response.status}): ${detail.slice(0, 500)}`);
+          throw new NonRetryableHttpStatusError(response.status, `LLM request failed (HTTP ${response.status}): ${detail.slice(0, 500)}`);
         }
 
         return response;
       } catch (err) {
+        if (err instanceof NonRetryableHttpStatusError) {
+          throw err;
+        }
         lastError = err instanceof Error ? err : new Error(String(err));
         if (attempt >= this.retry.maxRetries) break;
         await delay(delayMs);


### PR DESCRIPTION
### Summary
- Prevent Anthropic/Gemini clients from retrying non-retryable HTTP statuses (e.g. 400) through the generic retry loop.
- Add unit coverage proving 400 is not retried.

### Testing
- `npx vitest run packages/agent-sdk-ts/src/sdk/llm/__tests__/retryPolicy.test.ts`

### Bead

oh-tab-llm-retry-nonretryable-others: LLM transport: stop retrying non-retryable HTTP for Anthropic/Gemini
Status: open
Priority: P3
Type: task
Created: 2026-01-15 12:20
Updated: 2026-01-15 12:20

Description:
AnthropicClient and GeminiClient fetchWithRetry loops appear to retry even when HTTP status is non-retryable (e.g. 400). This mirrors the bug fixed for OpenAI clients in PR #794 and can cause wasted requests / confusing behavior.

Acceptance Criteria:
- Update `packages/agent-sdk-ts/src/sdk/llm/anthropic.ts` and `packages/agent-sdk-ts/src/sdk/llm/gemini.ts` so non-retryable HTTP statuses do not retry (throw through the catch loop)
- Add unit tests proving 400 does not retry (fetch called once) while 5xx/429 etc. still retry per RetryOptions
- Keep existing error messages as much as possible (unless parity demands change)

Labels: [llm tech-debt tests]



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AnthropicClient and GeminiClient are now exported from the LLM module.

* **Bug Fixes**
  * Improved HTTP error handling to prevent unnecessary retries on non-retryable status codes for AnthropicClient and GeminiClient.

* **Tests**
  * Extended test coverage for non-retryable HTTP status handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->