### PR TITLE
oh-tab-urlnorm: dedupe remote URL normalization

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteUrlNormalization.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteUrlNormalization.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeRemoteUrl } from '../../shared/remoteUrl';
+
+describe('normalizeRemoteUrl', () => {
+  it('trims whitespace and removes trailing slashes', () => {
+    expect(normalizeRemoteUrl('  http://example.com///  ')).toBe('http://example.com');
+  });
+
+  it('adds http:// when scheme is missing', () => {
+    expect(normalizeRemoteUrl('example.com')).toBe('http://example.com');
+  });
+
+  it('converts ws:// and wss:// to http:// and https://', () => {
+    expect(normalizeRemoteUrl('ws://localhost:3000/')).toBe('http://localhost:3000');
+    expect(normalizeRemoteUrl('wss://localhost:3000/')).toBe('https://localhost:3000');
+  });
+
+  it('preserves non-web schemes', () => {
+    expect(normalizeRemoteUrl('foo+bar://baz/qux/')).toBe('foo+bar://baz/qux');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(normalizeRemoteUrl('   ')).toBe('');
+  });
+});
+

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -13,6 +13,7 @@ import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
 import type { BaseWorkspace } from '../../workspace/BaseWorkspace';
 import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from '../../workspace/types';
 import { resolveToolsWithDefaultTools } from './includeDefaultTools';
+import { normalizeRemoteUrl } from '../../shared/remoteUrl';
 
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
@@ -49,16 +50,7 @@ const toStaticSecret = (value: unknown): StaticSecret | undefined => {
   return { kind: 'StaticSecret', value: trimmed };
 };
 
-const normalizeRemoteServerUrl = (raw: string): string => {
-  let url = raw.trim();
-  if (!url) return url;
-
-  if (url.startsWith('ws://')) url = `http://${url.slice('ws://'.length)}`;
-  else if (url.startsWith('wss://')) url = `https://${url.slice('wss://'.length)}`;
-  else if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) url = `http://${url}`;
-
-  return url.replace(/\/+$/, '');
-};
+const normalizeRemoteServerUrl = normalizeRemoteUrl;
 
 export interface RemoteConversationOptions {
   serverUrl: string;

--- a/packages/agent-sdk-ts/src/shared/remoteUrl.ts
+++ b/packages/agent-sdk-ts/src/shared/remoteUrl.ts
@@ -1,0 +1,13 @@
+const HAS_SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+
+export function normalizeRemoteUrl(raw: string): string {
+  let url = raw.trim();
+  if (!url) return url;
+
+  if (url.startsWith('ws://')) url = `http://${url.slice('ws://'.length)}`;
+  else if (url.startsWith('wss://')) url = `https://${url.slice('wss://'.length)}`;
+  else if (!HAS_SCHEME_RE.test(url)) url = `http://${url}`;
+
+  return url.replace(/\/+$/, '');
+}
+

--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -6,17 +6,9 @@ import type {
   DirectoryEntry,
   WorkspaceEncoding,
 } from './types';
+import { normalizeRemoteUrl } from '../shared/remoteUrl';
 
-const normalizeRemoteHostUrl = (raw: string): string => {
-  let url = raw.trim();
-  if (!url) return url;
-
-  if (url.startsWith('ws://')) url = `http://${url.slice('ws://'.length)}`;
-  else if (url.startsWith('wss://')) url = `https://${url.slice('wss://'.length)}`;
-  else if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(url)) url = `http://${url}`;
-
-  return url.replace(/\/+$/, '');
-};
+const normalizeRemoteHostUrl = normalizeRemoteUrl;
 
 const normalizePosixRoot = (raw: string): string => {
   const normalized = path.posix.normalize(raw.trim() || '/');


### PR DESCRIPTION
Deduplicates remote base URL normalization in `@openhands/agent-sdk-ts` so RemoteConversation and RemoteWorkspace can’t drift.

- Add `packages/agent-sdk-ts/src/shared/remoteUrl.ts` (`normalizeRemoteUrl`).
- Refactor RemoteConversation + RemoteWorkspace to use the shared helper.
- Add unit coverage for ws/wss, missing scheme, trailing slashes, and whitespace.

Checks run:
- `npm test -w @openhands/agent-sdk-ts`

### Bead

$(bd show oh-tab-urlnorm)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a centralized remote URL normalization utility providing consistent handling of WebSocket schemes, HTTP scheme auto-prefixing, and formatting cleanup.

* **Tests**
  * Added test suite validating scheme conversion, auto-prefixing, whitespace handling, and edge cases for URL normalization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Review

- OrangeCastle: LGTM to merge; ran `npx vitest run packages/agent-sdk-ts/src/sdk/__tests__/remoteUrlNormalization.test.ts` in detached worktree (2026-01-16).
- Note (non-blocking): scheme matching is currently case-sensitive (e.g. `WS://` won’t rewrite to http).
