### PR TITLE
oh-tab-usi: refresh env-info userMessageSuffix

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -714,6 +714,56 @@ describe('Chat view behavior', () => {
     expect(agentContext.systemMessageSuffix).toBeUndefined();
   });
 
+  it('updates the local AgentContext user message suffix with current environment info', async () => {
+    mockSettings = { ...mockSettings, serverUrl: '' as any };
+    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', '');
+
+    const initialEditor = {
+      document: {
+        uri: {
+          scheme: 'file',
+          fsPath: '/test/workspace/src/initial.ts',
+        },
+      },
+    };
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace' } }];
+    (vscode.window as any).activeTextEditor = initialEditor;
+    (vscode.window as any).visibleTextEditors = [initialEditor];
+
+    await resolveChatView(mockContext);
+
+    const { Conversation } = await import('@openhands/agent-sdk-ts');
+    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
+    expect(options?.agentContext).toBeTruthy();
+    const agentContext = options.agentContext as any;
+
+    expect(agentContext.userMessageSuffix).toContain('<environment information>');
+    expect(agentContext.userMessageSuffix).toContain('Active editor: initial.ts');
+    expect(agentContext.userMessageSuffix).toContain('Open editors:');
+    expect(agentContext.userMessageSuffix).toContain('- initial.ts');
+    expect(agentContext.userMessageSuffix).toContain('</environment information>');
+
+    const nextEditor = {
+      document: {
+        uri: {
+          scheme: 'file',
+          fsPath: '/test/workspace/src/next.ts',
+        },
+      },
+    };
+    (vscode.window as any).activeTextEditor = nextEditor;
+    (vscode.window as any).visibleTextEditors = [nextEditor];
+    (vscode as any).__triggerActiveTextEditorChange(nextEditor);
+    expect(agentContext.userMessageSuffix).toContain('Active editor: next.ts');
+    expect(agentContext.userMessageSuffix).toContain('- next.ts');
+
+    (vscode.window as any).activeTextEditor = undefined;
+    (vscode.window as any).visibleTextEditors = [];
+    (vscode as any).__triggerActiveTextEditorChange(undefined);
+    expect(agentContext.userMessageSuffix).toContain('Active editor: none');
+    expect(agentContext.userMessageSuffix).toContain('- none');
+  });
+
   it('auto-disables tool-call summarization when Gemini key is missing (local mode)', async () => {
     const priorEnv = process.env.GEMINI_API_KEY;
     delete process.env.GEMINI_API_KEY;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -185,6 +185,12 @@ function buildEnvironmentInfoSuffix(): string | null {
   }
 }
 
+function syncLocalUserMessageSuffix(): void {
+  if (!localAgentContext) return;
+  const env = buildEnvironmentInfoSuffix();
+  localAgentContext.userMessageSuffix = env ?? undefined;
+}
+
 export function activate(context: vscode.ExtensionContext) {
   const secrets = new SecretRegistry(context.secrets);
   secretRegistry = secrets;
@@ -445,6 +451,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       syncActiveEditorSystemMessageSuffix(editor);
+      syncLocalUserMessageSuffix();
     })
   );
 
@@ -656,8 +663,7 @@ export function activate(context: vscode.ExtensionContext) {
 
       // Populate user environment info suffix for local mode (after agentContext is created & system message synced)
       if (desiredMode === 'local' && localAgentContext) {
-        const env = buildEnvironmentInfoSuffix();
-        localAgentContext.userMessageSuffix = env ?? undefined;
+        syncLocalUserMessageSuffix();
       }
 
       try {


### PR DESCRIPTION
Fixes stale local-mode env info by refreshing `AgentContext.userMessageSuffix` whenever the active editor changes.

- Updates `src/extension.ts` to recompute `localAgentContext.userMessageSuffix` in the same `onDidChangeActiveTextEditor` path that already updates `systemMessageSuffix`.
- Adds a unit test proving `userMessageSuffix` updates when switching editors.

### Bead

```text

oh-tab-usi: Env info userMessageSuffix is stale after active editor changes
Status: open
Priority: P3
Type: bug
Created: 2026-01-15 09:51
Updated: 2026-01-15 09:51

Description:
Problem
- In local mode, env info is routed to the LLM via AgentContext.userMessageSuffix, but it’s only set during conversation creation/settings refresh.
- The extension already updates AgentContext.systemMessageSuffix on onDidChangeActiveTextEditor, but does not update userMessageSuffix.
- Result: after switching active editor, subsequent user messages can include stale <environment information> (wrong workspaceRoot/active editor/open editors), which also makes multi-root behavior harder to test reliably.

Goal
- Ensure user message env-info reflects the current active editor (and visible editors) at send time.

Acceptance Criteria
- Update src/extension.ts so localAgentContext.userMessageSuffix is recomputed when the active editor changes (and/or recomputed just-in-time before sendUserMessage).
- Add unit coverage around the update logic (or a focused integration test) proving userMessageSuffix changes after active editor change.
- No behavior regressions for remote mode.

Labels: [env-info multi-root]

Depends on (3):
  → oh-tab-exx: Fix workspaceRoot resolution to follow active editor (remove global cache) [P2]
  → oh-tab-32i: Env info: workspaceRoot should follow active editor [P2]
  → oh-tab-jqs: (tech debt) VS Code: centralize file-backed URI detection (file vs vscode-remote) [P3]

Blocks (1):
  ← oh-tab-dwq: (tech debt) Centralize environment info collection (workspaceRoot + file-backed URIs) [P3]

```


### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15); ran `npx vitest run src/__tests__/extension.test.ts`.
