### PR TITLE
oh-tab-law: query last user MessageEvent extended_content

### DIFF
--- a/src/dev/diagnosticsTypes.ts
+++ b/src/dev/diagnosticsTypes.ts
@@ -31,3 +31,9 @@ export type DiagnosticsInfo = {
   terminal?: TerminalLogInfo;
 };
 
+export type LastUserMessageInfo = {
+  seq: number;
+  contentTextPreview: string;
+  extendedContentTextPreview: string;
+  extendedContentCount: number;
+} | null;

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -3,16 +3,17 @@ import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsMan
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import { DEFAULT_HAL_STATE } from '../shared/halDefaults';
 import { resolveConfiguredLlmLabel } from '../shared/llmProfiles';
+import { maskSecretsInText } from '../shared/maskSecrets';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
 import { getServerSessionApiKeySecretKey, LEGACY_SESSION_API_KEY_SECRET_KEY } from '../auth/serverSessionApiKeys';
 import * as llmProfilesStore from '../webview/host/llmProfilesStore';
 import { OpenHandsTerminalLogPseudoterminal } from '../terminal/OpenHandsTerminalLogPseudoterminal';
-import { isBashEvent, type BashEvent, type ConversationInstance, type Event, type SecretRegistry } from '@openhands/agent-sdk-ts';
-import type { DiagnosticsInfo, TerminalLogInfo } from './diagnosticsTypes';
+import { isBashEvent, isTextContent, type BashEvent, type ConversationInstance, type Event, type SecretRegistry } from '@openhands/agent-sdk-ts';
+import type { DiagnosticsInfo, LastUserMessageInfo, TerminalLogInfo } from './diagnosticsTypes';
 
-export type { DiagnosticsInfo, TerminalLogInfo } from './diagnosticsTypes';
+export type { DiagnosticsInfo, LastUserMessageInfo, TerminalLogInfo } from './diagnosticsTypes';
 
 
 export type RenderedEventsInfo = {
@@ -115,6 +116,11 @@ function createPendingResponse<T>(
     },
   };
 }
