### PR TITLE
oh-tab-meh: type openhands._diagnostics payload

### DIFF
--- a/src/dev/diagnosticsTypes.ts
+++ b/src/dev/diagnosticsTypes.ts
@@ -1,0 +1,33 @@
+import type { OpenHandsSettings } from '../settings/SettingsManager';
+
+export type TerminalLogInfo = {
+  hasTerminal: boolean;
+  received: number;
+  ptyOpened?: boolean;
+  preopenBufferedChars?: number;
+  preopenDroppedChars?: number;
+  lastEvents?: Array<{ type?: string; timestamp: number }>;
+};
+
+export type DiagnosticsInfo = {
+  chat?: {
+    hasView?: boolean;
+    visible?: boolean;
+    webviewReady?: boolean;
+    clientConversationId?: string;
+    clientLastSeenSeq?: number;
+  };
+  eventBacklog?: {
+    activeConversationId?: string;
+    size?: number;
+    latestSeq?: number;
+  };
+  hasConversation?: boolean;
+  conversationId?: string;
+  status?: string;
+  mode?: 'local' | 'remote';
+  serverUrl?: string;
+  servers?: OpenHandsSettings['servers'];
+  terminal?: TerminalLogInfo;
+};
+

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -9,15 +9,9 @@ import type { HalStateSnapshot } from '../shared/halTypes';
 import * as llmProfilesStore from '../webview/host/llmProfilesStore';
 import { OpenHandsTerminalLogPseudoterminal } from '../terminal/OpenHandsTerminalLogPseudoterminal';
 import { isBashEvent, type BashEvent, type ConversationInstance, type Event, type SecretRegistry } from '@openhands/agent-sdk-ts';
+import type { DiagnosticsInfo, TerminalLogInfo } from './diagnosticsTypes';
 
-export type TerminalLogInfo = {
-  hasTerminal: boolean;
-  received: number;
-  ptyOpened?: boolean;
-  preopenBufferedChars?: number;
-  preopenDroppedChars?: number;
-  lastEvents?: Array<{ type?: string; timestamp: number }>;
-};
+export type { DiagnosticsInfo, TerminalLogInfo } from './diagnosticsTypes';
 
 
 export type RenderedEventsInfo = {
@@ -139,7 +133,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     return inspected?.globalValue ?? [];
   };
 
