### PR TITLE
Split webview host message handler into modules (oh-tab-mmk)

### DIFF
--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -1,149 +1,29 @@
 import * as vscode from 'vscode';
-import * as fs from 'fs/promises';
-import * as path from 'path';
-import * as os from 'os';
-import * as childProcess from 'child_process';
-import { assertValidProfileId, DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMProfileValidationError, type LLMProvider, type SecretRegistry } from '@openhands/agent-sdk-ts';
+import type { SecretRegistry } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
-import { ElevenLabsTtsService } from '../../hal/elevenlabs/ttsService';
-import { TtsConversationGate } from '../../hal/elevenlabs/ttsConversationGate';
-import { classifyHalVoiceDecision } from '../../hal/gemini/decisionClassifier';
-import { getHalDialogueLinesForMode } from '../../shared/halScript';
-import { DEFAULT_HAL_LLM_PROFILE_ID } from '../../shared/halDefaults';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
-import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../shared/pastedImages';
-import { MAX_PASTED_IMAGE_BYTES } from '../../shared/pasteLimits';
-import { normalizeServerUrl } from '../../shared/serverUrls';
-import { STATUS_MESSAGE_DISMISS_DELAY_MS, type HostToWebviewMessage, type WebviewToHostMessage } from '../../shared/webviewMessages';
-import { buildAttachmentBlocks, safeParseUri, toAttachmentLabel } from './attachments';
+
+import type { HostToWebviewMessage, WebviewToHostMessage } from '../../shared/webviewMessages';
 // Environment info is provided via AgentContext.userMessageSuffix (extension host).
-import { getEffectiveWorkspaceRoot, resolvePreferredWorkspaceFolderUri } from '../../shared/workspaceRoot';
-import { getConversationHistoryList, persistConversationTitle } from './conversationHistory';
-import { showWorkspaceDiff } from './diffDocuments';
-import { resolveGitHeadDiffContents } from './gitHeadDiff';
-import * as llmProfilesStore from './llmProfilesStore';
+
 import { listSkillFiles } from './skills';
 import { listWorkspaceFiles } from './workspaceFiles';
-import { resolveWorkspaceFilePath } from './workspacePaths';
-import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools, type LocalToolId } from '../../shared/localTools';
-import { summarizeWithLocalLlm } from '../../extension/summarizeWithLocalLlm';
+import { getDefaultLocalToolIds, resolveLocalTools } from '../../shared/localTools';
+import { handleWebviewConsole, handleWebviewError, handleWebviewNetwork, handleWebviewWebSocket } from './handlers/devBridge';
+import { handleHalStateResponse, handleRenderedEventsResponse, handleUiStateResponse } from './handlers/stateResponses';
+import { handleOpenMarkdownLink, handleOpenSkill, handleOpenWorkspaceDiff, handleOpenWorkspaceFile } from './handlers/openers';
+import { handleOpenAttachment, handleSelectAttachments } from './handlers/attachments';
+import { createPostToolsList, handleSetEnabledTools, isLocalConversationToolControls } from './handlers/tools';
+import { handleDeleteConversation, handleRequestHistory, handleRestoreConversation } from './handlers/history';
+import { handleAddServer, handleRemoveServer, handleSelectServer, handleSwitchToLocal } from './handlers/servers';
+import { handleSend } from './handlers/send';
+import { computeWelcomeSecretStatus, handleLlmProfileApiKeySetRequest, handleLlmProfileApiKeyStatusRequest, handleLlmProfileDeleteRequest, handleLlmProfileLoadRequest, handleLlmProfileSaveRequest, handleLlmProfilesListRequest, handleSetLlmProfileId, listAvailableLlmProfiles } from './handlers/llmProfiles';
+import { createElevenlabsTtsGateFactory, handleHalTtsRequest, handleHalVoiceConfirmRequest } from './handlers/hal';
 
 export type WebviewHost = {
   postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
 };
