### PR TITLE
oh-tab-wsurl: accept ws/wss server URLs

### DIFF
--- a/src/shared/__tests__/serverUrls.test.ts
+++ b/src/shared/__tests__/serverUrls.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeServerUrl } from '../serverUrls';
+
+describe('server URL normalization', () => {
+  it('accepts ws:// inputs by normalizing to http://', () => {
+    expect(normalizeServerUrl('ws://example.com')).toEqual({ ok: true, url: 'http://example.com' });
+    expect(normalizeServerUrl('ws://example.com/')).toEqual({ ok: true, url: 'http://example.com' });
+  });
+
+  it('accepts wss:// inputs by normalizing to https://', () => {
+    expect(normalizeServerUrl('wss://example.com')).toEqual({ ok: true, url: 'https://example.com' });
+    expect(normalizeServerUrl('wss://example.com/')).toEqual({ ok: true, url: 'https://example.com' });
+  });
+
+  it('rejects invalid ws/wss hosts', () => {
+    expect(normalizeServerUrl('ws://').ok).toBe(false);
+    expect(normalizeServerUrl('wss://').ok).toBe(false);
+  });
+
+  it('preserves existing http/https normalization behavior', () => {
+    expect(normalizeServerUrl('example.com')).toEqual({ ok: true, url: 'http://example.com' });
+    expect(normalizeServerUrl('http:example.com')).toEqual({ ok: true, url: 'http://example.com' });
+    expect(normalizeServerUrl('https:example.com')).toEqual({ ok: true, url: 'https://example.com' });
+  });
+});
+

--- a/src/shared/serverUrls.ts
+++ b/src/shared/serverUrls.ts
@@ -11,10 +11,16 @@ export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
   }
 
   let candidate = trimmed;
-  if (/^https?:/i.test(candidate) && !/^https?:\/\//i.test(candidate)) {
-    candidate = candidate.replace(/^https?:/i, (match) => `${match}//`);
+  if (/^(https?|wss?):/i.test(candidate) && !/^(https?|wss?):\/\//i.test(candidate)) {
+    candidate = candidate.replace(/^(https?|wss?):/i, (match) => `${match}//`);
   } else if (!HAS_EXPLICIT_SCHEME.test(candidate)) {
     candidate = `http://${candidate}`;
+  }
+
+  if (/^ws:\/\//i.test(candidate)) {
+    candidate = candidate.replace(/^ws:/i, 'http:');
+  } else if (/^wss:\/\//i.test(candidate)) {
+    candidate = candidate.replace(/^wss:/i, 'https:');
   }
 
   let parsed: URL;
@@ -39,4 +45,3 @@ export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
     parsed.pathname === '/' ? parsed.origin : parsed.toString();
   return { ok: true, url: canonical };
 }
-


### PR DESCRIPTION
### Summary

- Accepts `ws://` / `wss://` in `normalizeServerUrl` by normalizing to canonical `http(s)://`.
### Tests

- `npx vitest run src/shared/__tests__/serverUrls.test.ts`

### Bead


oh-tab-wsurl: Accept ws/wss URLs in server URL normalization
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 17:50
Updated: 2026-01-15 17:50

Description:
Users sometimes paste websocket URLs (ws:// or wss://) for remote runtimes. The agent-sdk RemoteConversation/RemoteWorkspace already normalize ws/wss to http/https, but src/shared/serverUrls.normalizeServerUrl rejects non-http(s). Align behavior so UI/server selection accepts ws/wss and normalizes to canonical http(s).

Acceptance Criteria:
- Update src/shared/serverUrls.normalizeServerUrl to accept ws:// and wss:// inputs by converting to http:// and https:// respectively
- Keep existing canonicalization rules (strip hash/search, trim trailing slashes)
- Add unit tests for ws:// and wss:// inputs (happy path + invalid host)
- Ensure no regressions for existing http/https inputs

Labels: [tech-debt urls ux]

Blocks (1):
  ← oh-tab-urlnorm: Agent SDK: dedupe remote server URL normalization [P4]



### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15); ran `npx vitest run src/shared/__tests__/serverUrls.test.ts`.
