### PR TITLE
oh-tab-52e: ban it.todo placeholders in tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -145,6 +145,19 @@ module.exports = [
       '@typescript-eslint/no-unsafe-function-type': 'off',
       'no-empty': 'off',
       'no-tabs': 'error',
+
+      // Avoid merging placeholder-only “tests” that keep CI green but add suite noise.
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "CallExpression[callee.type='MemberExpression'][callee.object.name='it'][callee.property.name='todo']",
+          message: 'Do not use it.todo() in standard test folders. Use a real test or explicitly opt out via eslint-disable.',
+        },
+        {
+          selector: "CallExpression[callee.type='MemberExpression'][callee.object.name='describe'][callee.property.name='todo']",
+          message: 'Do not use describe.todo() in standard test folders. Use a real test or explicitly opt out via eslint-disable.',
+        },
+      ],
     },
   },
 ];


### PR DESCRIPTION
### Bead

```
oh-tab-52e: (tech debt) Ban it.todo placeholders in merged tests
Status: open
Priority: P4
Type: chore
Created: 2026-01-15 07:54
Updated: 2026-01-15 08:49

Description:
Problem
- It’s tempting to merge “test plan” files that are 100% `it.todo(...)`; this keeps CI green but adds permanent suite noise and gives a false sense of coverage.

Goal
- Prevent accidental merges of placeholder-only tests (unless explicitly opted-in in a separate location).

Proposed approach
- Add an ESLint rule (or a simple test/CI check) that rejects `it.todo` / `describe.todo` usage under normal `__tests__` paths, or requires an explicit allowlist comment.

Acceptance Criteria
- CI/lint fails when new `it.todo` is introduced in standard test folders.
- Existing tests remain green after applying the rule (move any needed planning docs elsewhere).
```

### Notes

- Adds an ESLint `no-restricted-syntax` rule for test files that bans `it.todo()` / `describe.todo()`.
- Escape hatch: explicit `eslint-disable` (intentional opt-out).

### Testing

- `npm test`
- `npm run typecheck`
- `npm run lint`


### Review

- OrangeCastle: reviewed; rule is scoped to test files and blocks `it.todo()` / `describe.todo()` as intended (2026-01-16).