-
-type LocalConversationToolControls = {
-  mode: 'local';
-  getToolNames: () => string[];
-  setTools: (tools: unknown[]) => void;
-};
-
-const isLocalConversationToolControls = (value: unknown): value is LocalConversationToolControls => {
-  if (!value || typeof value !== 'object') return false;
-  const candidate = value as Partial<LocalConversationToolControls> & { [k: string]: unknown };
-  return candidate.mode === 'local'
-    && typeof candidate.getToolNames === 'function'
-    && typeof candidate.setTools === 'function';
-};
-
-function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    childProcess.execFile(command, args, { cwd }, (err, stdout, stderr) => {
-      if (err) {
-        const message = typeof stderr === 'string' && stderr.trim().length > 0 ? stderr.trim() : err.message;
-        reject(new Error(message));
-        return;
-      }
-      resolve(typeof stdout === 'string' ? stdout : String(stdout));
-    });
-  });
-}
-
-function normalizeGeneratedConversationTitle(raw: string): string | undefined {
-  const firstLine = raw
-    .split('\n')
-    .map((line) => line.trim())
-    .find((line) => line.length > 0);
-  if (!firstLine) return undefined;
-
-  const unquoted = firstLine.replace(/^["'`]+/, '').replace(/["'`]+$/, '').trim();
-  if (!unquoted) return undefined;
-
-  const strippedPrefix = unquoted.replace(/^title\\s*:\\s*/i, '').trim();
-  if (!strippedPrefix) return undefined;
-
-  const words = strippedPrefix.split(/\\s+/).filter(Boolean);
-  if (words.length === 0) return undefined;
-  return words.slice(0, 7).join(' ');
-}
-
-async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
-  const filePath = getPastedImagePath(baseDir, imageId);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, bytes);
-}
-
-const ensureRequiredLocalToolIds = (toolIds: LocalToolId[]): LocalToolId[] => {
-  // `finish` is always enabled by the runtime agent (for safe termination).
-  // Keep the UI/tool-selection source of truth consistent with what is actually sent to the LLM.
-  if (toolIds.includes('finish')) return toolIds;
-  return [...toolIds, 'finish'];
-};
-
-type RemoteToolListDeps = {
-  serverUrl: string;
-  sessionApiKey?: string;
-};
-
-const getRemoteToolListDeps = (conversation: unknown): RemoteToolListDeps | null => {
-  if (!conversation || typeof conversation !== 'object') return null;
-  const candidate = conversation as { [k: string]: unknown };
-  const serverUrl = candidate.serverUrl;
-  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) return null;
-
-  const rawSessionKey =
-    (candidate.settings as { secrets?: { sessionApiKey?: unknown } } | undefined)?.secrets?.sessionApiKey;
-  const sessionApiKey = typeof rawSessionKey === 'string' && rawSessionKey.trim().length > 0 ? rawSessionKey : undefined;
-  return { serverUrl: serverUrl.trim(), sessionApiKey };
-};
-
-async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[] | null> {
-  const normalized = normalizeServerUrl(params.serverUrl);
-  if (!normalized.ok) return null;
-  const url = `${normalized.url}/api/tools/`;
-  const headers: Record<string, string> = {};
-  if (params.sessionApiKey) {
-    headers['X-Session-API-Key'] = params.sessionApiKey;
-  }
-
-  const fetchFn = globalThis.fetch;
-  if (typeof fetchFn !== 'function') return null;
-
-  const abortController = new AbortController();
-  const timeoutMs = 4000;
-  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
-
-  try {
-    const res = await fetchFn(url, { method: 'GET', headers, signal: abortController.signal });
-    if (!res.ok) return null;
-    const payload = await res.json();
-    if (!Array.isArray(payload)) return null;
-
-    const out: string[] = [];
-    for (const tool of payload) {
-      if (typeof tool !== 'string') continue;
-      const trimmed = tool.trim();
-      if (!trimmed) continue;
-      out.push(trimmed);
-    }
-    return out;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timeout);
-  }
-}
 
 export type CreateWebviewMessageHandlerDeps = {
   context: vscode.ExtensionContext;
@@ -219,33 +99,10 @@ export type CreateWebviewMessageHandlerDeps = {
 export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDeps) {
   const { context, host } = deps;
   const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-  const elevenlabsCacheMaxBytes = 50 * 1024 * 1024;
-  let elevenlabsTtsGate: TtsConversationGate | null = null;
+  const getElevenlabsTtsGate = createElevenlabsTtsGateFactory({ context, maxCacheBytes: 50 * 1024 * 1024 });
   const historyTitleGenerationInFlight = new Set<string>();
 
-  const postToolsList = async (): Promise<void> => {
-    const mode = deps.getConversationMode();
-    if (mode !== 'local') {
-      const conversation = deps.getConversation();
-      const remoteDeps = getRemoteToolListDeps(conversation);
-      const toolNames = remoteDeps ? await fetchRemoteToolNames(remoteDeps) : null;
-      const tools = (toolNames ?? []).map((name) => ({ id: name, label: name }));
-      void host.postMessage({ type: 'toolsList', tools, enabledToolIds: toolNames ?? [] });
-      return;
-    }
-
-    const tools = listLocalToolDescriptors();
-    const conversation = deps.getConversation();
-    const enabledToolIds = (() => {
-      if (isLocalConversationToolControls(conversation)) {
-        const ids = normalizeLocalToolIds(conversation.getToolNames());
-        if (ids !== null) return ids;
-      }
-      return getDefaultLocalToolIds();
-    })();
-
-    void host.postMessage({ type: 'toolsList', tools, enabledToolIds: ensureRequiredLocalToolIds(enabledToolIds) });
-  };
+  const postToolsList = createPostToolsList({ deps, host });
 
   const postStatusError = (message: string): void => {
     void host.postMessage({
@@ -257,152 +114,12 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
     });
   };
 
-  const validateProfileId = (profileId: string): void => {
-    try {
-      assertValidProfileId(profileId);
-    } catch (err) {
-      if (err instanceof LLMProfileValidationError) {
-        throw new Error(err.message);
-      }
-      throw err;
-    }
-  };
-
-  const getProfileApiKeySecretKey = (profileId: string): string => {
-    validateProfileId(profileId);
-    return `openhands.llmProfileApiKey.${profileId}`;
-  };
-
-  const getProviderApiKeyName = (provider: LLMProvider): string => {
-    switch (provider) {
-      case 'openrouter':
-        return 'OPENROUTER_API_KEY';
-      case 'litellm_proxy':
-        return 'LITELLM_API_KEY';
-      case 'anthropic':
-        return 'ANTHROPIC_API_KEY';
-      case 'gemini':
-        return 'GEMINI_API_KEY';
-      default:
-        return 'OPENAI_API_KEY';
-    }
-  };
-
-  const isLlmProvider = (value: string): value is LLMProvider => {
-    return value === 'openai'
-      || value === 'litellm_proxy'
-      || value === 'openrouter'
-      || value === 'anthropic'
-      || value === 'gemini';
-  };
-
-  const getStoredSecret = async (key: string): Promise<string | undefined> => {
-    const trimmedKey = key.trim();
-    if (!trimmedKey) return undefined;
-    try {
-      const resolved = deps.secretRegistry
-        ? await deps.secretRegistry.get(trimmedKey)
-        : (process.env[trimmedKey] ?? (await context.secrets.get(trimmedKey)));
-      const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
-      return trimmedValue || undefined;
-    } catch {
-      return undefined;
-    }
-  };
-
-  const hasStoredSecret = async (key: string): Promise<boolean> => {
-    return Boolean(await getStoredSecret(key));
-  };
-
-  const getElevenlabsTtsGate = (): TtsConversationGate => {
-    if (elevenlabsTtsGate) return elevenlabsTtsGate;
-    const baseDir = context.globalStorageUri?.fsPath || path.join(os.tmpdir(), 'oh-tab-global-storage');
-    const cacheDir = path.join(baseDir, 'hal', 'elevenlabs', 'tts-cache');
-    elevenlabsTtsGate = new TtsConversationGate(
-      new ElevenLabsTtsService({
-        cacheDir,
-        maxCacheBytes: elevenlabsCacheMaxBytes,
-      })
-    );
-    return elevenlabsTtsGate;
-  };
-
   return async (msg: unknown) => {
     if (!msg || typeof msg !== 'object' || !('type' in msg)) return;
     const message = msg as WebviewToHostMessage;
 
     const outputChannel = deps.getOutputChannel();
     const conversation = deps.getConversation();
-
-    const llmProfileStoreOptions = (): { rootDir?: string } => {
-      const rootDir = typeof deps.getLlmProfilesStoreRoot === 'function' ? deps.getLlmProfilesStoreRoot() : undefined;
-      if (typeof rootDir !== 'string') return {};
-      const trimmed = rootDir.trim();
-      return trimmed ? { rootDir: trimmed } : {};
-    };
-
-    const listAvailableLlmProfiles = (): string[] => {
-      try {
-        return llmProfilesStore.listProfiles(llmProfileStoreOptions());
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        outputChannel?.appendLine(`[llm] Failed to list profiles: ${reason}`);
-        return [];
-      }
-    };
-
-    const sendHistoryList = async (): Promise<void> => {
-      try {
-        const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
-        const conversations = await getConversationHistoryList(convRoot, outputChannel);
-        void host.postMessage({ type: 'historyList', conversations });
-
-        // Best-effort: generate short titles for items that don't have one persisted yet.
-        // Non-blocking: HistoryView should render immediately and then update as titles become available.
-        void (async () => {
-          const secrets = deps.secretRegistry;
-          if (!secrets) return;
-
-          const missing = conversations
-            .filter((c) => !c.title && typeof c.firstMessage === 'string' && c.firstMessage.trim().length > 0)
-            .sort((a, b) => b.timestamp - a.timestamp)
-            .slice(0, 30);
-          if (missing.length === 0) return;
-
-          const settings = await settingsMgr.get();
-
-          for (const convo of missing) {
-            if (historyTitleGenerationInFlight.has(convo.id)) continue;
-            historyTitleGenerationInFlight.add(convo.id);
-            try {
-              const prompt =
-                `Generate a short conversation title (max 7 words).\\n` +
-                `Return ONLY the title text (no quotes, no punctuation at the end).\\n\\n` +
-                `First user message:\\n${convo.firstMessage}`;
-
-              const raw = await summarizeWithLocalLlm(settings, prompt, secrets);
-              const title = normalizeGeneratedConversationTitle(raw);
-              if (!title) continue;
-
-              await persistConversationTitle(convRoot, convo.id, title, outputChannel);
-              convo.title = title;
-              void host.postMessage({ type: 'historyList', conversations });
-            } catch (err) {
-              const reason = err instanceof Error ? err.message : String(err);
-              outputChannel?.appendLine(`[history] Failed to generate title for ${convo.id}: ${reason}`);
-              // If this fails once (missing key/profile/etc.), avoid spamming more calls this round.
-              break;
-            } finally {
-              historyTitleGenerationInFlight.delete(convo.id);
-            }
-          }
-        })();
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        outputChannel?.appendLine(`[history] ${reason}`);
-        void host.postMessage({ type: 'historyList', conversations: [] });
-      }
-    };
 
     switch (message.type) {
       case 'webviewReady': {
@@ -425,7 +142,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         void host.postMessage({
           type: 'llmProfilesUpdated',
-          profiles: listAvailableLlmProfiles(),
+          profiles: listAvailableLlmProfiles({ deps, outputChannel }),
           activeProfileId: initSettings.llm.profileId ?? null,
         });
 
@@ -444,54 +161,8 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         // Welcome page: communicate whether API keys are present so the UI can show onboarding prompts.
         void (async () => {
-          const secretIsSet = async (key: string): Promise<boolean> => {
-            try {
-              const value = await context.secrets.get(key);
-              return typeof value === 'string' && value.trim().length > 0;
-            } catch {
-              return false;
-            }
-          };
-
-          const envIsSet = (key: string): boolean => {
-            const value = process.env[key];
-            return typeof value === 'string' && value.trim().length > 0;
-          };
-
-          const hasGeminiKey = (await secretIsSet('GEMINI_API_KEY'))
-            || envIsSet('GEMINI_API_KEY')
-            || (initSettings.llm.provider === 'gemini' && typeof initSettings.secrets.llmApiKey === 'string' && initSettings.secrets.llmApiKey.trim().length > 0);
-
-          const hasGenericKey = typeof initSettings.secrets.llmApiKey === 'string' && initSettings.secrets.llmApiKey.trim().length > 0;
-
-          const providerStorageKeys = [
-            'OPENAI_API_KEY',
-            'ANTHROPIC_API_KEY',
-            'OPENROUTER_API_KEY',
-            'LITELLM_API_KEY',
-          ];
-          let hasAnyProviderStorageKey = false;
-          for (const key of providerStorageKeys) {
-            if (envIsSet(key) || await secretIsSet(key)) {
-              hasAnyProviderStorageKey = true;
-              break;
-            }
-          }
-
-          let hasAnyProfileKey = false;
-          try {
-            for (const profileId of listAvailableLlmProfiles()) {
-              if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
-                hasAnyProfileKey = true;
-                break;
-              }
-            }
-          } catch {
-            hasAnyProfileKey = false;
-          }
-
-          const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
-          void host.postMessage({ type: 'welcomeSecretStatus', hasProviderKey, hasGeminiKey });
+          const status = await computeWelcomeSecretStatus({ deps, context, settings: initSettings });
+          void host.postMessage({ type: 'welcomeSecretStatus', hasProviderKey: status.hasProviderKey, hasGeminiKey: status.hasGeminiKey });
         })();
 
         deps.flushConversationEventBacklog({
@@ -525,190 +196,36 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'setEnabledTools': {
-        const mode = deps.getConversationMode();
-        if (mode !== 'local') break;
-
-        const normalized = normalizeLocalToolIds(message.toolIds);
-        if (normalized === null) {
-          postStatusError('Invalid tools selection received from webview');
-          break;
-        }
-
-        const conversation = deps.getConversation();
-        if (!isLocalConversationToolControls(conversation)) {
-          postStatusError('Cannot update tools: conversation unavailable');
-          break;
-        }
-
-        const toolIds = ensureRequiredLocalToolIds(normalized);
-        try {
-          conversation.setTools(resolveLocalTools(toolIds));
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine(`[tools] Failed to update tools: ${reason}`);
-          void host.postMessage({ type: 'statusMessage', level: 'info', message: reason, autoDismiss: true, autoDismissDelay: 4000 });
-        }
-
-        await postToolsList();
+        await handleSetEnabledTools({ deps, host, outputChannel, postStatusError, postToolsList, message });
         break;
       }
       case 'openSkill': {
-        const skillPath = message.path;
-        if (!skillPath) break;
-        try {
-          const skillsRoot = path.resolve(os.homedir(), '.openhands', 'skills');
-          const resolvedPath = path.resolve(skillPath);
-          const relative = path.relative(skillsRoot, resolvedPath);
-          if (relative.startsWith('..') || path.isAbsolute(relative)) {
-            void vscode.window.showErrorMessage('Refusing to open skill outside of ~/.openhands/skills');
-            break;
-          }
-          const document = await vscode.workspace.openTextDocument(vscode.Uri.file(resolvedPath));
-          await vscode.window.showTextDocument(document, { preview: false });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`Failed to open skill file: ${reason}`);
-        }
+        await handleOpenSkill(message);
         break;
       }
       case 'openWorkspaceFile': {
-        const p = message.path;
-        if (!p) break;
-        try {
-          const { resolvedPath } = resolveWorkspaceFilePath(p);
-          await fs.stat(resolvedPath);
-          const document = await vscode.workspace.openTextDocument(vscode.Uri.file(resolvedPath));
-          await vscode.window.showTextDocument(document, { preview: false });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`Failed to open file: ${reason}`);
-        }
+        await handleOpenWorkspaceFile(message);
         break;
       }
       case 'openMarkdownLink': {
-        const raw = typeof message.href === 'string' ? message.href.trim() : '';
-        if (!raw || raw.startsWith('#')) break;
-
-        // Only allow http(s)/mailto links and workspace-internal file links.
-        if (/^https?:\/\//i.test(raw) || /^mailto:/i.test(raw)) {
-          const uri = safeParseUri(raw);
-          if (!uri || (uri.scheme !== 'http' && uri.scheme !== 'https' && uri.scheme !== 'mailto')) {
-            void vscode.window.showErrorMessage('Blocked unsafe link.');
-            break;
-          }
-          await vscode.env.openExternal(uri);
-          break;
-        }
-
-        const wsRoot = getEffectiveWorkspaceRoot();
-        if (!wsRoot) {
-          void vscode.window.showErrorMessage('Cannot open link: no workspace folder is open.');
-          break;
-        }
-
-        const withoutFragment = raw.split('#')[0];
-        const withoutQuery = withoutFragment.split('?')[0];
-        const inputPath = withoutQuery.trim();
-        if (!inputPath) break;
-
-        const resolvedPath = path.isAbsolute(inputPath) ? path.resolve(inputPath) : path.resolve(wsRoot, inputPath);
-        const rel = path.relative(wsRoot, resolvedPath);
-        const inWorkspace = rel && !rel.startsWith('..') && !path.isAbsolute(rel);
-        if (!inWorkspace) {
-          void vscode.window.showErrorMessage('Blocked unsafe link.');
-          break;
-        }
-
-        try {
-          await fs.stat(resolvedPath);
-          const document = await vscode.workspace.openTextDocument(vscode.Uri.file(resolvedPath));
-          await vscode.window.showTextDocument(document, { preview: false });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`Failed to open link: ${reason}`);
-        }
+        await handleOpenMarkdownLink(message);
         break;
       }
       case 'openWorkspaceDiff': {
-        const p = message.path;
-        if (!p) break;
-        if (typeof message.oldContent !== 'string' || typeof message.newContent !== 'string') {
-          void vscode.window.showErrorMessage('Failed to open diff: missing diff content.');
-          break;
-        }
-        try {
-          let oldContent = message.oldContent;
-          let newContent = message.newContent;
-
-          if (message.preferGitHead === true) {
-            const wsRoot = getEffectiveWorkspaceRoot();
-            const { resolvedPath } = resolveWorkspaceFilePath(p);
-            const resolved = await resolveGitHeadDiffContents({
-              workspaceRoot: wsRoot,
-              resolvedPath,
-              fallbackOldContent: '',
-              fallbackNewContent: newContent,
-              execFileText,
-              readFileText: (filePath) => fs.readFile(filePath, 'utf8'),
-            });
-            oldContent = resolved.oldContent;
-            newContent = resolved.newContent;
-          }
-
-          await showWorkspaceDiff({ context, filePath: p, oldContent, newContent });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`Failed to open diff: ${reason}`);
-        }
+        await handleOpenWorkspaceDiff({ context, message });
         break;
       }
       case 'requestHistory': {
-        await sendHistoryList();
+        await handleRequestHistory({ deps, host, settingsMgr, outputChannel, historyTitleGenerationInFlight });
         break;
       }
       case 'deleteConversation': {
-        const id = message.id;
-        if (!id) break;
-        const activeConversationId = conversation?.getConversationId?.();
-        if (activeConversationId && activeConversationId === id) {
-          void vscode.window.showWarningMessage('Cannot delete the active conversation.');
-          break;
-        }
-        try {
-          if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
-            throw new Error('Invalid conversation id');
-          }
-          const convRoot = deps.getConversationStoreRoot() ?? (await deps.resolveConversationStoreRoot());
-          const resolvedRoot = path.resolve(convRoot);
-          const targetDir = path.resolve(convRoot, id);
-          const relative = path.relative(resolvedRoot, targetDir);
-          if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
-            throw new Error('Invalid conversation id');
-          }
-          await fs.rm(targetDir, { recursive: true, force: true });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine(`[history] Failed to delete ${id}: ${reason}`);
-          void vscode.window.showErrorMessage(`Failed to delete conversation: ${reason}`);
-        }
-        await sendHistoryList();
+        await handleDeleteConversation({ deps, outputChannel, conversation, message });
+        await handleRequestHistory({ deps, host, settingsMgr, outputChannel, historyTitleGenerationInFlight });
         break;
       }
       case 'restoreConversation': {
-        const id = message.id;
-        if (!id) break;
-        try {
-          const maybe = conversation?.restoreConversation?.(id);
-          void Promise.resolve(maybe).catch((err: unknown) => {
-            const reason = err instanceof Error ? err.message : String(err);
-            outputChannel?.appendLine(`[restore] ${reason}`);
-            void vscode.window.showErrorMessage(`Failed to restore conversation: ${reason}`);
-          });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine(`[restore] ${reason}`);
-          void vscode.window.showErrorMessage(`Failed to restore conversation: ${reason}`);
-        }
+        handleRestoreConversation({ outputChannel, conversation, message });
         break;
       }
       case 'getConfig': {
@@ -717,638 +234,68 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'setLlmProfileId': {
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        const currentSettings = await settingsMgr.get();
-        const previousProfileId = currentSettings.llm.profileId || '(none)';
-        const debugProfiles = currentSettings.agent?.debug === true;
-        const convMode = deps.getConversationMode();
-        const convStatus = conversation?.getStatus() ?? 'offline';
-        const convId = conversation?.getConversationId?.() || '(no conversation)';
-
-        if (debugProfiles) {
-          outputChannel?.appendLine('[LLM Profile] ========== SWITCH REQUESTED ==========');
-          outputChannel?.appendLine(
-            `[LLM Profile] Switch requested: ${previousProfileId} -> ${profileId || '(none)'} (mode=${convMode}, status=${convStatus}, id=${convId})`,
-          );
-          outputChannel?.appendLine('[LLM Profile] Current settings.llm: ' + JSON.stringify(currentSettings.llm));
-        }
-
-        try {
-          if (debugProfiles) {
-            outputChannel?.appendLine(
-              '[LLM Profile] Calling settingsMgr.update({ llm: { profileId: "' + profileId + '" } }, "global")...',
-            );
-          }
-          await settingsMgr.update({ llm: { profileId } }, 'global');
-          if (debugProfiles) {
-            outputChannel?.appendLine('[LLM Profile] Settings persisted successfully');
-          }
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine('[LLM Profile] Failed to persist selection: ' + reason);
-          postStatusError(`Failed to save profile selection: ${reason}`);
-          break;
-        }
-
-        const updated = await settingsMgr.get();
-        if (debugProfiles) {
-          outputChannel?.appendLine('[LLM Profile] Updated settings.llm: ' + JSON.stringify(updated.llm));
-
-          outputChannel?.appendLine('[LLM Profile] Applying to conversation...');
-          outputChannel?.appendLine('[LLM Profile] conversation exists: ' + (conversation ? 'yes' : 'no'));
-          if (conversation) {
-            outputChannel?.appendLine(
-              '[LLM Profile] conversation.setSettings exists: ' + (typeof conversation.setSettings === 'function' ? 'yes' : 'no'),
-            );
-          }
-        }
-
-        try {
-          conversation?.setSettings(updated);
-          if (debugProfiles) {
-            outputChannel?.appendLine('[LLM Profile] Applied to conversation successfully');
-          }
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          outputChannel?.appendLine('[LLM Profile] Failed to apply to conversation: ' + reason);
-        }
-
-        const newLabel = resolveConfiguredLlmLabel(updated);
-        const oldLabel = deps.getLastKnownLlmLabel();
-        if (debugProfiles) {
-          outputChannel?.appendLine('[LLM Profile] Label: ' + (oldLabel || '(null)') + ' -> ' + (newLabel || '(null)'));
-        }
-        deps.setLastKnownLlmLabel(newLabel);
-
-        const finalStatus = conversation?.getStatus() ?? 'offline';
-        const finalMode = deps.getConversationMode();
-        const finalLabel = deps.getLastKnownLlmLabel();
-        if (debugProfiles) {
-          outputChannel?.appendLine(
-            '[LLM Profile] Posting status message: status=' + finalStatus + ', mode=' + finalMode + ', label=' + (finalLabel || '(null)'),
-          );
-        }
-
-        void host.postMessage({
-          type: 'status',
-          status: finalStatus,
-          mode: finalMode,
-          llmProfileLabel: finalLabel,
-        });
-
-        const profiles = listAvailableLlmProfiles();
-        const activeProfileId = updated.llm.profileId ?? null;
-        if (debugProfiles) {
-          outputChannel?.appendLine(
-            '[LLM Profile] Posting llmProfilesUpdated: profiles=[' + profiles.join(', ') + '], activeProfileId=' + (activeProfileId || '(null)'),
-          );
-        }
-
-        void host.postMessage({
-          type: 'llmProfilesUpdated',
-          profiles,
-          activeProfileId,
-        });
-
-        if (finalMode === 'remote' && finalStatus === 'online') {
-          void host.postMessage({
-            type: 'statusMessage',
-            level: 'warn',
-            message: 'Remote mode: LLM profile changes apply when you start a new conversation. The current remote conversation will continue using its existing model.',
-            autoDismiss: true,
-            autoDismissDelay: 8000,
-          });
-        }
-
-        outputChannel?.appendLine(
-          `[LLM Profile] Switched: ${previousProfileId} -> ${activeProfileId || '(none)'} (mode=${finalMode}, status=${finalStatus}, label=${finalLabel || '(null)'})`,
-        );
-        if (debugProfiles) {
-          outputChannel?.appendLine('[LLM Profile] ========== SWITCH COMPLETE ==========');
-        }
+        await handleSetLlmProfileId({ deps, host, settingsMgr, outputChannel, conversation, postStatusError, message });
         break;
       }
       case 'llmProfilesListRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        if (!requestId) break;
-        try {
-          const profiles = listAvailableLlmProfiles();
-          void host.postMessage({ type: 'llmProfilesListResponse', requestId, ok: true, profiles });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfilesListResponse', requestId, ok: false, error: reason });
-        }
+        handleLlmProfilesListRequest({ deps, host, outputChannel, message });
         break;
       }
       case 'llmProfileLoadRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        if (!requestId || !profileId) break;
