### PR TITLE
oh-tab-abc: dedupe welcome secret-status computation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,7 @@ import { createHalConfigurationChangeHandler } from './extension/halConfiguratio
 import { formatEnvironmentInformation } from './shared/environmentInformation';
 import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
+import { computeWelcomeSecretStatus } from './shared/welcomeSecretStatus';
 import { getServerSessionApiKeySecretKey } from './auth/serverSessionApiKeys';
 import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
 import { registerCloudLogoutCommand } from './extension/cloudLogoutCommand';
@@ -347,65 +348,11 @@ export function activate(context: vscode.ExtensionContext) {
   let lastWelcomeSecretStatus: { hasProviderKey: boolean; hasGeminiKey: boolean } | null = null;
   let welcomeSecretStatusTimer: ReturnType<typeof setTimeout> | null = null;
 
-  const computeWelcomeSecretStatus = async (): Promise<{ hasProviderKey: boolean; hasGeminiKey: boolean }> => {
-    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-    const settings = await settingsMgr.get();
-
-    const secretIsSet = async (key: string): Promise<boolean> => {
-      try {
-        const value = await context.secrets.get(key);
-        return typeof value === 'string' && value.trim().length > 0;
-      } catch {
-        return false;
-      }
-    };
-
-    const envIsSet = (key: string): boolean => {
-      const value = process.env[key];
-      return typeof value === 'string' && value.trim().length > 0;
-    };
-
-    const hasGeminiKey =
-      (await secretIsSet('GEMINI_API_KEY')) ||
-      envIsSet('GEMINI_API_KEY') ||
-      (settings.llm.provider === 'gemini' && typeof settings.secrets.llmApiKey === 'string' && settings.secrets.llmApiKey.trim().length > 0);
-
-    const hasGenericKey = typeof settings.secrets.llmApiKey === 'string' && settings.secrets.llmApiKey.trim().length > 0;
-
-    const providerStorageKeys = [
-      'OPENAI_API_KEY',
-      'ANTHROPIC_API_KEY',
-      'OPENROUTER_API_KEY',
-      'LITELLM_API_KEY',
-    ];
-
-    let hasAnyProviderStorageKey = false;
-    for (const key of providerStorageKeys) {
-      if (envIsSet(key) || await secretIsSet(key)) {
-        hasAnyProviderStorageKey = true;
-        break;
-      }
-    }
-
-    let hasAnyProfileKey = false;
-    try {
-      for (const profileId of listProfiles()) {
-        if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
-          hasAnyProfileKey = true;
-          break;
-        }
-      }
-    } catch {
-      hasAnyProfileKey = false;
-    }
-
-    const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
-    return { hasProviderKey, hasGeminiKey };
-  };
-
   const postWelcomeSecretStatus = async (): Promise<void> => {
     if (!chatView) return;
-    const status = await computeWelcomeSecretStatus();
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const settings = await settingsMgr.get();
+    const status = await computeWelcomeSecretStatus({ context, settings });
     if (
       lastWelcomeSecretStatus &&
       lastWelcomeSecretStatus.hasProviderKey === status.hasProviderKey &&

--- a/src/shared/welcomeSecretStatus.ts
+++ b/src/shared/welcomeSecretStatus.ts
@@ -1,0 +1,63 @@
+import type * as vscode from 'vscode';
+import { listProfiles } from '@openhands/agent-sdk-ts';
+import type { OpenHandsSettings } from '../settings/SettingsManager';
+
+const PROVIDER_STORAGE_KEYS = [
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
+  'LITELLM_API_KEY',
+] as const;
+
+export async function computeWelcomeSecretStatus(args: {
+  context: vscode.ExtensionContext;
+  settings: OpenHandsSettings;
+}): Promise<{ hasProviderKey: boolean; hasGeminiKey: boolean }> {
+  const secretIsSet = async (key: string): Promise<boolean> => {
+    try {
+      const value = await args.context.secrets.get(key);
+      return typeof value === 'string' && value.trim().length > 0;
+    } catch {
+      return false;
+    }
+  };
+
+  const envIsSet = (key: string): boolean => {
+    const value = process.env[key];
+    return typeof value === 'string' && value.trim().length > 0;
+  };
+
+  const hasGeminiKey =
+    (await secretIsSet('GEMINI_API_KEY')) ||
+    envIsSet('GEMINI_API_KEY') ||
+    (args.settings.llm.provider === 'gemini' &&
+      typeof args.settings.secrets.llmApiKey === 'string' &&
+      args.settings.secrets.llmApiKey.trim().length > 0);
+
+  const hasGenericKey =
+    typeof args.settings.secrets.llmApiKey === 'string' && args.settings.secrets.llmApiKey.trim().length > 0;
+
+  let hasAnyProviderStorageKey = false;
+  for (const key of PROVIDER_STORAGE_KEYS) {
+    if (envIsSet(key) || (await secretIsSet(key))) {
+      hasAnyProviderStorageKey = true;
+      break;
+    }
+  }
+
+  let hasAnyProfileKey = false;
+  try {
+    for (const profileId of listProfiles()) {
+      if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
+        hasAnyProfileKey = true;
+        break;
+      }
+    }
+  } catch {
+    hasAnyProfileKey = false;
+  }
+
+  const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
+  return { hasProviderKey, hasGeminiKey };
+}
+

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -18,7 +18,8 @@ import { createPostToolsList, handleSetEnabledTools, isLocalConversationToolCont
 import { handleDeleteConversation, handleRequestHistory, handleRestoreConversation } from './handlers/history';
 import { handleAddServer, handleRemoveServer, handleSelectServer, handleSwitchToLocal } from './handlers/servers';
 import { handleSend } from './handlers/send';
-import { computeWelcomeSecretStatus, handleLlmProfileApiKeySetRequest, handleLlmProfileApiKeyStatusRequest, handleLlmProfileDeleteRequest, handleLlmProfileLoadRequest, handleLlmProfileSaveRequest, handleLlmProfilesListRequest, handleSetLlmProfileId, listAvailableLlmProfiles } from './handlers/llmProfiles';
+import { handleLlmProfileApiKeySetRequest, handleLlmProfileApiKeyStatusRequest, handleLlmProfileDeleteRequest, handleLlmProfileLoadRequest, handleLlmProfileSaveRequest, handleLlmProfilesListRequest, handleSetLlmProfileId, listAvailableLlmProfiles } from './handlers/llmProfiles';
+import { computeWelcomeSecretStatus } from '../../shared/welcomeSecretStatus';
 import { createElevenlabsTtsGateFactory, handleHalTtsRequest, handleHalVoiceConfirmRequest } from './handlers/hal';
 
 export type WebviewHost = {
@@ -161,7 +162,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
 
         // Welcome page: communicate whether API keys are present so the UI can show onboarding prompts.
         void (async () => {
-          const status = await computeWelcomeSecretStatus({ deps, context, settings: initSettings });
+          const status = await computeWelcomeSecretStatus({ context, settings: initSettings });
           void host.postMessage({ type: 'welcomeSecretStatus', hasProviderKey: status.hasProviderKey, hasGeminiKey: status.hasGeminiKey });
         })();
 

--- a/src/webview/host/handlers/llmProfiles.ts
+++ b/src/webview/host/handlers/llmProfiles.ts
@@ -1,7 +1,7 @@
 import type * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import { assertValidProfileId, detectProviderFromBaseUrl, LLMProfileValidationError, type LLMProvider } from '@openhands/agent-sdk-ts';
-import type { OpenHandsSettings, SettingsManager } from '../../../settings/SettingsManager';
+import type { SettingsManager } from '../../../settings/SettingsManager';
 import { resolveConfiguredLlmLabel } from '../../../shared/llmProfiles';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS, type WebviewToHostMessage } from '../../../shared/webviewMessages';
 import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
@@ -366,59 +366,4 @@ export async function handleLlmProfileApiKeySetRequest(args: {
     const reason = err instanceof Error ? err.message : String(err);
     void args.host.postMessage({ type: 'llmProfileApiKeySetResponse', requestId, ok: false, profileId, error: reason });
   }
-}
-
-export async function computeWelcomeSecretStatus(args: {
-  deps: CreateWebviewMessageHandlerDeps;
-  context: vscode.ExtensionContext;
-  settings: OpenHandsSettings;
-}): Promise<{ hasProviderKey: boolean; hasGeminiKey: boolean }> {
-  const secretIsSet = async (key: string): Promise<boolean> => {
-    try {
-      const value = await args.context.secrets.get(key);
-      return typeof value === 'string' && value.trim().length > 0;
-    } catch {
-      return false;
-    }
-  };
-
-  const envIsSet = (key: string): boolean => {
-    const value = process.env[key];
-    return typeof value === 'string' && value.trim().length > 0;
-  };
-
-  const hasGeminiKey = (await secretIsSet('GEMINI_API_KEY'))
-    || envIsSet('GEMINI_API_KEY')
-    || (args.settings.llm.provider === 'gemini' && typeof args.settings.secrets.llmApiKey === 'string' && args.settings.secrets.llmApiKey.trim().length > 0);
-
-  const hasGenericKey = typeof args.settings.secrets.llmApiKey === 'string' && args.settings.secrets.llmApiKey.trim().length > 0;
-
-  const providerStorageKeys = [
-    'OPENAI_API_KEY',
-    'ANTHROPIC_API_KEY',
-    'OPENROUTER_API_KEY',
-    'LITELLM_API_KEY',
-  ];
-  let hasAnyProviderStorageKey = false;
-  for (const key of providerStorageKeys) {
-    if (envIsSet(key) || await secretIsSet(key)) {
-      hasAnyProviderStorageKey = true;
-      break;
-    }
-  }
-
-  let hasAnyProfileKey = false;
-  try {
-    for (const profileId of listAvailableLlmProfiles({ deps: args.deps, outputChannel: undefined })) {
-      if (await secretIsSet(`openhands.llmProfileApiKey.${profileId}`)) {
-        hasAnyProfileKey = true;
-        break;
-      }
-    }
-  } catch {
-    hasAnyProfileKey = false;
-  }
-
-  const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
-  return { hasProviderKey, hasGeminiKey };
 }


### PR DESCRIPTION
### Bead

```
oh-tab-abc: (tech debt) Deduplicate welcome secret-status computation
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 08:19
Updated: 2026-01-15 08:19

Description:
Problem
- Welcome secret-status detection logic is duplicated in `src/extension.ts` and `src/webview/host/createWebviewMessageHandler.ts`.
- This risks divergence (different key lists, profile scanning, etc.) and makes future changes harder.

Goal
- Centralize the logic (single source of truth) and have the other layer just forward/post `welcomeSecretStatus`.

Acceptance Criteria
- Only one implementation computes `{ hasProviderKey, hasGeminiKey }`.
- Existing unit + E2E tests for welcome prompts remain green.

Labels: [onboarding tech-debt welcome]
```

### Notes

- Centralizes the computation in `src/shared/welcomeSecretStatus.ts`.
- `src/extension.ts` and `src/webview/host/createWebviewMessageHandler.ts` now both call the shared helper.

### Testing

- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated API key validation logic into a shared module for improved code organization and reusability across components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review

- OrangeCastle: reviewed in detached worktree; consolidation is behavior-preserving (2026-01-16).