-  const diag = vscode.commands.registerCommand('openhands._diagnostics', () => {
+  const diag = vscode.commands.registerCommand('openhands._diagnostics', (): DiagnosticsInfo => {
     const chatView = deps.getChatView();
     const terminal = deps.getTerminal();
     const terminalPty = deps.getTerminalLogPty();

--- a/tests/e2e/suite/agentSdkEvents.ts
+++ b/tests/e2e/suite/agentSdkEvents.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,7 +8,7 @@ export async function run(): Promise<void> {
   // Wait until view and webview are ready
   const deadline = Date.now() + 15000;
   while (Date.now() < deadline) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
     await new Promise((r) => setTimeout(r, 200));
   }

--- a/tests/e2e/suite/agentServerRemote.ts
+++ b/tests/e2e/suite/agentServerRemote.ts
@@ -1,14 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
-
-type DiagnosticsInfo = {
-  chat?: { hasView?: boolean; webviewReady?: boolean };
-  mode?: string;
-  serverUrl?: string;
-  status?: string;
-  conversationId?: string;
-  eventBacklog?: { size?: number };
-};
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 type RenderedEventsInfo = {
   count?: number;

--- a/tests/e2e/suite/confirmation.ts
+++ b/tests/e2e/suite/confirmation.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,15 +8,15 @@ export async function run(): Promise<void> {
 
   // Wait until view and webview are ready
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   // Start fresh conversation
   await vscode.commands.executeCommand('openhands.startNewConversation');
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
   // Test 1: Send action events with different security risk levels

--- a/tests/e2e/suite/contextLimitRetry.ts
+++ b/tests/e2e/suite/contextLimitRetry.ts
@@ -3,12 +3,7 @@ import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
 import { waitForRequestCount } from './helpers/waitForRequestCount';
-
-type DiagnosticsInfo = {
-  chat?: { hasView?: boolean; webviewReady?: boolean };
-  conversationId?: string | null;
-  mode?: 'local' | 'remote';
-};
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 type ErrorInfo = { seq?: number } | null;
 
@@ -164,7 +159,7 @@ export async function run(): Promise<void> {
         return !(afterError && afterErrorSeq > beforeErrorSeq);
       }, 60000, 250);
     } catch (err) {
-      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
       const lastError: any = await vscode.commands.executeCommand('openhands._queryLastError');
       const rendered: any = await vscode.commands.executeCommand('openhands._queryRenderedEvents');
       const recent = mock.requests

--- a/tests/e2e/suite/errorHandling.ts
+++ b/tests/e2e/suite/errorHandling.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,15 +8,15 @@ export async function run(): Promise<void> {
 
   // Wait until view and webview are ready
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   // Start fresh conversation
   await vscode.commands.executeCommand('openhands.startNewConversation');
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
   // Test 1: Send AgentErrorEvent
@@ -190,13 +191,16 @@ export async function run(): Promise<void> {
   }
 
   // Test 7: Verify diagnostics show proper state
-  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diag?.chat) {
+    throw new Error('Diagnostics missing chat object');
+  }
 
   if (!diag.chat.webviewReady) {
     throw new Error('Webview should still be ready after error events');
   }
 
-  console.log(`Diagnostics - eventBacklog size: ${diag.eventBacklog.size}`);
+  console.log(`Diagnostics - eventBacklog size: ${diag.eventBacklog?.size ?? 0}`);
   const expectedMinBacklogSize = expectedAgentErrors + 1 + 1 + 1 + 1; // +ConversationError +Observation +Pause +Condensation
   if ((diag.eventBacklog?.size ?? 0) < expectedMinBacklogSize) {
     throw new Error(`Expected eventBacklog.size >= ${expectedMinBacklogSize}, got ${diag.eventBacklog?.size ?? 0}`);
@@ -208,11 +212,11 @@ export async function run(): Promise<void> {
 
   // Poll until webview is ready
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
-  const diagAfterRecovery: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diagAfterRecovery = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
   const backlogAfterRecovery = diagAfterRecovery?.eventBacklog?.size ?? 0;
   if (backlogAfterRecovery >= backlogBeforeRecovery) {
     throw new Error(`Expected eventBacklog.size to reset after recovery (before=${backlogBeforeRecovery}, after=${backlogAfterRecovery})`);

--- a/tests/e2e/suite/gvc.ts
+++ b/tests/e2e/suite/gvc.ts
@@ -4,12 +4,7 @@ import * as path from 'path';
 import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
-
-type DiagnosticsInfo = {
-  chat?: { hasView?: boolean; webviewReady?: boolean };
-  conversationId?: string | null;
-  mode?: 'local' | 'remote';
-};
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 function extractUserMessageTexts(json: unknown): string[] {
   if (!json || typeof json !== 'object' || Array.isArray(json)) return [];

--- a/tests/e2e/suite/halNegative.ts
+++ b/tests/e2e/suite/halNegative.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -20,7 +21,7 @@ export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
@@ -100,4 +101,3 @@ export async function run(): Promise<void> {
 
   await assertHalStaysIdle(2000);
 }
-

--- a/tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts
+++ b/tests/e2e/suite/helpers/sendAndWaitForRequestPath.ts
@@ -1,13 +1,10 @@
 import * as vscode from 'vscode';
 import type { MockLlmRequest } from '../mockLlmServer';
 import { waitForRequestCount } from './waitForRequestCount';
+import type { DiagnosticsInfo } from './diagnosticsInfo';
 
 type WebviewActionResult = {
   sent?: boolean;
-};
-
-type DiagnosticsInfo = {
-  eventBacklog?: { latestSeq?: number };
 };
 
 type ErrorInfo = { seq?: number } | null;
@@ -47,7 +44,7 @@ export async function sendAndWaitForRequestPath(options: {
   const afterError = await vscode.commands.executeCommand<ErrorInfo>('openhands._queryLastError');
   const afterErrorSeq = typeof afterError?.seq === 'number' ? afterError.seq : -1;
   if (afterError && afterErrorSeq > beforeErrorSeq) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     throw new Error(
       `Detected error event(s) after sending message.\n` +
       `- diag: ${JSON.stringify(diag)}\n` +

--- a/tests/e2e/suite/helpers/waitForRequestCount.ts
+++ b/tests/e2e/suite/helpers/waitForRequestCount.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
 import { pollUntil } from '../pollUntil';
 import type { MockLlmRequest } from '../mockLlmServer';
-
-type DiagnosticsInfo = {
-  eventBacklog?: { latestSeq?: number };
-};
+import type { DiagnosticsInfo } from './diagnosticsInfo';
 
 type ErrorInfo = { seq?: number } | null;
 

--- a/tests/e2e/suite/history.ts
+++ b/tests/e2e/suite/history.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,12 +8,15 @@ export async function run(): Promise<void> {
 
   // Wait until view and webview are ready
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   // Test 1: Verify initial state - webview should be ready
-  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diag) {
+    throw new Error('Diagnostics command returned null/undefined');
+  }
   if (!diag?.chat?.webviewReady) {
     throw new Error('Webview not ready');
   }
@@ -25,11 +29,14 @@ export async function run(): Promise<void> {
 
   // Poll until webview is ready after new conversation
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
-  const diagAfterNew: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diagAfterNew = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diagAfterNew) {
+    throw new Error('Diagnostics command returned null/undefined');
+  }
   console.log(`Conversation ID after new: ${diagAfterNew.conversationId || 'none'}`);
   if (initialConversationId && diagAfterNew.conversationId && diagAfterNew.conversationId === initialConversationId) {
     throw new Error(`Expected conversationId to change after startNewConversation (still ${diagAfterNew.conversationId})`);
@@ -89,7 +96,10 @@ export async function run(): Promise<void> {
   }
 
   // Test 5: Verify event backlog is tracked
-  const diagWithEvents: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diagWithEvents = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diagWithEvents) {
+    throw new Error('Diagnostics command returned null/undefined');
+  }
   console.log(`Event backlog size: ${diagWithEvents.eventBacklog?.size || 0}`);
   const backlogWithEvents = diagWithEvents.eventBacklog?.size ?? 0;
   if (backlogWithEvents < testEvents.length) {
@@ -101,11 +111,14 @@ export async function run(): Promise<void> {
 
   // Poll until webview is ready
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
-  const diagAfterReset: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diagAfterReset = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diagAfterReset) {
+    throw new Error('Diagnostics command returned null/undefined');
+  }
   const backlogAfterReset = diagAfterReset.eventBacklog?.size ?? 0;
   if (backlogAfterReset >= backlogWithEvents) {
     throw new Error(`Expected eventBacklog.size to reset after new conversation (before=${backlogWithEvents}, after=${backlogAfterReset})`);

--- a/tests/e2e/suite/llmProfiles.ts
+++ b/tests/e2e/suite/llmProfiles.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 type WebviewActionResult = {
   sent?: boolean;
@@ -16,7 +17,7 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands.open');
 
     await pollUntil(async () => {
-      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
       return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
     }, 15000);
 

--- a/tests/e2e/suite/llmSwitching.ts
+++ b/tests/e2e/suite/llmSwitching.ts
@@ -3,6 +3,7 @@ import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
 import type { MockLlmRequest } from './mockLlmServer';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 function assertRequestHeaders(
   request: MockLlmRequest,
@@ -35,7 +36,7 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands.open');
 
     await pollUntil(async () => {
-      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
       return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
     }, 15000);
 

--- a/tests/e2e/suite/messaging.ts
+++ b/tests/e2e/suite/messaging.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,15 +8,15 @@ export async function run(): Promise<void> {
 
   // Wait until view and webview are ready
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   // Start fresh conversation
   await vscode.commands.executeCommand('openhands.startNewConversation');
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
   // Test 1: Send various message events with different roles

--- a/tests/e2e/suite/oracleConfigured.ts
+++ b/tests/e2e/suite/oracleConfigured.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { startOpenAiToolCallsMockServer } from './helpers/openAiToolCallsServer';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 type WebviewActionResult = { sent?: boolean };
 
@@ -30,7 +31,7 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands.open');
 
     await pollUntil(async () => {
-      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
       return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
     }, 15000);
 

--- a/tests/e2e/suite/oracleUnset.ts
+++ b/tests/e2e/suite/oracleUnset.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import { startOpenAiToolCallsMockServer } from './helpers/openAiToolCallsServer';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 type WebviewActionResult = { sent?: boolean };
 
@@ -28,7 +29,7 @@ export async function run(): Promise<void> {
     await vscode.commands.executeCommand('openhands.open');
 
     await pollUntil(async () => {
-      const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+      const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
       return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
     }, 15000);
 

--- a/tests/e2e/suite/serverSelection.ts
+++ b/tests/e2e/suite/serverSelection.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,15 +8,18 @@ export async function run(): Promise<void> {
 
   // Wait until view and webview are ready
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   // Test 1: Check initial mode (should be local when no serverUrl configured)
-  let diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  let diag: DiagnosticsInfo | undefined = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
 
   if (!diag) {
     throw new Error('Diagnostics returned null');
+  }
+  if (!diag.chat) {
+    throw new Error('Diagnostics missing chat object');
   }
 
   console.log(`Initial mode: ${diag.mode}`);
@@ -58,11 +62,14 @@ export async function run(): Promise<void> {
 
   // Poll until webview is ready after reconnect
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
-  diag = await vscode.commands.executeCommand('openhands._diagnostics');
+  diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diag?.chat) {
+    throw new Error('Diagnostics missing chat object');
+  }
   console.log(`Mode after reconnect: ${diag.mode}`);
 
   // Test 6: Verify webview maintains readiness after reconnect
@@ -75,11 +82,14 @@ export async function run(): Promise<void> {
 
   // Poll until webview is ready after new conversation
   await pollUntil(async () => {
-    const d: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return d?.chat?.webviewReady;
+    const d = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(d?.chat?.webviewReady);
   });
 
-  diag = await vscode.commands.executeCommand('openhands._diagnostics');
+  diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diag?.chat) {
+    throw new Error('Diagnostics missing chat object');
+  }
   console.log(`Mode after new conversation: ${diag.mode}`);
 
   // Mode should persist across conversation changes
@@ -107,10 +117,13 @@ export async function run(): Promise<void> {
     return r?.count >= 1;
   });
 
-  diag = await vscode.commands.executeCommand('openhands._diagnostics');
+  diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+  if (!diag) {
+    throw new Error('Diagnostics returned null');
+  }
 
   // Verify backlog increased
-  if (diag.eventBacklog.size < 1) {
+  if ((diag.eventBacklog?.size ?? 0) < 1) {
     throw new Error('Event backlog should have increased after sending a test event');
   }
 

--- a/tests/e2e/suite/settings.ts
+++ b/tests/e2e/suite/settings.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Ensure chat view is created
@@ -7,13 +8,13 @@ export async function run(): Promise<void> {
   // Wait until view and webview are ready
   const deadline = Date.now() + 15000;
   while (Date.now() < deadline) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     if (diag?.chat?.hasView && diag?.chat?.webviewReady) break;
     await new Promise((r) => setTimeout(r, 200));
   }
 
   // Test 1: Verify diagnostics command returns expected structure
-  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
 
   if (!diag) {
     throw new Error('Diagnostics command returned null/undefined');
@@ -69,9 +70,9 @@ export async function run(): Promise<void> {
 
   // Poll until webview is ready after new conversation
   const afterDeadline = Date.now() + 10000;
-  let diagAfter: any;
+  let diagAfter: DiagnosticsInfo | undefined;
   while (Date.now() < afterDeadline) {
-    diagAfter = await vscode.commands.executeCommand('openhands._diagnostics');
+    diagAfter = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     if (diagAfter?.chat?.webviewReady) break;
     await new Promise((r) => setTimeout(r, 200));
   }

--- a/tests/e2e/suite/terminalProgress.ts
+++ b/tests/e2e/suite/terminalProgress.ts
@@ -1,12 +1,13 @@
 import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import type { BashEvent } from '@openhands/agent-sdk-ts';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
@@ -35,7 +36,7 @@ export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands._injectTerminalEvent', exit);
 
   // Ensure terminal exists and we saw lots of events (coalesced)
-  const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+  const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
   if (!diag?.terminal?.hasTerminal) throw new Error('Expected OpenHands terminal to exist');
   if (typeof diag?.terminal?.received !== 'number' || diag.terminal.received < 10) {
     throw new Error(`Expected many terminal events, got: ${JSON.stringify(diag?.terminal)}`);

--- a/tests/e2e/suite/tpq.ts
+++ b/tests/e2e/suite/tpq.ts
@@ -2,10 +2,7 @@ import * as vscode from 'vscode';
 import { pollUntil } from './pollUntil';
 import { startMockLlmServer } from './mockLlmServer';
 import { sendAndWaitForRequestPath } from './helpers/sendAndWaitForRequestPath';
-
-type DiagnosticsInfo = {
-  chat?: { hasView?: boolean; webviewReady?: boolean };
-};
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 function extractEnvInfoBlock(bodyText: string): string | null {
   const start = bodyText.indexOf('<environment information>');

--- a/tests/e2e/suite/uiFlows.ts
+++ b/tests/e2e/suite/uiFlows.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
 
 export async function run(): Promise<void> {
   // Skills: create a temp skill file *before* opening the webview so the initial
@@ -15,8 +16,8 @@ export async function run(): Promise<void> {
   await vscode.commands.executeCommand('openhands.open');
 
   await pollUntil(async () => {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
-    return diag?.chat?.hasView && diag?.chat?.webviewReady;
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
   await pollUntil(async () => {
@@ -36,7 +37,7 @@ export async function run(): Promise<void> {
       return state?.showContextPicker === true && typeof state.workspaceFilesCount === 'number';
     }, 15000);
   } catch (err) {
-    const diag: any = await vscode.commands.executeCommand('openhands._diagnostics');
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
     const state: any = await vscode.commands.executeCommand('openhands._queryUiState');
     console.log('diagnosticsOnFailure', diag);
     console.log('uiStateOnFailure', state);


### PR DESCRIPTION
Type `openhands._diagnostics` payload and use it across E2E suite.

- Add typed `DiagnosticsInfo`/`TerminalLogInfo` for the command output.
- Update `openhands._diagnostics` command registration to return the typed payload.
- Replace `any` diagnostics usages in E2E suite with `DiagnosticsInfo`.

Tests:
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx tsc -p tests/e2e/tsconfig.suite.json`

### Bead

oh-tab-meh: (tech debt) Dev: type the openhands._diagnostics payload
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 06:18
Updated: 2026-01-15 06:18

Description:
Problem
- The `_diagnostics` command payload is treated as `any`/`unknown` in several places, leading to repeated `as unknown as ...` casts and brittle tests.
- This makes it easy to accidentally break diagnostics consumers and hard to refactor safely.

Goal
- Define a proper `DiagnosticsInfo` type (or interface) for the `_diagnostics` command output and use it consistently.

Proposed approach
- Add a shared type definition (suggested location: `src/dev/diagnosticsTypes.ts` or `src/shared/diagnostics.ts`).
- Update `src/dev/registerDiagnosticsCommands.ts` to return that typed structure.
- Update callsites/tests that consume `_diagnostics` to use the type instead of `any`.

Constraints
- No behavior changes; this is typing + light cleanup.

Acceptance Criteria:
- `_diagnostics` output has an exported type and is used at key callsites/tests.
- Removes a meaningful number of `as unknown as` casts around diagnostics.
- Unit tests remain green.

Labels: [dev tech-debt types]


### Review

- OrangeCastle: LGTM to merge (Agent Mail 2026-01-15); ran `npx tsc -p tests/e2e/tsconfig.suite.json --noEmit`.