-
-        try {
-          const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
-          void host.postMessage({
-            type: 'llmProfileLoadResponse',
-            requestId,
-            ok: true,
-            profileId: profile.profileId,
-            profile: profile.config,
-          });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfileLoadResponse', requestId, ok: false, profileId, error: reason });
-        }
+        handleLlmProfileLoadRequest({ deps, host, message });
         break;
       }
       case 'llmProfileSaveRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        if (!requestId || !profileId) break;
-
-        try {
-          llmProfilesStore.saveProfile(profileId, message.profile, llmProfileStoreOptions());
-          void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: true, profileId });
-
-          const updated = await settingsMgr.get();
-          void host.postMessage({
-            type: 'llmProfilesUpdated',
-            profiles: listAvailableLlmProfiles(),
-            activeProfileId: updated.llm.profileId ?? null,
-          });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: false, profileId, error: reason });
-        }
+        await handleLlmProfileSaveRequest({ deps, host, settingsMgr, outputChannel, message });
         break;
       }
       case 'llmProfileDeleteRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        if (!requestId || !profileId) break;
-
-        try {
-          llmProfilesStore.deleteProfile(profileId, llmProfileStoreOptions());
-          const key = getProfileApiKeySecretKey(profileId);
-          await context.secrets.delete(key);
-          deps.secretRegistry?.set(key, undefined);
-          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: true, profileId });
-
-          const before = await settingsMgr.get();
-          const activeProfileId = before.llm.profileId ?? null;
-          if (activeProfileId === profileId) {
-            await settingsMgr.update({ llm: { profileId: '' } }, 'global');
-            void host.postMessage({
-              type: 'statusMessage',
-              level: 'error',
-              message: `Active LLM profile '${profileId}' was deleted; selection cleared.`,
-              autoDismiss: true,
-              autoDismissDelay: STATUS_MESSAGE_DISMISS_DELAY_MS,
-            });
-          } else {
-            void host.postMessage({
-              type: 'statusMessage',
-              level: 'info',
-              message: `Deleted profile '${profileId}'.`,
-              autoDismiss: true,
-              autoDismissDelay: STATUS_MESSAGE_DISMISS_DELAY_MS,
-            });
-          }
-
-          const updated = await settingsMgr.get();
-          deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(updated));
-
-          void host.postMessage({
-            type: 'status',
-            status: conversation?.getStatus() ?? 'offline',
-            mode: deps.getConversationMode(),
-            llmProfileLabel: deps.getLastKnownLlmLabel(),
-          });
-
-          void host.postMessage({
-            type: 'llmProfilesUpdated',
-            profiles: listAvailableLlmProfiles(),
-            activeProfileId: updated.llm.profileId ?? null,
-          });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: false, profileId, error: reason });
-        }
+        await handleLlmProfileDeleteRequest({ deps, host, context, settingsMgr, outputChannel, conversation, message });
         break;
       }
       case 'llmProfileApiKeyStatusRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        if (!requestId || !profileId) break;
-
-        try {
-          const key = getProfileApiKeySecretKey(profileId);
-          const stored = await context.secrets.get(key);
-          const hasProfileKey = typeof stored === 'string' && stored.trim().length > 0;
-          const overrideProviderRaw = typeof message.provider === 'string' ? message.provider.trim() : '';
-          const overrideProvider = overrideProviderRaw && isLlmProvider(overrideProviderRaw) ? overrideProviderRaw : null;
-          const overrideBaseUrl = typeof message.baseUrl === 'string' ? message.baseUrl.trim() : '';
-
-          // Prefer explicit provider/baseUrl overrides so we can check provider keys even for
-          // draft/new profiles that do not exist yet on disk.
-          const provider = (() => {
-            if (overrideProvider) return overrideProvider;
-            if (overrideBaseUrl) return detectProviderFromBaseUrl(overrideBaseUrl);
-
-            const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions());
-            return profile.config.provider ?? detectProviderFromBaseUrl(profile.config.baseUrl);
-          })();
-          const providerKeyName = getProviderApiKeyName(provider);
-          const hasProviderKey = await hasStoredSecret(providerKeyName);
-          void host.postMessage({
-            type: 'llmProfileApiKeyStatusResponse',
-            requestId,
-            ok: true,
-            profileId,
-            hasKey: hasProfileKey || hasProviderKey,
-            hasProfileKey,
-            hasProviderKey,
-            providerKeyName,
-          });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfileApiKeyStatusResponse', requestId, ok: false, profileId, error: reason });
-        }
+        await handleLlmProfileApiKeyStatusRequest({ deps, host, context, message });
         break;
       }
       case 'llmProfileApiKeySetRequest': {
-        const requestId = typeof message.requestId === 'string' ? message.requestId.trim() : '';
-        const profileId = typeof message.profileId === 'string' ? message.profileId.trim() : '';
-        const apiKey = typeof message.apiKey === 'string' ? message.apiKey.trim() : '';
-        if (!requestId || !profileId) break;
-
-        try {
-          const key = getProfileApiKeySecretKey(profileId);
-          if (!apiKey) {
-            await context.secrets.delete(key);
-            deps.secretRegistry?.set(key, undefined);
-          } else {
-            await context.secrets.store(key, apiKey);
-            deps.secretRegistry?.set(key, apiKey);
-          }
-          void host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: true, profileId });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: false, profileId, error: reason });
-        }
+        await handleLlmProfileApiKeySetRequest({ deps, host, context, message });
         break;
       }
       case 'selectServer': {
-        const rawUrl = typeof message.url === 'string' ? message.url.trim() : '';
-        const url = rawUrl ? normalizeServerUrl(rawUrl) : { ok: true as const, url: '' };
-        if (!url.ok) {
-          postStatusError(url.error);
-          break;
-        }
-        const currentSettings = await settingsMgr.get();
-
-        const serverExists = currentSettings.servers.some((s) => s.url === url.url);
-        if (!serverExists && url.url) {
-          await settingsMgr.update({
-            servers: [...currentSettings.servers, { url: url.url }],
-            serverUrl: url.url,
-          });
-        } else {
-          await settingsMgr.update({ serverUrl: url.url });
-        }
-
-        const updated = await settingsMgr.get();
-        void host.postMessage({
-          type: 'serverListUpdated',
-          servers: updated.servers,
-          serverUrl: updated.serverUrl ?? '',
-        });
+        await handleSelectServer({ host, settingsMgr, postStatusError, message });
         break;
       }
       case 'addServer': {
-        const server = message.server;
-        if (!server?.url) break;
-
-        const normalized = normalizeServerUrl(server.url);
-        if (!normalized.ok) {
-          postStatusError(normalized.error);
-          break;
-        }
-
-        const label = typeof server.label === 'string' ? server.label.trim() : '';
-        const canonicalServer = label ? { url: normalized.url, label } : { url: normalized.url };
-
-        const currentSettings = await settingsMgr.get();
-        const exists = currentSettings.servers.some((s) => s.url === normalized.url);
-        if (!exists) {
-          const newServers = [...currentSettings.servers, canonicalServer];
-          await settingsMgr.update({ servers: newServers });
-          void host.postMessage({
-            type: 'serverListUpdated',
-            servers: newServers,
-            serverUrl: currentSettings.serverUrl ?? '',
-          });
-        }
+        await handleAddServer({ host, settingsMgr, postStatusError, message });
         break;
       }
       case 'removeServer': {
-        const rawUrl = typeof message.url === 'string' ? message.url.trim() : '';
-        if (!rawUrl) break;
-
-        const normalized = normalizeServerUrl(rawUrl);
-        if (!normalized.ok) {
-          postStatusError(normalized.error);
-          break;
-        }
-        const url = normalized.url;
-
-        const currentSettings = await settingsMgr.get();
-        const newServers = currentSettings.servers.filter((s) => s.url !== url);
-        const newServerUrl = currentSettings.serverUrl === url ? '' : currentSettings.serverUrl;
-
-        await settingsMgr.update({
-          servers: newServers,
-          serverUrl: newServerUrl,
-        });
-
-        void host.postMessage({
-          type: 'serverListUpdated',
-          servers: newServers,
-          serverUrl: newServerUrl ?? '',
-        });
+        await handleRemoveServer({ host, settingsMgr, postStatusError, message });
         break;
       }
       case 'switchToLocal': {
-        await settingsMgr.update({ serverUrl: '' });
-
-        const updated = await settingsMgr.get();
-        void host.postMessage({
-          type: 'serverListUpdated',
-          servers: updated.servers,
-          serverUrl: '',
-        });
+        await handleSwitchToLocal({ host, settingsMgr });
         break;
       }
       case 'selectAttachments': {
-        try {
-          const extensionMode = vscode.ExtensionMode;
-          const isTestMode =
-            extensionMode?.Test !== undefined &&
-            context.extensionMode === extensionMode.Test;
-          if (isTestMode && process.env.E2E_MOCK_ATTACHMENTS === '1') {
-            const mockUris = [vscode.Uri.joinPath(context.extensionUri, 'README.md')];
-            const attachments = await Promise.all(
-              mockUris.map(async (uri) => {
-                const label = toAttachmentLabel(uri);
-                let sizeBytes: number | undefined;
-                try {
-                  const stat = await vscode.workspace.fs.stat(uri);
-                  sizeBytes = stat.size;
-                } catch (err) {
-                  console.warn('[OpenHands] Failed to stat attachment', err);
-                }
-                return { uri: uri.toString(), label, sizeBytes };
-              })
-            );
-            void host.postMessage({ type: 'attachmentsSelected', attachments });
-            break;
-          }
-
-          const defaultUri = resolvePreferredWorkspaceFolderUri();
-          const picked = await vscode.window.showOpenDialog({
-            canSelectFiles: true,
-            canSelectFolders: false,
-            canSelectMany: true,
-            defaultUri,
-            openLabel: 'Attach',
-          });
-          if (!picked || picked.length === 0) break;
-
-          const attachments = await Promise.all(
-            picked.map(async (uri) => {
-              const label = toAttachmentLabel(uri);
-              let sizeBytes: number | undefined;
-              try {
-                const stat = await vscode.workspace.fs.stat(uri);
-                sizeBytes = stat.size;
-              } catch (err) {
-                console.warn('[OpenHands] Failed to stat attachment', err);
-              }
-              return { uri: uri.toString(), label, sizeBytes };
-            })
-          );
-          void host.postMessage({ type: 'attachmentsSelected', attachments });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`Failed to select attachments: ${reason}`);
-        }
+        await handleSelectAttachments({ context, host, message });
         break;
       }
       case 'openAttachment': {
-        const raw = message.uri;
-        if (!raw) break;
-        try {
-          const uri = vscode.Uri.parse(raw, true);
-          const document = await vscode.workspace.openTextDocument(uri);
-          await vscode.window.showTextDocument(document, { preview: false });
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`Failed to open attachment: ${reason}`);
-        }
+        await handleOpenAttachment(message);
         break;
       }
       case 'send': {
         if (!conversation) break;
-        const baseText = message.text;
-        const contextFiles = Array.isArray(message.contextFiles)
-          ? message.contextFiles.filter((f): f is string => typeof f === 'string' && f.length > 0)
-          : [];
-        const attachmentUris = Array.isArray(message.attachments)
-          ? message.attachments
-            .filter((u): u is string => typeof u === 'string' && u.length > 0)
-            .map((u) => safeParseUri(u))
-            .filter((u): u is vscode.Uri => u !== undefined)
-          : [];
-
-        const globalStorageBaseDir = getGlobalStorageBaseDir(context.globalStorageUri?.fsPath);
-        const pastedImages = new Map<string, Uint8Array>();
-        const rewriteResult = rewriteDataImageMarkdown(baseText, (dataUrl) => {
-          const parsed = parseBase64DataImageUrl(dataUrl);
-          if (!parsed) return { url: '' };
-          if (parsed.bytes.length > MAX_PASTED_IMAGE_BYTES) return { url: '' };
-          pastedImages.set(parsed.imageId, parsed.bytes);
-          return { url: `${OPENHANDS_IMAGE_URL_PREFIX}${parsed.imageId}` };
-        });
-
-        let sanitizedText = rewriteResult.text;
-        if (pastedImages.size > 0) {
-          const failed = new Set<string>();
-          for (const [imageId, bytes] of pastedImages.entries()) {
-            try {
-              await persistPastedImage(globalStorageBaseDir, imageId, bytes);
-            } catch (err) {
-              failed.add(imageId);
-              const reason = err instanceof Error ? err.message : String(err);
-              outputChannel?.appendLine(`[pasted-images] Failed to persist ${imageId}: ${reason}`);
-            }
-          }
-          if (failed.size > 0) {
-            sanitizedText = rewriteOpenHandsImageUrls(sanitizedText, (imageId) => (failed.has(imageId) ? '' : undefined));
-            void vscode.window.showWarningMessage(`Some pasted images could not be saved (${failed.size}). They were omitted from the message.`);
-          }
-        } else if (rewriteResult.rewritten > 0) {
-          void vscode.window.showWarningMessage('Some pasted images were not supported and were omitted from the message.');
-        }
-
-        const attachmentsText = await buildAttachmentBlocks(attachmentUris);
-
-        let finalText = sanitizedText;
-        if (attachmentsText) {
-          finalText += attachmentsText;
-        }
-        if (contextFiles.length > 0) {
-          finalText += `\n\nUser has selected the following files for you to read:\n${contextFiles.join('\n')}`;
-        }
-
-        const queuedNotes = deps.getQueuedUserEditNotes();
-        const queuedNotesText = queuedNotes
-          .filter((note) => typeof note === 'string' && note.trim().length > 0)
-          .map((note) => note.trimEnd())
-          .join('\n\n');
-
-        if (queuedNotesText) {
-          await conversation.sendUserMessage(finalText, { extendedContent: [{ type: 'text', text: queuedNotesText }] });
-          deps.clearQueuedUserEditNotes();
-        } else {
-          await conversation.sendUserMessage(finalText);
-        }
+        await handleSend({ context, deps, conversation, message, outputChannel });
         break;
       }
       case 'halTtsRequest': {
-        if (typeof message.requestId !== 'string' || typeof message.conversationId !== 'string') break;
-        if (typeof message.stepIndex !== 'number' || !Number.isFinite(message.stepIndex)) break;
-
-        const stepIndex = Math.trunc(message.stepIndex);
-        if (stepIndex < 0) break;
-
-        const settings = await settingsMgr.get();
-        const script = getHalDialogueLinesForMode(settings.hal.userName, settings.hal.mode);
-        const line = script[stepIndex];
-        if (!line) {
-          void host.postMessage({ type: 'halTtsResponse', requestId: message.requestId, ok: false, error: 'Invalid HAL script line', shouldNotify: true });
-          break;
-        }
-
-        const apiKey = settings.secrets.halTtsApiKey ?? '';
-        const voiceId = line.voice === 'voice_hal' ? (settings.hal.voiceAId ?? '') : (settings.hal.voiceUserId ?? '');
-
-        const result = await getElevenlabsTtsGate().synthesize({
-          conversationId: message.conversationId,
-          apiKey,
-          voiceId,
-          text: line.text,
-          modelId: settings.hal.modelId,
-          cacheEnabled: settings.hal.cache,
-        });
-
-        if (result.ok) {
-          void host.postMessage({
-            type: 'halTtsResponse',
-            requestId: message.requestId,
-            ok: true,
-            audioBase64: Buffer.from(result.bytes).toString('base64'),
-            volume: settings.hal.volume,
-            mimeType: 'audio/mpeg',
-          });
-          break;
-        }
-
-        void host.postMessage({
-          type: 'halTtsResponse',
-          requestId: message.requestId,
-          ok: false,
-          error: result.error,
-          shouldNotify: result.shouldNotify,
-          disabled: result.disabled,
-        });
+        await handleHalTtsRequest({ deps, host, settingsMgr, getElevenlabsTtsGate, message });
         break;
       }
       case 'halVoiceConfirmRequest': {
-        if (typeof message.requestId !== 'string') break;
-        if (typeof message.mimeType !== 'string') break;
-        if (typeof message.audioBase64 !== 'string' || message.audioBase64.length === 0) {
-          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error: 'No audio provided' });
-          break;
-        }
-
-        const settings = await settingsMgr.get();
-
-        const defaultHalProfileId = DEFAULT_HAL_LLM_PROFILE_ID;
-        const configuredHalProfileId = typeof settings.hal.llmProfileId === 'string'
-          ? settings.hal.llmProfileId.trim()
-          : '';
-        const halProfileId = (() => {
-          if (!configuredHalProfileId) return defaultHalProfileId;
-          try {
-            validateProfileId(configuredHalProfileId);
-            return configuredHalProfileId;
-          } catch (err) {
-            const reason = err instanceof Error ? err.message : String(err);
-            outputChannel?.appendLine(`[hal] Invalid HAL llmProfileId '${configuredHalProfileId}'; using '${defaultHalProfileId}': ${reason}`);
-            return defaultHalProfileId;
-          }
-        })();
-
-        let halProfile: ReturnType<typeof llmProfilesStore.loadProfile> | undefined;
-        try {
-          halProfile = llmProfilesStore.loadProfile(halProfileId, llmProfileStoreOptions());
-        } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error: reason });
-          outputChannel?.appendLine(`[hal] Failed to load HAL LLM profile '${halProfileId}': ${reason}`);
-          break;
-        }
-
-        const model = typeof halProfile.config.model === 'string' ? halProfile.config.model.trim() : '';
-        const baseUrlFromProfile = typeof halProfile.config.baseUrl === 'string' ? halProfile.config.baseUrl.trim() : '';
-        const provider = halProfile.config.provider ?? detectProviderFromBaseUrl(baseUrlFromProfile);
-        if (provider !== 'gemini') {
-          const error = `HAL voice_confirm requires a Gemini profile (got provider '${provider}').`;
-          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error });
-          outputChannel?.appendLine(`[hal] ${error}`);
-          break;
-        }
-
-        const baseUrl = baseUrlFromProfile || DEFAULT_PROVIDER_BASE_URLS.gemini;
-
-        const keyOrder = [
-          getProfileApiKeySecretKey(halProfileId),
-          getProviderApiKeyName(provider),
-          'openhands.llmApiKey',
-          'LLM_API_KEY',
-        ];
-        let halGeminiKey: string | undefined;
-        for (const key of keyOrder) {
-          const candidate = await getStoredSecret(key);
-          if (candidate) {
-            halGeminiKey = candidate;
-            break;
-          }
-        }
-
-        const result = await classifyHalVoiceDecision({
-          baseUrl,
-          apiKey: halGeminiKey ?? '',
-          model,
-          mimeType: message.mimeType,
-          audioBase64: message.audioBase64,
-        });
-
-        if (result.ok) {
-          void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: true, decision: result.decision });
-          break;
-        }
-
-        void host.postMessage({ type: 'halVoiceConfirmResponse', requestId: message.requestId, ok: false, error: result.error });
+        await handleHalVoiceConfirmRequest({ deps, host, context, settingsMgr, outputChannel, message });
         break;
       }
       case 'command': {
@@ -1404,67 +351,28 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
         break;
       }
       case 'renderedEventsResponse':
