### PR TITLE
oh-tab-diagnostics-redaction: mask diagnostics outputs

### DIFF
--- a/src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
+++ b/src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeDiagnosticsText } from '../registerDiagnosticsCommands';
+
+describe('sanitizeDiagnosticsText', () => {
+  it('masks before truncating to avoid partial-secret leaks', () => {
+    const secret = 'super-secret-token';
+    const text = `prefix ${secret} suffix`;
+
+    const preview = sanitizeDiagnosticsText(text, {
+      // Only `getRegisteredValues()` is needed by maskSecretsInText()
+      secretRegistry: { getRegisteredValues: () => [secret] } as any,
+      maxChars: 'prefix '.length + 6, // would include only a partial secret if we truncated first
+    });
+
+    expect(preview).not.toContain('super');
+    expect(preview).not.toContain(secret);
+    expect(preview).toContain('prefix ');
+  });
+});
+

--- a/src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
+++ b/src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { SecretRegistry } from '@openhands/agent-sdk-ts';
 import { sanitizeDiagnosticsText } from '../registerDiagnosticsCommands';
 
 describe('sanitizeDiagnosticsText', () => {
@@ -6,9 +7,11 @@ describe('sanitizeDiagnosticsText', () => {
     const secret = 'super-secret-token';
     const text = `prefix ${secret} suffix`;
 
+    const secretRegistry = new SecretRegistry();
+    secretRegistry.register('test', secret);
+
     const preview = sanitizeDiagnosticsText(text, {
-      // Only `getRegisteredValues()` is needed by maskSecretsInText()
-      secretRegistry: { getRegisteredValues: () => [secret] } as any,
+      secretRegistry,
       maxChars: 'prefix '.length + 6, // would include only a partial secret if we truncated first
     });
 
@@ -16,5 +19,17 @@ describe('sanitizeDiagnosticsText', () => {
     expect(preview).not.toContain(secret);
     expect(preview).toContain('prefix ');
   });
-});
 
+  it('does not add a truncated suffix when the masked text is short enough', () => {
+    const secret = 'super-secret-token';
+    const text = `prefix ${secret} suffix`;
+
+    const secretRegistry = new SecretRegistry();
+    secretRegistry.register('test', secret);
+
+    const preview = sanitizeDiagnosticsText(text, { secretRegistry, maxChars: 4000 });
+
+    expect(preview).not.toContain(secret);
+    expect(preview).not.toContain('…(truncated)');
+  });
+});

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -124,7 +124,7 @@ const truncatePreview = (text: string, maxChars: number): string => {
 
 export function sanitizeDiagnosticsText(text: string, params: { secretRegistry?: SecretRegistry; maxChars: number }): string {
   const masked = maskSecretsInText(text, params.secretRegistry);
-  return truncatePreview(masked, params.maxChars);
+  return masked.length > params.maxChars ? truncatePreview(masked, params.maxChars) : masked;
 }
 
 export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDeps): vscode.Disposable[] {

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -122,6 +122,11 @@ const truncatePreview = (text: string, maxChars: number): string => {
   return `${text.slice(0, maxChars)}…(truncated)`;
 };
 
+export function sanitizeDiagnosticsText(text: string, params: { secretRegistry?: SecretRegistry; maxChars: number }): string {
+  const masked = maskSecretsInText(text, params.secretRegistry);
+  return truncatePreview(masked, params.maxChars);
+}
+
 export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDeps): vscode.Disposable[] {
   const postToWebview = async (message: HostToWebviewMessage): Promise<boolean> => {
     const chatView = deps.getChatView();
@@ -274,8 +279,8 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
       source: e.source,
     };
     if (typeof e.code === 'string') payload.code = e.code;
-    if (typeof e.detail === 'string') payload.detail = e.detail;
-    if (typeof e.error === 'string') payload.error = e.error;
+    if (typeof e.detail === 'string') payload.detail = sanitizeDiagnosticsText(e.detail, { secretRegistry: deps.secretRegistry, maxChars: 4000 });
+    if (typeof e.error === 'string') payload.error = sanitizeDiagnosticsText(e.error, { secretRegistry: deps.secretRegistry, maxChars: 4000 });
     if (typeof e.tool_name === 'string') payload.tool_name = e.tool_name;
     if (typeof e.tool_call_id === 'string') payload.tool_call_id = e.tool_call_id;
     return payload;
@@ -317,7 +322,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
       source: e.source,
       tool_name: e.tool_name,
       tool_call_id: e.tool_call_id,
-      observationText: observationText.length > 4000 ? `${observationText.slice(0, 4000)}…(truncated)` : observationText,
+      observationText: sanitizeDiagnosticsText(observationText, { secretRegistry: deps.secretRegistry, maxChars: 4000 }),
     };
 
     return payload;


### PR DESCRIPTION
Masks + truncates internal diagnostics command outputs so E2E logs/debug output can’t leak secrets (including partial-secret truncation cases).

- Add `sanitizeDiagnosticsText()` (mask-before-truncate) and apply it to `_queryLastError` and `_queryLastObservation`.
- Add a unit test proving partial-secret truncation cannot leak.

Checks run:
- `npx vitest run src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts`
- `npm run lint`
- `npm run typecheck`

### Bead

$(bd show oh-tab-diagnostics-redaction)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Diagnostic messages and observation previews now consistently mask secrets before any truncation, ensuring previews do not reveal partial secrets.

* **Tests**
  * Added unit tests covering secret masking behavior, including cases where masking occurs prior to truncation and where no truncation indicator is added when text fits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- OrangeCastle: re-reviewed at head `c7c4878`; ran `npx vitest run src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts` in detached worktree (2026-01-16).
