### PR TITLE
Clarify SecretRegistry trimming semantics (oh-tab-secret-storage-semantics)

### DIFF
--- a/docs/secret_storage_semantics.md
+++ b/docs/secret_storage_semantics.md
@@ -1,0 +1,31 @@
+# Secret storage semantics (OpenHands-Tab)
+
+This note documents how secrets are interpreted when flowing through the TypeScript SDK’s `SecretRegistry` (used for LLM API keys, auth tokens, etc).
+
+## Canonical behavior
+
+**`SecretRegistry.set(name, value)`**
+- Trims `value`.
+- If the trimmed value is empty, the secret is treated as **unset** (the entry is deleted).
+- Otherwise, the trimmed value is stored.
+
+**`SecretRegistry.get(name)`**
+- Returns the in-memory cached value if present.
+- Otherwise queries VS Code `SecretStorage` (when available):
+  - Trims the stored value.
+  - If the trimmed value is empty, it is treated as **unset** and ignored.
+  - If non-empty, the trimmed value is returned and cached.
+- Otherwise queries `process.env[name.toUpperCase()]`:
+  - Trims the env value.
+  - If the trimmed value is empty, it is treated as **unset**.
+  - If non-empty, the trimmed value is returned and cached.
+
+## Rationale
+
+- Avoids treating accidental whitespace-only secrets as “set” (which can produce confusing auth failures).
+- Keeps behavior consistent between writes (`set`) and reads (`get`).
+
+## When you need “empty string counts as set”
+
+Some features may need CLI-like semantics where “present but empty” should be considered *set*. Don’t route those through `SecretRegistry`; instead, use a dedicated wrapper with explicit semantics (e.g. a token/settings adapter that preserves empty-string values).
+

--- a/packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts
@@ -40,17 +40,19 @@ export class SecretRegistry {
     // Prefer SecretStorage over environment variables to allow user-set keys to override env.
     if (this.storage) {
       const stored = await this.storage.get(name);
-      if (stored) {
-        this.secrets.set(name, stored);
-        return stored;
+      const trimmed = typeof stored === 'string' ? stored.trim() : '';
+      if (trimmed) {
+        this.secrets.set(name, trimmed);
+        return trimmed;
       }
     }
 
     const envKey = name.toUpperCase();
     const envValue = process.env[envKey];
-    if (envValue) {
-      this.secrets.set(name, envValue);
-      return envValue;
+    const envTrimmed = typeof envValue === 'string' ? envValue.trim() : '';
+    if (envTrimmed) {
+      this.secrets.set(name, envTrimmed);
+      return envTrimmed;
     }
 
     return undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts
@@ -47,6 +47,30 @@ describe('SecretRegistry', () => {
     expect(getSpy).toHaveBeenCalledTimes(1);
   });
 
+  it('treats empty/whitespace SecretStorage values as unset (falls back to env)', async () => {
+    process.env[envKey] = 'from-env';
+    const { storage, getSpy } = makeStorage('   ');
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-env');
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('trims SecretStorage values when present', async () => {
+    const { storage } = makeStorage('  from-storage  ');
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-storage');
+  });
+
+  it('trims env values when SecretStorage is empty', async () => {
+    process.env[envKey] = '  from-env  ';
+    const { storage } = makeStorage('');
+    const registry = new SecretRegistry(storage, null);
+
+    await expect(registry.get(secretName)).resolves.toBe('from-env');
+  });
+
   it('returns SecretStorage when env is absent', async () => {
     const { storage, getSpy } = makeStorage('from-storage');
     const registry = new SecretRegistry(storage, null);


### PR DESCRIPTION
Implements bead **oh-tab-secret-storage-semantics**.

- Document `SecretRegistry` trim/empty-string semantics in `docs/secret_storage_semantics.md`.
- Make reads consistent with writes: trim values from `SecretStorage` and `process.env`, and treat empty/whitespace-only values as unset.
- Add unit tests covering empty/whitespace SecretStorage values and trimming behavior.

Test: `npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation detailing secret storage behavior, including trimming semantics and fallback precedence.

* **Bug Fixes**
  * Secret values are now trimmed of whitespace when retrieved from storage or environment variables.
  * Empty or whitespace-only secrets are treated as unset and properly fall back to alternative sources.

* **Tests**
  * Added test coverage for whitespace trimming and fallback behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Bead

```text

oh-tab-secret-storage-semantics: Clarify SecretRegistry/SecretStorage semantics (trim + empty string)
Status: open
Priority: P3
Type: task
Created: 2026-01-15 11:15
Updated: 2026-01-15 11:15

Description:
We currently treat empty/whitespace-only secrets as unset (SecretRegistry.set trims and deletes; SecretRegistry.get ignores empty-string SecretStorage values). Upcoming auth/token-storage parity work may require different semantics (e.g. empty string counts as set). Decide the desired behavior and update code/tests accordingly without breaking existing onboarding markers.

Acceptance Criteria:
- Document the chosen semantics (trim rules + empty-string handling) in a short note (issue design or docs)
- If changing behavior: update `packages/agent-sdk-ts/src/sdk/runtime/SecretRegistry.ts` and affected extension code/tests
- Add/adjust unit tests to lock in behavior (including empty-string SecretStorage return path)

Labels: [auth storage tech-debt]

```

### Review

- Reviewer: OrangeCastle (detached-worktree review).
- Verdict: LGTM to merge.
- Validation: `npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/SecretRegistry.test.ts` ✅
- Notes: semantics are now explicit in docs and covered by tests.
