### PR TITLE
Treat $0 cost as known (oh-tab-3g8)

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -149,7 +149,8 @@ describe('App toolbar interactions', () => {
 
     expect(totalsRow).toHaveTextContent('Context: 12 tokens');
     expect(totalsRow).toHaveTextContent('Total cost:');
-    expect(totalsRow).toHaveTextContent('—');
+    expect(totalsRow).toHaveTextContent('Total cost: $0.00');
+    expect(totalsRow).not.toHaveTextContent('—');
     expect(totalsRow).not.toHaveTextContent('$0.0123');
   });
 

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -128,7 +128,12 @@ export function Header({
   const formatInt = (value: number) => Math.max(0, Math.trunc(value)).toLocaleString();
   const formatCost = (value: number) => {
     const clamped = Number.isFinite(value) ? Math.max(0, value) : 0;
-    return `$${clamped.toFixed(4)}`;
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 4,
+    }).format(clamped);
   };
 
   // Get display name using shared helper for consistency

--- a/src/webview-src/components/app/conversationStats.ts
+++ b/src/webview-src/components/app/conversationStats.ts
@@ -68,12 +68,16 @@ export const computeConversationTotalsFromStats = (
   let accumulatedPromptTokens = 0;
   let accumulatedCompletionTokens = 0;
   let totalCost = 0;
+  let hasKnownCost = false;
 
   for (const metricRaw of Object.values(usageToMetricsRaw)) {
     if (!isRecord(metricRaw)) continue;
     const costRaw = metricRaw.accumulatedCost ?? metricRaw.accumulated_cost;
     const cost = asFiniteNumber(costRaw);
-    if (cost !== null && cost > 0) totalCost += cost;
+    if (cost !== null && cost >= 0) {
+      hasKnownCost = true;
+      totalCost += cost;
+    }
 
     const usageRaw = metricRaw.accumulatedTokenUsage ?? metricRaw.accumulated_token_usage;
     if (!isRecord(usageRaw)) continue;
@@ -84,8 +88,7 @@ export const computeConversationTotalsFromStats = (
   }
 
   const totalTokens = accumulatedPromptTokens + accumulatedCompletionTokens;
-  // Best-effort: treat cost as "known" only once we have non-zero usage + non-zero cost.
-  const costIsKnown = totalTokens > 0 && totalCost > 0;
+  const costIsKnown = totalTokens > 0 && hasKnownCost;
 
   return { contextTokens, totalTokens, totalCost, costIsKnown };
 };


### PR DESCRIPTION
Implements bead **oh-tab-3g8**.

- Treat explicit zero cost (`accumulated_cost: 0`) as a known price signal when token usage exists.
- Header cost formatting now shows `$0.00` for zero while keeping up to 4 decimals for small non-zero costs.
- Updates `src/webview-src/__tests__/App.toolbar.test.tsx` to assert the zero-cost case renders as known.

Test: `npx vitest run src/webview-src/__tests__/App.toolbar.test.tsx`.
