### PR TITLE
oh-tab-805: update E2E README

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -100,6 +100,21 @@ const mock = await startMockLlmServer({
 npm run e2e
 ```
 
+## Multi-root workspace E2E
+
+Some suites need multi-root workspace coverage. To launch VS Code against a `.code-workspace` file, pass it via `--file-uri` in `runTests({ launchArgs })`:
+
+```ts
+import { pathToFileURL } from 'url';
+
+launchArgs: [
+  // ...
+  `--file-uri=${pathToFileURL(workspaceFile).toString()}`,
+],
+```
+
+See `tests/e2e/tpq.test.ts` for a concrete example that creates a temporary workspace with two folders.
+
 ### Remote agent-server E2E (optional)
 
 Requires:
@@ -185,11 +200,28 @@ Verifies error event handling:
 
 ## Internal Commands Used
 
-The tests use these internal extension commands:
+The tests use these internal extension commands (test-only; not a stable public API):
 
 - `openhands._diagnostics`: Returns extension state for verification
-- `openhands._sendTestEvent`: Injects mock events into the webview
 - `openhands._queryRenderedEvents`: Queries webview rendered state
+- `openhands._queryUiState`: Queries webview UI state (welcome, counts, toggles, etc.)
+- `openhands._sendTestEvent`: Injects mock events into the webview
+- `openhands._injectTerminalEvent`: Injects terminal events into the webview/terminal log
+- `openhands._queryLastError`: Returns the most recent error captured by the extension
+- `openhands._queryHalState`: Returns HAL overlay state (enabled/phase/teleport state)
+- `openhands._webviewAction`: Performs a small scripted UI action in the webview (send message, open panels, etc.)
+- `openhands._queryLastObservation`: Returns the most recent tool observation snapshot (used by oracle suites)
+- `openhands._serversSet`: Sets the saved server list + current server selection (used by remote-mode suites)
+- `openhands._setProviderApiKey`: Stores a provider API key for the E2E run
+- `openhands._listProfiles`: Lists LLM profiles
+- `openhands._createProfile`: Creates an LLM profile
+- `openhands._updateProfile`: Updates an LLM profile
+- `openhands._deleteProfile`: Deletes an LLM profile
+- `openhands._selectProfile`: Selects the active LLM profile (or clears selection)
+- `openhands._setProfileApiKey`: Stores an API key for a specific profile
+- `openhands._testMarkAgentEditedFile`: Marks a file as “agent edited” for test assertions
+
+If you add a new suite that requires a new internal command, update this section so the docs stay in sync with harness usage.
 
 ## Notes
 


### PR DESCRIPTION
### Notes

- Docs-only change; no behavior changes.

### Bead


oh-tab-805: Docs: update tests/e2e/README.md for new internal commands and multi-root workspaces
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 06:45
Updated: 2026-01-15 06:45

Description:
Problem
- tests/e2e/README.md lists a subset of internal commands used by the E2E harness; newer suites rely on additional commands (e.g. openhands._webviewAction, openhands._queryLastError, openhands._queryBacklogSummary).
- README does not mention how to launch VS Code E2E against a `.code-workspace` file (needed for multi-root coverage like oh-tab-tpq).

Goal
- Keep E2E docs accurate and reduce test-author friction.

Acceptance
- README enumerates the currently-used internal commands.
- README includes a short note on passing a `.code-workspace` path via runTests launchArgs for multi-root scenarios.

Acceptance Criteria:
- tests/e2e/README.md updated and matches actual harness usage.
- No behavior changes; tests remain green.

Labels: [docs e2e tests]



### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15).
