### PR TITLE
Remove workspaceFolders[0] defaults in host callsites (oh-tab-mr8)

### DIFF
--- a/src/extension/conversationStoreRoot.ts
+++ b/src/extension/conversationStoreRoot.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { normalizeNonEmptyString } from '../shared/stringUtils';
+import { getEffectiveWorkspaceRoot } from '../shared/workspaceRoot';
 import { migrateWorkspaceConversationStore } from './conversationStoreMigration';
 
 function resolveConfiguredPath(p: string): string {
@@ -58,7 +59,7 @@ export async function resolveConversationStoreRoot(params: {
 
       // One-time best-effort migration away from legacy workspace persistence.
       // This keeps restore working for users who previously wrote to `./.openhands/conversations`.
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workspaceRoot = getEffectiveWorkspaceRoot();
       if (workspaceRoot) {
         const resolvedCandidate = path.resolve(candidate.dir);
         const resolvedWorkspace = path.resolve(workspaceRoot);

--- a/src/extension/explainSelectionCommand.ts
+++ b/src/extension/explainSelectionCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import { formatEnvironmentInformation } from '../shared/environmentInformation';
+import { getEffectiveWorkspaceRoot } from '../shared/workspaceRoot';
 
 export function registerExplainSelectionCommand(options: {
   getConversation: () => ConversationInstance | undefined;
@@ -62,7 +63,7 @@ export function registerExplainSelectionCommand(options: {
 
     let finalPrompt = prompt;
     if (getConversationMode() === 'local') {
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workspaceRoot = getEffectiveWorkspaceRoot();
       const activeEditorPath =
         (vscode.window.activeTextEditor?.document?.uri?.scheme === 'file' || vscode.window.activeTextEditor?.document?.uri?.scheme === 'vscode-remote')
           ? vscode.window.activeTextEditor.document.uri.fsPath

--- a/src/hal/registerHalCommands.ts
+++ b/src/hal/registerHalCommands.ts
@@ -3,6 +3,7 @@ import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsMan
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import { renderCondensationSummarizingPrompt, takeLastTeleportableEvents, TELEPORT_FALLBACK_EVENT_LIMIT, TELEPORT_SUMMARY_EVENT_LIMIT } from '../shared/halTeleport';
 import { safeStringify } from '../shared/safeStringify';
+import { getEffectiveWorkspaceRoot } from '../shared/workspaceRoot';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { ConversationInstance, Event, SecretRegistry } from '@openhands/agent-sdk-ts';
@@ -206,7 +207,7 @@ export function registerHalCommands(deps: RegisterHalCommandsDeps): vscode.Dispo
       }
 
       // STEP 3: Prepare the summary message (only after connection is established)
-      const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const workspaceRoot = getEffectiveWorkspaceRoot();
       const { repoName, branchName, remoteUrl } = await deps.resolveGitContext(workspaceRoot);
       const introLines = [
         'Teleported from the local VS Code runtime after a HIGH-risk confirmation.',

--- a/src/shared/__tests__/workspaceRoot.test.ts
+++ b/src/shared/__tests__/workspaceRoot.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { getEffectiveWorkspaceRoot, resolvePreferredWorkspaceRoot } from '../workspaceRoot';
+import { getEffectiveWorkspaceRoot, resolvePreferredWorkspaceFolderUri, resolvePreferredWorkspaceRoot } from '../workspaceRoot';
 
 describe('workspaceRoot helpers', () => {
   beforeEach(() => {
@@ -13,6 +13,7 @@ describe('workspaceRoot helpers', () => {
 
     expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-a');
     expect(getEffectiveWorkspaceRoot()).toBe('/test/workspace-a');
+    expect(resolvePreferredWorkspaceFolderUri()).toBeUndefined();
   });
 
   it('prefers the workspace folder containing the active editor', () => {
@@ -26,6 +27,7 @@ describe('workspaceRoot helpers', () => {
 
     expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-b');
     expect(getEffectiveWorkspaceRoot()).toBe('/test/workspace-b');
+    expect(resolvePreferredWorkspaceFolderUri()).toEqual({ fsPath: '/test/workspace-b' });
   });
 
   it('falls back to workspaceFolders[0] when active editor is outside all workspace folders', () => {
@@ -35,5 +37,13 @@ describe('workspaceRoot helpers', () => {
 
     expect(resolvePreferredWorkspaceRoot()).toBe('/test/workspace-a');
     expect(getEffectiveWorkspaceRoot()).toBe('/test/workspace-a');
+    expect(resolvePreferredWorkspaceFolderUri()).toBeUndefined();
+  });
+
+  it('returns workspaceFolders[0].uri when there is exactly one workspace folder', () => {
+    (vscode.window as any).activeTextEditor = undefined;
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }];
+
+    expect(resolvePreferredWorkspaceFolderUri()).toEqual({ fsPath: '/test/workspace-a' });
   });
 });

--- a/src/shared/workspaceRoot.ts
+++ b/src/shared/workspaceRoot.ts
@@ -1,5 +1,26 @@
 import * as vscode from 'vscode';
 
+export const resolvePreferredWorkspaceFolderUri = (): vscode.Uri | undefined => {
+  const activeUri = vscode.window.activeTextEditor?.document?.uri;
+  const getWorkspaceFolder = (vscode.workspace as unknown as { getWorkspaceFolder?: (uri: vscode.Uri) => { uri?: vscode.Uri } | undefined })
+    .getWorkspaceFolder;
+
+  if (activeUri && typeof getWorkspaceFolder === 'function') {
+    try {
+      const folder = getWorkspaceFolder(activeUri);
+      const uri = folder?.uri;
+      if (uri) return uri;
+    } catch {
+      // ignore and fall back
+    }
+  }
+
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  if (folders.length === 1) return folders[0]?.uri;
+
+  return undefined;
+};
+
 export const resolvePreferredWorkspaceRoot = (): string | undefined => {
   const activeUri = vscode.window.activeTextEditor?.document?.uri;
   const getWorkspaceFolder = (vscode.workspace as unknown as { getWorkspaceFolder?: (uri: vscode.Uri) => { uri?: vscode.Uri } | undefined })

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -18,7 +18,7 @@ import { normalizeServerUrl } from '../../shared/serverUrls';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS, type HostToWebviewMessage, type WebviewToHostMessage } from '../../shared/webviewMessages';
 import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
 // Environment info is provided via AgentContext.userMessageSuffix (extension host).
-import { getEffectiveWorkspaceRoot } from '../../shared/workspaceRoot';
+import { getEffectiveWorkspaceRoot, resolvePreferredWorkspaceFolderUri } from '../../shared/workspaceRoot';
 import { getConversationHistoryList, persistConversationTitle } from './conversationHistory';
 import { showWorkspaceDiff } from './diffDocuments';
 import { resolveGitHeadDiffContents } from './gitHeadDiff';
@@ -1113,7 +1113,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
             break;
           }
 
-          const defaultUri = vscode.workspace.workspaceFolders?.[0]?.uri;
+          const defaultUri = resolvePreferredWorkspaceFolderUri();
           const picked = await vscode.window.showOpenDialog({
             canSelectFiles: true,
             canSelectFolders: false,


### PR DESCRIPTION
Implements bead **oh-tab-mr8**.

- Remove remaining host-side `workspaceFolders[0]` defaults in the listed callsites.
- Use shared active-editor-first helpers (`getEffectiveWorkspaceRoot` / `resolvePreferredWorkspaceFolderUri`).
- Extend `src/shared/__tests__/workspaceRoot.test.ts` to cover new helper behavior.

Test: `npx vitest run src/shared/__tests__/workspaceRoot.test.ts`.
