### PR TITLE
Strip legacy env-info suffix only (oh-tab-86q)

### DIFF
--- a/src/webview-src/__tests__/stripEnvironmentInformationBlocks.test.ts
+++ b/src/webview-src/__tests__/stripEnvironmentInformationBlocks.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { stripEnvironmentInformationBlocks } from '../components/eventBlocks/shared';
+
+describe('stripEnvironmentInformationBlocks', () => {
+  it('strips a trailing legacy env-info block', () => {
+    const text = [
+      'hello',
+      '',
+      '<environment information>',
+      'Active editor: README.md',
+      '</environment information>',
+      '',
+    ].join('\n');
+
+    expect(stripEnvironmentInformationBlocks(text)).toBe('hello');
+  });
+
+  it('does not strip an env-info block when it is not trailing', () => {
+    const text = [
+      'prefix',
+      '<environment information>',
+      'USER_INSERTED_ENV_BLOCK',
+      '</environment information>',
+      'suffix',
+    ].join('\n');
+
+    expect(stripEnvironmentInformationBlocks(text)).toBe(text);
+  });
+});

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -79,8 +79,10 @@ export const stripEnvironmentInformationBlocks = (text: string): string => {
   const raw = typeof text === 'string' ? text : '';
   if (!raw) return raw;
 
+  // Only strip legacy env-info blocks when they appear as a trailing suffix.
+  // Avoid removing user-authored text that happens to include similar tags mid-message.
   const withoutBlocks = raw.replace(
-    /(?:\r?\n){0,2}<environment information>[\s\S]*?<\/environment information>(?:\r?\n){0,2}/gi,
+    /(?:\r?\n){0,2}<environment information>[\s\S]*?<\/environment information>\s*$/i,
     '\n\n',
   );
 


### PR DESCRIPTION
Implements bead **oh-tab-86q**.

- Strip legacy `<environment information>` blocks only when they appear *at the very end* of the rendered event text.
- Adds a unit test to lock the trailing-only behavior (and preserve mid-message user content).
