### PR TITLE
oh-tab-voc.4: expand device-flow cloud auth E2E

### DIFF
--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -112,6 +112,30 @@ Whether testing manually or automated, verify:
 - ✅ Command "OpenHands: Start New Conversation" succeeds (HTTP 201)
 - ✅ WebSocket connects (status shows online) and events stream when you send a message
 
+## OpenHands Cloud auth (Device Flow)
+
+### Hermetic E2E (CI-safe)
+
+The suite `tests/e2e/deviceFlowAuth.test.ts` validates the device-flow login loop against a **local mock OAuth server** (no real credentials, no external network dependency).
+
+- Run all E2E: `npm run e2e`
+- The suite sets `E2E_CLOUD_LOGIN=1` so the extension uses test-friendly UX (no browser open, no post-login prompts).
+- Covered scenarios include:
+  - Happy path login stores a per-server session key
+  - Logout clears stored credentials
+  - Error paths: `access_denied`, `expired_token`
+  - Polling backoff: `slow_down` then success
+
+### Manual live test (OpenHands Cloud)
+
+To validate against the real cloud server (`https://app.all-hands.dev`):
+
+1) Set server URL to `https://app.all-hands.dev` (via “OpenHands: Configure”)
+2) Run “OpenHands: Login to Remote Server (Device Flow)” and complete the browser flow
+3) Verify remote usage works (e.g., “OpenHands: Start New Conversation” succeeds and the chat goes online)
+4) Restart VS Code and verify the token persists (remote usage still works without re-login)
+5) Run “OpenHands: Logout of Remote Server” and verify remote usage fails (401/403) until you re-login
+
 ## CI Integration
 
 GitHub Actions workflows can be added in `.github/workflows/`:

