### PR TITLE
Queued-message badge while running (oh-tab-tkt)

### DIFF
--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -153,6 +153,90 @@ describe('App toolbar interactions', () => {
     expect(totalsRow).not.toHaveTextContent('$0.0123');
   });
 
+  it('shows a queued-messages badge when sending while the agent is running', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'status', status: 'online', mode: 'remote', llmProfileLabel: 'gpt-5' },
+        }),
+      );
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              agent_status: 'RUNNING',
+              key: 'llm_usage',
+              value: {
+                input: 1,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+    fireEvent.change(input, { target: { value: 'queued-1' } });
+    fireEvent.click(screen.getByLabelText('Send message'));
+
+    expect(await screen.findByTestId('queued-messages-badge')).toHaveTextContent('1');
+
+    fireEvent.change(input, { target: { value: 'queued-2' } });
+    fireEvent.click(screen.getByLabelText('Send message'));
+
+    expect(await screen.findByTestId('queued-messages-badge')).toHaveTextContent('2');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'MessageEvent',
+              source: 'user',
+              llm_message: {
+                role: 'user',
+                content: [{ type: 'text', text: 'dequeued' }],
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(await screen.findByTestId('queued-messages-badge')).toHaveTextContent('1');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'event',
+            event: {
+              kind: 'ConversationStateUpdateEvent',
+              agent_status: 'PAUSED',
+              key: 'llm_usage',
+              value: {
+                input: 1,
+                output: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            },
+          },
+        }),
+      );
+    });
+
+    expect(screen.queryByTestId('queued-messages-badge')).not.toBeInTheDocument();
+  });
+
   it('uses the main agent usage bucket for context tokens (not sum across usages)', async () => {
     render(<App />);
 

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -53,6 +53,7 @@ export function App() {
   // Input state
   const [input, setInput] = useState('');
   const selectionRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+  const [queuedMessagesCount, setQueuedMessagesCount] = useState(0);
 
   // Attachments state
   const [attachments, setAttachments] = useState<Array<{ uri: string; label: string; sizeBytes?: number }>>([]);
@@ -266,6 +267,7 @@ export function App() {
     setIsSubmitting,
     setStreamingContent,
     setEvents,
+    setQueuedMessagesCount,
     setConversationTotals,
   });
 
@@ -306,6 +308,7 @@ export function App() {
     setLlmProfiles,
     setMode,
     setPendingActions,
+    setQueuedMessagesCount,
     setSelectedContextFiles,
     setServers,
     setShowContextPicker,
@@ -396,6 +399,7 @@ export function App() {
     setEvents([]);
     setPendingActions([]);
     setAgentStatus(undefined);
+    setQueuedMessagesCount(0);
     setStreamingContent(null);
     setConversationTotals(INITIAL_CONVERSATION_TOTALS);
     hasLlmUsageRef.current = false;
@@ -452,6 +456,10 @@ export function App() {
     const finalText = [text, imageMarkdown].filter(Boolean).join('\n\n');
     if (!finalText) return;
 
+    if (agentStatus === 'RUNNING') {
+      setQueuedMessagesCount((prev) => prev + 1);
+    }
+
     setInput('');
     setShowContextPicker(false);
     setShowSkillsPopover(false);
@@ -467,7 +475,7 @@ export function App() {
       contextFiles: selectedContextFiles.slice(),
       attachments: attachments.map((a) => a.uri),
     });
-  }, [attachments, inlineImages, input, postMessage, selectedContextFiles, setInlineImages]);
+  }, [agentStatus, attachments, inlineImages, input, postMessage, selectedContextFiles, setInlineImages]);
 
   // Context picker handlers
   const handleOpenContext = useCallback(() => {
@@ -792,6 +800,7 @@ export function App() {
             onPasteImageFiles: (files) => { void handlePasteImageFiles(files); },
             onRemoveInlineImage: handleRemoveInlineImage,
             onSelectionChange: handleSelectionChange,
+            queuedMessagesCount,
           }}
           statusBanner={statusBanner}
           onDismissStatusBanner={() => setStatusBanner(null)}

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -60,6 +60,8 @@ interface InputAreaProps {
   // Stop agent (shown when running)
   isRunning?: boolean;
   onStopAgent?: () => void;
+  // Queued messages (shown while running)
+  queuedMessagesCount?: number;
 }
 
 export function InputArea({
@@ -107,6 +109,7 @@ export function InputArea({
   onSelectionChange,
   isRunning = false,
   onStopAgent,
+  queuedMessagesCount = 0,
 }: InputAreaProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isFocused, setIsFocused] = useState(false);
@@ -269,25 +272,40 @@ export function InputArea({
               )}
 
               {/* Send button */}
-              <button
-                type="button"
-                onClick={handleSubmit}
-                disabled={disabled || !canSend}
-                className={`
-                  h-9 w-9 rounded-lg
-                  flex items-center justify-center
-                  transition-all duration-200
-                  oh-focus-outline
-                  ${canSend && !disabled
-                    ? 'bg-gradient-to-b from-brand-500 to-brand-600 text-white shadow-glow-sm hover:from-brand-400 hover:to-brand-500'
-                    : 'bg-white/[0.06] text-stone-500 cursor-not-allowed border border-white/[0.04]'
-                  }
-                `}
-                aria-label="Send message"
-                title="Send message (Enter)"
-              >
-                <span className="codicon codicon-send" />
-              </button>
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={disabled || !canSend}
+                  className={`
+                    h-9 w-9 rounded-lg
+                    flex items-center justify-center
+                    transition-all duration-200
+                    oh-focus-outline
+                    ${canSend && !disabled
+                      ? 'bg-gradient-to-b from-brand-500 to-brand-600 text-white shadow-glow-sm hover:from-brand-400 hover:to-brand-500'
+                      : 'bg-white/[0.06] text-stone-500 cursor-not-allowed border border-white/[0.04]'
+                    }
+                  `}
+                  aria-label="Send message"
+                  title="Send message (Enter)"
+                >
+                  <span className="codicon codicon-send" />
+                </button>
+
+                {isRunning && queuedMessagesCount > 0 && (
+                  <span
+                    className="absolute -top-1 -right-1 h-4 min-w-4 px-1 rounded-full bg-gradient-to-b from-brand-400 to-brand-600 text-white text-[10px] font-semibold flex items-center justify-center shadow-glow-sm"
+                    title="Queued messages waiting for the agent to finish the current turn"
+                    aria-label={`Queued messages: ${queuedMessagesCount}`}
+                    role="status"
+                    aria-live="polite"
+                    data-testid="queued-messages-badge"
+                  >
+                    {queuedMessagesCount}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
 

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -6,6 +6,7 @@ import {
   isConversationErrorEvent,
   isConversationStateUpdateEvent,
   isEvent,
+  isMessageEvent,
   isObservationEvent,
   isPauseEvent,
   isUserRejectObservation,
@@ -41,6 +42,7 @@ type UseConversationEventsOptions = {
   setIsSubmitting: Dispatch<SetStateAction<boolean>>;
   setStreamingContent: Dispatch<SetStateAction<string | null>>;
   setEvents: Dispatch<SetStateAction<RenderedEvent[]>>;
+  setQueuedMessagesCount: Dispatch<SetStateAction<number>>;
   setConversationTotals: Dispatch<SetStateAction<ConversationTotals>>;
 };
 
@@ -62,6 +64,7 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     setIsSubmitting,
     setStreamingContent,
     setEvents,
+    setQueuedMessagesCount,
     setConversationTotals,
   } = options;
 
@@ -74,6 +77,9 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
       const previousStatus = agentStatusRef.current;
       agentStatusRef.current = event.agent_status;
       setAgentStatus(event.agent_status);
+      if (event.agent_status !== 'RUNNING') {
+        setQueuedMessagesCount(0);
+      }
       if (event.agent_status === 'WAITING_FOR_CONFIRMATION' && lastAgentStatusRef.current !== 'WAITING_FOR_CONFIRMATION') {
         showStatusMessage('warn', 'Agent is waiting for confirmation');
       }
@@ -133,6 +139,7 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
     setConversationTotals,
     setIsSubmitting,
     setPendingActions,
+    setQueuedMessagesCount,
     showStatusMessage,
     submissionTimeoutRef,
   ]);
@@ -205,11 +212,15 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
 
+    if (isMessageEvent(event) && event.source === 'user') {
+      setQueuedMessagesCount((prev) => Math.max(0, prev - 1));
+    }
+
     setEvents((ev) => {
       const next = [...ev, { id: eventId.current++, event }];
       return next.length > MAX_RENDERED_EVENTS ? next.slice(-MAX_RENDERED_EVENTS) : next;
     });
-  }, [eventId, setEvents]);
+  }, [eventId, setEvents, setQueuedMessagesCount]);
 
   const handleEvent = useCallback((incomingEvent: unknown) => {
     if (!isEvent(incomingEvent)) return;

--- a/src/webview-src/components/app/useHostMessages.ts
+++ b/src/webview-src/components/app/useHostMessages.ts
@@ -85,6 +85,7 @@ export type HostMessageHandlerOptions = {
   setLlmProfiles: Dispatch<SetStateAction<string[]>>;
   setMode: Dispatch<SetStateAction<'local' | 'remote'>>;
   setPendingActions: Dispatch<SetStateAction<ActionEvent[]>>;
+  setQueuedMessagesCount: Dispatch<SetStateAction<number>>;
   setSelectedContextFiles: Dispatch<SetStateAction<string[]>>;
   setServers: Dispatch<SetStateAction<{ url: string; label?: string }[]>>;
   setShowContextPicker: Dispatch<SetStateAction<boolean>>;
@@ -147,6 +148,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
     setLlmProfiles,
     setMode,
     setPendingActions,
+    setQueuedMessagesCount,
     setSelectedContextFiles,
     setServers,
     setShowContextPicker,
@@ -518,6 +520,7 @@ export function useHostMessages(options: HostMessageHandlerOptions): void {
             setPendingActions([]);
             agentStatusRef.current = undefined;
             setAgentStatus(undefined);
+            setQueuedMessagesCount(0);
             setStreamingContent(null);
             eventId.current = 1;
             setShowToolsPopover(false);


### PR DESCRIPTION
Implements bead **oh-tab-tkt**.

- Track queued user messages while `agent_status === RUNNING`.
- Show a small badge on the Send button with the queued count (aria-live polite + tooltip).
- Decrement as queued messages are dequeued (user `MessageEvent`s arrive), and clear on conversation start / agent stop.

Test: `npx vitest run src/webview-src/__tests__/App.toolbar.test.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a queued messages badge on the Send button that displays the count of messages sent while the agent is running. The badge provides visual feedback of pending messages and automatically clears when the agent stops executing.

* **Tests**
  * Added test coverage for queued messages badge behavior during agent execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->