### PR TITLE
E2E helper: wait for N mock requests (oh-tab-e2e-reqcount)

### DIFF
--- a/tests/e2e/suite/contextLimitRetry.ts
+++ b/tests/e2e/suite/contextLimitRetry.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
+import { waitForRequestCount } from './helpers/waitForRequestCount';
 
 type DiagnosticsInfo = {
   chat?: { hasView?: boolean; webviewReady?: boolean };
@@ -136,6 +137,16 @@ export async function run(): Promise<void> {
     if (!send?.sent) throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
 
     try {
+      await waitForRequestCount({
+        expectedPath: '/v1/chat/completions',
+        baselineIndex: beforeReqCount,
+        additionalCount: 3,
+        timeoutMs: 60000,
+        pollIntervalMs: 250,
+        getRequests: () => mock.requests,
+        beforeErrorSeq,
+      });
+
       await pollUntil(async () => {
         const newRequests = mock.requests.slice(beforeReqCount);
         const chatReqs = newRequests.filter((r) => r.path === '/v1/chat/completions');
@@ -143,8 +154,6 @@ export async function run(): Promise<void> {
         const condenseReqs = chatReqs.filter((r) => isCondensationRequest(r.json));
         if (mainReqs.length < 2) return false;
         if (condenseReqs.length < 1) return false;
-        if (chatReqs.length < 3) return false;
-
         const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
         const condensationCount = (rendered?.eventTypes ?? []).filter((t) => t === 'Condensation').length;
         const hasCondensation = condensationCount > beforeCondensations;

--- a/tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts
+++ b/tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { pollUntil } from '../pollUntil';
 import type { MockLlmRequest } from '../mockLlmServer';
+import { waitForRequestCount } from './waitForRequestCount';
 
 type WebviewActionResult = {
   sent?: boolean;
@@ -33,30 +34,16 @@ export async function sendAndWaitForRequestPath(options: {
     throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
   }
 
-  try {
-    await pollUntil(async () => {
-      const reqs = getRequests();
-      const hasExpected = reqs.slice(beforeReqCount).some((r) => r.path === expectedPath);
-      if (!hasExpected) return false;
-      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
-      const seq = typeof diag?.eventBacklog?.latestSeq === 'number' ? diag.eventBacklog.latestSeq : 0;
-      return seq > beforeSeq;
-    }, timeoutMs, 200);
-  } catch (err) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
-    const recent = getRequests()
-      .slice(beforeReqCount)
-      .map((r) => r.path)
-      .slice(-20);
-    throw new Error(
-      `Timed out waiting for mock request (${expectedPath}).\n` +
-      `- diag: ${JSON.stringify(diag)}\n` +
-      `- lastError: ${JSON.stringify(lastError)}\n` +
-      `- requestsSinceSend: ${recent.join(', ') || '(none)'}\n` +
-      `- original: ${err instanceof Error ? err.message : String(err)}`,
-    );
-  }
+  await waitForRequestCount({
+    expectedPath,
+    baselineIndex: beforeReqCount,
+    additionalCount: 1,
+    timeoutMs,
+    pollIntervalMs: 200,
+    getRequests,
+    beforeSeq,
+    beforeErrorSeq,
+  });
 
   const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
   const afterErrorSeq = typeof afterError?.seq === 'number' ? afterError.seq : -1;
@@ -78,4 +65,3 @@ export async function sendAndWaitForRequestPath(options: {
   }
   return last;
 }
-

--- a/tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts
+++ b/tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { pollUntil } from '../pollUntil';
 import type { MockLlmRequest } from '../mockLlmServer';
 import { waitForRequestCount } from './waitForRequestCount';
 

--- a/tests/e2e/suite/helpers/waitForRequestCount.ts
+++ b/tests/e2e/suite/helpers/waitForRequestCount.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import { pollUntil } from '../pollUntil';
+import type { MockLlmRequest } from '../mockLlmServer';
+
+type DiagnosticsInfo = {
+  eventBacklog?: { latestSeq?: number };
+};
+
+type ErrorInfo = { seq?: number } | null;
+
+export async function waitForRequestCount(options: {
+  expectedPath: string;
+  baselineIndex: number;
+  additionalCount: number;
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+  getRequests: () => MockLlmRequest[];
+  beforeSeq?: number;
+  beforeErrorSeq?: number;
+}): Promise<MockLlmRequest[]> {
+  const {
+    expectedPath,
+    baselineIndex,
+    additionalCount,
+    timeoutMs = 45000,
+    pollIntervalMs = 200,
+    getRequests,
+    beforeSeq,
+    beforeErrorSeq,
+  } = options;
+
+  const initialReqCount = getRequests().length;
+  if (baselineIndex > initialReqCount) {
+    throw new Error(`baselineIndex (${baselineIndex}) > current request count (${initialReqCount})`);
+  }
+
+  const predicate = async () => {
+    const newRequests = getRequests().slice(baselineIndex);
+    const matching = newRequests.filter((r) => r.path === expectedPath);
+    if (matching.length < additionalCount) return false;
+
+    if (typeof beforeSeq === 'number') {
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+      const latestSeq = typeof diag?.eventBacklog?.latestSeq === 'number' ? diag.eventBacklog.latestSeq : 0;
+      if (latestSeq <= beforeSeq) return false;
+    }
+
+    if (typeof beforeErrorSeq === 'number') {
+      const lastError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
+      const lastErrorSeq = typeof lastError?.seq === 'number' ? lastError.seq : -1;
+      if (lastError && lastErrorSeq > beforeErrorSeq) {
+        throw new Error(`Detected error event(s) after baseline (seq ${lastErrorSeq} > ${beforeErrorSeq}).`);
+      }
+    }
+
+    return true;
+  };
+
+  try {
+    await pollUntil(predicate, timeoutMs, pollIntervalMs);
+  } catch (err) {
+    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
+    const newRequests = getRequests().slice(baselineIndex);
+    const matching = newRequests.filter((r) => r.path === expectedPath);
+    const recentPaths = newRequests.map((r) => r.path).slice(-25);
+    throw new Error(
+      `Timed out waiting for ${additionalCount} mock request(s) to (${expectedPath}).\n` +
+      `- baselineIndex: ${baselineIndex}\n` +
+      `- observedMatching: ${matching.length}\n` +
+      `- diag: ${JSON.stringify(diag)}\n` +
+      `- lastError: ${JSON.stringify(lastError)}\n` +
+      `- recentPathsSinceBaseline: ${recentPaths.join(', ') || '(none)'}\n` +
+      `- original: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return getRequests()
+    .slice(baselineIndex)
+    .filter((r) => r.path === expectedPath);
+}
+

--- a/tests/e2e/suite/helpers/waitForRequestCount.ts
+++ b/tests/e2e/suite/helpers/waitForRequestCount.ts
@@ -59,19 +59,26 @@ export async function waitForRequestCount(options: {
   try {
     await pollUntil(predicate, timeoutMs, pollIntervalMs);
   } catch (err) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
+    const diag = (await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics')) ?? {};
+    const lastError = (await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError')) ?? null;
     const newRequests = getRequests().slice(baselineIndex);
     const matching = newRequests.filter((r) => r.path === expectedPath);
     const recentPaths = newRequests.map((r) => r.path).slice(-25);
+    const original = err instanceof Error ? err.message : String(err);
+    const isTimeout = original.startsWith('pollUntil timed out after');
+    const headline = isTimeout
+      ? `Timed out waiting for ${additionalCount} mock request(s) to (${expectedPath}).`
+      : `waitForRequestCount failed while waiting for ${additionalCount} mock request(s) to (${expectedPath}).`;
+
     throw new Error(
-      `Timed out waiting for ${additionalCount} mock request(s) to (${expectedPath}).\n` +
+      `${headline}\n` +
       `- baselineIndex: ${baselineIndex}\n` +
       `- observedMatching: ${matching.length}\n` +
       `- diag: ${JSON.stringify(diag)}\n` +
       `- lastError: ${JSON.stringify(lastError)}\n` +
       `- recentPathsSinceBaseline: ${recentPaths.join(', ') || '(none)'}\n` +
-      `- original: ${err instanceof Error ? err.message : String(err)}`,
+      `- original: ${original}`,
+      { cause: err },
     );
   }
 
@@ -79,4 +86,3 @@ export async function waitForRequestCount(options: {
     .slice(baselineIndex)
     .filter((r) => r.path === expectedPath);
 }
-


### PR DESCRIPTION
Implements bead **oh-tab-e2e-reqcount**.

- Add `tests/e2e/suite/helpers/waitForRequestCount.ts` to wait for N new mock requests to a path since a baseline index, with detailed timeout diagnostics.
- Refactor `tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts` to reuse the helper.
- Refactor `tests/e2e/suite/contextLimitRetry.ts` to use the helper and remove ad-hoc request-count polling.

### Bead

```text

oh-tab-e2e-reqcount: E2E helper: wait for N mock requests to a path
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 10:55
Updated: 2026-01-15 10:55

Description:
We frequently need to assert multi-request behavior (e.g., context-limit retry causes exactly 2 LLM calls). Current helper sendAndWaitForRequestPath() returns after the first matching request, so suites re-implement ad-hoc counting/polling.

Acceptance Criteria:
- Add a helper under tests/e2e/suite/helpers (e.g. waitForRequestCount.ts) that polls until mock.requests has N additional entries matching expectedPath since a baseline index
- Helper should include useful timeout diagnostics (recent paths, lastError, diagnostics)
- Update/optionally refactor sendAndWaitForRequestPath to reuse the helper or add a sibling helper sendAndWaitForRequestCount
- Use it in oh-tab-0ph.2 (or another suite) to prove it works and reduce duplicated polling logic

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for better synchronization and reliability in request retry testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- Reviewer: OrangeCastle (detached-worktree review + re-review after changes).
- Verdict: LGTM to merge.
- Validation: CI green; reviewer re-reviewed after commit `def1273`.
- Notes: requested changes addressed (timeout vs predicate failure headline; removed unused import; typed diagnostics in catch).