--- a/src/extension/cloudLogoutCommand.ts
+++ b/src/extension/cloudLogoutCommand.ts
@@ -28,6 +28,12 @@ export function registerCloudLogoutCommand(options: {
   const { context } = options;
 
   return vscode.commands.registerCommand('openhands.cloudLogout', async () => {
+    const extensionMode = vscode.ExtensionMode;
+    const isTestMode =
+      extensionMode?.Test !== undefined &&
+      context.extensionMode === extensionMode.Test;
+    const isE2eMode = isTestMode && process.env.E2E_CLOUD_LOGIN === '1';
+
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
 
@@ -44,11 +50,13 @@ export function registerCloudLogoutCommand(options: {
     }
 
     const serverLabel = renderServerLabel(keyInfo.normalizedServerUrl);
-    const confirm = await vscode.window.showWarningMessage(
-      `OpenHands: Log out of ${serverLabel}? This will clear stored credentials for this server.`,
-      { modal: true },
-      'Log out',
-    );
+    const confirm = isE2eMode
+      ? 'Log out'
+      : await vscode.window.showWarningMessage(
+        `OpenHands: Log out of ${serverLabel}? This will clear stored credentials for this server.`,
+        { modal: true },
+        'Log out',
+      );
     if (confirm !== 'Log out') return;
 
     const output = options.getOutputChannel();
@@ -83,4 +91,3 @@ export function registerCloudLogoutCommand(options: {
     void vscode.window.showInformationMessage(`OpenHands: Logged out of ${serverLabel}.`);
   });
 }
-

--- a/tests/e2e/deviceFlowAuth.test.ts
+++ b/tests/e2e/deviceFlowAuth.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import * as os from 'os';
 import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-device-flow-auth-${Date.now()}`);
+const userDataDir = path.join(os.tmpdir(), `vscode-t-dfa-${Date.now()}`);
 
 describe('OpenHands-Tab OAuth Device Flow E2E', function () {
   this.timeout(180000);
@@ -37,4 +37,3 @@ describe('OpenHands-Tab OAuth Device Flow E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/suite/deviceFlowAuth.ts
+++ b/tests/e2e/suite/deviceFlowAuth.ts
@@ -7,6 +7,7 @@ type SessionApiKeyStatus = {
   ok?: boolean;
   normalizedServerUrl?: string;
   hasSessionApiKey?: boolean;
+  hasLegacySessionApiKey?: boolean;
 };
 
 async function setServerUrl(serverUrl: string): Promise<void> {
@@ -17,27 +18,33 @@ async function getSessionStatus(serverUrl: string): Promise<SessionApiKeyStatus>
   return await vscode.commands.executeCommand<SessionApiKeyStatus>('openhands._e2eGetServerSessionApiKeyStatus', { serverUrl });
 }
 
-async function runScenario(params: { scenario: DeviceFlowScenarioName; expectStored: boolean }): Promise<void> {
+async function runScenario(params: { scenario: DeviceFlowScenarioName; expectStored: boolean }): Promise<{ serverUrl: string }> {
   const server = await startMockOAuthDeviceFlowServer();
   server.enqueueScenario(params.scenario);
+  const serverUrl = server.baseUrl;
 
   try {
-    await setServerUrl(server.baseUrl);
+    await setServerUrl(serverUrl);
 
     await vscode.commands.executeCommand('openhands.cloudLogin');
 
     if (params.expectStored) {
       await pollUntil(async () => {
-        const status = await getSessionStatus(server.baseUrl);
+        const status = await getSessionStatus(serverUrl);
         return Boolean(status?.ok && status?.hasSessionApiKey);
       }, 60000, 250);
-      return;
+      return { serverUrl };
     }
 
-    const status = await getSessionStatus(server.baseUrl);
+    const status = await getSessionStatus(serverUrl);
     if (status?.ok && status?.hasSessionApiKey) {
       throw new Error(`Expected no stored session key for scenario=${params.scenario}, but status=${JSON.stringify(status)}`);
     }
+    if (status?.ok && status?.hasLegacySessionApiKey) {
+      throw new Error(`Expected legacy session key to remain unset for scenario=${params.scenario}, but status=${JSON.stringify(status)}`);
+    }
+
+    return { serverUrl };
   } finally {
     await server.close();
   }
@@ -55,9 +62,17 @@ export async function run(): Promise<void> {
     predicate: (diag) => Boolean(diag.chat?.hasView && diag.chat?.webviewReady),
   });
 
-  await runScenario({ scenario: 'happy', expectStored: true });
+  const happy = await runScenario({ scenario: 'happy', expectStored: true });
+
+  await vscode.commands.executeCommand('openhands.cloudLogout');
+  await pollUntil(async () => {
+    const status = await getSessionStatus(happy.serverUrl);
+    return Boolean(status?.ok && !status?.hasSessionApiKey && !status?.hasLegacySessionApiKey);
+  }, 60000, 250);
+
   await runScenario({ scenario: 'access_denied', expectStored: false });
+  await runScenario({ scenario: 'expired_token', expectStored: false });
+  await runScenario({ scenario: 'slow_down_then_success', expectStored: true });
 
   console.log('✓ OAuth device-flow E2E test passed');
 }
-


### PR DESCRIPTION
Expands the device-flow E2E coverage and documents how to validate against the real OpenHands Cloud server.

- Extend hermetic OAuth device-flow E2E to cover logout + additional OAuth polling/error scenarios.
- Make `openhands.cloudLogout` non-interactive in E2E mode (`E2E_CLOUD_LOGIN=1`) so tests don’t hang on modal confirmation.
- Document a manual live test procedure for `https://app.all-hands.dev`.
- Shorten the E2E `--user-data-dir` basename to reduce macOS IPC-handle warnings.

Checks run:
- `npm run typecheck`
- `npm run lint`
- `npm run e2e -- --grep "OAuth Device Flow"`

### Bead

$(bd show oh-tab-voc.4)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive E2E testing documentation for device flow authentication scenarios

* **Tests**
  * Enhanced device flow authentication test suite with improved session tracking and logout workflow validation
  * Added support for extended testing scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Review

- OrangeCastle: LGTM to merge; ran `npm run e2e -- --grep "OAuth Device Flow E2E"` in detached worktree (2026-01-16).
