### PR TITLE
oh-tab-voc.6: add cloud logout command

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "onCommand:openhands.setGeminiLlmApiKey",
     "onCommand:openhands.setSessionApiKey",
     "onCommand:openhands.cloudLogin",
+    "onCommand:openhands.cloudLogout",
     "onCommand:openhands.setGithubToken",
     "onCommand:openhands.setHalTtsApiKey",
     "onCommand:openhands.setCustomSecret1",
@@ -98,6 +99,10 @@
       {
         "command": "openhands.cloudLogin",
         "title": "OpenHands: Login to Remote Server (Device Flow)"
+      },
+      {
+        "command": "openhands.cloudLogout",
+        "title": "OpenHands: Logout of Remote Server"
       },
       {
         "command": "openhands.setGithubToken",

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -273,6 +273,81 @@ describe('Extension Activation', () => {
     expect(secretStorage.get('openhands.sessionApiKey')).toBe('server-token');
   });
 
+  it('cloudLogout clears the per-server session key and legacy when they match', async () => {
+    const secretStorage = new Map<string, string>();
+
+    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
+    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+
+    secretStorage.set(keyInfo.secretKey, 'server-token');
+    secretStorage.set('openhands.sessionApiKey', 'server-token');
+
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.delete = vi.fn(async (key: string) => {
+      secretStorage.delete(key);
+    });
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Log out');
+
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.cloudLogout');
+
+    expect(secretStorage.has(keyInfo.secretKey)).toBe(false);
+    expect(secretStorage.has('openhands.sessionApiKey')).toBe(false);
+  });
+
+  it('cloudLogout clears the per-server session key without clobbering legacy when different', async () => {
+    const secretStorage = new Map<string, string>();
+
+    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
+    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+
+    secretStorage.set(keyInfo.secretKey, 'server-token');
+    secretStorage.set('openhands.sessionApiKey', 'legacy-key');
+
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.delete = vi.fn(async (key: string) => {
+      secretStorage.delete(key);
+    });
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Log out');
+
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.cloudLogout');
+
+    expect(secretStorage.has(keyInfo.secretKey)).toBe(false);
+    expect(secretStorage.get('openhands.sessionApiKey')).toBe('legacy-key');
+  });
+
+  it('cloudLogout clears legacy openhands.sessionApiKey when empty', async () => {
+    const secretStorage = new Map<string, string>();
+
+    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
+    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+
+    secretStorage.set(keyInfo.secretKey, 'server-token');
+    secretStorage.set('openhands.sessionApiKey', '');
+
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.delete = vi.fn(async (key: string) => {
+      secretStorage.delete(key);
+    });
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Log out');
+
+    await extension.activate(mockContext);
+    await vscode.commands.executeCommand('openhands.cloudLogout');
+
+    expect(secretStorage.has(keyInfo.secretKey)).toBe(false);
+    expect(secretStorage.has('openhands.sessionApiKey')).toBe(false);
+  });
+
   it('does not create a conversation until the chat view resolves', async () => {
     const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
     await extension.activate(mockContext);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,6 +31,7 @@ import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import { getServerSessionApiKeySecretKey } from './auth/serverSessionApiKeys';
 import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
+import { registerCloudLogoutCommand } from './extension/cloudLogoutCommand';
 import {
   createOutputLogger,
   normalizeOutputVerbosity,
@@ -782,6 +783,10 @@ export function activate(context: vscode.ExtensionContext) {
     context,
     getOutputChannel: () => outputChannel,
   });
+  const cloudLogout = registerCloudLogoutCommand({
+    context,
+    getOutputChannel: () => outputChannel,
+  });
 
   const diagnosticsCommands = registerDiagnosticsCommands({
     context,
@@ -936,6 +941,7 @@ export function activate(context: vscode.ExtensionContext) {
     open,
     explainSelection,
     cloudLogin,
+    cloudLogout,
     ...diagnosticsCommands,
     ...halCommands,
     startNew,

--- a/src/extension/cloudLogoutCommand.ts
+++ b/src/extension/cloudLogoutCommand.ts
@@ -1,0 +1,86 @@
+import * as vscode from 'vscode';
+import { SettingsManager } from '../settings/SettingsManager';
+import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
+import {
+  getServerSessionApiKeySecretKey,
+  LEGACY_SESSION_API_KEY_SECRET_KEY,
+} from '../auth/serverSessionApiKeys';
+
+type Output = Pick<vscode.OutputChannel, 'appendLine'>;
+
+function renderServerLabel(serverUrl: string): string {
+  try {
+    const url = new URL(serverUrl);
+    return url.hostname + (url.port ? `:${url.port}` : '');
+  } catch {
+    return serverUrl;
+  }
+}
+
+function trimOrEmpty(value: string | undefined): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function registerCloudLogoutCommand(options: {
+  context: vscode.ExtensionContext;
+  getOutputChannel: () => Output | undefined;
+}): vscode.Disposable {
+  const { context } = options;
+
+  return vscode.commands.registerCommand('openhands.cloudLogout', async () => {
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const settings = await settingsMgr.get();
+
+    const currentServerUrl = typeof settings.serverUrl === 'string' ? settings.serverUrl.trim() : '';
+    if (!currentServerUrl) {
+      void vscode.window.showErrorMessage('OpenHands: Select a remote server before logging out.');
+      return;
+    }
+
+    const keyInfo = getServerSessionApiKeySecretKey(currentServerUrl);
+    if (!keyInfo.ok) {
+      void vscode.window.showErrorMessage(`OpenHands: Invalid server URL: ${keyInfo.error}`);
+      return;
+    }
+
+    const serverLabel = renderServerLabel(keyInfo.normalizedServerUrl);
+    const confirm = await vscode.window.showWarningMessage(
+      `OpenHands: Log out of ${serverLabel}? This will clear stored credentials for this server.`,
+      { modal: true },
+      'Log out',
+    );
+    if (confirm !== 'Log out') return;
+
+    const output = options.getOutputChannel();
+
+    let serverTokenRaw: string | undefined;
+    try {
+      serverTokenRaw = await context.secrets.get(keyInfo.secretKey);
+    } catch {
+      serverTokenRaw = undefined;
+    }
+    const serverToken = trimOrEmpty(serverTokenRaw);
+
+    await context.secrets.delete(keyInfo.secretKey);
+
+    let legacyRaw: string | undefined;
+    try {
+      legacyRaw = await context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
+    } catch {
+      legacyRaw = undefined;
+    }
+    const legacyValue = trimOrEmpty(legacyRaw);
+    const shouldClearLegacy = !legacyValue || (!!serverToken && legacyValue === serverToken);
+    if (shouldClearLegacy) {
+      await context.secrets.delete(LEGACY_SESSION_API_KEY_SECRET_KEY);
+    }
+
+    output?.appendLine(`[auth] Cleared session API key for ${keyInfo.normalizedServerUrl}.`);
+    if (!shouldClearLegacy && legacyValue) {
+      output?.appendLine('[auth] Legacy openhands.sessionApiKey was not cleared (different value already set).');
+    }
+
+    void vscode.window.showInformationMessage(`OpenHands: Logged out of ${serverLabel}.`);
+  });
+}
+

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -668,6 +668,11 @@ export function App() {
     showStatusMessage('info', 'Starting login…');
   }, [postMessage, showStatusMessage]);
 
+  const handleLogoutFromServer = useCallback(() => {
+    postMessage({ type: 'command', command: 'cloudAuthLogout' });
+    showStatusMessage('info', 'Logging out…');
+  }, [postMessage, showStatusMessage]);
+
   const handleSelectLlmProfileId = useCallback((profileId: string) => {
     setLlmProfileId(profileId);
     postMessage({ type: 'setLlmProfileId', profileId });
@@ -710,6 +715,7 @@ export function App() {
         onOpenHistory={handleOpenHistory}
         onOpenSettings={handleOpenSettings}
         onLoginToServer={handleLoginToServer}
+        onLogoutFromServer={handleLogoutFromServer}
         onReconnect={handleReconnect}
         onSelectServer={handleSelectServer}
         onAddServer={handleAddServer}

--- a/src/webview-src/components/Header.tsx
+++ b/src/webview-src/components/Header.tsx
@@ -17,6 +17,7 @@ interface HeaderProps {
   onOpenHistory: () => void;
   onOpenSettings: () => void;
   onLoginToServer: () => void;
+  onLogoutFromServer: () => void;
   onReconnect: () => void;
   onSelectServer: (url: string) => void;
   onAddServer: (server: SavedServer) => void;
@@ -120,6 +121,7 @@ export function Header({
   onOpenHistory,
   onOpenSettings,
   onLoginToServer,
+  onLogoutFromServer,
   onReconnect,
   onSelectServer,
   onAddServer,
@@ -212,7 +214,10 @@ export function Header({
           <div className="w-px h-6 bg-white/[0.08]" />
 
           {mode === 'remote' && Boolean(currentServerUrl?.trim()) && (
-            <IconButton icon="key" label="Login to server" onClick={onLoginToServer} />
+            <>
+              <IconButton icon="key" label="Login to server" onClick={onLoginToServer} />
+              <IconButton icon="sign-out" label="Logout from server" onClick={onLogoutFromServer} />
+            </>
           )}
 
           <IconButton

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -303,6 +303,9 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
           case 'cloudAuthLogin':
             await vscode.commands.executeCommand('openhands.cloudLogin');
             break;
+          case 'cloudAuthLogout':
+            await vscode.commands.executeCommand('openhands.cloudLogout');
+            break;
           case 'reconnect':
             // Use the VS Code command so we re-evaluate settings (local ↔ remote) before reconnecting.
             await vscode.commands.executeCommand('openhands.reconnect');


### PR DESCRIPTION
### Summary

- Adds `openhands.cloudLogout` to clear the per-server Session API key for the current `settings.serverUrl`.
- Deletes legacy `openhands.sessionApiKey` only when empty or matching the server-scoped value.
- Adds a header UI button + unit tests for SecretStorage deletion semantics.

### Tests

- `npx vitest run src/__tests__/extension.test.ts`
- `npm run compile`

### Bead


oh-tab-voc.6: Device-flow auth: add logout/clear-token command
Status: open
Priority: P2
Type: task
Created: 2026-01-15 17:43
Updated: 2026-01-15 17:43

Description:
We now support OAuth device flow login and per-server session API key storage, but there is no first-class way to log out / clear credentials from VS Code SecretStorage. Users should be able to revoke/clear the token for the currently-selected remote server without manually hunting secret keys.

Acceptance Criteria:
- Add a new command (e.g. openhands.cloudLogout) available in remote mode
- Clears the per-server secret key derived from the current settings.serverUrl
- If legacy openhands.sessionApiKey matches the per-server value being removed (or is empty), clear it too; otherwise leave it alone
- Update UI: expose a small action in the header/server UI or command palette (minimal UX is OK)
- Add unit coverage in src/__tests__/extension.test.ts verifying SecretStorage deletion behavior and legacy-handling
- Ensure no behavior regressions for remote mode

Labels: [auth cloud security teleport]

Blocks (1):
  ← oh-tab-voc: HAL teleport auth: OAuth 2.0 Device Flow for cloud servers [P1]



### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15); ran `npx vitest run src/__tests__/extension.test.ts`.