-        deps.onRenderedEventsResponse(message.requestId, {
-          count: message.count,
-          eventTypes: message.eventTypes,
-          events: message.events,
-        });
+        handleRenderedEventsResponse({ deps, message });
         break;
       case 'uiStateResponse':
-        deps.onUiStateResponse(message.requestId, {
-          input: message.input,
-          showContextPicker: message.showContextPicker,
-          showSkillsPopover: message.showSkillsPopover,
-          showHistory: message.showHistory,
-          workspaceFilesCount: message.workspaceFilesCount,
-          selectedContextFiles: message.selectedContextFiles,
-          skillsCount: message.skillsCount,
-          attachmentsCount: message.attachmentsCount,
-          hasWelcomeProviderKey: message.hasWelcomeProviderKey,
-          hasWelcomeGeminiKey: message.hasWelcomeGeminiKey,
-          showWelcomeProviderKeyMessage: message.showWelcomeProviderKeyMessage,
-          showWelcomeGeminiKeyMessage: message.showWelcomeGeminiKeyMessage,
-        });
+        handleUiStateResponse({ deps, message });
         break;
       case 'halStateResponse':
-        deps.onHalStateResponse(message.requestId, {
-          enabled: message.enabled,
-          mode: message.mode,
-          phase: message.phase,
-          eye: message.eye,
-          stepIndex: message.stepIndex,
-          decision: message.decision,
-          lastError: message.lastError,
-        });
+        handleHalStateResponse({ deps, message });
         break;
       case 'webviewConsole': {
-        if (!deps.isDevBridgeEnabled()) break;
-        outputChannel?.appendLine(`[webview ${message.level}] ${message.args.join(' ')}`);
-        deps.fileLog(`[console.${message.level}] ${message.args.join(' ')}`);
+        handleWebviewConsole({ deps, outputChannel, message });
         break;
       }
       case 'webviewError': {
-        if (!deps.isDevBridgeEnabled()) break;
-        outputChannel?.appendLine(`[webview error] ${message.message}`);
-        if (message.stack) outputChannel?.appendLine(message.stack);
-        deps.fileLog(`[error] ${message.message}${message.stack ? `\n${message.stack}` : ''}`);
+        handleWebviewError({ deps, outputChannel, message });
         break;
       }
       case 'webviewNetwork': {
-        if (!deps.isDevBridgeEnabled()) break;
-        const line = `[webview net] ${message.phase} id=${message.id} ${message.method} ${message.url}${message.status !== undefined ? ` status=${message.status} ok=${message.ok}` : ''}`;
-        outputChannel?.appendLine(line);
-        deps.fileLog(line);
+        handleWebviewNetwork({ deps, outputChannel, message });
         break;
       }
       case 'webviewWebSocket': {
-        if (!deps.isDevBridgeEnabled()) break;
-        const parts = [`[webview ws] ${message.phase}`];
-        if (message.url) parts.push(`url=${message.url}`);
-        if (message.code !== undefined) parts.push(`code=${message.code}`);
-        if (message.reason) parts.push(`reason=${message.reason}`);
-        outputChannel?.appendLine(parts.join(' '));
-        deps.fileLog(parts.join(' '));
+        handleWebviewWebSocket({ deps, outputChannel, message });
         break;
       }
     }

--- a/src/webview/host/handlers/attachments.ts
+++ b/src/webview/host/handlers/attachments.ts
@@ -1,0 +1,78 @@
+import * as vscode from 'vscode';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import { resolvePreferredWorkspaceFolderUri } from '../../../shared/workspaceRoot';
+import { toAttachmentLabel } from '../attachments';
+import type { WebviewHost } from '../createWebviewMessageHandler';
+
+export async function handleSelectAttachments(args: {
+  context: vscode.ExtensionContext;
+  host: WebviewHost;
+  message: Extract<WebviewToHostMessage, { type: 'selectAttachments' }>;
+}): Promise<void> {
+  try {
+    const extensionMode = vscode.ExtensionMode;
+    const isTestMode =
+      extensionMode?.Test !== undefined &&
+      args.context.extensionMode === extensionMode.Test;
+    if (isTestMode && process.env.E2E_MOCK_ATTACHMENTS === '1') {
+      const mockUris = [vscode.Uri.joinPath(args.context.extensionUri, 'README.md')];
+      const attachments = await Promise.all(
+        mockUris.map(async (uri) => {
+          const label = toAttachmentLabel(uri);
+          let sizeBytes: number | undefined;
+          try {
+            const stat = await vscode.workspace.fs.stat(uri);
+            sizeBytes = stat.size;
+          } catch (err) {
+            console.warn('[OpenHands] Failed to stat attachment', err);
+          }
+          return { uri: uri.toString(), label, sizeBytes };
+        })
+      );
+      void args.host.postMessage({ type: 'attachmentsSelected', attachments });
+      return;
+    }
+
+    const defaultUri = resolvePreferredWorkspaceFolderUri();
+    const picked = await vscode.window.showOpenDialog({
+      canSelectFiles: true,
+      canSelectFolders: false,
+      canSelectMany: true,
+      defaultUri,
+      openLabel: 'Attach',
+    });
+    if (!picked || picked.length === 0) return;
+
+    const attachments = await Promise.all(
+      picked.map(async (uri) => {
+        const label = toAttachmentLabel(uri);
+        let sizeBytes: number | undefined;
+        try {
+          const stat = await vscode.workspace.fs.stat(uri);
+          sizeBytes = stat.size;
+        } catch (err) {
+          console.warn('[OpenHands] Failed to stat attachment', err);
+        }
+        return { uri: uri.toString(), label, sizeBytes };
+      })
+    );
+    void args.host.postMessage({ type: 'attachmentsSelected', attachments });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Failed to select attachments: ${reason}`);
+  }
+}
+
+export async function handleOpenAttachment(message: Extract<WebviewToHostMessage, { type: 'openAttachment' }>): Promise<void> {
+  const raw = message.uri;
+  if (!raw) return;
+  try {
+    const uri = vscode.Uri.parse(raw, true);
+    const document = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(document, { preview: false });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Failed to open attachment: ${reason}`);
+  }
+}
+

--- a/src/webview/host/handlers/devBridge.ts
+++ b/src/webview/host/handlers/devBridge.ts
@@ -1,0 +1,50 @@
+import type * as vscode from 'vscode';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+
+export function handleWebviewConsole(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'webviewConsole' }>;
+}): void {
+  if (!args.deps.isDevBridgeEnabled()) return;
+  args.outputChannel?.appendLine(`[webview ${args.message.level}] ${args.message.args.join(' ')}`);
+  args.deps.fileLog(`[console.${args.message.level}] ${args.message.args.join(' ')}`);
+}
+
+export function handleWebviewError(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'webviewError' }>;
+}): void {
+  if (!args.deps.isDevBridgeEnabled()) return;
+  args.outputChannel?.appendLine(`[webview error] ${args.message.message}`);
+  if (args.message.stack) args.outputChannel?.appendLine(args.message.stack);
+  args.deps.fileLog(`[error] ${args.message.message}${args.message.stack ? `\n${args.message.stack}` : ''}`);
+}
+
+export function handleWebviewNetwork(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'webviewNetwork' }>;
+}): void {
+  if (!args.deps.isDevBridgeEnabled()) return;
+  const line = `[webview net] ${args.message.phase} id=${args.message.id} ${args.message.method} ${args.message.url}${args.message.status !== undefined ? ` status=${args.message.status} ok=${args.message.ok}` : ''}`;
+  args.outputChannel?.appendLine(line);
+  args.deps.fileLog(line);
+}
+
+export function handleWebviewWebSocket(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'webviewWebSocket' }>;
+}): void {
+  if (!args.deps.isDevBridgeEnabled()) return;
+  const parts = [`[webview ws] ${args.message.phase}`];
+  if (args.message.url) parts.push(`url=${args.message.url}`);
+  if (args.message.code !== undefined) parts.push(`code=${args.message.code}`);
+  if (args.message.reason) parts.push(`reason=${args.message.reason}`);
+  args.outputChannel?.appendLine(parts.join(' '));
+  args.deps.fileLog(parts.join(' '));
+}
+

