### PR TITLE
Centralize file-backed URI detection (oh-tab-jqs)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
+import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import {
   createOutputLogger,
@@ -150,11 +151,7 @@ function renderError(err: unknown): string {
 }
 
 function resolveActiveEditorFilePath(editor: vscode.TextEditor | undefined): string | undefined {
-  if (!editor) return undefined;
-  const uri = editor.document.uri;
-  if (uri.scheme !== 'file' && uri.scheme !== 'vscode-remote') return undefined;
-  const fsPath = typeof uri.fsPath === 'string' ? uri.fsPath.trim() : '';
-  return fsPath || undefined;
+  return getFileBackedFsPath(editor?.document?.uri);
 }
 
 function syncActiveEditorSystemMessageSuffix(editor: vscode.TextEditor | undefined): void {
@@ -175,12 +172,9 @@ function syncActiveEditorSystemMessageSuffix(editor: vscode.TextEditor | undefin
 function buildEnvironmentInfoSuffix(): string | null {
   try {
     const workspaceRoot = resolvePreferredWorkspaceRoot();
-    const activeEditorPath =
-      (vscode.window.activeTextEditor?.document?.uri?.scheme === 'file' || vscode.window.activeTextEditor?.document?.uri?.scheme === 'vscode-remote')
-        ? vscode.window.activeTextEditor.document.uri.fsPath
-        : null;
+    const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
     const openEditorPaths = (vscode.window.visibleTextEditors ?? [])
-      .map((e) => ((e?.document?.uri?.scheme === 'file' || e?.document?.uri?.scheme === 'vscode-remote') ? e.document.uri.fsPath : null))
+      .map((e) => getFileBackedFsPath(e?.document?.uri))
       .filter((p): p is string => typeof p === 'string' && p.length > 0);
     return formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths });
   } catch {

--- a/src/extension/explainSelectionCommand.ts
+++ b/src/extension/explainSelectionCommand.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import { formatEnvironmentInformation } from '../shared/environmentInformation';
 import { getEffectiveWorkspaceRoot } from '../shared/workspaceRoot';
+import { getFileBackedFsPath } from '../shared/uri';
 
 export function registerExplainSelectionCommand(options: {
   getConversation: () => ConversationInstance | undefined;
@@ -35,7 +36,7 @@ export function registerExplainSelectionCommand(options: {
         : selectedText;
 
     const languageId = editor.document.languageId;
-    const filePath = editor.document.uri.scheme === 'file' ? editor.document.uri.fsPath : editor.document.uri.toString();
+    const filePath = getFileBackedFsPath(editor.document.uri) ?? editor.document.uri.toString();
     const start = selection.start;
     const end = selection.end;
     const range = `${filePath}:${start.line + 1}:${start.character + 1}-${end.line + 1}:${end.character + 1}`;
@@ -64,12 +65,9 @@ export function registerExplainSelectionCommand(options: {
     let finalPrompt = prompt;
     if (getConversationMode() === 'local') {
       const workspaceRoot = getEffectiveWorkspaceRoot();
-      const activeEditorPath =
-        (vscode.window.activeTextEditor?.document?.uri?.scheme === 'file' || vscode.window.activeTextEditor?.document?.uri?.scheme === 'vscode-remote')
-          ? vscode.window.activeTextEditor.document.uri.fsPath
-          : null;
+      const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
       const openEditorPaths = (vscode.window.visibleTextEditors ?? [])
-        .map((e) => ((e?.document?.uri?.scheme === 'file' || e?.document?.uri?.scheme === 'vscode-remote') ? e.document.uri.fsPath : null))
+        .map((e) => getFileBackedFsPath(e?.document?.uri))
         .filter((p): p is string => typeof p === 'string' && p.length > 0);
       finalPrompt += `\n\n${formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths })}`;
     }

--- a/src/shared/__tests__/uri.test.ts
+++ b/src/shared/__tests__/uri.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getFileBackedFsPath, isFileBackedUri } from '../uri';
+
+describe('uri helpers', () => {
+  it('treats file and vscode-remote schemes as file-backed', () => {
+    expect(isFileBackedUri({ scheme: 'file', fsPath: '/a' } as any)).toBe(true);
+    expect(isFileBackedUri({ scheme: 'vscode-remote', fsPath: '/b' } as any)).toBe(true);
+  });
+
+  it('does not treat other schemes as file-backed', () => {
+    expect(isFileBackedUri({ scheme: 'untitled', fsPath: '/a' } as any)).toBe(false);
+    expect(isFileBackedUri({ scheme: 'vscode', fsPath: '/a' } as any)).toBe(false);
+    expect(isFileBackedUri(null)).toBe(false);
+  });
+
+  it('returns a trimmed fsPath for file-backed URIs', () => {
+    expect(getFileBackedFsPath({ scheme: 'file', fsPath: '  /a  ' } as any)).toBe('/a');
+    expect(getFileBackedFsPath({ scheme: 'vscode-remote', fsPath: '/b' } as any)).toBe('/b');
+  });
+
+  it('returns undefined when there is no usable fsPath', () => {
+    expect(getFileBackedFsPath({ scheme: 'file', fsPath: '   ' } as any)).toBeUndefined();
+    expect(getFileBackedFsPath({ scheme: 'untitled', fsPath: '/a' } as any)).toBeUndefined();
+    expect(getFileBackedFsPath(undefined)).toBeUndefined();
+  });
+});
+

--- a/src/shared/uri.ts
+++ b/src/shared/uri.ts
@@ -1,0 +1,13 @@
+import * as vscode from 'vscode';
+
+export function isFileBackedUri(uri: vscode.Uri | undefined | null): boolean {
+  const scheme = typeof uri?.scheme === 'string' ? uri.scheme : '';
+  return scheme === 'file' || scheme === 'vscode-remote';
+}
+
+export function getFileBackedFsPath(uri: vscode.Uri | undefined | null): string | undefined {
+  if (!isFileBackedUri(uri)) return undefined;
+  const fsPath = typeof uri?.fsPath === 'string' ? uri.fsPath.trim() : '';
+  return fsPath || undefined;
+}
+


### PR DESCRIPTION
Implements bead **oh-tab-jqs**.

- Adds shared helpers `isFileBackedUri` / `getFileBackedFsPath` to treat `file` and `vscode-remote` URIs as file-backed.
- Refactors host callsites to use the helper instead of ad-hoc URI checks.
- Adds unit tests for the helper and exercises the integration via `src/__tests__/extension.test.ts`.

Tests: `npx vitest run src/shared/__tests__/uri.test.ts src/__tests__/extension.test.ts`.

### Bead

```text

oh-tab-jqs: (tech debt) VS Code: centralize file-backed URI detection (file vs vscode-remote)
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 06:16
Updated: 2026-01-15 06:16

Description:
Problem
- Multiple places gate behavior on `uri.scheme === 'file'` when deciding whether an editor/document is “file-backed”.
- In VS Code Remote, documents often use `vscode-remote` scheme but still represent real files; treating them as non-file leads to degraded features (env info, selection helpers, etc.).

Goal
- Centralize “file-backed URI” logic into a shared helper and use it consistently.

Proposed approach
- Add `src/shared/uri.ts` (or similar) exporting `getFileBackedFsPath(uri)` / `isFileBackedUri(uri)`.
- Treat `file` and `vscode-remote` as file-backed (and keep other schemes non-file-backed by default).
- Update callsites that currently special-case `file` (env info collection, selection helpers, path resolution as appropriate).
- Add unit tests for the helper (file, vscode-remote, data/mailto/etc.).

Acceptance Criteria:
- Shared helper exists and is used in relevant callsites.
- Unit tests cover `file` vs `vscode-remote` vs non-file schemes.
- No behavior change for non-remote local workspaces.

Labels: [tech-debt uri vscode]

Blocks (2):
  ← oh-tab-dwq: (tech debt) Centralize environment info collection (workspaceRoot + file-backed URIs) [P3]
  ← oh-tab-usi: Env info userMessageSuffix is stale after active editor changes [P3]

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in file path resolution across editor operations for more reliable handling of file-backed URIs and edge cases.

* **Tests**
  * Added test coverage for URI utility functions and edge case handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- Reviewer: OrangeCastle (detached-worktree review).
- Verdict: LGTM to merge.
- Validation: `npx vitest run src/shared/__tests__/uri.test.ts src/__tests__/extension.test.ts` ✅
- Notes: optional nit to add explicit `isFileBackedUri(undefined)` assertion in `src/shared/__tests__/uri.test.ts`.
