### PR TITLE
oh-tab-voc.3: OAuth device-flow login for remote servers

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "onCommand:openhands.setLiteLlmApiKey",
     "onCommand:openhands.setGeminiLlmApiKey",
     "onCommand:openhands.setSessionApiKey",
+    "onCommand:openhands.cloudLogin",
     "onCommand:openhands.setGithubToken",
     "onCommand:openhands.setHalTtsApiKey",
     "onCommand:openhands.setCustomSecret1",
@@ -93,6 +94,10 @@
       {
         "command": "openhands.setSessionApiKey",
         "title": "OpenHands: Set Session API Key"
+      },
+      {
+        "command": "openhands.cloudLogin",
+        "title": "OpenHands: Login to Remote Server (Device Flow)"
       },
       {
         "command": "openhands.setGithubToken",

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -981,6 +981,7 @@ describe('RemoteConversation', () => {
       if (url.includes('/confirmation_policy')) {
         expect(init?.method).toBe('POST');
         expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
+        expect(init?.headers?.Authorization).toBe('Bearer session-key');
         const body = JSON.parse(init?.body ?? '{}');
         expect(body).toEqual({
           policy: { kind: 'ConfirmRisky', threshold: 'HIGH', confirm_unknown: false },
@@ -1034,6 +1035,7 @@ describe('RemoteConversation', () => {
         call += 1;
         expect(init?.method).toBe('POST');
         expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
+        expect(init?.headers?.Authorization).toBe('Bearer session-key');
         const body = JSON.parse(init?.body ?? '{}');
         if (call === 1) {
           expect(body).toEqual({ security_analyzer: { kind: 'LLMSecurityAnalyzer' } });
@@ -1081,6 +1083,7 @@ describe('RemoteConversation', () => {
         expect(init?.method).toBe('POST');
         uploadCalls += 1;
         expect(init?.headers?.['X-Session-API-Key']).toBe(uploadCalls === 1 ? 'session-key-1' : 'session-key-2');
+        expect(init?.headers?.Authorization).toBe(uploadCalls === 1 ? 'Bearer session-key-1' : 'Bearer session-key-2');
         return {
           ok: true,
           status: 200,

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import WebSocket from 'ws';
+import WebSocket, { type ClientOptions } from 'ws';
 import type { BashEvent, Event, Message, TextContent } from '../types';
 import { isEvent as isAgentEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
@@ -739,7 +739,10 @@ export class RemoteConversation extends EventEmitter {
   private getAuthHeaders(): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     const sessionKey = this.settings?.secrets.sessionApiKey || '';
-    if (sessionKey) headers['X-Session-API-Key'] = sessionKey;
+    if (sessionKey) {
+      headers['X-Session-API-Key'] = sessionKey;
+      headers['Authorization'] = `Bearer ${sessionKey}`;
+    }
     return headers;
   }
 
@@ -793,7 +796,9 @@ export class RemoteConversation extends EventEmitter {
     const qs = params.toString();
     const wsUrl = `${base.replace(/^http/, 'ws')}/sockets/events/${this.conversationId}?${qs}`;
     this.setStatus('connecting');
-    const ws = new WebSocket(wsUrl);
+    const wsHeaders = this.getAuthHeaders();
+    delete wsHeaders['Content-Type'];
+    const ws = new WebSocket(wsUrl, { headers: wsHeaders } satisfies ClientOptions);
     this.ws = ws;
     this.clearWsHandshakeTimer();
     this.wsHandshakeTimer = setTimeout(() => {

--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -428,7 +428,10 @@ export class RemoteWorkspace implements BaseWorkspace {
 
   private getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
     const headers: Record<string, string> = { ...extra };
-    if (this.apiKey) headers['X-Session-API-Key'] = this.apiKey;
+    if (this.apiKey) {
+      headers['X-Session-API-Key'] = this.apiKey;
+      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    }
     return headers;
   }
 

--- a/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
@@ -129,6 +129,7 @@ describe('RemoteWorkspace', () => {
       expect(url).toContain('/workspace/project/hello.txt');
       expect(init?.method).toBe('POST');
       expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
+      expect(init?.headers?.Authorization).toBe('Bearer session-key');
       expect(init?.body).toBeInstanceOf(FormData);
       return okJson({ ok: true }) as any;
     });

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -32,6 +32,14 @@ const defaultMockSettings = {
 
 let mockSettings = structuredClone(defaultMockSettings);
 
+const startDeviceAuthorizationMock = vi.fn();
+const pollDeviceTokenMock = vi.fn();
+
+vi.mock('../auth/deviceFlow', () => ({
+  startDeviceAuthorization: (...args: any[]) => startDeviceAuthorizationMock(...args),
+  pollDeviceToken: (...args: any[]) => pollDeviceTokenMock(...args),
+}));
+
 vi.mock('../settings/SettingsManager', () => ({
   SettingsManager: vi.fn(function (this: any) {
     this.get = vi.fn(async () => mockSettings);
@@ -206,6 +214,63 @@ describe('Extension Activation', () => {
   it('registers commands on activation', async () => {
     await extension.activate(mockContext);
     expect(vscode.commands.registerCommand).toHaveBeenCalled();
+  });
+
+  it('cloudLogin stores a per-server session key without clobbering legacy when different', async () => {
+    const secretStorage = new Map<string, string>();
+    secretStorage.set('openhands.sessionApiKey', 'legacy-key');
+
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+
+    startDeviceAuthorizationMock.mockResolvedValue({
+      deviceCode: 'dev',
+      userCode: 'ABC-123',
+      verificationUri: 'https://example.com/verify',
+      verificationUriComplete: 'https://example.com/verify?user_code=ABC-123',
+      intervalMs: 1000,
+    });
+    pollDeviceTokenMock.mockResolvedValue({ accessToken: 'server-token' });
+    (vscode.env.openExternal as Mock).mockResolvedValue(true);
+    (vscode.window.showInformationMessage as Mock).mockResolvedValue(undefined);
+
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.cloudLogin');
+
+    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
+    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+
+    expect(secretStorage.get(keyInfo.secretKey)).toBe('server-token');
+    expect(secretStorage.get('openhands.sessionApiKey')).toBe('legacy-key');
+  });
+
+  it('cloudLogin updates legacy openhands.sessionApiKey when unset', async () => {
+    const secretStorage = new Map<string, string>();
+
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+
+    startDeviceAuthorizationMock.mockResolvedValue({
+      deviceCode: 'dev',
+      userCode: 'ABC-123',
+      verificationUri: 'https://example.com/verify',
+      verificationUriComplete: 'https://example.com/verify?user_code=ABC-123',
+      intervalMs: 1000,
+    });
+    pollDeviceTokenMock.mockResolvedValue({ accessToken: 'server-token' });
+    (vscode.env.openExternal as Mock).mockResolvedValue(true);
+    (vscode.window.showInformationMessage as Mock).mockResolvedValue(undefined);
+
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.cloudLogin');
+
+    expect(secretStorage.get('openhands.sessionApiKey')).toBe('server-token');
   });
 
   it('does not create a conversation until the chat view resolves', async () => {

--- a/src/__tests__/openMarkdownLink.security.test.ts
+++ b/src/__tests__/openMarkdownLink.security.test.ts
@@ -18,7 +18,7 @@ describe('openMarkdownLink security rules', () => {
     (vscode.workspace as any).openTextDocument = vi.fn(async (uri: vscode.Uri) => ({ uri }));
     (vscode.window as any).showTextDocument = vi.fn(async () => ({}));
 
-    (vscode as any).env = { openExternal: vi.fn(async () => true) };
+    (vscode.env.openExternal as any).mockImplementation(async () => true);
 
     (vscode.Uri.parse as any).mockImplementation((raw: string) => {
       const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(raw);
@@ -61,8 +61,8 @@ describe('openMarkdownLink security rules', () => {
 
     await handler({ type: 'openMarkdownLink', href: 'https://example.com' } as any);
 
-    expect((vscode as any).env.openExternal).toHaveBeenCalledTimes(1);
-    const uriArg = ((vscode as any).env.openExternal as any).mock.calls[0][0] as vscode.Uri;
+    expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+    const uriArg = (vscode.env.openExternal as any).mock.calls[0][0] as vscode.Uri;
     expect(uriArg.scheme).toBe('https');
     expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
   });
@@ -72,8 +72,8 @@ describe('openMarkdownLink security rules', () => {
 
     await handler({ type: 'openMarkdownLink', href: 'mailto:test@example.com' } as any);
 
-    expect((vscode as any).env.openExternal).toHaveBeenCalledTimes(1);
-    const uriArg = ((vscode as any).env.openExternal as any).mock.calls[0][0] as vscode.Uri;
+    expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+    const uriArg = (vscode.env.openExternal as any).mock.calls[0][0] as vscode.Uri;
     expect(uriArg.scheme).toBe('mailto');
     expect((vscode.workspace as any).openTextDocument).not.toHaveBeenCalled();
     expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
@@ -84,7 +84,7 @@ describe('openMarkdownLink security rules', () => {
 
     await handler({ type: 'openMarkdownLink', href: 'javascript:alert(1)' } as any);
 
-    expect((vscode as any).env.openExternal).not.toHaveBeenCalled();
+    expect(vscode.env.openExternal).not.toHaveBeenCalled();
     expect(vscode.window.showErrorMessage).toHaveBeenCalled();
   });
 
@@ -93,7 +93,7 @@ describe('openMarkdownLink security rules', () => {
 
     await handler({ type: 'openMarkdownLink', href: 'file:///etc/passwd' } as any);
 
-    expect((vscode as any).env.openExternal).not.toHaveBeenCalled();
+    expect(vscode.env.openExternal).not.toHaveBeenCalled();
     expect(vscode.window.showErrorMessage).toHaveBeenCalled();
   });
 
@@ -113,7 +113,7 @@ describe('openMarkdownLink security rules', () => {
 
     await handler({ type: 'openMarkdownLink', href: '../secrets.txt' } as any);
 
-    expect((vscode as any).env.openExternal).not.toHaveBeenCalled();
+    expect(vscode.env.openExternal).not.toHaveBeenCalled();
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith('Blocked unsafe link.');
     expect((vscode.workspace as any).openTextDocument).not.toHaveBeenCalled();
   });

--- a/src/auth/__tests__/deviceFlow.test.ts
+++ b/src/auth/__tests__/deviceFlow.test.ts
@@ -73,6 +73,7 @@ describe('device flow client', () => {
         expect(url).toBe('https://example.com/oauth/device/token');
         expect(init.headers?.['content-type']).toBe('application/x-www-form-urlencoded');
         expect(init.body).toContain('device_code=dev');
+        expect(init.body).toContain('grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code');
         return jsonResponse(400, { error: 'authorization_pending' });
       },
       () => jsonResponse(200, { access_token: 'tok', token_type: 'bearer', expires_in: 123 }),

--- a/src/auth/deviceFlow.ts
+++ b/src/auth/deviceFlow.ts
@@ -187,6 +187,7 @@ export async function pollDeviceToken(options: {
 
   const body = new URLSearchParams({
     device_code: deviceCode,
+    grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
   }).toString();
 
   while (true) {

--- a/src/auth/serverSessionApiKeys.ts
+++ b/src/auth/serverSessionApiKeys.ts
@@ -1,0 +1,21 @@
+import { createHash } from 'crypto';
+import { normalizeServerUrl } from '../shared/serverUrls';
+
+export const LEGACY_SESSION_API_KEY_SECRET_KEY = 'openhands.sessionApiKey';
+
+export type ServerSessionApiKeySecretKeyResult =
+  | { ok: true; normalizedServerUrl: string; secretKey: string }
+  | { ok: false; error: string };
+
+export function getServerSessionApiKeySecretKey(serverUrl: string): ServerSessionApiKeySecretKeyResult {
+  const normalized = normalizeServerUrl(serverUrl);
+  if (!normalized.ok) return { ok: false, error: normalized.error };
+
+  const hash = createHash('sha256').update(normalized.url).digest('hex');
+  return {
+    ok: true,
+    normalizedServerUrl: normalized.url,
+    secretKey: `${LEGACY_SESSION_API_KEY_SECRET_KEY}.server.${hash}`,
+  };
+}
+

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,8 @@ import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
+import { getServerSessionApiKeySecretKey } from './auth/serverSessionApiKeys';
+import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
 import {
   createOutputLogger,
   normalizeOutputVerbosity,
@@ -75,6 +77,7 @@ let lastKnownLlmLabel: string | null = null;
 let verboseEventLogging = false;
 let localAgentContext: AgentContext | undefined;
 let activeEditorFilePath: string | undefined;
+let lastRemoteAuthPromptAtMs = 0;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -521,6 +524,25 @@ export function activate(context: vscode.ExtensionContext) {
     let settings = await settingsMgr.get();
     lastKnownLlmLabel = resolveConfiguredLlmLabel(settings);
 
+    if (typeof settings.serverUrl === 'string' && settings.serverUrl.trim()) {
+      const serverKey = getServerSessionApiKeySecretKey(settings.serverUrl);
+      if (serverKey.ok) {
+        let stored: string | undefined;
+        try {
+          stored = await context.secrets.get(serverKey.secretKey);
+        } catch {
+          stored = undefined;
+        }
+        const token = typeof stored === 'string' ? stored.trim() : '';
+        if (token) {
+          settings = {
+            ...settings,
+            secrets: { ...settings.secrets, sessionApiKey: token },
+          };
+        }
+      }
+    }
+
     const cfg = vscode.workspace.getConfiguration();
     outputVerbosity = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
     verboseEventLogging =
@@ -685,6 +707,30 @@ export function activate(context: vscode.ExtensionContext) {
         handleTerminalEvent,
       });
 
+      conversation.on('error', (err: unknown) => {
+        void (async () => {
+          if (conversationMode !== 'remote') return;
+
+          const message = err instanceof Error ? err.message : String(err);
+          const isAuthFailure = /\(HTTP (401|403)\)/.test(message) && message.toLowerCase().includes('authentication failed');
+          if (!isAuthFailure) return;
+
+          const now = Date.now();
+          // Avoid spamming the user if the server keeps rejecting auth (e.g. wrong key or user cancels login).
+          if (now - lastRemoteAuthPromptAtMs < 60_000) return;
+          lastRemoteAuthPromptAtMs = now;
+
+          const action = await vscode.window.showWarningMessage(
+            'OpenHands: Authentication failed connecting to the selected server. Login now?',
+            'Login',
+            'Dismiss',
+          );
+          if (action !== 'Login') return;
+
+          await vscode.commands.executeCommand('openhands.cloudLogin');
+        })();
+      });
+
       if (savedId && conversation) {
         try {
           const maybe = conversation.restoreConversation(savedId);
@@ -736,6 +782,11 @@ export function activate(context: vscode.ExtensionContext) {
   const explainSelection = registerExplainSelectionCommand({
     getConversation: () => conversation,
     getConversationMode: () => conversationMode,
+  });
+
+  const cloudLogin = registerCloudLoginCommand({
+    context,
+    getOutputChannel: () => outputChannel,
   });
 
   const diagnosticsCommands = registerDiagnosticsCommands({
@@ -890,6 +941,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     open,
     explainSelection,
+    cloudLogin,
     ...diagnosticsCommands,
     ...halCommands,
     startNew,
@@ -928,6 +980,7 @@ export function deactivate() {
   chatLastConversationId = undefined;
   chatLastSeenSeq = undefined;
   conversationStoreRoot = undefined;
+  lastRemoteAuthPromptAtMs = 0;
   resetConversationEventBacklog(undefined);
   receivedTerminalEvents.length = 0;
   sentTestEvents.length = 0;

--- a/src/extension/cloudLoginCommand.ts
+++ b/src/extension/cloudLoginCommand.ts
@@ -1,0 +1,160 @@
+import * as vscode from 'vscode';
+import { SettingsManager } from '../settings/SettingsManager';
+import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
+import { startDeviceAuthorization, pollDeviceToken, type HttpClientLike } from '../auth/deviceFlow';
+import {
+  getServerSessionApiKeySecretKey,
+  LEGACY_SESSION_API_KEY_SECRET_KEY,
+} from '../auth/serverSessionApiKeys';
+
+type Output = Pick<vscode.OutputChannel, 'appendLine'>;
+
+function renderServerLabel(serverUrl: string): string {
+  try {
+    const url = new URL(serverUrl);
+    return url.hostname + (url.port ? `:${url.port}` : '');
+  } catch {
+    return serverUrl;
+  }
+}
+
+function trimOrEmpty(value: string | undefined): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function registerCloudLoginCommand(options: {
+  context: vscode.ExtensionContext;
+  getOutputChannel: () => Output | undefined;
+  onLoginCompleted?: (params: { normalizedServerUrl: string }) => void;
+}): vscode.Disposable {
+  const { context } = options;
+
+  return vscode.commands.registerCommand('openhands.cloudLogin', async () => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const settings = await settingsMgr.get();
+
+    const currentServerUrl = typeof settings.serverUrl === 'string' ? settings.serverUrl.trim() : '';
+    if (!currentServerUrl) {
+      void vscode.window.showErrorMessage('OpenHands: Select a remote server before logging in.');
+      return;
+    }
+
+    const keyInfo = getServerSessionApiKeySecretKey(currentServerUrl);
+    if (!keyInfo.ok) {
+      void vscode.window.showErrorMessage(`OpenHands: Invalid server URL: ${keyInfo.error}`);
+      return;
+    }
+
+    const output = options.getOutputChannel();
+    const serverLabel = renderServerLabel(keyInfo.normalizedServerUrl);
+
+    const controller = new AbortController();
+
+    let token: string;
+    try {
+      token = await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          cancellable: true,
+          title: `OpenHands: Login to ${serverLabel}`,
+        },
+        async (progress, cancelToken) => {
+          cancelToken.onCancellationRequested(() => controller.abort());
+
+          const http: HttpClientLike = async (url, init) =>
+            fetch(url, {
+              method: init.method,
+              headers: init.headers,
+              body: init.body,
+              signal: init.signal as unknown as AbortSignal | undefined,
+            });
+
+          progress.report({ message: 'Requesting device code…' });
+          const auth = await startDeviceAuthorization({
+            baseUrl: keyInfo.normalizedServerUrl,
+            http,
+            signal: controller.signal,
+          });
+
+          progress.report({ message: 'Open browser to enter code…' });
+          const opened = await vscode.env.openExternal(vscode.Uri.parse(auth.verificationUriComplete));
+          if (!opened) {
+            void vscode.window.showInformationMessage(
+              `OpenHands: Open this URL to login: ${auth.verificationUriComplete} (code: ${auth.userCode})`,
+            );
+          } else {
+            const action = await vscode.window.showInformationMessage(
+              `OpenHands: Enter code ${auth.userCode} to login to ${serverLabel}.`,
+              'Copy code',
+              'Copy URL',
+            );
+            if (action === 'Copy code') {
+              await vscode.env.clipboard.writeText(auth.userCode);
+            } else if (action === 'Copy URL') {
+              await vscode.env.clipboard.writeText(auth.verificationUriComplete);
+            }
+          }
+
+          progress.report({ message: 'Waiting for authorization…' });
+          const deviceToken = await pollDeviceToken({
+            baseUrl: keyInfo.normalizedServerUrl,
+            http,
+            deviceCode: auth.deviceCode,
+            pollIntervalMs: auth.intervalMs,
+            signal: controller.signal,
+          });
+
+          return deviceToken.accessToken;
+        }
+      );
+    } catch (err) {
+      const name = err instanceof Error ? err.name : '';
+      const message = err instanceof Error ? err.message : String(err);
+      if (name === 'DeviceFlowCancelledError' || name === 'AbortError') {
+        void vscode.window.showInformationMessage('OpenHands: Login canceled.');
+        return;
+      }
+      output?.appendLine(`[auth] Login failed: ${message}`);
+      void vscode.window.showErrorMessage(`OpenHands: Login failed: ${message}`);
+      return;
+    }
+
+    const trimmedToken = token.trim();
+    if (!trimmedToken) {
+      void vscode.window.showErrorMessage('OpenHands: Login succeeded but returned an empty token.');
+      return;
+    }
+
+    await context.secrets.store(keyInfo.secretKey, trimmedToken);
+
+    let legacyRaw: string | undefined;
+    try {
+      legacyRaw = await context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
+    } catch {
+      legacyRaw = undefined;
+    }
+    const legacyValue = trimOrEmpty(legacyRaw);
+    const canUpdateLegacy = !legacyValue || legacyValue === trimmedToken;
+    if (canUpdateLegacy) {
+      await context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmedToken);
+    }
+
+    output?.appendLine(`[auth] Stored session API key for ${keyInfo.normalizedServerUrl}.`);
+    if (!canUpdateLegacy && legacyValue) {
+      output?.appendLine('[auth] Legacy openhands.sessionApiKey was not overwritten (different value already set).');
+    }
+
+    options.onLoginCompleted?.({ normalizedServerUrl: keyInfo.normalizedServerUrl });
+
+    const next = await vscode.window.showInformationMessage(
+      `OpenHands: Logged in to ${serverLabel}.`,
+      'Reconnect',
+      'Start new conversation',
+    );
+    if (next === 'Reconnect') {
+      await vscode.commands.executeCommand('openhands.reconnect');
+    } else if (next === 'Start new conversation') {
+      await vscode.commands.executeCommand('openhands.startNewConversation');
+    }
+  });
+}

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -663,6 +663,11 @@ export function App() {
     postMessage({ type: 'switchToLocal' });
   }, [postMessage]);
 
+  const handleLoginToServer = useCallback(() => {
+    postMessage({ type: 'command', command: 'cloudAuthLogin' });
+    showStatusMessage('info', 'Starting login…');
+  }, [postMessage, showStatusMessage]);
+
   const handleSelectLlmProfileId = useCallback((profileId: string) => {
     setLlmProfileId(profileId);
     postMessage({ type: 'setLlmProfileId', profileId });
@@ -704,6 +709,7 @@ export function App() {
         onNewConversation={handleStartNewConversation}
         onOpenHistory={handleOpenHistory}
         onOpenSettings={handleOpenSettings}
+        onLoginToServer={handleLoginToServer}
         onReconnect={handleReconnect}
         onSelectServer={handleSelectServer}
         onAddServer={handleAddServer}

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -16,6 +16,7 @@ interface HeaderProps {
   onNewConversation: () => void;
   onOpenHistory: () => void;
   onOpenSettings: () => void;
+  onLoginToServer: () => void;
   onReconnect: () => void;
   onSelectServer: (url: string) => void;
   onAddServer: (server: SavedServer) => void;
@@ -118,6 +119,7 @@ export function Header({
   onNewConversation,
   onOpenHistory,
   onOpenSettings,
+  onLoginToServer,
   onReconnect,
   onSelectServer,
   onAddServer,
@@ -208,6 +210,10 @@ export function Header({
           <IconButton icon="add" label="Start new conversation" onClick={onNewConversation} />
 
           <div className="w-px h-6 bg-white/[0.08]" />
+
+          {mode === 'remote' && Boolean(currentServerUrl?.trim()) && (
+            <IconButton icon="key" label="Login to server" onClick={onLoginToServer} />
+          )}
 
           <IconButton
             icon="history"

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -1353,6 +1353,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       }
       case 'command': {
         switch (message.command) {
+          case 'cloudAuthLogin':
+            await vscode.commands.executeCommand('openhands.cloudLogin');
+            break;
           case 'reconnect':
             // Use the VS Code command so we re-evaluate settings (local ↔ remote) before reconnecting.
             await vscode.commands.executeCommand('openhands.reconnect');

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -68,6 +68,11 @@ export const window = {
   showInformationMessage: vi.fn(),
   showErrorMessage: vi.fn(),
   showWarningMessage: vi.fn(),
+  withProgress: vi.fn(async (_options: any, task: any) => {
+    const progress = { report: vi.fn() };
+    const token = { onCancellationRequested: vi.fn(), isCancellationRequested: false };
+    return await task(progress, token);
+  }),
   createOutputChannel: vi.fn((name: string) => {
     const channel = {
       name,
@@ -125,6 +130,17 @@ export const Uri = {
     fsPath: args.join('/'),
   })),
 };
+
+export const env = {
+  openExternal: vi.fn(async () => true),
+  clipboard: {
+    writeText: vi.fn(async () => undefined),
+  },
+};
+
+export const ProgressLocation = {
+  Notification: 15,
+} as const;
 
 // ViewColumn used by extension.openTab
 export const ViewColumn = {


### PR DESCRIPTION
Implements Bead `oh-tab-voc.3`.

- Adds `openhands.cloudLogin` command (palette + webview button) to run OAuth 2.0 Device Flow (cancellable progress, opens browser, copy code/URL).
- Stores tokens per normalized server URL in SecretStorage (hashed key) and does **not** clobber legacy `openhands.sessionApiKey` if it differs.
- Remote mode prefers the per-server token when present.
- Sends both `X-Session-API-Key` and `Authorization: Bearer …` for remote HTTP calls (plus WS handshake headers).
- Prompts to login on remote 401/403 auth failures (rate-limited).

Tests:
- `npm test`

### Bead

```text

oh-tab-voc.3: Implement OAuth 2.0 Device Flow for oh-tab
Status: open
Priority: P1
Type: task
Created: 2026-01-15 06:10
Updated: 2026-01-15 13:20

Description:
## Goal

Wire up OAuth 2.0 Device Authorization Grant (Device Flow) to actually authenticate **remote mode** against OpenHands Cloud (e.g. `app.all-hands.dev`) and persist the resulting **session API key** in VS Code SecretStorage.

## Current state (already exists in repo)

- Pure device-flow client + tests exist:
  - `src/auth/deviceFlow.ts` (`startDeviceAuthorization`, `pollDeviceToken`)
  - `src/auth/__tests__/deviceFlow.test.ts`
- Supporting helpers exist:
  - `src/auth/httpClient.ts` + tests
  - `src/auth/tokenStorage.ts` + tests
- Design notes exist: `docs/cloud_oauth_device_flow.md` (Bead `oh-tab-voc.1`).

## Remaining work (this bead)

1. **Extension-host orchestration**
   - Add a command (palette + UI hook) to trigger login for the currently-selected remote server.
   - Use VS Code UX: `vscode.env.openExternal()` + cancellable `withProgress()` while polling.

2. **Token storage (per server, no silent clobber)**
   - Store token per normalized server URL (see `docs/cloud_oauth_device_flow.md`), falling back to legacy `openhands.sessionApiKey`.

3. **Remote auth header compatibility**
   - Confirm/implement sending `Authorization: Bearer <token>` in addition to `X-Session-API-Key` for cloud endpoints if needed.

4. **Integration points**
   - Handle a 401/403 from remote connect by prompting user to login (no infinite loops).
   - Keep token values out of OutputChannel/webview messages.

Acceptance Criteria:
- Login command exists and completes device flow (happy path) and stores token in SecretStorage.
- Polling is cancellable and respects `interval` / `slow_down` backoff.
- Per-server token storage is implemented (normalized URL keying) and does not silently clobber `openhands.sessionApiKey` if it differs.
- Remote mode includes the stored token when connecting; 401/403 results in a user-facing login prompt.
- Unit tests cover orchestration + storage edge cases.
- Follow-up E2E is tracked separately (see `oh-tab-voc.4.1`).

Labels: [auth implementation teleport typescript]

Depends on (3):
  → oh-tab-voc: HAL teleport auth: OAuth 2.0 Device Flow for cloud servers [P1]
  → oh-tab-voc.2: Device-flow auth: test plan doc + URL helper unit tests [P1]
  → oh-tab-voc.5: Device-flow auth: port OpenHands-CLI auth tests to TypeScript (full suite) [P1]

Blocks (2):
  ← oh-tab-voc.4: E2E integration testing with OpenHands Cloud [P1]
  ← oh-tab-voc.4.1: E2E: mock OAuth device-flow server + hermetic CI test [P2]

```

### Review

- Reviewer: OrangeCastle (detached-worktree review).
- Verdict: LGTM to merge.
- Validation: `npx vitest run src/auth/__tests__/deviceFlow.test.ts src/__tests__/extension.test.ts packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts` ✅
- Notes: reviewer flagged `cloudAuthLogin` handling during merge; PR is currently clean/mergeable vs `develop`.
