### PR TITLE
Multi-root settings scoping (oh-tab-01u)

### DIFF
--- a/src/settings/VscodeSettingsAdapter.ts
+++ b/src/settings/VscodeSettingsAdapter.ts
@@ -15,10 +15,23 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
       || key === 'openhands.oracle.profileId';
   }
 
+  private getWorkspaceFolderUriForConfiguration(): vscode.Uri | undefined {
+    const activeUri = vscode.window.activeTextEditor?.document?.uri;
+    if (activeUri) {
+      const folder = vscode.workspace.getWorkspaceFolder(activeUri);
+      if (folder) return folder.uri;
+    }
+
+    const folders = vscode.workspace.workspaceFolders ?? [];
+    if (folders.length === 1) return folders[0].uri;
+
+    return undefined;
+  }
+
   private getWorkspaceConfiguration(): vscode.WorkspaceConfiguration {
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-    return workspaceFolder
-      ? vscode.workspace.getConfiguration(undefined, workspaceFolder.uri)
+    const workspaceFolderUri = this.getWorkspaceFolderUriForConfiguration();
+    return workspaceFolderUri
+      ? vscode.workspace.getConfiguration(undefined, workspaceFolderUri)
       : vscode.workspace.getConfiguration();
   }
 
@@ -77,11 +90,16 @@ export class VscodeSettingsAdapter implements SettingsAdapter {
       await vscode.workspace.getConfiguration().update(key, value, vscode.ConfigurationTarget.Global);
       return;
     }
-    const hasWorkspaceFolder = !!vscode.workspace.workspaceFolders?.length;
-    const effectiveTarget =
-      target === 'workspace' && hasWorkspaceFolder
-        ? vscode.ConfigurationTarget.WorkspaceFolder
-        : vscode.ConfigurationTarget.Global;
+
+    const hasWorkspace = (vscode.workspace.workspaceFolders?.length ?? 0) > 0;
+    const isMultiRootWorkspace = !!vscode.workspace.workspaceFile;
+    const effectiveTarget = (() => {
+      if (target !== 'workspace') return vscode.ConfigurationTarget.Global;
+      if (!hasWorkspace) return vscode.ConfigurationTarget.Global;
+      return isMultiRootWorkspace
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.WorkspaceFolder;
+    })();
 
     const cfg =
       effectiveTarget === vscode.ConfigurationTarget.WorkspaceFolder

--- a/src/settings/__tests__/VscodeSettingsAdapter.test.ts
+++ b/src/settings/__tests__/VscodeSettingsAdapter.test.ts
@@ -18,6 +18,21 @@ describe('VscodeSettingsAdapter', () => {
       configurable: true,
     });
 
+    Object.defineProperty(vscode.workspace, 'getWorkspaceFolder', {
+      value: vi.fn(),
+      configurable: true,
+    });
+
+    Object.defineProperty(vscode.workspace, 'workspaceFile', {
+      value: undefined,
+      configurable: true,
+    });
+
+    Object.defineProperty(vscode.window, 'activeTextEditor', {
+      value: undefined,
+      configurable: true,
+    });
+
     // Create mock objects
     mockWorkspaceConfiguration = {
       get: vi.fn(),
@@ -46,6 +61,8 @@ describe('VscodeSettingsAdapter', () => {
         ? (mockWorkspaceConfiguration as vscode.WorkspaceConfiguration)
         : (mockGlobalConfiguration as vscode.WorkspaceConfiguration);
     });
+
+    vi.mocked(vscode.workspace.getWorkspaceFolder).mockReturnValue(undefined);
 
     // Create adapter with mocked context
     adapter = new VscodeSettingsAdapter(mockContext as vscode.ExtensionContext);
@@ -85,6 +102,28 @@ describe('VscodeSettingsAdapter', () => {
       expect(vscode.workspace.getConfiguration).toHaveBeenCalled();
       expect(mockWorkspaceConfiguration.get).toHaveBeenCalledWith(nestedKey, {});
       expect(result).toEqual(expectedValue);
+    });
+
+    it('scopes workspace configuration to the active editor workspace folder (not workspaceFolders[0])', () => {
+      const folder1 = { uri: { fsPath: '/test/workspace-1' } } as unknown as vscode.WorkspaceFolder;
+      const folder2 = { uri: { fsPath: '/test/workspace-2' } } as unknown as vscode.WorkspaceFolder;
+
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value: [folder1, folder2],
+        configurable: true,
+      });
+
+      Object.defineProperty(vscode.window, 'activeTextEditor', {
+        value: { document: { uri: { fsPath: '/test/workspace-2/file.ts' } } },
+        configurable: true,
+      });
+
+      vi.mocked(vscode.workspace.getWorkspaceFolder).mockReturnValue(folder2);
+
+      adapter.get('test.key');
+
+      expect(vscode.workspace.getConfiguration).toHaveBeenCalledWith(undefined, folder2.uri);
+      expect(vscode.workspace.getConfiguration).not.toHaveBeenCalledWith(undefined, folder1.uri);
     });
   });
 
@@ -178,6 +217,27 @@ describe('VscodeSettingsAdapter', () => {
         value,
         vscode.ConfigurationTarget.WorkspaceFolder
       );
+    });
+
+    it('updates workspace target at workspace scope in multi-root (.code-workspace) workspaces', async () => {
+      const key = 'test.key';
+      const value = 'test-value';
+      mockGlobalConfiguration.update.mockResolvedValue(undefined);
+
+      Object.defineProperty(vscode.workspace, 'workspaceFile', {
+        value: { fsPath: '/test/workspace.code-workspace' },
+        configurable: true,
+      });
+
+      Object.defineProperty(vscode.workspace, 'workspaceFolders', {
+        value: [{ uri: { fsPath: '/test/workspace-1' } }, { uri: { fsPath: '/test/workspace-2' } }],
+        configurable: true,
+      });
+
+      await adapter.update(key, value, 'workspace');
+
+      expect(mockGlobalConfiguration.update).toHaveBeenCalledWith(key, value, vscode.ConfigurationTarget.Workspace);
+      expect(mockWorkspaceConfiguration.update).not.toHaveBeenCalled();
     });
 
     it('should fall back to global when no workspace is open', async () => {


### PR DESCRIPTION
Implements bead **oh-tab-01u**.

- Remove `workspaceFolders[0]` scoping from `VscodeSettingsAdapter`.
- Scope workspace-folder reads to the active editor’s workspace folder when available; fallback to single-folder workspace.
- When running under a `.code-workspace` (multi-root), workspace updates now target `ConfigurationTarget.Workspace` instead of `WorkspaceFolder`.
- Adds unit tests covering multi-root scoping + update target selection.

Test: `npx vitest run src/settings/__tests__/VscodeSettingsAdapter.test.ts`.