--- a/src/webview/host/handlers/hal.ts
+++ b/src/webview/host/handlers/hal.ts
@@ -1,0 +1,199 @@
+import * as path from 'path';
+import * as os from 'os';
+import type * as vscode from 'vscode';
+import { assertValidProfileId, DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, LLMProfileValidationError } from '@openhands/agent-sdk-ts';
+import { ElevenLabsTtsService } from '../../../hal/elevenlabs/ttsService';
+import { TtsConversationGate } from '../../../hal/elevenlabs/ttsConversationGate';
+import { classifyHalVoiceDecision } from '../../../hal/gemini/decisionClassifier';
+import { DEFAULT_HAL_LLM_PROFILE_ID } from '../../../shared/halDefaults';
+import { getHalDialogueLinesForMode } from '../../../shared/halScript';
+import type { SettingsManager } from '../../../settings/SettingsManager';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
+import * as llmProfilesStore from '../llmProfilesStore';
+import { createStoredSecretHelpers, getProviderApiKeyName } from './secretHelpers';
+
+const validateProfileId = (profileId: string): void => {
+  try {
+    assertValidProfileId(profileId);
+  } catch (err) {
+    if (err instanceof LLMProfileValidationError) {
+      throw new Error(err.message);
+    }
+    throw err;
+  }
+};
+
+const getProfileApiKeySecretKey = (profileId: string): string => {
+  validateProfileId(profileId);
+  return `openhands.llmProfileApiKey.${profileId}`;
+};
+
+const llmProfileStoreOptions = (deps: CreateWebviewMessageHandlerDeps): { rootDir?: string } => {
+  const rootDir = typeof deps.getLlmProfilesStoreRoot === 'function' ? deps.getLlmProfilesStoreRoot() : undefined;
+  if (typeof rootDir !== 'string') return {};
+  const trimmed = rootDir.trim();
+  return trimmed ? { rootDir: trimmed } : {};
+};
+
+export const createElevenlabsTtsGateFactory = (args: {
+  context: vscode.ExtensionContext;
+  maxCacheBytes: number;
+}): (() => TtsConversationGate) => {
+  let gate: TtsConversationGate | null = null;
+  return () => {
+    if (gate) return gate;
+    const baseDir = args.context.globalStorageUri?.fsPath || path.join(os.tmpdir(), 'oh-tab-global-storage');
+    const cacheDir = path.join(baseDir, 'hal', 'elevenlabs', 'tts-cache');
+    gate = new TtsConversationGate(
+      new ElevenLabsTtsService({
+        cacheDir,
+        maxCacheBytes: args.maxCacheBytes,
+      })
+    );
+    return gate;
+  };
+};
+
+export async function handleHalTtsRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  settingsMgr: Pick<SettingsManager, 'get'>;
+  getElevenlabsTtsGate: () => TtsConversationGate;
+  message: Extract<WebviewToHostMessage, { type: 'halTtsRequest' }>;
+}): Promise<void> {
+  if (typeof args.message.requestId !== 'string' || typeof args.message.conversationId !== 'string') return;
+  if (typeof args.message.stepIndex !== 'number' || !Number.isFinite(args.message.stepIndex)) return;
+
+  const stepIndex = Math.trunc(args.message.stepIndex);
+  if (stepIndex < 0) return;
+
+  const settings = await args.settingsMgr.get();
+  const script = getHalDialogueLinesForMode(settings.hal.userName, settings.hal.mode);
+  const line = script[stepIndex];
+  if (!line) {
+    void args.host.postMessage({ type: 'halTtsResponse', requestId: args.message.requestId, ok: false, error: 'Invalid HAL script line', shouldNotify: true });
+    return;
+  }
+
+  const apiKey = settings.secrets.halTtsApiKey ?? '';
+  const voiceId = line.voice === 'voice_hal' ? (settings.hal.voiceAId ?? '') : (settings.hal.voiceUserId ?? '');
+
+  const result = await args.getElevenlabsTtsGate().synthesize({
+    conversationId: args.message.conversationId,
+    apiKey,
+    voiceId,
+    text: line.text,
+    modelId: settings.hal.modelId,
+    cacheEnabled: settings.hal.cache,
+  });
+
+  if (result.ok) {
+    void args.host.postMessage({
+      type: 'halTtsResponse',
+      requestId: args.message.requestId,
+      ok: true,
+      audioBase64: Buffer.from(result.bytes).toString('base64'),
+      volume: settings.hal.volume,
+      mimeType: 'audio/mpeg',
+    });
+    return;
+  }
+
+  void args.host.postMessage({
+    type: 'halTtsResponse',
+    requestId: args.message.requestId,
+    ok: false,
+    error: result.error,
+    shouldNotify: result.shouldNotify,
+    disabled: result.disabled,
+  });
+}
+
+export async function handleHalVoiceConfirmRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  context: vscode.ExtensionContext;
+  settingsMgr: Pick<SettingsManager, 'get'>;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'halVoiceConfirmRequest' }>;
+}): Promise<void> {
+  if (typeof args.message.requestId !== 'string') return;
+  if (typeof args.message.mimeType !== 'string') return;
+  if (typeof args.message.audioBase64 !== 'string' || args.message.audioBase64.length === 0) {
+    void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: false, error: 'No audio provided' });
+    return;
+  }
+
+  const settings = await args.settingsMgr.get();
+
+  const defaultHalProfileId = DEFAULT_HAL_LLM_PROFILE_ID;
+  const configuredHalProfileId = typeof settings.hal.llmProfileId === 'string'
+    ? settings.hal.llmProfileId.trim()
+    : '';
+  const halProfileId = (() => {
+    if (!configuredHalProfileId) return defaultHalProfileId;
+    try {
+      validateProfileId(configuredHalProfileId);
+      return configuredHalProfileId;
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      args.outputChannel?.appendLine(`[hal] Invalid HAL llmProfileId '${configuredHalProfileId}'; using '${defaultHalProfileId}': ${reason}`);
+      return defaultHalProfileId;
+    }
+  })();
+
+  let halProfile: ReturnType<typeof llmProfilesStore.loadProfile> | undefined;
+  try {
+    halProfile = llmProfilesStore.loadProfile(halProfileId, llmProfileStoreOptions(args.deps));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: false, error: reason });
+    args.outputChannel?.appendLine(`[hal] Failed to load HAL LLM profile '${halProfileId}': ${reason}`);
+    return;
+  }
+
+  const model = typeof halProfile.config.model === 'string' ? halProfile.config.model.trim() : '';
+  const baseUrlFromProfile = typeof halProfile.config.baseUrl === 'string' ? halProfile.config.baseUrl.trim() : '';
+  const provider = halProfile.config.provider ?? detectProviderFromBaseUrl(baseUrlFromProfile);
+  if (provider !== 'gemini') {
+    const error = `HAL voice_confirm requires a Gemini profile (got provider '${provider}').`;
+    void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: false, error });
+    args.outputChannel?.appendLine(`[hal] ${error}`);
+    return;
+  }
+
+  const baseUrl = baseUrlFromProfile || DEFAULT_PROVIDER_BASE_URLS.gemini;
+
+  const { getStoredSecret } = createStoredSecretHelpers({ context: args.context, secretRegistry: args.deps.secretRegistry });
+
+  const keyOrder = [
+    getProfileApiKeySecretKey(halProfileId),
+    getProviderApiKeyName(provider),
+    'openhands.llmApiKey',
+    'LLM_API_KEY',
+  ];
+  let halGeminiKey: string | undefined;
+  for (const key of keyOrder) {
+    const candidate = await getStoredSecret(key);
+    if (candidate) {
+      halGeminiKey = candidate;
+      break;
+    }
+  }
+
+  const result = await classifyHalVoiceDecision({
+    baseUrl,
+    apiKey: halGeminiKey ?? '',
+    model,
+    mimeType: args.message.mimeType,
+    audioBase64: args.message.audioBase64,
+  });
+
+  if (result.ok) {
+    void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: true, decision: result.decision });
+    return;
+  }
+
+  void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: false, error: result.error });
+}

