### PR TITLE
oh-tab-jt1: update workspaceRoot docs

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -1450,6 +1450,20 @@ import {
   isObservationEvent
 } from '@openhands/agent-sdk-ts';
 
+// Workspace root selection (multi-root-safe):
+// Prefer the workspace folder containing the active editor, fall back only when the workspace has a single folder.
+function resolveWorkspaceRoot(): string {
+  const activeUri = vscode.window.activeTextEditor?.document?.uri;
+  const folder = activeUri ? vscode.workspace.getWorkspaceFolder(activeUri) : undefined;
+  const activeRoot = folder?.uri?.fsPath;
+  if (typeof activeRoot === 'string' && activeRoot.trim().length > 0) return activeRoot;
+
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  if (folders.length === 1) return folders.at(0)!.uri.fsPath;
+
+  return process.cwd();
+}
+
 // Create conversation (auto-detects local vs remote)
 const conversation: ConversationInstance = Conversation({
   serverUrl: settings.serverUrl ?? undefined, // undefined = local mode
@@ -1467,7 +1481,7 @@ const conversation: ConversationInstance = Conversation({
       llmApiKey: await context.secrets.get('openhands.llmApiKey'),
     },
   },
-  workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || process.cwd(),
+  workspaceRoot: resolveWorkspaceRoot(),
 });
 
 // Listen to events
@@ -1553,6 +1567,20 @@ For VS Code usage without an external server, run agent-server on localhost:
 ```typescript
 import { Conversation, isMessageEvent } from '@openhands/agent-sdk-ts';
 
+// Workspace root selection (multi-root-safe):
+// Prefer the workspace folder containing the active editor, fall back only when the workspace has a single folder.
+function resolveWorkspaceRoot(): string {
+  const activeUri = vscode.window.activeTextEditor?.document?.uri;
+  const folder = activeUri ? vscode.workspace.getWorkspaceFolder(activeUri) : undefined;
+  const activeRoot = folder?.uri?.fsPath;
+  if (typeof activeRoot === 'string' && activeRoot.trim().length > 0) return activeRoot;
+
+  const folders = vscode.workspace.workspaceFolders ?? [];
+  if (folders.length === 1) return folders.at(0)!.uri.fsPath;
+
+  return process.cwd();
+}
+
 // Run agent-server locally: uv run agent-server --host 127.0.0.1 --port 3000 (use 0.0.0.0 only if you need remote access)
 const conversation = Conversation({
   serverUrl: 'http://localhost:3000', // connects to local agent-server
@@ -1565,7 +1593,7 @@ const conversation = Conversation({
       llmApiKey: process.env.ANTHROPIC_API_KEY,
     },
   },
-  workspaceRoot: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath || '/workspace',
+  workspaceRoot: resolveWorkspaceRoot(),
 });
 
 conversation.on('event', (event) => {


### PR DESCRIPTION
### Bead


oh-tab-jt1: Docs: update agent-sdk-architecture.md examples to avoid workspaceFolders[0] workspaceRoot
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 06:55
Updated: 2026-01-15 06:55

Description:
Problem
- `docs/agent-sdk-architecture.md` includes code snippets using `vscode.workspace.workspaceFolders?.[0]?.uri.fsPath` as workspaceRoot fallback.
- After fixing multi-root workspaceRoot semantics (oh-tab-exx), these examples will be misleading.

Goal
- Update the doc snippets to match the new recommended workspaceRoot resolution strategy (selected folder / active editor folder), or reference the shared helper if one exists.

Acceptance
- docs updated; no behavior change.

Acceptance Criteria:
- docs/agent-sdk-architecture.md no longer recommends workspaceFolders[0] as the default workspaceRoot.
- References the canonical helper/approach used in code.

Labels: [docs multi-root workspace]

Depends on (1):
  → oh-tab-exx: Fix workspaceRoot resolution to follow active editor (remove global cache) [P2]



### Notes
- Docs-only change; no tests run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace root detection in multi-root VS Code environments for more consistent and reliable behavior across different workspace configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15); noted a non-blocking nit about duplicate `resolveWorkspaceRoot()` snippet.