+
+const truncatePreview = (text: string, maxChars: number): string => {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, maxChars)}…(truncated)`;
+};
 
 export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDeps): vscode.Disposable[] {
   const postToWebview = async (message: HostToWebviewMessage): Promise<boolean> => {
@@ -343,6 +349,28 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
       lastEventKind,
       lastUserMessageSeq,
       lastAssistantMessageSeq,
+    };
+  });
+
+  const queryLastUserMessage = vscode.commands.registerCommand('openhands._queryLastUserMessage', (): LastUserMessageInfo => {
+    let last: { seq: number; event: Extract<Event, { kind: 'MessageEvent' }> } | undefined;
+    for (const item of deps.iterConversationEventBacklog()) {
+      if (item.event.kind !== 'MessageEvent') continue;
+      if (item.event.source !== 'user') continue;
+      last = { seq: item.seq, event: item.event };
+    }
+    if (!last) return null;
+
+    const contentText = last.event.llm_message.content.filter(isTextContent).map((c) => c.text).join('\n');
+    const extended = last.event.extended_content ?? [];
+    const extendedText = extended.map((c) => c.text).join('\n');
+    const maxChars = 400;
+
+    return {
+      seq: last.seq,
+      contentTextPreview: maskSecretsInText(truncatePreview(contentText, maxChars), deps.secretRegistry),
+      extendedContentTextPreview: maskSecretsInText(truncatePreview(extendedText, maxChars), deps.secretRegistry),
+      extendedContentCount: extended.length,
     };
   });
 
@@ -648,6 +676,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     queryLastError,
     queryLastObservation,
     queryBacklogSummary,
+    queryLastUserMessage,
     sendTestEvent,
     queryRenderedEvents,
     queryUiState,

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -365,11 +365,13 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     const extended = last.event.extended_content ?? [];
     const extendedText = extended.map((c) => c.text).join('\n');
     const maxChars = 400;
+    const maskedContentText = maskSecretsInText(contentText, deps.secretRegistry);
+    const maskedExtendedText = maskSecretsInText(extendedText, deps.secretRegistry);
 
     return {
       seq: last.seq,
-      contentTextPreview: maskSecretsInText(truncatePreview(contentText, maxChars), deps.secretRegistry),
-      extendedContentTextPreview: maskSecretsInText(truncatePreview(extendedText, maxChars), deps.secretRegistry),
+      contentTextPreview: truncatePreview(maskedContentText, maxChars),
+      extendedContentTextPreview: truncatePreview(maskedExtendedText, maxChars),
       extendedContentCount: extended.length,
     };
   });

--- a/tests/e2e/lastUserMessage.test.ts
+++ b/tests/e2e/lastUserMessage.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-last-user-message-${Date.now()}`);
+const userDataDir = path.join(os.tmpdir(), `vscode-t-lum-${Date.now()}`);
 
 describe('OpenHands-Tab last user message diagnostics E2E', function () {
   this.timeout(120000);
@@ -36,4 +36,3 @@ describe('OpenHands-Tab last user message diagnostics E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/lastUserMessage.test.ts
+++ b/tests/e2e/lastUserMessage.test.ts
@@ -1,0 +1,39 @@
+import * as assert from 'assert';
+import { runTests } from '@vscode/test-electron';
+import * as path from 'path';
+import * as os from 'os';
+import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = path.join(os.tmpdir(), `vscode-test-last-user-message-${Date.now()}`);
+
+describe('OpenHands-Tab last user message diagnostics E2E', function () {
+  this.timeout(120000);
+
+  it('returns last user MessageEvent content vs extended_content', async () => {
+    const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
+    const extensionTestsPath = path.resolve(__dirname, './suite');
+
+    await ensureVsCodeArgvJson(userDataDir);
+
+    await runTests({
+      vscodeExecutablePath,
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      launchArgs: [
+        '--no-sandbox',
+        '--user-data-dir', userDataDir,
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        extensionDevelopmentPath,
+      ],
+      extensionTestsEnv: {
+        TEST_NAME: 'lastUserMessage',
+      },
+    });
+
+    assert.ok(true);
+  });
+});
+

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -120,6 +120,11 @@ export async function run(): Promise<void> {
     return runDeviceFlowAuthTest();
   }
 
+  if (testName === 'lastUserMessage') {
+    const { run: runLastUserMessageTest } = await import('./lastUserMessage');
+    return runLastUserMessageTest();
+  }
+
   // Default smoke test: open the chat view and verify it works
   await vscode.commands.executeCommand('openhands.open');
   // Wait until view and webview are ready via diagnostics to avoid flakiness

--- a/tests/e2e/suite/lastUserMessage.ts
+++ b/tests/e2e/suite/lastUserMessage.ts
@@ -1,0 +1,60 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import { waitForDiagnostics } from './helpers/waitForDiagnostics';
+
+type LastUserMessageInfo = {
+  seq: number;
+  contentTextPreview: string;
+  extendedContentTextPreview: string;
+  extendedContentCount: number;
+} | null;
+
+export async function run(): Promise<void> {
+  await vscode.commands.executeCommand('openhands.open');
+  await waitForDiagnostics({
+    label: 'chat view ready',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.chat?.hasView && diag.chat?.webviewReady),
+  });
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await waitForDiagnostics({
+    label: 'after startNewConversation',
+    timeoutMs: 15000,
+    predicate: (diag) => Boolean(diag.chat?.webviewReady),
+  });
+
+  const contentText = 'E2E lastUserMessage: content text';
+  const extendedText = 'E2E lastUserMessage: extended content';
+
+  await vscode.commands.executeCommand('openhands._sendTestEvent', {
+    kind: 'MessageEvent',
+    source: 'user',
+    llm_message: { role: 'user', content: [{ type: 'text', text: contentText }] },
+    extended_content: [{ type: 'text', text: extendedText }],
+  });
+
+  await pollUntil(async () => {
+    const info = await vscode.commands.executeCommand<LastUserMessageInfo>('openhands._queryLastUserMessage');
+    return Boolean(
+      info &&
+        typeof info.seq === 'number' &&
+        info.extendedContentCount === 1 &&
+        info.contentTextPreview.includes(contentText) &&
+        info.extendedContentTextPreview.includes(extendedText),
+    );
+  }, 15000);
+
+  const info = await vscode.commands.executeCommand<LastUserMessageInfo>('openhands._queryLastUserMessage');
+  if (!info) throw new Error('Expected openhands._queryLastUserMessage to return a payload');
+  if (info.extendedContentCount !== 1) {
+    throw new Error(`Expected extendedContentCount to be 1, got ${info.extendedContentCount}`);
+  }
+  if (!info.contentTextPreview.includes(contentText)) {
+    throw new Error(`Expected contentTextPreview to include content text, got: ${JSON.stringify(info)}`);
+  }
+  if (!info.extendedContentTextPreview.includes(extendedText)) {
+    throw new Error(`Expected extendedContentTextPreview to include extended content, got: ${JSON.stringify(info)}`);
+  }
+}
+


### PR DESCRIPTION
Adds an internal diagnostics command for E2E to inspect the last user `MessageEvent` content vs `extended_content`.

- Add `openhands._queryLastUserMessage` (redacted + truncated previews).
- Add E2E suite `lastUserMessage` exercising the command.

Checks run:
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npx tsc -p tests/e2e/tsconfig.suite.json`
- `npm run e2e -- --grep "last user message"`

### Bead

oh-tab-law: (tech debt) E2E: add diagnostics command to inspect last user MessageEvent extended_content
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 06:25
Updated: 2026-01-15 06:25

Description:
Problem
- Several behaviors depend on `MessageEvent.extended_content` (env info suffix, watched-file notes, skill suffixes), but our E2E harness cannot easily assert `llm_message.content` vs `extended_content` separation.
- Today E2E tests can only inspect outbound LLM requests (where extended content is merged), which loses signal.

Goal
- Add an internal diagnostics command to support E2E assertions about the raw event backlog.

Proposed approach
- Add `openhands._queryLastUserMessage` (or similar) that returns a small, redacted summary of the last user `MessageEvent` in the backlog:
  - `seq`, `contentTextPreview`, `extendedContentPreview`, `extendedContentCount`
  - No secrets; truncate previews.

Acceptance Criteria:
- New internal diagnostics command exists and is used by at least one E2E suite.
- Payload is redacted/truncated and safe for logs.
- Tests remain green.

Labels: [dev e2e tech-debt tests]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic command to query and retrieve the last user message from conversation history, including text previews and extended content count information for support diagnostics.

* **Tests**
  * Added end-to-end test suite to validate the functionality and reliability of the last user message query diagnostics feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



### Review

- OrangeCastle re-reviewed after the mask-before-truncate fix + shorter E2E `--user-data-dir` basename; ran `npm run e2e -- --grep "last user message"` and replied **LGTM to merge** via Agent Mail.