--- a/src/webview/host/handlers/history.ts
+++ b/src/webview/host/handlers/history.ts
@@ -1,0 +1,138 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { WebviewHost, CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+import { getConversationHistoryList, persistConversationTitle } from '../conversationHistory';
+import { summarizeWithLocalLlm } from '../../../extension/summarizeWithLocalLlm';
+import type { OpenHandsSettings } from '../../../settings/SettingsManager';
+
+function normalizeGeneratedConversationTitle(raw: string): string | undefined {
+  const firstLine = raw
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  if (!firstLine) return undefined;
+
+  const unquoted = firstLine.replace(/^["'`]+/, '').replace(/["'`]+$/, '').trim();
+  if (!unquoted) return undefined;
+
+  const strippedPrefix = unquoted.replace(/^title\\s*:\\s*/i, '').trim();
+  if (!strippedPrefix) return undefined;
+
+  const words = strippedPrefix.split(/\\s+/).filter(Boolean);
+  if (words.length === 0) return undefined;
+  return words.slice(0, 7).join(' ');
+}
+
+export async function handleRequestHistory(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  settingsMgr: { get: () => Promise<OpenHandsSettings> };
+  outputChannel: vscode.OutputChannel | undefined;
+  historyTitleGenerationInFlight: Set<string>;
+}): Promise<void> {
+  try {
+    const convRoot = args.deps.getConversationStoreRoot() ?? (await args.deps.resolveConversationStoreRoot());
+    const conversations = await getConversationHistoryList(convRoot, args.outputChannel);
+    void args.host.postMessage({ type: 'historyList', conversations });
+
+    // Best-effort: generate short titles for items that don't have one persisted yet.
+    // Non-blocking: HistoryView should render immediately and then update as titles become available.
+    void (async () => {
+      const secrets = args.deps.secretRegistry;
+      if (!secrets) return;
+
+      const missing = conversations
+        .filter((c) => !c.title && typeof c.firstMessage === 'string' && c.firstMessage.trim().length > 0)
+        .sort((a, b) => b.timestamp - a.timestamp)
+        .slice(0, 30);
+      if (missing.length === 0) return;
+
+      const settings = await args.settingsMgr.get();
+
+      for (const convo of missing) {
+        if (args.historyTitleGenerationInFlight.has(convo.id)) continue;
+        args.historyTitleGenerationInFlight.add(convo.id);
+        try {
+          const prompt =
+            `Generate a short conversation title (max 7 words).\\n` +
+            `Return ONLY the title text (no quotes, no punctuation at the end).\\n\\n` +
+            `First user message:\\n${convo.firstMessage}`;
+
+          const raw = await summarizeWithLocalLlm(settings, prompt, secrets);
+          const title = normalizeGeneratedConversationTitle(raw);
+          if (!title) continue;
+
+          await persistConversationTitle(convRoot, convo.id, title, args.outputChannel);
+          convo.title = title;
+          void args.host.postMessage({ type: 'historyList', conversations });
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : String(err);
+          args.outputChannel?.appendLine(`[history] Failed to generate title for ${convo.id}: ${reason}`);
+          // If this fails once (missing key/profile/etc.), avoid spamming more calls this round.
+          break;
+        } finally {
+          args.historyTitleGenerationInFlight.delete(convo.id);
+        }
+      }
+    })();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine(`[history] ${reason}`);
+    void args.host.postMessage({ type: 'historyList', conversations: [] });
+  }
+}
+
+export async function handleDeleteConversation(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  outputChannel: vscode.OutputChannel | undefined;
+  conversation: unknown;
+  message: Extract<WebviewToHostMessage, { type: 'deleteConversation' }>;
+}): Promise<void> {
+  const id = args.message.id;
+  if (!id) return;
+  const activeConversationId = (args.conversation as { getConversationId?: () => string } | undefined)?.getConversationId?.();
+  if (activeConversationId && activeConversationId === id) {
+    void vscode.window.showWarningMessage('Cannot delete the active conversation.');
+    return;
+  }
+  try {
+    if (!/^[a-zA-Z0-9_-]+$/.test(id)) {
+      throw new Error('Invalid conversation id');
+    }
+    const convRoot = args.deps.getConversationStoreRoot() ?? (await args.deps.resolveConversationStoreRoot());
+    const resolvedRoot = path.resolve(convRoot);
+    const targetDir = path.resolve(convRoot, id);
+    const relative = path.relative(resolvedRoot, targetDir);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+      throw new Error('Invalid conversation id');
+    }
+    await fs.rm(targetDir, { recursive: true, force: true });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine(`[history] Failed to delete ${id}: ${reason}`);
+    void vscode.window.showErrorMessage(`Failed to delete conversation: ${reason}`);
+  }
+}
+
+export function handleRestoreConversation(args: {
+  outputChannel: vscode.OutputChannel | undefined;
+  conversation: unknown;
+  message: Extract<WebviewToHostMessage, { type: 'restoreConversation' }>;
+}): void {
+  const id = args.message.id;
+  if (!id) return;
+  try {
+    const maybe = (args.conversation as { restoreConversation?: (id: string) => unknown } | undefined)?.restoreConversation?.(id);
+    void Promise.resolve(maybe).catch((err: unknown) => {
+      const reason = err instanceof Error ? err.message : String(err);
+      args.outputChannel?.appendLine(`[restore] ${reason}`);
+      void vscode.window.showErrorMessage(`Failed to restore conversation: ${reason}`);
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine(`[restore] ${reason}`);
+    void vscode.window.showErrorMessage(`Failed to restore conversation: ${reason}`);
+  }
+}

--- a/src/webview/host/handlers/llmProfiles.ts
+++ b/src/webview/host/handlers/llmProfiles.ts
@@ -1,0 +1,424 @@
+import type * as vscode from 'vscode';
+import type { ConversationInstance } from '@openhands/agent-sdk-ts';
+import { assertValidProfileId, detectProviderFromBaseUrl, LLMProfileValidationError, type LLMProvider } from '@openhands/agent-sdk-ts';
+import type { OpenHandsSettings, SettingsManager } from '../../../settings/SettingsManager';
+import { resolveConfiguredLlmLabel } from '../../../shared/llmProfiles';
+import { STATUS_MESSAGE_DISMISS_DELAY_MS, type WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
+import * as llmProfilesStore from '../llmProfilesStore';
+import { createStoredSecretHelpers, getProviderApiKeyName, isLlmProvider } from './secretHelpers';
+
+const validateProfileId = (profileId: string): void => {
+  try {
+    assertValidProfileId(profileId);
+  } catch (err) {
+    if (err instanceof LLMProfileValidationError) {
+      throw new Error(err.message);
+    }
+    throw err;
+  }
+};
+
+const getProfileApiKeySecretKey = (profileId: string): string => {
+  validateProfileId(profileId);
+  return `openhands.llmProfileApiKey.${profileId}`;
+};
+
+const llmProfileStoreOptions = (deps: CreateWebviewMessageHandlerDeps): { rootDir?: string } => {
+  const rootDir = typeof deps.getLlmProfilesStoreRoot === 'function' ? deps.getLlmProfilesStoreRoot() : undefined;
+  if (typeof rootDir !== 'string') return {};
+  const trimmed = rootDir.trim();
+  return trimmed ? { rootDir: trimmed } : {};
+};
+
+export const listAvailableLlmProfiles = (args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  outputChannel: vscode.OutputChannel | undefined;
+}): string[] => {
+  try {
+    return llmProfilesStore.listProfiles(llmProfileStoreOptions(args.deps));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine(`[llm] Failed to list profiles: ${reason}`);
+    return [];
+  }
+};
+
+export async function handleSetLlmProfileId(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  settingsMgr: SettingsManager;
+  outputChannel: vscode.OutputChannel | undefined;
+  conversation: ConversationInstance | undefined;
+  postStatusError: (message: string) => void;
+  message: Extract<WebviewToHostMessage, { type: 'setLlmProfileId' }>;
+}): Promise<void> {
+  const profileId = typeof args.message.profileId === 'string' ? args.message.profileId.trim() : '';
+  const currentSettings = await args.settingsMgr.get();
+  const previousProfileId = currentSettings.llm.profileId || '(none)';
+  const debugProfiles = currentSettings.agent?.debug === true;
+  const convMode = args.deps.getConversationMode();
+  const convStatus = args.conversation?.getStatus() ?? 'offline';
+  const convId = args.conversation?.getConversationId?.() || '(no conversation)';
+
+  if (debugProfiles) {
+    args.outputChannel?.appendLine('[LLM Profile] ========== SWITCH REQUESTED ==========');
+    args.outputChannel?.appendLine(
+      `[LLM Profile] Switch requested: ${previousProfileId} -> ${profileId || '(none)'} (mode=${convMode}, status=${convStatus}, id=${convId})`,
+    );
+    args.outputChannel?.appendLine('[LLM Profile] Current settings.llm: ' + JSON.stringify(currentSettings.llm));
+  }
+
+  try {
+    if (debugProfiles) {
+      args.outputChannel?.appendLine(
+        '[LLM Profile] Calling settingsMgr.update({ llm: { profileId: "' + profileId + '" } }, "global")...',
+      );
+    }
+    await args.settingsMgr.update({ llm: { profileId } }, 'global');
+    if (debugProfiles) {
+      args.outputChannel?.appendLine('[LLM Profile] Settings persisted successfully');
+    }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine('[LLM Profile] Failed to persist selection: ' + reason);
+    args.postStatusError(`Failed to save profile selection: ${reason}`);
+    return;
+  }
+
+  const updated = await args.settingsMgr.get();
+  if (debugProfiles) {
+    args.outputChannel?.appendLine('[LLM Profile] Updated settings.llm: ' + JSON.stringify(updated.llm));
+
+    args.outputChannel?.appendLine('[LLM Profile] Applying to conversation...');
+    args.outputChannel?.appendLine('[LLM Profile] conversation exists: ' + (args.conversation ? 'yes' : 'no'));
+    if (args.conversation) {
+      args.outputChannel?.appendLine(
+        '[LLM Profile] conversation.setSettings exists: ' + (typeof args.conversation.setSettings === 'function' ? 'yes' : 'no'),
+      );
+    }
+  }
+
+  try {
+    args.conversation?.setSettings(updated);
+    if (debugProfiles) {
+      args.outputChannel?.appendLine('[LLM Profile] Applied to conversation successfully');
+    }
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine('[LLM Profile] Failed to apply to conversation: ' + reason);
+  }
+
+  const newLabel = resolveConfiguredLlmLabel(updated);
+  const oldLabel = args.deps.getLastKnownLlmLabel();
+  if (debugProfiles) {
+    args.outputChannel?.appendLine('[LLM Profile] Label: ' + (oldLabel || '(null)') + ' -> ' + (newLabel || '(null)'));
+  }
+  args.deps.setLastKnownLlmLabel(newLabel);
+
+  const finalStatus = args.conversation?.getStatus() ?? 'offline';
+  const finalMode = args.deps.getConversationMode();
+  const finalLabel = args.deps.getLastKnownLlmLabel();
+  if (debugProfiles) {
+    args.outputChannel?.appendLine(
+      '[LLM Profile] Posting status message: status=' + finalStatus + ', mode=' + finalMode + ', label=' + (finalLabel || '(null)'),
+    );
+  }
+
+  void args.host.postMessage({
+    type: 'status',
+    status: finalStatus,
+    mode: finalMode,
+    llmProfileLabel: finalLabel,
+  });
+
+  const profiles = listAvailableLlmProfiles({ deps: args.deps, outputChannel: args.outputChannel });
+  const activeProfileId = updated.llm.profileId ?? null;
+  if (debugProfiles) {
+    args.outputChannel?.appendLine(
+      '[LLM Profile] Posting llmProfilesUpdated: profiles=[' + profiles.join(', ') + '], activeProfileId=' + (activeProfileId || '(null)'),
+    );
+  }
+
+  void args.host.postMessage({
+    type: 'llmProfilesUpdated',
+    profiles,
+    activeProfileId,
+  });
+
+  if (finalMode === 'remote' && finalStatus === 'online') {
+    void args.host.postMessage({
+      type: 'statusMessage',
+      level: 'warn',
+      message: 'Remote mode: LLM profile changes apply when you start a new conversation. The current remote conversation will continue using its existing model.',
+      autoDismiss: true,
+      autoDismissDelay: 8000,
+    });
+  }
+
+  args.outputChannel?.appendLine(
+    `[LLM Profile] Switched: ${previousProfileId} -> ${activeProfileId || '(none)'} (mode=${finalMode}, status=${finalStatus}, label=${finalLabel || '(null)'})`,
+  );
+  if (debugProfiles) {
+    args.outputChannel?.appendLine('[LLM Profile] ========== SWITCH COMPLETE ==========');
+  }
+}
+
+export function handleLlmProfilesListRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'llmProfilesListRequest' }>;
+}): void {
+  const requestId = typeof args.message.requestId === 'string' ? args.message.requestId.trim() : '';
+  if (!requestId) return;
+  try {
+    const profiles = listAvailableLlmProfiles({ deps: args.deps, outputChannel: args.outputChannel });
+    void args.host.postMessage({ type: 'llmProfilesListResponse', requestId, ok: true, profiles });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'llmProfilesListResponse', requestId, ok: false, error: reason });
+  }
+}
+
+export function handleLlmProfileLoadRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  message: Extract<WebviewToHostMessage, { type: 'llmProfileLoadRequest' }>;
+}): void {
+  const requestId = typeof args.message.requestId === 'string' ? args.message.requestId.trim() : '';
+  const profileId = typeof args.message.profileId === 'string' ? args.message.profileId.trim() : '';
+  if (!requestId || !profileId) return;
+
+  try {
+    const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions(args.deps));
+    void args.host.postMessage({
+      type: 'llmProfileLoadResponse',
+      requestId,
+      ok: true,
+      profileId: profile.profileId,
+      profile: profile.config,
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'llmProfileLoadResponse', requestId, ok: false, profileId, error: reason });
+  }
+}
+
+export async function handleLlmProfileSaveRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  settingsMgr: SettingsManager;
+  outputChannel: vscode.OutputChannel | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'llmProfileSaveRequest' }>;
+}): Promise<void> {
+  const requestId = typeof args.message.requestId === 'string' ? args.message.requestId.trim() : '';
+  const profileId = typeof args.message.profileId === 'string' ? args.message.profileId.trim() : '';
+  if (!requestId || !profileId) return;
+
+  try {
+    llmProfilesStore.saveProfile(profileId, args.message.profile, llmProfileStoreOptions(args.deps));
+    void args.host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: true, profileId });
+
+    const updated = await args.settingsMgr.get();
+    void args.host.postMessage({
+      type: 'llmProfilesUpdated',
+      profiles: listAvailableLlmProfiles({ deps: args.deps, outputChannel: args.outputChannel }),
+      activeProfileId: updated.llm.profileId ?? null,
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'llmProfileSaveResponse', requestId, ok: false, profileId, error: reason });
+  }
+}
+
+export async function handleLlmProfileDeleteRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  context: vscode.ExtensionContext;
+  settingsMgr: SettingsManager;
+  outputChannel: vscode.OutputChannel | undefined;
+  conversation: ConversationInstance | undefined;
+  message: Extract<WebviewToHostMessage, { type: 'llmProfileDeleteRequest' }>;
+}): Promise<void> {
+  const requestId = typeof args.message.requestId === 'string' ? args.message.requestId.trim() : '';
+  const profileId = typeof args.message.profileId === 'string' ? args.message.profileId.trim() : '';
+  if (!requestId || !profileId) return;
+
+  try {
+    llmProfilesStore.deleteProfile(profileId, llmProfileStoreOptions(args.deps));
+    const key = getProfileApiKeySecretKey(profileId);
+    await args.context.secrets.delete(key);
+    args.deps.secretRegistry?.set(key, undefined);
+    void args.host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: true, profileId });
+
+    const currentSettings = await args.settingsMgr.get();
+    const currentProfileId = currentSettings.llm.profileId ?? '';
+    if (currentProfileId === profileId) {
+      await args.settingsMgr.update({ llm: { profileId: '' } }, 'global');
+      void args.host.postMessage({
+        type: 'statusMessage',
+        level: 'error',
+        message: `Active LLM profile '${profileId}' was deleted; selection cleared.`,
+        autoDismiss: true,
+        autoDismissDelay: STATUS_MESSAGE_DISMISS_DELAY_MS,
+      });
+    } else {
+      void args.host.postMessage({
+        type: 'statusMessage',
+        level: 'info',
+        message: `Deleted profile '${profileId}'.`,
+        autoDismiss: true,
+        autoDismissDelay: STATUS_MESSAGE_DISMISS_DELAY_MS,
+      });
+    }
+
+    const updated = await args.settingsMgr.get();
+    args.deps.setLastKnownLlmLabel(resolveConfiguredLlmLabel(updated));
+
+    void args.host.postMessage({
+      type: 'status',
+      status: args.conversation?.getStatus() ?? 'offline',
+      mode: args.deps.getConversationMode(),
+      llmProfileLabel: args.deps.getLastKnownLlmLabel(),
+    });
+
+    void args.host.postMessage({
+      type: 'llmProfilesUpdated',
+      profiles: listAvailableLlmProfiles({ deps: args.deps, outputChannel: args.outputChannel }),
+      activeProfileId: updated.llm.profileId ?? null,
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'llmProfileDeleteResponse', requestId, ok: false, profileId, error: reason });
+  }
+}
+
+export async function handleLlmProfileApiKeyStatusRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  context: vscode.ExtensionContext;
+  message: Extract<WebviewToHostMessage, { type: 'llmProfileApiKeyStatusRequest' }>;
+}): Promise<void> {
+  const requestId = typeof args.message.requestId === 'string' ? args.message.requestId.trim() : '';
+  const profileId = typeof args.message.profileId === 'string' ? args.message.profileId.trim() : '';
+  if (!requestId || !profileId) return;
+
+  const { hasStoredSecret } = createStoredSecretHelpers({ context: args.context, secretRegistry: args.deps.secretRegistry });
+
+  try {
+    const key = getProfileApiKeySecretKey(profileId);
+    const stored = await args.context.secrets.get(key);
+    const hasProfileKey = typeof stored === 'string' && stored.trim().length > 0;
+    const overrideProviderRaw = typeof args.message.provider === 'string' ? args.message.provider.trim() : '';
+    const overrideProvider = overrideProviderRaw && isLlmProvider(overrideProviderRaw) ? overrideProviderRaw : null;
+    const overrideBaseUrl = typeof args.message.baseUrl === 'string' ? args.message.baseUrl.trim() : '';
+
+    // Prefer explicit provider/baseUrl overrides so we can check provider keys even for
+    // draft/new profiles that do not exist yet on disk.
+    const provider: LLMProvider = (() => {
+      if (overrideProvider) return overrideProvider;
+      if (overrideBaseUrl) return detectProviderFromBaseUrl(overrideBaseUrl);
+
+      const profile = llmProfilesStore.loadProfile(profileId, llmProfileStoreOptions(args.deps));
+      return profile.config.provider ?? detectProviderFromBaseUrl(profile.config.baseUrl);
+    })();
+    const providerKeyName = getProviderApiKeyName(provider);
+    const hasProviderKey = await hasStoredSecret(providerKeyName);
+    void args.host.postMessage({
+      type: 'llmProfileApiKeyStatusResponse',
+      requestId,
+      ok: true,
+      profileId,
+      hasKey: hasProfileKey || hasProviderKey,
+      hasProfileKey,
+      hasProviderKey,
+      providerKeyName,
+    });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'llmProfileApiKeyStatusResponse', requestId, ok: false, profileId, error: reason });
+  }
+}
+
+export async function handleLlmProfileApiKeySetRequest(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  context: vscode.ExtensionContext;
+  message: Extract<WebviewToHostMessage, { type: 'llmProfileApiKeySetRequest' }>;
+}): Promise<void> {
+  const requestId = typeof args.message.requestId === 'string' ? args.message.requestId.trim() : '';
+  const profileId = typeof args.message.profileId === 'string' ? args.message.profileId.trim() : '';
+  const apiKey = typeof args.message.apiKey === 'string' ? args.message.apiKey.trim() : '';
+  if (!requestId || !profileId) return;
+
+  try {
+    const key = getProfileApiKeySecretKey(profileId);
+    if (!apiKey) {
+      await args.context.secrets.delete(key);
+      args.deps.secretRegistry?.set(key, undefined);
+    } else {
+      await args.context.secrets.store(key, apiKey);
+      args.deps.secretRegistry?.set(key, apiKey);
+    }
+    void args.host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: true, profileId });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void args.host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: false, profileId, error: reason });
+  }
+}
+
+export async function computeWelcomeSecretStatus(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  context: vscode.ExtensionContext;
+  settings: OpenHandsSettings;
+}): Promise<{ hasProviderKey: boolean; hasGeminiKey: boolean }> {
+  const secretIsSet = async (key: string): Promise<boolean> => {
+    try {
+      const value = await args.context.secrets.get(key);
+      return typeof value === 'string' && value.trim().length > 0;
+    } catch {
+      return false;
+    }
+  };
+
+  const envIsSet = (key: string): boolean => {
+    const value = process.env[key];
+    return typeof value === 'string' && value.trim().length > 0;
+  };
+
+  const hasGeminiKey = (await secretIsSet('GEMINI_API_KEY'))
+    || envIsSet('GEMINI_API_KEY')
+    || (args.settings.llm.provider === 'gemini' && typeof args.settings.secrets.llmApiKey === 'string' && args.settings.secrets.llmApiKey.trim().length > 0);
+
+  const hasGenericKey = typeof args.settings.secrets.llmApiKey === 'string' && args.settings.secrets.llmApiKey.trim().length > 0;
+
+  const providerStorageKeys = [
+    'OPENAI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'OPENROUTER_API_KEY',
+    'LITELLM_API_KEY',
+  ];
+  let hasAnyProviderStorageKey = false;
+  for (const key of providerStorageKeys) {
+    if (envIsSet(key) || await secretIsSet(key)) {
+      hasAnyProviderStorageKey = true;
+      break;
+    }
+  }
+
+  let hasAnyProfileKey = false;
+  try {
+    for (const profileId of listAvailableLlmProfiles({ deps: args.deps, outputChannel: undefined })) {
+      if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
+        hasAnyProfileKey = true;
+        break;
+      }
+    }
+  } catch {
+    hasAnyProfileKey = false;
+  }
+
+  const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
+  return { hasProviderKey, hasGeminiKey };
+}

