### PR TITLE
oh-tab-e2e-cleanup: cleanup E2E user-data-dir temp folders

### DIFF
--- a/tests/e2e/agentSdkEvents.test.ts
+++ b/tests/e2e/agentSdkEvents.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-sdk-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('agentSdkEvents');
 
 // E2E test for agent-sdk event rendering in the webview
 // This test exercises all event types from the agent-sdk conversation visualizer

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -4,7 +4,9 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+
+const userDataDir = createE2EUserDataDir('agentServerRemote');
 
 function getDefaultAgentSdkDir(): string {
   return path.join(os.homedir(), 'repos', 'agent-sdk');
@@ -198,7 +200,6 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
       const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
       const extensionTestsPath = path.resolve(__dirname, './suite');
-      const userDataDir = path.join(os.tmpdir(), `vscode-test-agent-server-${Date.now()}`);
 
       await ensureVsCodeArgvJson(userDataDir);
 

--- a/tests/e2e/confirmation.test.ts
+++ b/tests/e2e/confirmation.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-confirmation-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('confirmation');
 
 // E2E test for action confirmation workflow
 describe('OpenHands-Tab Confirmation E2E', function () {

--- a/tests/e2e/contextLimitRetry.test.ts
+++ b/tests/e2e/contextLimitRetry.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-0ph2-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('contextLimitRetry');
 
 describe('OpenHands-Tab context-limit condensation + retry E2E', function () {
   this.timeout(180000);
@@ -40,4 +39,3 @@ describe('OpenHands-Tab context-limit condensation + retry E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/defaultProfileSelection.test.ts
+++ b/tests/e2e/defaultProfileSelection.test.ts
@@ -1,18 +1,12 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-default-profile-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('defaultProfileSelection');
 
 describe('OpenHands-Tab default profile selection E2E', function () {
   this.timeout(180000);
-
-  after(async () => {
-    await fs.rm(userDataDir, { recursive: true, force: true });
-  });
 
   it('defaults profileId on fresh install and uses profile config', async () => {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');

--- a/tests/e2e/defaultProfilesSeeding.test.ts
+++ b/tests/e2e/defaultProfilesSeeding.test.ts
@@ -1,18 +1,12 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as fs from 'fs/promises';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-default-profiles-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('defaultProfilesSeeding');
 
 describe('OpenHands-Tab default profiles seeding E2E', function () {
   this.timeout(180000);
-
-  after(async () => {
-    await fs.rm(userDataDir, { recursive: true, force: true });
-  });
 
   it('seeds default LLM profiles on first install and does not overwrite existing defaults', async () => {
     const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
@@ -46,4 +40,3 @@ describe('OpenHands-Tab default profiles seeding E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/deviceFlowAuth.test.ts
+++ b/tests/e2e/deviceFlowAuth.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-t-dfa-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('deviceFlowAuth');
 
 describe('OpenHands-Tab OAuth Device Flow E2E', function () {
   this.timeout(180000);

--- a/tests/e2e/diagnostics.test.ts
+++ b/tests/e2e/diagnostics.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('diagnostics');
 
 // A smaller test that queries the diagnostics command
 // We do not rely on CLI here; we just run the suite which can call the command

--- a/tests/e2e/errorHandling.test.ts
+++ b/tests/e2e/errorHandling.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-errors-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('errorHandling');
 
 // E2E test for error handling and error event rendering
 describe('OpenHands-Tab Error Handling E2E', function () {

--- a/tests/e2e/gvc.test.ts
+++ b/tests/e2e/gvc.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-gvc-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('gvc');
 
 describe('OpenHands-Tab watched-file notes E2E', function () {
   this.timeout(180000);
@@ -40,4 +39,3 @@ describe('OpenHands-Tab watched-file notes E2E', function () {
     assert.ok(true);
   });
 });
-

--- a/tests/e2e/halNegative.test.ts
+++ b/tests/e2e/halNegative.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-hal-negative-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('halNegative');
 
 describe('OpenHands-Tab HAL negative cases E2E', function () {
   this.timeout(180000);

--- a/tests/e2e/history.test.ts
+++ b/tests/e2e/history.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-history-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('history');
 
 // E2E test for conversation history functionality
 describe('OpenHands-Tab History E2E', function () {

--- a/tests/e2e/lastUserMessage.test.ts
+++ b/tests/e2e/lastUserMessage.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-t-lum-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('lastUserMessage');
 
 describe('OpenHands-Tab last user message diagnostics E2E', function () {
   this.timeout(120000);

--- a/tests/e2e/llmProfiles.test.ts
+++ b/tests/e2e/llmProfiles.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-profiles-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('llmProfiles');
 
 describe('OpenHands-Tab LLM Profiles E2E', function () {
   this.timeout(180000);

--- a/tests/e2e/llmSwitching.test.ts
+++ b/tests/e2e/llmSwitching.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-llm-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('llmSwitching');
 
 // E2E test for switching LLM provider/model/apiMode in local mode.
 describe('OpenHands-Tab LLM Switching E2E', function () {

--- a/tests/e2e/messaging.test.ts
+++ b/tests/e2e/messaging.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-messaging-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('messaging');
 
 // E2E test for message input and event rendering
 describe('OpenHands-Tab Messaging E2E', function () {

--- a/tests/e2e/open.test.ts
+++ b/tests/e2e/open.test.ts
@@ -2,10 +2,9 @@ import * as assert from 'assert';
 import { runTests, resolveCliPathFromVSCodeExecutablePath } from '@vscode/test-electron';
 import * as cp from 'child_process';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('open');
 
 // Basic E2E: launch VS Code with the extension and ensure commands run without error.
 describe('OpenHands-Tab E2E', function () {

--- a/tests/e2e/oracleConfigured.test.ts
+++ b/tests/e2e/oracleConfigured.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-oracle-configured-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('oracleConfigured');
 
 describe('OpenHands-Tab ask_oracle configured profile E2E', function () {
   this.timeout(180000);

--- a/tests/e2e/oracleUnset.test.ts
+++ b/tests/e2e/oracleUnset.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-oracle-unset-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('oracleUnset');
 
 describe('OpenHands-Tab ask_oracle unset profileId E2E', function () {
   this.timeout(180000);

--- a/tests/e2e/serverSelection.test.ts
+++ b/tests/e2e/serverSelection.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-server-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('serverSelection');
 
 // E2E test for server selection and local/remote mode switching
 describe('OpenHands-Tab Server Selection E2E', function () {

--- a/tests/e2e/settings.test.ts
+++ b/tests/e2e/settings.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-settings-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('settings');
 
 // E2E test for settings and configuration functionality
 describe('OpenHands-Tab Settings E2E', function () {

--- a/tests/e2e/terminalLog.test.ts
+++ b/tests/e2e/terminalLog.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-terminal-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('terminalLog');
 
 describe('OpenHands-Tab Terminal Log E2E', function () {
   this.timeout(120000);

--- a/tests/e2e/terminalProgress.test.ts
+++ b/tests/e2e/terminalProgress.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-terminal-progress-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('terminalProgress');
 
 describe('OpenHands-Tab Terminal Progress E2E', function () {
   this.timeout(120000);

--- a/tests/e2e/testHelpers.ts
+++ b/tests/e2e/testHelpers.ts
@@ -1,5 +1,6 @@
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
 import * as fs from 'fs/promises';
+import * as os from 'os';
 import * as path from 'path';
 
 /**
@@ -44,4 +45,22 @@ export async function ensureVsCodeArgvJson(userDataDir: string): Promise<void> {
   const vscodeDir = path.join(userDataDir, '.vscode');
   await fs.mkdir(vscodeDir, { recursive: true });
   await fs.writeFile(path.join(vscodeDir, 'argv.json'), '{}\n', 'utf8');
+}
+
+function sanitizeTestNameForPath(raw: string): string {
+  const trimmed = raw.trim().toLowerCase();
+  const cleaned = trimmed.replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned.slice(0, 16) || 'e2e';
+}
+
+export function createE2EUserDataDir(testName: string): string {
+  const slug = sanitizeTestNameForPath(testName);
+  // Keep basename short to avoid macOS IPC handle path warnings.
+  const userDataDir = path.join(os.tmpdir(), `vscode-t-${slug}-${Date.now().toString(36)}`);
+
+  after(async () => {
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  });
+
+  return userDataDir;
 }

--- a/tests/e2e/tpq.test.ts
+++ b/tests/e2e/tpq.test.ts
@@ -4,9 +4,9 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-tpq-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('tpq');
 
 describe('OpenHands-Tab multi-root env-info workspaceRoot E2E', function () {
   this.timeout(180000);

--- a/tests/e2e/uiFlows.test.ts
+++ b/tests/e2e/uiFlows.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
 import * as path from 'path';
-import * as os from 'os';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `vscode-test-ui-flows-${Date.now()}`);
+const userDataDir = createE2EUserDataDir('uiFlows');
 
 describe('OpenHands-Tab UI Flows E2E', function () {
   this.timeout(120000);

--- a/tests/e2e/welcome.test.ts
+++ b/tests/e2e/welcome.test.ts
@@ -1,10 +1,9 @@
 import * as assert from 'assert';
 import { runTests } from '@vscode/test-electron';
-import * as os from 'os';
 import * as path from 'path';
-import { downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
 
-const userDataDir = path.join(os.tmpdir(), `oh-tab-welcome-${Date.now().toString(36)}`);
+const userDataDir = createE2EUserDataDir('welcome');
 
 describe('OpenHands-Tab welcome missing-key prompts E2E', function () {
   this.timeout(180000);
@@ -44,4 +43,3 @@ describe('OpenHands-Tab welcome missing-key prompts E2E', function () {
     assert.ok(true);
   });
 });
-


### PR DESCRIPTION
### Bead

```
oh-tab-e2e-cleanup: (tech debt) E2E: always cleanup user-data-dir temp folders
Status: open
Priority: P3
Type: chore
Assignee: BlackDog
Created: 2026-01-16 01:29
Updated: 2026-01-16 01:29

Description:
Problem
- Most E2E entrypoint tests create a unique `--user-data-dir` under `os.tmpdir()` but never delete it. Over time this can accumulate hundreds of folders locally (and can bloat CI runners / make repro harder).

Goal
- Ensure each E2E test suite removes its `userDataDir` reliably (even on failure).

Proposed approach
- Add a helper (e.g. `createE2EUserDataDir(testName)` in `tests/e2e/testHelpers.ts`) that:
  - Creates a short, unique directory name (align with `oh-tab-e2e-tmpdir`)
  - Registers an `after()` hook (or returns a cleanup fn) that calls `fs.rm(userDataDir, { recursive: true, force: true })`
- Migrate existing `tests/e2e/*.test.ts` suites to use the helper.

Acceptance criteria
- No `tests/e2e/*.test.ts` leaves user-data-dir behind (verified by helper usage / code audit).
- Tests continue to pass (at least `npm run e2e -- --grep "diagnostics"` + one other suite).

Labels: [dev e2e tech-debt tests]

Blocks (1):
  <- oh-tab-e2e-tmpdir: E2E: shorten --user-data-dir to avoid IPC path length warnings [P4]
```

### Notes

- Adds `createE2EUserDataDir(testName)` in `tests/e2e/testHelpers.ts` that registers an `after()` cleanup hook.
- Migrates all `tests/e2e/*.test.ts` entrypoints (including `deviceFlowAuth`) to use it.

### Testing

- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run e2e -- --grep "OpenHands-Tab diagnostics"`
- `npm run e2e -- --grep "OpenHands-Tab welcome missing-key prompts E2E"`
- `npm run e2e -- --grep "OAuth Device Flow E2E"`


### Review

- OrangeCastle: verified `createE2EUserDataDir()` and that all `tests/e2e/*.test.ts` use it (2026-01-16).
