### PR TITLE
oh-tab-voc.7: scope sessionApiKey to server

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -598,6 +598,111 @@ describe('Chat view behavior', () => {
     expect(__getLastConversation()).toBeTruthy();
   });
 
+  it('does not send legacy sessionApiKey to a server when the per-server key is missing', async () => {
+    const secretStorage = new Map<string, string>();
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+
+    mockSettings = {
+      ...mockSettings,
+      serverUrl: 'http://localhost:3000',
+      secrets: {
+        ...mockSettings.secrets,
+        sessionApiKey: 'legacy-token',
+      },
+    };
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Not now');
+
+    await resolveChatView(mockContext);
+
+    const { Conversation } = await import('@openhands/agent-sdk-ts');
+    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
+    expect(options?.settings?.secrets?.sessionApiKey).toBeUndefined();
+
+    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
+    const keyInfo = getServerSessionApiKeySecretKey(mockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+
+    expect(mockContext.secrets.store).not.toHaveBeenCalledWith(keyInfo.secretKey, expect.anything());
+  });
+
+  it('migrates legacy sessionApiKey to the per-server secret key after confirmation', async () => {
+    const secretStorage = new Map<string, string>();
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+
+    mockSettings = {
+      ...mockSettings,
+      serverUrl: 'http://localhost:3000',
+      secrets: {
+        ...mockSettings.secrets,
+        sessionApiKey: 'legacy-token',
+      },
+    };
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Use key for this server');
+
+    await resolveChatView(mockContext);
+
+    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
+    const keyInfo = getServerSessionApiKeySecretKey(mockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+
+    expect(secretStorage.get(keyInfo.secretKey)).toBe('legacy-token');
+
+    const { Conversation } = await import('@openhands/agent-sdk-ts');
+    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
+    expect(options?.settings?.secrets?.sessionApiKey).toBe('legacy-token');
+  });
+
+  it('does not reuse legacy sessionApiKey when switching servers without a per-server key', async () => {
+    const secretStorage = new Map<string, string>();
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
+      secretStorage.set(key, value);
+    });
+
+    mockSettings = {
+      ...mockSettings,
+      serverUrl: 'http://server-a.test:3000',
+      secrets: {
+        ...mockSettings.secrets,
+        sessionApiKey: 'legacy-token',
+      },
+    };
+
+    (vscode.window.showWarningMessage as Mock)
+      .mockResolvedValueOnce('Not now')
+      .mockResolvedValueOnce('Not now');
+
+    await resolveChatView(mockContext);
+
+    mockSettings = { ...mockSettings, serverUrl: 'http://server-b.test:3000' };
+    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', mockSettings.serverUrl);
+    (vscode as any).__triggerConfigChange({
+      affectsConfiguration: (key: string) => key === 'openhands.serverUrl',
+    });
+
+    const { Conversation } = await import('@openhands/agent-sdk-ts');
+    const beforeCalls = (Conversation as unknown as Mock).mock.calls.length;
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if ((Conversation as unknown as Mock).mock.calls.length > beforeCalls) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
+    expect(options?.settings?.secrets?.sessionApiKey).toBeUndefined();
+  });
+
   it('does not auto-restore saved conversation on first chat view resolve', async () => {
     // Intentionally does not restore on first open - users may return after weeks
     // and won't remember what the conversation was about

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -526,21 +526,77 @@ export function activate(context: vscode.ExtensionContext) {
     let settings = await settingsMgr.get();
     lastKnownLlmLabel = resolveConfiguredLlmLabel(settings);
 
+    const trimOrEmpty = (value: unknown): string => typeof value === 'string' ? value.trim() : '';
+
+    const withSessionApiKey = (token: string | undefined): typeof settings => {
+      const secrets = { ...(settings.secrets ?? {}) } as Record<string, unknown>;
+      if (token) {
+        secrets.sessionApiKey = token;
+      } else {
+        delete secrets.sessionApiKey;
+      }
+      return { ...settings, secrets: secrets as typeof settings.secrets };
+    };
+
     if (typeof settings.serverUrl === 'string' && settings.serverUrl.trim()) {
-      const serverKey = getServerSessionApiKeySecretKey(settings.serverUrl);
-      if (serverKey.ok) {
+      const keyInfo = getServerSessionApiKeySecretKey(settings.serverUrl);
+      if (keyInfo.ok) {
+        const legacyToken = trimOrEmpty(settings.secrets?.sessionApiKey);
+
         let stored: string | undefined;
         try {
-          stored = await context.secrets.get(serverKey.secretKey);
+          stored = await context.secrets.get(keyInfo.secretKey);
         } catch {
           stored = undefined;
         }
-        const token = typeof stored === 'string' ? stored.trim() : '';
-        if (token) {
-          settings = {
-            ...settings,
-            secrets: { ...settings.secrets, sessionApiKey: token },
-          };
+        const perServerToken = trimOrEmpty(stored);
+
+        if (perServerToken) {
+          settings = withSessionApiKey(perServerToken);
+        } else if (!legacyToken) {
+          // No per-server token and no legacy token: do not send a session key at all.
+          settings = withSessionApiKey(undefined);
+        } else {
+          // Legacy token exists, but do not auto-send it to an arbitrary server. Offer one-time migration.
+          const serverHash = keyInfo.secretKey.split('.server.')[1] ?? keyInfo.secretKey;
+          const promptKey = `openhands.sessionApiKey.migrationPrompted.${serverHash}`;
+          const alreadyPrompted = context.globalState.get<boolean>(promptKey) === true;
+
+          if (alreadyPrompted) {
+            settings = withSessionApiKey(undefined);
+          } else {
+            // Mark prompted before awaiting UI to avoid duplicate prompts from rapid config changes.
+            await context.globalState.update(promptKey, true);
+
+            const serverLabel = (() => {
+              try {
+                const url = new URL(keyInfo.normalizedServerUrl);
+                return url.hostname + (url.port ? `:${url.port}` : '');
+              } catch {
+                return keyInfo.normalizedServerUrl;
+              }
+            })();
+
+            const action = await vscode.window.showWarningMessage(
+              `OpenHands: A legacy Session API Key is set. Use it for ${serverLabel}?`,
+              { modal: true },
+              'Use key for this server',
+              'Not now',
+            );
+
+            if (action === 'Use key for this server') {
+              try {
+                await context.secrets.store(keyInfo.secretKey, legacyToken);
+                secrets.set(keyInfo.secretKey, legacyToken);
+                settings = withSessionApiKey(legacyToken);
+              } catch (err) {
+                outputChannel?.appendLine(`[auth] Failed to migrate session API key for ${keyInfo.normalizedServerUrl}: ${renderError(err)}`);
+                settings = withSessionApiKey(undefined);
+              }
+            } else {
+              settings = withSessionApiKey(undefined);
+            }
+          }
         }
       }
     }

--- a/src/extension/secretCommands.ts
+++ b/src/extension/secretCommands.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import type { ConversationInstance, SecretRegistry } from '@openhands/agent-sdk-ts';
+import { getServerSessionApiKeySecretKey, LEGACY_SESSION_API_KEY_SECRET_KEY } from '../auth/serverSessionApiKeys';
 
 type SecretKey = keyof OpenHandsSettings['secrets'];
 
@@ -270,13 +271,111 @@ export function registerSecretCommands(params: {
     errorPrefix: 'Failed to save Gemini API key',
   });
 
-  const setSessionApiKey = registerSecretCommand('openhands.setSessionApiKey', {
-    title: 'Session API Key',
-    secretKey: 'sessionApiKey',
-    prompt: 'Enter your Session API key. It will be stored securely in VS Code SecretStorage.',
-    successMessage: 'Session API Key saved securely.',
-    clearedMessage: 'Session API Key cleared.',
-    errorPrefix: 'Failed to save Session API Key',
+  const setSessionApiKey = vscode.commands.registerCommand('openhands.setSessionApiKey', async () => {
+    const title = 'Session API Key';
+    const prompt = 'Enter your Session API key. It will be stored securely in VS Code SecretStorage.';
+    const successMessage = 'Session API Key saved securely.';
+    const clearedMessage = 'Session API Key cleared.';
+    const errorPrefix = 'Failed to save Session API Key';
+
+    const trimOrEmpty = (value: unknown): string => typeof value === 'string' ? value.trim() : '';
+
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(params.context));
+      const existing = await settingsMgr.get();
+      const serverUrl = typeof existing.serverUrl === 'string' ? existing.serverUrl.trim() : '';
+
+      const keyInfo = serverUrl ? getServerSessionApiKeySecretKey(serverUrl) : null;
+      const storageKey = keyInfo?.ok ? keyInfo.secretKey : LEGACY_SESSION_API_KEY_SECRET_KEY;
+
+      let currentValue: string | undefined;
+      try {
+        currentValue = await params.context.secrets.get(storageKey);
+      } catch {
+        currentValue = undefined;
+      }
+      const isCurrentlySet = trimOrEmpty(currentValue).length > 0;
+
+      if (isCurrentlySet) {
+        const action = await vscode.window.showQuickPick(
+          [
+            { label: 'Update', value: 'update', description: 'Enter a new value (stored securely)' },
+            { label: 'Clear', value: 'clear', description: 'Remove the stored value' },
+          ],
+          {
+            title,
+            placeHolder: 'Choose an action',
+            canPickMany: false,
+          }
+        );
+        if (!action) return;
+
+        if (action.value === 'clear') {
+          const confirmed = await vscode.window.showWarningMessage(
+            `Clear ${title}${keyInfo?.ok ? ` for ${keyInfo.normalizedServerUrl}` : ''}?`,
+            { modal: true },
+            'Clear'
+          );
+          if (confirmed !== 'Clear') return;
+
+          await params.context.secrets.delete(storageKey);
+          params.secrets.set(storageKey, undefined);
+          vscode.window.showInformationMessage(clearedMessage);
+
+          const updated = await settingsMgr.get();
+          const next = keyInfo?.ok
+            ? { ...updated, secrets: { ...updated.secrets, sessionApiKey: undefined } }
+            : updated;
+          params.getConversation()?.setSettings(next);
+          await syncSecretStatusIndicatorsBestEffort();
+          return;
+        }
+      }
+
+      const value = await vscode.window.showInputBox({
+        title,
+        password: true,
+        prompt,
+        placeHolder: 'sk-...',
+      });
+
+      if (value === undefined) return;
+      const trimmed = value.trim();
+      if (!trimmed) return;
+
+      if (keyInfo?.ok) {
+        await params.context.secrets.store(storageKey, trimmed);
+        params.secrets.set(storageKey, trimmed);
+
+        let legacyRaw: string | undefined;
+        try {
+          legacyRaw = await params.context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
+        } catch {
+          legacyRaw = undefined;
+        }
+        const legacyValue = trimOrEmpty(legacyRaw);
+        const canUpdateLegacy = !legacyValue || legacyValue === trimmed;
+        if (canUpdateLegacy) {
+          await params.context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
+          params.secrets.set(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
+        }
+      } else {
+        await params.context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
+        params.secrets.set(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
+      }
+
+      vscode.window.showInformationMessage(successMessage);
+
+      const updated = await settingsMgr.get();
+      const next = keyInfo?.ok
+        ? { ...updated, secrets: { ...updated.secrets, sessionApiKey: trimmed } }
+        : updated;
+      params.getConversation()?.setSettings(next);
+      await syncSecretStatusIndicatorsBestEffort();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      vscode.window.showErrorMessage(`${errorPrefix}: ${message}`);
+    }
   });
 
   const setGithubToken = registerSecretCommand('openhands.setGithubToken', {


### PR DESCRIPTION
Stops leaking the legacy global `openhands.sessionApiKey` to unrelated servers by scoping session API keys to the selected `serverUrl`.

- Remote mode now uses only the per-server key from `getServerSessionApiKeySecretKey(serverUrl)`.
- If per-server is missing but legacy is set, prompts once to migrate legacy → per-server for the current server.
- `openhands.setSessionApiKey` writes the per-server key when `serverUrl` is set.
- Adds unit coverage for the “don’t reuse legacy when switching servers” behavior.

Checks run:
- `npx vitest run src/__tests__/extension.test.ts`
- `npm run typecheck`
- `npm run lint`

### Bead

oh-tab-voc.7: Session API Key: scope to server + avoid cross-server leak
Status: open
Priority: P2
Type: task
Created: 2026-01-15 23:58
Updated: 2026-01-15 23:58

Description:
Now that we support per-server session API keys (device-flow login stores under a derived per-server secret key), the legacy global secret openhands.sessionApiKey can be accidentally sent to the wrong server when the user switches servers (if the per-server key is missing). We should avoid leaking a token to an unrelated host while keeping backward compatibility for existing users who only have the legacy secret set.

Acceptance Criteria:
- When settings.serverUrl is set, prefer using the per-server session key only; do not send the legacy global key to arbitrary servers
- Add a migration path: if per-server key is missing but legacy openhands.sessionApiKey is set, copy/associate it into the per-server key for the current server (one-time)
- Update the manual command openhands.setSessionApiKey to write the per-server key for the current serverUrl (and optionally update legacy only if empty/same)
- Add unit coverage (src/__tests__/extension.test.ts) to prove switching servers does not send legacy key to a different host when no per-server key exists
- Ensure remote tool-list fetch (src/webview/host/handlers/tools.ts) uses the same scoped key behavior

Labels: [auth security storage teleport]

Depends on (1):
  → oh-tab-voc.6: Device-flow auth: add logout/clear-token command [P2]

Blocks (1):
  ← oh-tab-voc: HAL teleport auth: OAuth 2.0 Device Flow for cloud servers [P1]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced per-server API key management to support server-specific session keys.
  * Added migration flow for legacy API keys with user confirmation prompts when switching servers.
  * Enhanced session API key update and clear experience with improved user prompts.

* **Tests**
  * Expanded test coverage for API key migration scenarios and per-server key handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- OrangeCastle reviewed in detached worktree; ran `npm run typecheck` + `npx vitest run src/__tests__/extension.test.ts` and replied **LGTM to merge** via Agent Mail.
