### PR TITLE
oh-tab-e2e-diag: add waitForDiagnostics helper

### DIFF
--- a/tests/e2e/suite/helpers/diagnosticsInfo.ts
+++ b/tests/e2e/suite/helpers/diagnosticsInfo.ts
@@ -1,0 +1,28 @@
+export type DiagnosticsInfo = {
+  chat?: {
+    hasView?: boolean;
+    visible?: boolean;
+    webviewReady?: boolean;
+    clientConversationId?: string;
+    clientLastSeenSeq?: number;
+  };
+  eventBacklog?: {
+    activeConversationId?: string;
+    size?: number;
+    latestSeq?: number;
+  };
+  terminal?: {
+    hasTerminal?: boolean;
+    received?: number;
+    ptyOpened?: boolean;
+    preopenBufferedChars?: number;
+    preopenDroppedChars?: number;
+  };
+  hasConversation?: boolean;
+  conversationId?: string;
+  status?: string;
+  mode?: 'local' | 'remote';
+  serverUrl?: string;
+  servers?: Array<{ url: string; label?: string }>;
+};
+

--- a/tests/e2e/suite/helpers/waitForDiagnostics.ts
+++ b/tests/e2e/suite/helpers/waitForDiagnostics.ts
@@ -1,0 +1,34 @@
+import * as vscode from 'vscode';
+import type { DiagnosticsInfo } from './diagnosticsInfo';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function getDiagnostics(): Promise<DiagnosticsInfo> {
+  return await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+}
+
+export async function waitForDiagnostics(options: {
+  predicate: (diag: DiagnosticsInfo) => boolean;
+  timeoutMs?: number;
+  intervalMs?: number;
+  label?: string;
+}): Promise<DiagnosticsInfo> {
+  const { predicate, timeoutMs = 10000, intervalMs = 200, label } = options;
+  const deadline = Date.now() + timeoutMs;
+
+  let lastDiag: DiagnosticsInfo | undefined;
+  while (Date.now() < deadline) {
+    lastDiag = await getDiagnostics();
+    if (predicate(lastDiag)) return lastDiag;
+    await sleep(intervalMs);
+  }
+
+  const lastError = await vscode.commands.executeCommand('openhands._queryLastError').catch(() => undefined);
+  const labelSuffix = label ? ` (${label})` : '';
+  throw new Error(
+    `Timed out waiting for diagnostics${labelSuffix} after ${timeoutMs}ms.\n` +
+    `- diag: ${JSON.stringify(lastDiag)}\n` +
+    `- lastError: ${JSON.stringify(lastError)}`
+  );
+}
+

--- a/tests/e2e/suite/helpers/waitForDiagnostics.ts
+++ b/tests/e2e/suite/helpers/waitForDiagnostics.ts
@@ -4,7 +4,8 @@ import type { DiagnosticsInfo } from './diagnosticsInfo';
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export async function getDiagnostics(): Promise<DiagnosticsInfo> {
-  return await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  return diag ?? {};
 }
 
 export async function waitForDiagnostics(options: {

--- a/tests/e2e/suite/helpers/waitForDiagnostics.ts
+++ b/tests/e2e/suite/helpers/waitForDiagnostics.ts
@@ -23,7 +23,12 @@ export async function waitForDiagnostics(options: {
     await sleep(intervalMs);
   }
 
-  const lastError = await vscode.commands.executeCommand('openhands._queryLastError').catch(() => undefined);
+  let lastError: unknown;
+  try {
+    lastError = await vscode.commands.executeCommand('openhands._queryLastError');
+  } catch {
+    lastError = undefined;
+  }
   const labelSuffix = label ? ` (${label})` : '';
   throw new Error(
     `Timed out waiting for diagnostics${labelSuffix} after ${timeoutMs}ms.\n` +
@@ -31,4 +36,3 @@ export async function waitForDiagnostics(options: {
     `- lastError: ${JSON.stringify(lastError)}`
   );
 }
-

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { waitForDiagnostics } from './helpers/waitForDiagnostics';
 
 export async function run(): Promise<void> {
   // Route to specific test suite based on TEST_NAME environment variable
@@ -117,11 +118,10 @@ export async function run(): Promise<void> {
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness
-  const deadline = Date.now() + 15000;
-  while (Date.now() < deadline) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
-    await new Promise((r) => setTimeout(r, 200));
-  }
+  await waitForDiagnostics({
+    label: 'chat view ready',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.chat?.hasView && diag.chat?.webviewReady),
+  });
   await vscode.commands.executeCommand('openhands.reconnect');
 }

--- a/tests/e2e/suite/terminalLog.ts
+++ b/tests/e2e/suite/terminalLog.ts
@@ -1,14 +1,16 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import type { BashEvent } from '@openhands/agent-sdk-ts';
+import { getDiagnostics, waitForDiagnostics } from './helpers/waitForDiagnostics';
 
 export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
-  await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
-  }, 15000);
+  await waitForDiagnostics({
+    label: 'chat view ready',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.chat?.hasView && diag.chat?.webviewReady),
+  });
 
   // Force local mode to ensure terminal log is available
   const cfg = vscode.workspace.getConfiguration();