--- a/src/webview/host/handlers/openers.ts
+++ b/src/webview/host/handlers/openers.ts
@@ -1,0 +1,138 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import * as childProcess from 'child_process';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import { getEffectiveWorkspaceRoot } from '../../../shared/workspaceRoot';
+import { safeParseUri } from '../attachments';
+import { showWorkspaceDiff } from '../diffDocuments';
+import { resolveGitHeadDiffContents } from '../gitHeadDiff';
+import { resolveWorkspaceFilePath } from '../workspacePaths';
+
+function execFileText(command: string, args: string[], cwd?: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childProcess.execFile(command, args, { cwd }, (err, stdout, stderr) => {
+      if (err) {
+        const message = typeof stderr === 'string' && stderr.trim().length > 0 ? stderr.trim() : err.message;
+        reject(new Error(message));
+        return;
+      }
+      resolve(typeof stdout === 'string' ? stdout : String(stdout));
+    });
+  });
+}
+
+export async function handleOpenSkill(message: Extract<WebviewToHostMessage, { type: 'openSkill' }>): Promise<void> {
+  const skillPath = message.path;
+  if (!skillPath) return;
+  try {
+    const skillsRoot = path.resolve(os.homedir(), '.openhands', 'skills');
+    const resolvedPath = path.resolve(skillPath);
+    const relative = path.relative(skillsRoot, resolvedPath);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+      void vscode.window.showErrorMessage('Refusing to open skill outside of ~/.openhands/skills');
+      return;
+    }
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(resolvedPath));
+    await vscode.window.showTextDocument(document, { preview: false });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Failed to open skill file: ${reason}`);
+  }
+}
+
+export async function handleOpenWorkspaceFile(message: Extract<WebviewToHostMessage, { type: 'openWorkspaceFile' }>): Promise<void> {
+  const p = message.path;
+  if (!p) return;
+  try {
+    const { resolvedPath } = resolveWorkspaceFilePath(p);
+    await fs.stat(resolvedPath);
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(resolvedPath));
+    await vscode.window.showTextDocument(document, { preview: false });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Failed to open file: ${reason}`);
+  }
+}
+
+export async function handleOpenMarkdownLink(message: Extract<WebviewToHostMessage, { type: 'openMarkdownLink' }>): Promise<void> {
+  const raw = typeof message.href === 'string' ? message.href.trim() : '';
+  if (!raw || raw.startsWith('#')) return;
+
+  // Only allow http(s)/mailto links and workspace-internal file links.
+  if (/^https?:\/\//i.test(raw) || /^mailto:/i.test(raw)) {
+    const uri = safeParseUri(raw);
+    if (!uri || (uri.scheme !== 'http' && uri.scheme !== 'https' && uri.scheme !== 'mailto')) {
+      void vscode.window.showErrorMessage('Blocked unsafe link.');
+      return;
+    }
+    await vscode.env.openExternal(uri);
+    return;
+  }
+
+  const wsRoot = getEffectiveWorkspaceRoot();
+  if (!wsRoot) {
+    void vscode.window.showErrorMessage('Cannot open link: no workspace folder is open.');
+    return;
+  }
+
+  const withoutFragment = raw.split('#')[0];
+  const withoutQuery = withoutFragment.split('?')[0];
+  const inputPath = withoutQuery.trim();
+  if (!inputPath) return;
+
+  const resolvedPath = path.isAbsolute(inputPath) ? path.resolve(inputPath) : path.resolve(wsRoot, inputPath);
+  const rel = path.relative(wsRoot, resolvedPath);
+  const inWorkspace = rel && !rel.startsWith('..') && !path.isAbsolute(rel);
+  if (!inWorkspace) {
+    void vscode.window.showErrorMessage('Blocked unsafe link.');
+    return;
+  }
+
+  try {
+    await fs.stat(resolvedPath);
+    const document = await vscode.workspace.openTextDocument(vscode.Uri.file(resolvedPath));
+    await vscode.window.showTextDocument(document, { preview: false });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Failed to open link: ${reason}`);
+  }
+}
+
+export async function handleOpenWorkspaceDiff(args: {
+  context: vscode.ExtensionContext;
+  message: Extract<WebviewToHostMessage, { type: 'openWorkspaceDiff' }>;
+}): Promise<void> {
+  const p = args.message.path;
+  if (!p) return;
+  if (typeof args.message.oldContent !== 'string' || typeof args.message.newContent !== 'string') {
+    void vscode.window.showErrorMessage('Failed to open diff: missing diff content.');
+    return;
+  }
+  try {
+    let oldContent = args.message.oldContent;
+    let newContent = args.message.newContent;
+
+    if (args.message.preferGitHead === true) {
+      const wsRoot = getEffectiveWorkspaceRoot();
+      const { resolvedPath } = resolveWorkspaceFilePath(p);
+      const resolved = await resolveGitHeadDiffContents({
+        workspaceRoot: wsRoot,
+        resolvedPath,
+        fallbackOldContent: '',
+        fallbackNewContent: newContent,
+        execFileText,
+        readFileText: (filePath) => fs.readFile(filePath, 'utf8'),
+      });
+      oldContent = resolved.oldContent;
+      newContent = resolved.newContent;
+    }
+
+    await showWorkspaceDiff({ context: args.context, filePath: p, oldContent, newContent });
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    void vscode.window.showErrorMessage(`Failed to open diff: ${reason}`);
+  }
+}
+

--- a/src/webview/host/handlers/secretHelpers.ts
+++ b/src/webview/host/handlers/secretHelpers.ts
@@ -1,0 +1,54 @@
+import type * as vscode from 'vscode';
+import type { LLMProvider, SecretRegistry } from '@openhands/agent-sdk-ts';
+
+export const isLlmProvider = (value: string): value is LLMProvider => {
+  return value === 'openai'
+    || value === 'litellm_proxy'
+    || value === 'openrouter'
+    || value === 'anthropic'
+    || value === 'gemini';
+};
+
+export const getProviderApiKeyName = (provider: LLMProvider): string => {
+  switch (provider) {
+    case 'openrouter':
+      return 'OPENROUTER_API_KEY';
+    case 'litellm_proxy':
+      return 'LITELLM_API_KEY';
+    case 'anthropic':
+      return 'ANTHROPIC_API_KEY';
+    case 'gemini':
+      return 'GEMINI_API_KEY';
+    default:
+      return 'OPENAI_API_KEY';
+  }
+};
+
+export const createStoredSecretHelpers = (args: {
+  context: vscode.ExtensionContext;
+  secretRegistry?: SecretRegistry;
+}): {
+  getStoredSecret: (key: string) => Promise<string | undefined>;
+  hasStoredSecret: (key: string) => Promise<boolean>;
+} => {
+  const getStoredSecret = async (key: string): Promise<string | undefined> => {
+    const trimmedKey = key.trim();
+    if (!trimmedKey) return undefined;
+    try {
+      const resolved = args.secretRegistry
+        ? await args.secretRegistry.get(trimmedKey)
+        : (process.env[trimmedKey] ?? (await args.context.secrets.get(trimmedKey)));
+      const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
+      return trimmedValue || undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const hasStoredSecret = async (key: string): Promise<boolean> => {
+    return Boolean(await getStoredSecret(key));
+  };
+
+  return { getStoredSecret, hasStoredSecret };
+};
+

--- a/src/webview/host/handlers/send.ts
+++ b/src/webview/host/handlers/send.ts
@@ -1,0 +1,87 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import type { ConversationInstance } from '@openhands/agent-sdk-ts';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../../shared/pastedImages';
+import { MAX_PASTED_IMAGE_BYTES } from '../../../shared/pasteLimits';
+import { buildAttachmentBlocks, safeParseUri } from '../attachments';
+import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+
+async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
+  const filePath = getPastedImagePath(baseDir, imageId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, bytes);
+}
+
+export async function handleSend(args: {
+  context: vscode.ExtensionContext;
+  deps: CreateWebviewMessageHandlerDeps;
+  conversation: ConversationInstance;
+  message: Extract<WebviewToHostMessage, { type: 'send' }>;
+  outputChannel: vscode.OutputChannel | undefined;
+}): Promise<void> {
+  const baseText = args.message.text;
+  const contextFiles = Array.isArray(args.message.contextFiles)
+    ? args.message.contextFiles.filter((f): f is string => typeof f === 'string' && f.length > 0)
+    : [];
+  const attachmentUris = Array.isArray(args.message.attachments)
+    ? args.message.attachments
+      .filter((u): u is string => typeof u === 'string' && u.length > 0)
+      .map((u) => safeParseUri(u))
+      .filter((u): u is vscode.Uri => u !== undefined)
+    : [];
+
+  const globalStorageBaseDir = getGlobalStorageBaseDir(args.context.globalStorageUri?.fsPath);
+  const pastedImages = new Map<string, Uint8Array>();
+  const rewriteResult = rewriteDataImageMarkdown(baseText, (dataUrl) => {
+    const parsed = parseBase64DataImageUrl(dataUrl);
+    if (!parsed) return { url: '' };
+    if (parsed.bytes.length > MAX_PASTED_IMAGE_BYTES) return { url: '' };
+    pastedImages.set(parsed.imageId, parsed.bytes);
+    return { url: `${OPENHANDS_IMAGE_URL_PREFIX}${parsed.imageId}` };
+  });
+
+  let sanitizedText = rewriteResult.text;
+  if (pastedImages.size > 0) {
+    const failed = new Set<string>();
+    for (const [imageId, bytes] of pastedImages.entries()) {
+      try {
+        await persistPastedImage(globalStorageBaseDir, imageId, bytes);
+      } catch (err) {
+        failed.add(imageId);
+        const reason = err instanceof Error ? err.message : String(err);
+        args.outputChannel?.appendLine(`[pasted-images] Failed to persist ${imageId}: ${reason}`);
+      }
+    }
+    if (failed.size > 0) {
+      sanitizedText = rewriteOpenHandsImageUrls(sanitizedText, (imageId) => (failed.has(imageId) ? '' : undefined));
+      void vscode.window.showWarningMessage(`Some pasted images could not be saved (${failed.size}). They were omitted from the message.`);
+    }
+  } else if (rewriteResult.rewritten > 0) {
+    void vscode.window.showWarningMessage('Some pasted images were not supported and were omitted from the message.');
+  }
+
+  const attachmentsText = await buildAttachmentBlocks(attachmentUris);
+
+  let finalText = sanitizedText;
+  if (attachmentsText) {
+    finalText += attachmentsText;
+  }
+  if (contextFiles.length > 0) {
+    finalText += `\n\nUser has selected the following files for you to read:\n${contextFiles.join('\n')}`;
+  }
+
+  const queuedNotes = args.deps.getQueuedUserEditNotes();
+  const queuedNotesText = queuedNotes
+    .filter((note) => typeof note === 'string' && note.trim().length > 0)
+    .map((note) => note.trimEnd())
+    .join('\n\n');
+
+  if (queuedNotesText) {
+    await args.conversation.sendUserMessage(finalText, { extendedContent: [{ type: 'text', text: queuedNotesText }] });
+    args.deps.clearQueuedUserEditNotes();
+  } else {
+    await args.conversation.sendUserMessage(finalText);
+  }
+}

--- a/src/webview/host/handlers/servers.ts
+++ b/src/webview/host/handlers/servers.ts
@@ -1,0 +1,118 @@
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { WebviewHost } from '../createWebviewMessageHandler';
+import { normalizeServerUrl } from '../../../shared/serverUrls';
+
+type SettingsManagerLike = {
+  get: () => Promise<{ servers: Array<{ url: string; label?: string }>; serverUrl?: string | null }>;
+  update: (patch: Record<string, unknown>) => Promise<void>;
+};
+
+export async function handleSelectServer(args: {
+  host: WebviewHost;
+  settingsMgr: SettingsManagerLike;
+  postStatusError: (message: string) => void;
+  message: Extract<WebviewToHostMessage, { type: 'selectServer' }>;
+}): Promise<void> {
+  const rawUrl = typeof args.message.url === 'string' ? args.message.url.trim() : '';
+  const url = rawUrl ? normalizeServerUrl(rawUrl) : { ok: true as const, url: '' };
+  if (!url.ok) {
+    args.postStatusError(url.error);
+    return;
+  }
+  const currentSettings = await args.settingsMgr.get();
+
+  const serverExists = currentSettings.servers.some((s) => s.url === url.url);
+  if (!serverExists && url.url) {
+    await args.settingsMgr.update({
+      servers: [...currentSettings.servers, { url: url.url }],
+      serverUrl: url.url,
+    });
+  } else {
+    await args.settingsMgr.update({ serverUrl: url.url });
+  }
+
+  const updated = await args.settingsMgr.get();
+  void args.host.postMessage({
+    type: 'serverListUpdated',
+    servers: updated.servers,
+    serverUrl: updated.serverUrl ?? '',
+  });
+}
+
+export async function handleAddServer(args: {
+  host: WebviewHost;
+  settingsMgr: SettingsManagerLike;
+  postStatusError: (message: string) => void;
+  message: Extract<WebviewToHostMessage, { type: 'addServer' }>;
+}): Promise<void> {
+  const server = args.message.server;
+  if (!server?.url) return;
+
+  const normalized = normalizeServerUrl(server.url);
+  if (!normalized.ok) {
+    args.postStatusError(normalized.error);
+    return;
+  }
+
+  const label = typeof server.label === 'string' ? server.label.trim() : '';
+  const canonicalServer = label ? { url: normalized.url, label } : { url: normalized.url };
+
+  const currentSettings = await args.settingsMgr.get();
+  const exists = currentSettings.servers.some((s) => s.url === normalized.url);
+  if (!exists) {
+    const newServers = [...currentSettings.servers, canonicalServer];
+    await args.settingsMgr.update({ servers: newServers });
+    void args.host.postMessage({
+      type: 'serverListUpdated',
+      servers: newServers,
+      serverUrl: currentSettings.serverUrl ?? '',
+    });
+  }
+}
+
+export async function handleRemoveServer(args: {
+  host: WebviewHost;
+  settingsMgr: SettingsManagerLike;
+  postStatusError: (message: string) => void;
+  message: Extract<WebviewToHostMessage, { type: 'removeServer' }>;
+}): Promise<void> {
+  const rawUrl = typeof args.message.url === 'string' ? args.message.url.trim() : '';
+  if (!rawUrl) return;
+
+  const normalized = normalizeServerUrl(rawUrl);
+  if (!normalized.ok) {
+    args.postStatusError(normalized.error);
+    return;
+  }
+  const url = normalized.url;
+
+  const currentSettings = await args.settingsMgr.get();
+  const newServers = currentSettings.servers.filter((s) => s.url !== url);
+  const newServerUrl = currentSettings.serverUrl === url ? '' : currentSettings.serverUrl;
+
+  await args.settingsMgr.update({
+    servers: newServers,
+    serverUrl: newServerUrl,
+  });
+
+  void args.host.postMessage({
+    type: 'serverListUpdated',
+    servers: newServers,
+    serverUrl: newServerUrl ?? '',
+  });
+}
+
+export async function handleSwitchToLocal(args: {
+  host: WebviewHost;
+  settingsMgr: SettingsManagerLike;
+}): Promise<void> {
+  await args.settingsMgr.update({ serverUrl: '' });
+
+  const updated = await args.settingsMgr.get();
+  void args.host.postMessage({
+    type: 'serverListUpdated',
+    servers: updated.servers,
+    serverUrl: '',
+  });
+}
+

--- a/src/webview/host/handlers/stateResponses.ts
+++ b/src/webview/host/handlers/stateResponses.ts
@@ -1,0 +1,49 @@
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+
+export function handleRenderedEventsResponse(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  message: Extract<WebviewToHostMessage, { type: 'renderedEventsResponse' }>;
+}): void {
+  args.deps.onRenderedEventsResponse(args.message.requestId, {
+    count: args.message.count,
+    eventTypes: args.message.eventTypes,
+    events: args.message.events,
+  });
+}
+
+export function handleUiStateResponse(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  message: Extract<WebviewToHostMessage, { type: 'uiStateResponse' }>;
+}): void {
+  args.deps.onUiStateResponse(args.message.requestId, {
+    input: args.message.input,
+    showContextPicker: args.message.showContextPicker,
+    showSkillsPopover: args.message.showSkillsPopover,
+    showHistory: args.message.showHistory,
+    workspaceFilesCount: args.message.workspaceFilesCount,
+    selectedContextFiles: args.message.selectedContextFiles,
+    skillsCount: args.message.skillsCount,
+    attachmentsCount: args.message.attachmentsCount,
+    hasWelcomeProviderKey: args.message.hasWelcomeProviderKey,
+    hasWelcomeGeminiKey: args.message.hasWelcomeGeminiKey,
+    showWelcomeProviderKeyMessage: args.message.showWelcomeProviderKeyMessage,
+    showWelcomeGeminiKeyMessage: args.message.showWelcomeGeminiKeyMessage,
+  });
+}
+
+export function handleHalStateResponse(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  message: Extract<WebviewToHostMessage, { type: 'halStateResponse' }>;
+}): void {
+  args.deps.onHalStateResponse(args.message.requestId, {
+    enabled: args.message.enabled,
+    mode: args.message.mode,
+    phase: args.message.phase,
+    eye: args.message.eye,
+    stepIndex: args.message.stepIndex,
+    decision: args.message.decision,
+    lastError: args.message.lastError,
+  });
+}
+

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -1,0 +1,145 @@
+import type * as vscode from 'vscode';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools, type LocalToolId } from '../../../shared/localTools';
+import { normalizeServerUrl } from '../../../shared/serverUrls';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
+
+type LocalConversationToolControls = {
+  mode: 'local';
+  getToolNames: () => string[];
+  setTools: (tools: unknown[]) => void;
+};
+
+export const isLocalConversationToolControls = (value: unknown): value is LocalConversationToolControls => {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<LocalConversationToolControls> & { [k: string]: unknown };
+  return candidate.mode === 'local'
+    && typeof candidate.getToolNames === 'function'
+    && typeof candidate.setTools === 'function';
+};
+
+const ensureRequiredLocalToolIds = (toolIds: LocalToolId[]): LocalToolId[] => {
+  // `finish` is always enabled by the runtime agent (for safe termination).
+  // Keep the UI/tool-selection source of truth consistent with what is actually sent to the LLM.
+  if (toolIds.includes('finish')) return toolIds;
+  return [...toolIds, 'finish'];
+};
+
+type RemoteToolListDeps = {
+  serverUrl: string;
+  sessionApiKey?: string;
+};
+
+const getRemoteToolListDeps = (conversation: unknown): RemoteToolListDeps | null => {
+  if (!conversation || typeof conversation !== 'object') return null;
+  const candidate = conversation as { [k: string]: unknown };
+  const serverUrl = candidate.serverUrl;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) return null;
+
+  const rawSessionKey =
+    (candidate.settings as { secrets?: { sessionApiKey?: unknown } } | undefined)?.secrets?.sessionApiKey;
+  const sessionApiKey = typeof rawSessionKey === 'string' && rawSessionKey.trim().length > 0 ? rawSessionKey : undefined;
+  return { serverUrl: serverUrl.trim(), sessionApiKey };
+};
+
+async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[] | null> {
+  const normalized = normalizeServerUrl(params.serverUrl);
+  if (!normalized.ok) return null;
+  const url = `${normalized.url}/api/tools/`;
+  const headers: Record<string, string> = {};
+  if (params.sessionApiKey) {
+    headers['X-Session-API-Key'] = params.sessionApiKey;
+  }
+
+  const fetchFn = globalThis.fetch;
+  if (typeof fetchFn !== 'function') return null;
+
+  const abortController = new AbortController();
+  const timeoutMs = 4000;
+  const timeout = setTimeout(() => abortController.abort(), timeoutMs);
+
+  try {
+    const res = await fetchFn(url, { method: 'GET', headers, signal: abortController.signal });
+    if (!res.ok) return null;
+    const payload = await res.json();
+    if (!Array.isArray(payload)) return null;
+
+    const out: string[] = [];
+    for (const tool of payload) {
+      if (typeof tool !== 'string') continue;
+      const trimmed = tool.trim();
+      if (!trimmed) continue;
+      out.push(trimmed);
+    }
+    return out;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export function createPostToolsList(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+}): () => Promise<void> {
+  return async (): Promise<void> => {
+    const mode = args.deps.getConversationMode();
+    if (mode !== 'local') {
+      const conversation = args.deps.getConversation();
+      const remoteDeps = getRemoteToolListDeps(conversation);
+      const toolNames = remoteDeps ? await fetchRemoteToolNames(remoteDeps) : null;
+      const tools = (toolNames ?? []).map((name) => ({ id: name, label: name }));
+      void args.host.postMessage({ type: 'toolsList', tools, enabledToolIds: toolNames ?? [] });
+      return;
+    }
+
+    const tools = listLocalToolDescriptors();
+    const conversation = args.deps.getConversation();
+    const enabledToolIds = (() => {
+      if (isLocalConversationToolControls(conversation)) {
+        const ids = normalizeLocalToolIds(conversation.getToolNames());
+        if (ids !== null) return ids;
+      }
+      return getDefaultLocalToolIds();
+    })();
+
+    void args.host.postMessage({ type: 'toolsList', tools, enabledToolIds: ensureRequiredLocalToolIds(enabledToolIds) });
+  };
+}
+
+export async function handleSetEnabledTools(args: {
+  deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
+  outputChannel: vscode.OutputChannel | undefined;
+  postStatusError: (message: string) => void;
+  postToolsList: () => Promise<void>;
+  message: Extract<WebviewToHostMessage, { type: 'setEnabledTools' }>;
+}): Promise<void> {
+  const mode = args.deps.getConversationMode();
+  if (mode !== 'local') return;
+
+  const normalized = normalizeLocalToolIds(args.message.toolIds);
+  if (normalized === null) {
+    args.postStatusError('Invalid tools selection received from webview');
+    return;
+  }
+
+  const conversation = args.deps.getConversation();
+  if (!isLocalConversationToolControls(conversation)) {
+    args.postStatusError('Cannot update tools: conversation unavailable');
+    return;
+  }
+
+  const toolIds = ensureRequiredLocalToolIds(normalized);
+  try {
+    conversation.setTools(resolveLocalTools(toolIds));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    args.outputChannel?.appendLine(`[tools] Failed to update tools: ${reason}`);
+    void args.host.postMessage({ type: 'statusMessage', level: 'info', message: reason, autoDismiss: true, autoDismissDelay: 4000 });
+  }
+
+  await args.postToolsList();
+}
+


### PR DESCRIPTION
### Bead

oh-tab-mmk: (tech debt) Webview host: split createWebviewMessageHandler.ts into modules
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 06:16
Updated: 2026-01-15 06:16

Description:
Problem
- `src/webview/host/createWebviewMessageHandler.ts` is ~1400 LOC and handles many message types, mixes concerns (routing, validation, VS Code UI interactions, persistence, etc.), and is a frequent merge-conflict hotspot.

Goal
- Behavior-preserving refactor to make host message handling easier to reason about, safer to change, and easier to test.

Proposed approach
- Split by message type into small modules (suggested):
  - `src/webview/host/handlers/send.ts`
  - `src/webview/host/handlers/openWorkspaceDiff.ts`
  - `src/webview/host/handlers/openMarkdownLink.ts`
  - `src/webview/host/handlers/openWorkspaceFile.ts`
  - `src/webview/host/handlers/restoreConversation.ts` (etc.)
- Keep `createWebviewMessageHandler.ts` as a thin dispatcher that validates input and calls the appropriate handler.
- Prefer passing explicit deps/params into handlers rather than relying on ambient VS Code state.

Constraints
- No message schema changes.
- Keep existing tests green; add only minimal new tests if needed.

Acceptance Criteria:
- `src/webview/host/createWebviewMessageHandler.ts` shrinks materially and is primarily a dispatcher.
- Each extracted handler is small and single-purpose.
- `npm test` / `npm run typecheck` / `npm run lint` remain green.

Labels: [host refactor tech-debt webview]

### Summary
- Moves most `WebviewToHostMessage` handling into `src/webview/host/handlers/*`.
- Keeps `src/webview/host/createWebviewMessageHandler.ts` as a thin dispatcher.

### Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added attachment file selection and opening capabilities
  * Enhanced LLM profile management with API key handling
  * Improved server management and remote mode support
  * Added text-to-speech synthesis and voice confirmation features
  * Conversation history improvements including auto-generated titles, deletion, and restoration
  * Tool management with enable/disable functionality

* **Improvements**
  * Enhanced error handling and user-facing messages
  * Improved logging for development and debugging

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- Reviewer: OrangeCastle (detached-worktree review).
- Verdict: LGTM to merge.
- Validation: `npx vitest run src/webview/host/__tests__/*.test.ts` ✅
- Notes: clean refactor split; no behavioral concerns spotted.
