### PR TITLE
oh-tab-voc.4.1: hermetic OAuth device-flow E2E

### DIFF
--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -6,6 +6,7 @@ import { resolveConfiguredLlmLabel } from '../shared/llmProfiles';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
+import { getServerSessionApiKeySecretKey, LEGACY_SESSION_API_KEY_SECRET_KEY } from '../auth/serverSessionApiKeys';
 import * as llmProfilesStore from '../webview/host/llmProfilesStore';
 import { OpenHandsTerminalLogPseudoterminal } from '../terminal/OpenHandsTerminalLogPseudoterminal';
 import { isBashEvent, type BashEvent, type ConversationInstance, type Event, type SecretRegistry } from '@openhands/agent-sdk-ts';
@@ -207,6 +208,48 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     const updated = await settingsMgr.get();
     return { serverUrl: updated.serverUrl ?? '', servers: updated.servers ?? [] };
   });
+
+  const extensionMode = vscode.ExtensionMode;
+  const isTestMode =
+    extensionMode?.Test !== undefined &&
+    deps.context.extensionMode === extensionMode.Test;
+  const e2eSessionApiKeyStatus = isTestMode && process.env.E2E_CLOUD_LOGIN === '1'
+    ? vscode.commands.registerCommand('openhands._e2eGetServerSessionApiKeyStatus', async (raw: unknown) => {
+        const payload = raw as { serverUrl?: unknown } | undefined;
+        const payloadUrl = typeof payload?.serverUrl === 'string' ? payload.serverUrl.trim() : '';
+        const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
+        const settings = await settingsMgr.get();
+        const serverUrl = payloadUrl || (typeof settings.serverUrl === 'string' ? settings.serverUrl.trim() : '');
+
+        if (!serverUrl) return { ok: false, error: 'Missing serverUrl' };
+
+        const keyInfo = getServerSessionApiKeySecretKey(serverUrl);
+        if (!keyInfo.ok) return { ok: false, error: keyInfo.error };
+
+        let stored: string | undefined;
+        try {
+          stored = await deps.context.secrets.get(keyInfo.secretKey);
+        } catch {
+          stored = undefined;
+        }
+        const token = typeof stored === 'string' ? stored.trim() : '';
+
+        let legacyRaw: string | undefined;
+        try {
+          legacyRaw = await deps.context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
+        } catch {
+          legacyRaw = undefined;
+        }
+        const legacy = typeof legacyRaw === 'string' ? legacyRaw.trim() : '';
+
+        return {
+          ok: true,
+          normalizedServerUrl: keyInfo.normalizedServerUrl,
+          hasSessionApiKey: Boolean(token),
+          hasLegacySessionApiKey: Boolean(legacy),
+        };
+      })
+    : undefined;
 
   const serversReset = vscode.commands.registerCommand('openhands._serversReset', async () => {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(deps.context));
@@ -603,7 +646,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     return { ok: true };
   });
 
-  return [
+  const disposables: vscode.Disposable[] = [
     diag,
     serversGet,
     serversSet,
@@ -627,4 +670,10 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     injectTerminalEvent,
     testMarkAgentEditedFile,
   ];
+
+  if (e2eSessionApiKeyStatus) {
+    disposables.push(e2eSessionApiKeyStatus);
+  }
+
+  return disposables;
 }