@@ -46,29 +48,33 @@ export async function run(): Promise<void> {
   const exit: BashEvent = { ...nextBase(), type: 'BashExit', exit_code: 0 };
   await vscode.commands.executeCommand('openhands._injectTerminalEvent', exit);
 
-  await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return Boolean(diag?.terminal?.hasTerminal);
-  }, 15000);
+  await waitForDiagnostics({
+    label: 'terminal exists',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.terminal?.hasTerminal),
+  });
 
   // Verify diagnostics reflect terminal received events and that output is buffered until the terminal is opened.
-  const diagBeforeOpen: any = await vscode.commands.executeCommand('openhands._diagnostics');
-  if (typeof diagBeforeOpen?.terminal?.received !== 'number' || diagBeforeOpen.terminal.received < 3) {
-    throw new Error(`Expected some terminal events, got: ${JSON.stringify(diagBeforeOpen?.terminal)}`);
+  const diagBeforeOpen = await getDiagnostics();
+  const received = diagBeforeOpen.terminal?.received;
+  if (typeof received !== 'number' || received < 3) {
+    throw new Error(`Expected some terminal events, got: ${JSON.stringify(diagBeforeOpen.terminal)}`);
   }
-  if (diagBeforeOpen?.terminal?.ptyOpened !== false) {
-    throw new Error(`Expected terminal PTY to be unopened before showing it, got: ${JSON.stringify(diagBeforeOpen?.terminal)}`);
+  if (diagBeforeOpen.terminal?.ptyOpened !== false) {
+    throw new Error(`Expected terminal PTY to be unopened before showing it, got: ${JSON.stringify(diagBeforeOpen.terminal)}`);
   }
-  if (typeof diagBeforeOpen?.terminal?.preopenBufferedChars !== 'number' || diagBeforeOpen.terminal.preopenBufferedChars <= 0) {
-    throw new Error(`Expected some pre-open buffered output, got: ${JSON.stringify(diagBeforeOpen?.terminal)}`);
+  const buffered = diagBeforeOpen.terminal?.preopenBufferedChars;
+  if (typeof buffered !== 'number' || buffered <= 0) {
+    throw new Error(`Expected some pre-open buffered output, got: ${JSON.stringify(diagBeforeOpen.terminal)}`);
   }
 
   const terminal = vscode.window.terminals.find((t) => t.name === 'OpenHands');
   if (!terminal) throw new Error('Expected OpenHands terminal to exist');
   terminal.show(false);
 
-  await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.terminal?.ptyOpened === true && diag?.terminal?.preopenBufferedChars === 0;
-  }, 15000);
+  await waitForDiagnostics({
+    label: 'terminal pty opened + flushed',
+    timeoutMs: 15000,
+    predicate: (diag) => diag.terminal?.ptyOpened === true && diag.terminal?.preopenBufferedChars === 0,
+  });
 }

--- a/tests/e2e/suite/welcome.ts
+++ b/tests/e2e/suite/welcome.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import { waitForDiagnostics } from './helpers/waitForDiagnostics';
 
 type UiStateSnapshot = {
   showWelcomeProviderKeyMessage?: boolean;
@@ -35,10 +36,11 @@ async function setProviderKey(provider: string, apiKey: string): Promise<void> {
 export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
-  await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
-  }, 15000);
+  await waitForDiagnostics({
+    label: 'chat view ready',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.chat?.hasView && diag.chat?.webviewReady),
+  });
 
   await vscode.commands.executeCommand('openhands.startNewConversation');
 
@@ -69,4 +71,3 @@ export async function run(): Promise<void> {
     throw new Error(`Expected provider-only keys but got: ${JSON.stringify(openaiOnly)}`);
   }
 }
-


### PR DESCRIPTION
Implements Bead `oh-tab-e2e-diag`.

- Adds `tests/e2e/suite/helpers/diagnosticsInfo.ts` (typed `DiagnosticsInfo`).
- Adds `tests/e2e/suite/helpers/waitForDiagnostics.ts` with `waitForDiagnostics({ predicate, timeoutMs })` and better timeout diagnostics.
- Refactors `tests/e2e/suite/index.ts`, `tests/e2e/suite/welcome.ts`, and `tests/e2e/suite/terminalLog.ts` to use the helper (removes `any` for diagnostics polling).

Local:
- `npm run lint` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced end-to-end test diagnostics infrastructure with improved polling utilities for better reliability and error reporting during test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Bead

```text

oh-tab-e2e-diag: E2E: helper waitForDiagnostics + typed DiagnosticsInfo
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 10:21
Updated: 2026-01-15 10:21

Description:
Many E2E suites duplicate ad-hoc polling loops around the openhands._diagnostics command and use any for the diagnostics payload. This increases flakiness and makes it easy to accidentally wait for the wrong condition (e.g. chat view readiness, active editor readiness).

Acceptance Criteria:
- Add tests/e2e/suite/helpers/waitForDiagnostics.ts (or similar) that polls openhands._diagnostics with a predicate + timeout
- Expose/centralize a DiagnosticsInfo type for E2E suites to consume
- Refactor at least tests/e2e/suite/index.ts plus 2+ suites to use the helper and remove any
- Keep behavior identical; reduce flake risk

```

### Review

- Reviewer: OrangeCastle (detached-worktree review + re-review after changes).
- Verdict: LGTM to merge.
- Validation: CI green; reviewer re-reviewed after commit `3d0ac6e`.
- Notes: `getDiagnostics()` now returns `diag ?? {}` to avoid E2E flake/crash on undefined.