--- a/src/extension/cloudLoginCommand.ts
+++ b/src/extension/cloudLoginCommand.ts
@@ -30,6 +30,12 @@ export function registerCloudLoginCommand(options: {
   const { context } = options;
 
   return vscode.commands.registerCommand('openhands.cloudLogin', async () => {
+    const extensionMode = vscode.ExtensionMode;
+    const isTestMode =
+      extensionMode?.Test !== undefined &&
+      context.extensionMode === extensionMode.Test;
+    const isE2eMode = isTestMode && process.env.E2E_CLOUD_LOGIN === '1';
+
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
 
@@ -77,21 +83,23 @@ export function registerCloudLoginCommand(options: {
           });
 
           progress.report({ message: 'Open browser to enter code…' });
-          const opened = await vscode.env.openExternal(vscode.Uri.parse(auth.verificationUriComplete));
-          if (!opened) {
-            void vscode.window.showInformationMessage(
-              `OpenHands: Open this URL to login: ${auth.verificationUriComplete} (code: ${auth.userCode})`,
-            );
-          } else {
-            const action = await vscode.window.showInformationMessage(
-              `OpenHands: Enter code ${auth.userCode} to login to ${serverLabel}.`,
-              'Copy code',
-              'Copy URL',
-            );
-            if (action === 'Copy code') {
-              await vscode.env.clipboard.writeText(auth.userCode);
-            } else if (action === 'Copy URL') {
-              await vscode.env.clipboard.writeText(auth.verificationUriComplete);
+          if (!isE2eMode) {
+            const opened = await vscode.env.openExternal(vscode.Uri.parse(auth.verificationUriComplete));
+            if (!opened) {
+              void vscode.window.showInformationMessage(
+                `OpenHands: Open this URL to login: ${auth.verificationUriComplete} (code: ${auth.userCode})`,
+              );
+            } else {
+              const action = await vscode.window.showInformationMessage(
+                `OpenHands: Enter code ${auth.userCode} to login to ${serverLabel}.`,
+                'Copy code',
+                'Copy URL',
+              );
+              if (action === 'Copy code') {
+                await vscode.env.clipboard.writeText(auth.userCode);
+              } else if (action === 'Copy URL') {
+                await vscode.env.clipboard.writeText(auth.verificationUriComplete);
+              }
             }
           }
 
@@ -145,6 +153,11 @@ export function registerCloudLoginCommand(options: {
     }
 
     options.onLoginCompleted?.({ normalizedServerUrl: keyInfo.normalizedServerUrl });
+
+    if (isE2eMode) {
+      output?.appendLine('[auth] Skipping post-login UI prompt in E2E mode.');
+      return;
+    }
 
     const next = await vscode.window.showInformationMessage(
       `OpenHands: Logged in to ${serverLabel}.`,

--- a/tests/e2e/deviceFlowAuth.test.ts
+++ b/tests/e2e/deviceFlowAuth.test.ts
@@ -1,0 +1,40 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-device-flow-auth-${Date.now()}`);
+
+describe('OpenHands-Tab OAuth Device Flow E2E', function () {
+  this.timeout(180000);
+
+  it('runs hermetic device-flow login against a local mock server', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'deviceFlowAuth',
+        E2E_CLOUD_LOGIN: '1',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/deviceFlowAuth.ts
+++ b/tests/e2e/suite/deviceFlowAuth.ts
@@ -1,0 +1,63 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import { waitForDiagnostics } from './helpers/waitForDiagnostics';
+import { startMockOAuthDeviceFlowServer, type DeviceFlowScenarioName } from './helpers/oauthDeviceFlowServer';
+
+type SessionApiKeyStatus = {
+  ok?: boolean;
+  normalizedServerUrl?: string;
+  hasSessionApiKey?: boolean;
+};
+
+async function setServerUrl(serverUrl: string): Promise<void> {
+  await vscode.commands.executeCommand('openhands._serversSet', { serverUrl, servers: [serverUrl] });
+}
+
+async function getSessionStatus(serverUrl: string): Promise<SessionApiKeyStatus> {
+  return await vscode.commands.executeCommand<SessionApiKeyStatus>('openhands._e2eGetServerSessionApiKeyStatus', { serverUrl });
+}
+
+async function runScenario(params: { scenario: DeviceFlowScenarioName; expectStored: boolean }): Promise<void> {
+  const server = await startMockOAuthDeviceFlowServer();
+  server.enqueueScenario(params.scenario);
+
+  try {
+    await setServerUrl(server.baseUrl);
+
+    await vscode.commands.executeCommand('openhands.cloudLogin');
+
+    if (params.expectStored) {
+      await pollUntil(async () => {
+        const status = await getSessionStatus(server.baseUrl);
+        return Boolean(status?.ok && status?.hasSessionApiKey);
+      }, 60000, 250);
+      return;
+    }
+
+    const status = await getSessionStatus(server.baseUrl);
+    if (status?.ok && status?.hasSessionApiKey) {
+      throw new Error(`Expected no stored session key for scenario=${params.scenario}, but status=${JSON.stringify(status)}`);
+    }
+  } finally {
+    await server.close();
+  }
+}
+
+export async function run(): Promise<void> {
+  if (process.env.E2E_CLOUD_LOGIN !== '1') {
+    throw new Error('Missing required env var: E2E_CLOUD_LOGIN=1');
+  }
+
+  await vscode.commands.executeCommand('openhands.open');
+  await waitForDiagnostics({
+    label: 'chat view ready',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.chat?.hasView && diag.chat?.webviewReady),
+  });
+
+  await runScenario({ scenario: 'happy', expectStored: true });
+  await runScenario({ scenario: 'access_denied', expectStored: false });
+
+  console.log('✓ OAuth device-flow E2E test passed');
+}
+

--- a/tests/e2e/suite/helpers/oauthDeviceFlowServer.ts
+++ b/tests/e2e/suite/helpers/oauthDeviceFlowServer.ts
@@ -1,0 +1,147 @@
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import { randomBytes } from 'crypto';
+
+export type OAuthDeviceAuthorizationResponse = {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  verification_uri_complete?: string;
+  interval?: number;
+};
+
+export type OAuthDeviceTokenResponse = {
+  access_token?: string;
+  token_type?: string;
+  expires_in?: number;
+  error?: string;
+  error_description?: string;
+};
+
+export type DeviceFlowScenarioName = 'happy' | 'access_denied' | 'expired_token' | 'slow_down_then_success';
+
+export type MockOAuthDeviceFlowServer = {
+  baseUrl: string;
+  enqueueScenario: (name: DeviceFlowScenarioName) => void;
+  close: () => Promise<void>;
+  reset: () => void;
+};
+
+function json(res: http.ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readBodyText(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c) => chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(String(c))));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+function newCode(prefix: string): string {
+  return `${prefix}_${randomBytes(8).toString('hex')}`;
+}
+
+function buildScenario(name: DeviceFlowScenarioName): OAuthDeviceTokenResponse[] {
+  if (name === 'happy') {
+    return [{ error: 'authorization_pending' }, { access_token: newCode('tok') }];
+  }
+  if (name === 'access_denied') {
+    return [{ error: 'authorization_pending' }, { error: 'access_denied' }];
+  }
+  if (name === 'expired_token') {
+    return [{ error: 'authorization_pending' }, { error: 'expired_token' }];
+  }
+  // slow_down_then_success
+  return [{ error: 'slow_down' }, { error: 'authorization_pending' }, { access_token: newCode('tok') }];
+}
+
+export async function startMockOAuthDeviceFlowServer(): Promise<MockOAuthDeviceFlowServer> {
+  const deviceStates = new Map<string, { cursor: number; responses: OAuthDeviceTokenResponse[] }>();
+  const scenarioQueue: DeviceFlowScenarioName[] = [];
+
+  let port = 0;
+
+  const reset = (): void => {
+    deviceStates.clear();
+    scenarioQueue.splice(0, scenarioQueue.length);
+  };
+
+  const server = http.createServer((req, res) => {
+    void (async () => {
+      try {
+        const method = req.method ?? 'GET';
+        const rawUrl = req.url ?? '/';
+        const url = new URL(rawUrl, `http://${req.headers.host ?? `127.0.0.1:${port}`}`);
+        const path = url.pathname;
+
+        if (method !== 'POST') {
+          json(res, 405, { error: 'method_not_allowed' });
+          return;
+        }
+
+        if (path === '/oauth/device/authorize') {
+          const deviceCode = newCode('device');
+          const userCode = newCode('user');
+          const scenario = scenarioQueue.shift() ?? 'happy';
+          deviceStates.set(deviceCode, { cursor: 0, responses: buildScenario(scenario) });
+
+          const body: OAuthDeviceAuthorizationResponse = {
+            device_code: deviceCode,
+            user_code: userCode,
+            // Use an unknown scheme so `vscode.env.openExternal()` returns false in headless-ish environments.
+            verification_uri: 'openhands+e2e://device-flow',
+            interval: 1,
+          };
+
+          json(res, 200, body);
+          return;
+        }
+
+        if (path === '/oauth/device/token') {
+          const text = await readBodyText(req);
+          const parsed = new URLSearchParams(text);
+          const deviceCode = (parsed.get('device_code') ?? '').trim();
+          const state = deviceCode ? deviceStates.get(deviceCode) : undefined;
+          if (!state) {
+            json(res, 200, { error: 'invalid_request', error_description: 'Unknown device_code' } satisfies OAuthDeviceTokenResponse);
+            return;
+          }
+
+          const response =
+            state.cursor < state.responses.length ? state.responses[state.cursor] : state.responses[state.responses.length - 1];
+          state.cursor += 1;
+          json(res, 200, response);
+          return;
+        }
+
+        json(res, 404, { error: 'not_found' });
+      } catch (err) {
+        json(res, 500, { error: 'server_error', message: err instanceof Error ? err.message : String(err) });
+      }
+    })();
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+
+  port = (server.address() as AddressInfo).port;
+
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    enqueueScenario: (name) => {
+      scenarioQueue.push(name);
+    },
+    reset,
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}
+

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -115,6 +115,11 @@ export async function run(): Promise<void> {
     return runContextLimitRetryTest();
   }
 
+  if (testName === 'deviceFlowAuth') {
+    const { run: runDeviceFlowAuthTest } = await import('./deviceFlowAuth');
+    return runDeviceFlowAuthTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness


### PR DESCRIPTION
Implements hermetic OAuth device-flow E2E coverage for `oh-tab-voc.4.1`:
- Adds a local mock OAuth device-flow server with scripted responses.
- Adds an E2E suite + wrapper test that runs `openhands.cloudLogin` against the mock (happy + `access_denied`).
- Adds E2E-only guards so `cloudLogin` doesn’t hang on interactive prompts, plus a gated diagnostics command to assert session-key storage (boolean only).

Local run:
- `npx mocha tests/e2e/out/deviceFlowAuth.test.js` ✅

### Bead

```text

oh-tab-voc.4.1: E2E: mock OAuth device-flow server + hermetic CI test
Status: open
Priority: P2
Type: task
Created: 2026-01-15 12:36
Updated: 2026-01-15 12:36

Description:
Problem
- `oh-tab-voc.4` needs device-flow validation, but testing against the real cloud server (app.all-hands.dev) is hard to automate in CI (credentials, flake, rate limits).

Goal
- Add a hermetic OAuth 2.0 Device Authorization Grant mock server in `tests/e2e/suite/` and an E2E test that exercises the extension login flow end-to-end against it.

Notes
- The mock should implement: `POST /oauth/device/authorize` and `POST /oauth/device/token` with scripted state transitions (authorization_pending -> success, slow_down, access_denied, expired_token).
- The E2E should avoid any real network; everything runs locally.
- If full UI automation is too heavy, it's acceptable to expose a minimal test-only command/entrypoint to kick the login flow (guarded behind `process.env` / dev mode) rather than driving the entire UI.

Acceptance Criteria:
- A reusable mock OAuth device-flow server exists under `tests/e2e/suite/` (or equivalent) with scripted scenarios for the key OAuth polling states.
- A new E2E test suite launches VS Code and proves the happy-path login stores a token and enables a remote conversation start (or at least unblocks the authenticated path).
- At least one negative-path scenario is covered (e.g., access_denied or expired_token).
- Test is hermetic and runs in CI (`npm run e2e`).

Labels: [auth e2e teleport tests]

Depends on (1):
  → oh-tab-voc.3: Implement OAuth 2.0 Device Flow for oh-tab [P1]

Blocks (1):
  ← oh-tab-voc.4: E2E integration testing with OpenHands Cloud [P1]

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for device flow authentication scenarios, including successful authentication and error handling paths.
  * Implemented testing infrastructure with mock OAuth server support to validate authentication flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15); ran `npm run e2e -- --grep "OAuth Device Flow"` (noted non-blocking macOS `--user-data-dir` IPC path length warning).
