### PR TITLE
Add /audit security audit AgentSkill for OpenHands-Tab

### DIFF
--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -178,11 +178,11 @@ Tokens must be sent in headers, never as query parameters.
 If you have repo access, run quick checks:
 
 - Find potential secret patterns committed to code:
-  - `grep -RInE "\bsk-[A-Za-z0-9_-]{12,}\b|\bgh[pousr]_[A-Za-z0-9]{12,}\b|github_pat_" src packages`
+  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}" src packages`
 
 - Find places secrets might be written:
-  - `grep -RIn "writeFile\|appendFile\|fs\." src packages`
-  - `grep -RIn "console\.log\|console\.warn\|console\.error" src packages`
+  - `grep -RInE "writeFile|appendFile|fs\\." src packages`
+  - `grep -RInE "console\\.(log|warn|error)" src packages`
 
 - Run tests that cover redaction and profile persistence:
   - `npm test`

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -224,4 +224,31 @@ These patterns are considered good practice in this repo; if present, explicitly
 - Webview messages that echo secrets back to the UI or store them in persistent webview state
 - Tokens included in URLs, query strings, or file paths
 
+
+---
+
+## ATTENTION: FOOTGUNS
+
+This section documents **current reality (today)** in this repo: the name `apiKey` is used across multiple domains and does **not** always mean the same thing.
+
+This is a source of audit mistakes and security regressions. We should **improve this over time** (clearer naming and explicit types/formats), but in the meantime we must be careful to **not make it worse** (no new ambiguous `apiKey` uses; avoid copying patterns blindly).
+
+### `apiKey` flows (source → sink) — verify each independently
+
+| Domain / meaning | Where it lives (structure) | Typical source (where it comes from) | Sinks (where it ends up) | What can go wrong |
+|---|---|---|---|---|
+| **LLM provider API key** (OpenAI/Anthropic/Gemini/etc.) | `LLMConfiguration.apiKey` (`packages/agent-sdk-ts/src/sdk/llm/types.ts`) and on-disk profile JSON (`~/.openhands/llm-profiles/*.json` when `includeSecrets=true`) | From SecretStorage / SecretRegistry, or inline config, or (today) sometimes “env-var-shaped” strings treated as references | Network requests to provider clients (`Authorization`, `x-api-key`, `x-goog-api-key`) | Easy to accidentally persist to disk, log, or treat a reference as a secret (or vice versa). **Do not add new heuristics.** Prefer explicit formats.
+| **Webview → host payload secret** (user typed key) | Webview message: `llmProfileApiKeySetRequest.apiKey` (`src/shared/webviewMessages.ts`) | User types into webview UI (`src/webview-src/components/LlmProfilesView.tsx`) | Stored in `context.secrets.store(...)` and optionally `secretRegistry.set(...)` (`src/webview/host/handlers/llmProfiles.ts`) | Webview JS memory is a leak surface (console logs, devtools, XSS, persistence via `acquireVsCodeApi().setState`). Host must **never** echo secrets back to webview.
+| **Agent-server session API key** (auth to OpenHands server) | `RemoteWorkspaceOptions.apiKey` / `RemoteWorkspace.apiKey` (`packages/agent-sdk-ts/src/workspace/*`) | `settings.secrets.sessionApiKey` (remote conversation setup) | Network requests to agent-server via `X-Session-API-Key` / `Authorization: Bearer ...` | Confusing it with provider keys can cause wrong-host leakage. Ensure per-server scoping and never attach to unintended hosts/redirects.
+| **HAL / auxiliary service keys** (Gemini classifier, ElevenLabs, etc.) | Feature params objects (e.g. `src/hal/gemini/decisionClassifier.ts`, `src/hal/elevenlabs/ttsClient.ts`) | From SecretStorage-backed settings / secrets | Outbound requests to those services | Same logging/persistence risks, plus accidental reuse in unrelated contexts.
+
+### Audit guidance
+
+- Treat each `apiKey` occurrence as **domain-specific**. During audit, always answer: *“which system is this key for?”* before evaluating risk.
+- **Do not assume** an `apiKey` string is a literal secret value. Today, some code paths treat `/^[A-Z0-9_]+$/` values as “env-var / key-name references”. This ambiguity is a known footgun.
+- When modifying code:
+  - do not introduce new `apiKey` fields/messages without strong justification
+  - prefer explicit names (`sessionApiKey`, `providerApiKey`, `ttsApiKey`, etc.) and explicit reference formats (e.g. `${env:NAME}`) over heuristics
+  - ensure secrets never cross host → webview boundaries
+
 If you suspect a leak but cannot prove it, write it as a **risk hypothesis** and point to the exact file + code region to inspect next.

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: audit
+description: >
+  Security audit checklist for the OpenHands-Tab VS Code extension, focused on preventing API keys
+  and tokens from being persisted or logged. Use when asked to audit security, secret handling,
+  credential storage, logging redaction, or data exfiltration risks in this repo. Trigger with /audit.
+license: MIT
+triggers:
+  - /audit
+  - security audit
+  - audit security
+  - api key leak
+  - token leak
+  - credential leak
+  - SecretStorage
+---
+
+# OpenHands-Tab Security Audit Skill
+
+This skill teaches you how to audit **this repository** (the OpenHands-Tab VS Code extension) for common secret-handling and credential-leak problems.
+
+## Command: `/audit`
+
+When the user asks for a security review (or types `/audit`), produce a short written audit report by following the steps below.
+
+### Output format (required)
+
+Return a report with:
+
+1. **Scope** (what you reviewed)
+2. **High risk findings** (must fix)
+3. **Medium/low risk findings** (should fix)
+4. **Good practices already present** (keep)
+5. **Suggested follow-ups** (tests, hardening, docs)
+
+Never include real secret values in the report.
+
+---
+
+## 1) Threat model (keep it concrete)
+
+For this extension, the primary risks are:
+
+- **Accidental persistence of secrets to disk** (VS Code settings JSON, profile files, logs, conversation stores)
+- **Accidental logging of secrets** (OutputChannel, debug channels, dev bridge logs, error messages)
+- **Webview boundary leaks** (secrets sent to webview, persisted in webview state, or logged to console)
+- **Network exfiltration** (tokens placed in URLs, sent to wrong host, or sent without TLS)
+
+---
+
+## 2) Inventory: what counts as a secret in this repo
+
+### VS Code SecretStorage keys (provider keys)
+
+These keys are stored via `context.secrets` and must never be written to disk or logs:
+
+- `OPENAI_API_KEY`
+- `ANTHROPIC_API_KEY`
+- `GEMINI_API_KEY`
+- `OPENROUTER_API_KEY`
+- `LITELLM_API_KEY`
+
+Relevant code:
+
+- `src/webview/host/handlers/secretHelpers.ts` (maps provider → env/SecretStorage key)
+- `src/extension/secretCommands.ts` (UI to set/clear provider keys)
+
+### Extension-managed secrets (stored under `openhands.*` keys)
+
+These are also secrets; they should be stored **only** in SecretStorage:
+
+- `openhands.sessionApiKey` (legacy)
+- `openhands.llmApiKey`
+- `openhands.awsAccessKeyId`
+- `openhands.awsSecretAccessKey`
+- `openhands.githubToken`
+- `openhands.hal.ttsApiKey`
+- `openhands.customSecret1/2/3`
+
+Relevant code:
+
+- `src/settings/SettingsManager.ts` (loads/stores these via `adapter.getSecret/storeSecret`)
+- `src/settings/VscodeSettingsAdapter.ts` (backed by `context.secrets`)
+
+---
+
+## 3) Audit checklist (step-by-step)
+
+### A. Confirm secrets are not persisted in VS Code settings
+
+1. Verify the settings adapter does **not** store secrets via `workspace.getConfiguration().update(...)`.
+   - Expectation: all secret writes go through `context.secrets.store/delete`.
+   - Files:
+     - `src/settings/VscodeSettingsAdapter.ts`
+     - `src/settings/SettingsManager.ts`
+     - `src/extension/secretCommands.ts`
+
+2. Verify any “status indicators” written to settings are non-sensitive.
+   - File: `src/extension/secretCommands.ts`
+   - Expectation: only a marker like `"✓ set"`, never the secret.
+
+### B. Confirm per-server session API keys cannot be reused for arbitrary servers
+
+1. Locate the per-server session key naming.
+   - File: `src/auth/serverSessionApiKeys.ts`
+   - Expectation: key name includes a **hash** of the normalized server URL:
+     - `openhands.sessionApiKey.server.${sha256(normalizedUrl)}`
+
+2. Verify migration behavior is conservative.
+   - File: `src/extension.ts`
+   - Expectation: if a legacy session key exists, the extension should:
+     - NOT auto-send it to whatever server is configured
+     - Prompt the user before storing it under the hashed per-server key
+
+### C. Confirm secrets don’t cross into the webview unnecessarily
+
+1. Inspect webview ↔ host messages related to API key overrides.
+   - Host handler: `src/webview/host/handlers/llmProfiles.ts` (`llmProfileApiKeySetRequest`)
+   - UI: `src/webview-src/components/LlmProfilesView.tsx`
+
+2. Expectations:
+   - The webview may temporarily hold a draft API key in memory for UX, but it must not be persisted.
+   - The host must store the API key in `context.secrets`, not in files.
+   - No `console.log`/debug logging should print the key or headers.
+
+### D. Confirm profile persistence strips secrets by default
+
+Profiles can contain inline `apiKey` or `headers` in config, which are high risk if persisted.
+
+1. Verify profile persistence removes inline secrets unless explicitly opted-in.
+   - Host store wrapper: `src/webview/host/llmProfilesStore.ts`
+   - SDK store: `packages/agent-sdk-ts/src/sdk/llm/profiles.ts`
+
+2. Expectations:
+   - `includeSecrets` defaults to `false`.
+   - When `includeSecrets=false`, both `apiKey` (if it looks like a real key, not an ENV var name) and `headers` are stripped.
+
+### E. Confirm logs are redacted everywhere secrets may appear
+
+This repo has multiple logging surfaces. Verify each is covered.
+
+1. Output channel masking
+   - File: `src/extension/devBridgeLogger.ts` (`createMaskedOutputChannel`)
+   - Expectation: any `append/appendLine/replace` path masks via `maskSecretsInText(...)`.
+
+2. Debug JSON channel masking
+   - File: `src/extension/debugJsonOutputChannel.ts`
+   - Expectation: redacts using `maskSecretsInText(...)`.
+
+3. Generic string redaction
+   - File: `src/shared/safeStringify.ts`
+   - Expectation: heuristically redacts common patterns (`Authorization: Bearer ...`, `sk-...`, GitHub tokens, etc.).
+
+4. “Known secret value” masking
+   - File: `src/shared/maskSecrets.ts`
+   - Expectation: uses a registry of known secret values (`SecretRegistry`) to replace exact matches.
+
+Audit technique:
+
+- Search for new/unmasked loggers:
+  - `console.log`, `console.warn`, `console.error`
+  - `outputChannel.appendLine` / `append`
+  - any `JSON.stringify(...)` used for logging
+
+If you find a logging path that doesn’t go through redaction utilities, flag it.
+
+### F. Confirm secrets are not placed in URLs
+
+Tokens must be sent in headers, never as query parameters.
+
+- Search for code that builds URLs with `token=`, `api_key=`, `key=`.
+- Ensure remote calls use `Authorization: Bearer ...` headers.
+
+---
+
+## 4) Suggested commands (optional, but recommended)
+
+If you have repo access, run quick checks:
+
+- Find potential secret patterns committed to code:
+  - `grep -RInE "\bsk-[A-Za-z0-9_-]{12,}\b|\bgh[pousr]_[A-Za-z0-9]{12,}\b|github_pat_" src packages`
+
+- Find places secrets might be written:
+  - `grep -RIn "writeFile\|appendFile\|fs\." src packages`
+  - `grep -RIn "console\.log\|console\.warn\|console\.error" src packages`
+
+- Run tests that cover redaction and profile persistence:
+  - `npm test`
+
+---
+
+## 5) What “good” looks like (call out positives)
+
+These patterns are considered good practice in this repo; if present, explicitly list them under “Good practices already present”:
+
+- Secrets stored using **VS Code SecretStorage** (`context.secrets.*`) and never written to settings JSON.
+- Per-server session API keys keyed by a **hash of the server URL** to reduce accidental cross-server reuse.
+- Centralized masking utilities (`maskSecretsInText`, `safeStringify`) used for every logging surface.
+- Profile persistence defaults to **not** saving inline `apiKey`/`headers`.
+
+---
+
+## 6) Common pitfalls (flag if you see them)
+
+- Any secret value written to:
+  - `globalState`, `workspaceState`, `workspace.getConfiguration()`, or any JSON file under the repo
+- Any secret printed in logs or thrown in error messages without masking
+- Webview messages that echo secrets back to the UI or store them in persistent webview state
+- Tokens included in URLs, query strings, or file paths
+
+If you suspect a leak but cannot prove it, write it as a **risk hypothesis** and point to the exact file + code region to inspect next.

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -1,190 +1,207 @@
 ---
 name: audit
 description: >
-  Security audit checklist for the OpenHands-Tab VS Code extension, focused on preventing API keys
-  and tokens from being persisted or logged. Use when asked to audit security, secret handling,
-  credential storage, logging redaction, or data exfiltration risks in this repo. Trigger with /audit.
+  AgentSkill: run a repo-specific security audit of the OpenHands-Tab VS Code extension with a focus on
+  secret handling, webview/host boundaries, persistence, and logging redaction. Trigger with /audit.
 license: MIT
 triggers:
   - /audit
-  - security audit
   - audit security
-  - api key leak
-  - token leak
-  - credential leak
-  - SecretStorage
+  - security audit
 ---
 
-# OpenHands-Tab Security Audit Skill
+# OpenHands-Tab Security Audit (AgentSkill)
 
-This skill teaches you how to audit **this repository** (the OpenHands-Tab VS Code extension) for common secret-handling and credential-leak problems.
+This is **not the audit report**. This is a **repeatable checklist** for an agent to run against *this repository*.
 
-## Command: `/audit`
+When invoked (e.g. the user types `/audit`), follow the checklist below, inspect the referenced code, and then output a short audit report.
 
-When the user asks for a security review (or types `/audit`), produce a short written audit report by following the steps below.
-
-### Output format (required)
+## Output format (required)
 
 Return a report with:
 
-1. **Scope** (what you reviewed)
-2. **High risk findings** (must fix)
-3. **Medium/low risk findings** (should fix)
+1. **Scope** (what you inspected)
+2. **High-risk findings** (must fix)
+3. **Medium/low-risk findings** (should fix)
 4. **Good practices already present** (keep)
 5. **Suggested follow-ups** (tests, hardening, docs)
 
-Never include real secret values in the report.
+**Never include real secret values** in the report (including partial tokens).
 
 ---
 
-## 1) Threat model (keep it concrete)
+## 1) Threat model (repo-specific)
 
-For this extension, the primary risks are:
+Primary risks for this VS Code extension:
 
-- **Accidental persistence of secrets to disk** (VS Code settings JSON, profile files, logs, conversation stores)
-- **Accidental logging of secrets** (OutputChannel, debug channels, dev bridge logs, error messages)
-- **Webview boundary leaks** (secrets sent to webview, persisted in webview state, or logged to console)
-- **Network exfiltration** (tokens placed in URLs, sent to wrong host, or sent without TLS)
-
----
-
-## 2) Inventory: what counts as a secret in this repo
-
-### VS Code SecretStorage keys (provider keys)
-
-These keys are stored via `context.secrets` and must never be written to disk or logs:
-
-- `OPENAI_API_KEY`
-- `ANTHROPIC_API_KEY`
-- `GEMINI_API_KEY`
-- `OPENROUTER_API_KEY`
-- `LITELLM_API_KEY`
-
-Relevant code:
-
-- `src/webview/host/handlers/secretHelpers.ts` (maps provider → env/SecretStorage key)
-- `src/extension/secretCommands.ts` (UI to set/clear provider keys)
-
-### Extension-managed secrets (stored under `openhands.*` keys)
-
-These are also secrets; they should be stored **only** in SecretStorage:
-
-- `openhands.sessionApiKey` (legacy)
-- `openhands.llmApiKey`
-- `openhands.awsAccessKeyId`
-- `openhands.awsSecretAccessKey`
-- `openhands.githubToken`
-- `openhands.hal.ttsApiKey`
-- `openhands.customSecret1/2/3`
-
-Relevant code:
-
-- `src/settings/SettingsManager.ts` (loads/stores these via `adapter.getSecret/storeSecret`)
-- `src/settings/VscodeSettingsAdapter.ts` (backed by `context.secrets`)
+- **Persistence leaks**: secrets written to disk (VS Code settings JSON, profile files, workspace/global state, logs, conversation stores)
+- **Logging leaks**: secrets exposed via OutputChannel, debug channels, error strings/stack traces, dev bridge logs, webview console
+- **Webview boundary leaks**: secrets crossing extension-host ↔ webview boundary; secrets persisted in webview state (`acquireVsCodeApi().setState`) or leaked via console
+- **Network leaks**: secrets in URLs/query params, secrets sent to wrong host, secrets attached to redirected requests, non-HTTPS when not explicitly intended
 
 ---
 
-## 3) Audit checklist (step-by-step)
+## 2) Inventory (authoritative sources, avoid stale lists)
+
+### A. Provider API key names and SecretStorage keys
+
+**Do not trust hardcoded lists in docs**. Derive the set of provider key names from code.
+
+- Authoritative code: `src/webview/host/handlers/secretHelpers.ts`
+  - Enumerate provider → key name mapping (e.g. `getProviderApiKeyName(...)`).
+  - Treat *all* provider keys as secrets.
+
+### B. Extension-managed secret keys
+
+- Authoritative code: `src/settings/SettingsManager.ts`, `src/settings/VscodeSettingsAdapter.ts`
+  - Enumerate any keys stored via `adapter.storeSecret(...)` / `context.secrets.store(...)`.
+
+---
+
+## 3) Audit checklist (step-by-step, falsifiable)
 
 ### A. Confirm secrets are not persisted in VS Code settings
 
-1. Verify the settings adapter does **not** store secrets via `workspace.getConfiguration().update(...)`.
-   - Expectation: all secret writes go through `context.secrets.store/delete`.
-   - Files:
-     - `src/settings/VscodeSettingsAdapter.ts`
-     - `src/settings/SettingsManager.ts`
-     - `src/extension/secretCommands.ts`
+**Check**: no secret values are written via `workspace.getConfiguration().update(...)` (or any other settings persistence).
 
-2. Verify any “status indicators” written to settings are non-sensitive.
-   - File: `src/extension/secretCommands.ts`
-   - Expectation: only a marker like `"✓ set"`, never the secret.
+- Files to inspect:
+  - `src/settings/VscodeSettingsAdapter.ts`
+  - `src/settings/SettingsManager.ts`
+  - `src/extension/secretCommands.ts`
 
-### B. Confirm per-server session API keys cannot be reused for arbitrary servers
+**Pass criteria**:
+- All secret writes go through `context.secrets.store(...)` / `context.secrets.delete(...)`.
+- Any settings written as “status indicators” are non-sensitive (boolean/marker only) and cannot be used to reconstruct the secret.
 
-1. Locate the per-server session key naming.
-   - File: `src/auth/serverSessionApiKeys.ts`
-   - Expectation: key name includes a **hash** of the normalized server URL:
-     - `openhands.sessionApiKey.server.${sha256(normalizedUrl)}`
+**Fail examples**:
+- Writing `apiKey`, `token`, `Authorization` headers, or full provider configs into settings JSON.
 
-2. Verify migration behavior is conservative.
-   - File: `src/extension.ts`
-   - Expectation: if a legacy session key exists, the extension should:
-     - NOT auto-send it to whatever server is configured
-     - Prompt the user before storing it under the hashed per-server key
+### B. Confirm per-server session API keys are scoped to a specific server
 
-### C. Confirm secrets don’t cross into the webview unnecessarily
+**Check**: session keys are not “global”; they must be bound to a specific normalized server URL.
 
-1. Inspect webview ↔ host messages related to API key overrides.
-   - Host handler: `src/webview/host/handlers/llmProfiles.ts` (`llmProfileApiKeySetRequest`)
-   - UI: `src/webview-src/components/LlmProfilesView.tsx`
+- Files to inspect:
+  - `src/auth/serverSessionApiKeys.ts`
+  - `src/shared/serverUrls.ts` (normalization rules)
+  - `src/extension.ts` (migration / usage)
 
-2. Expectations:
-   - The webview may temporarily hold a draft API key in memory for UX, but it must not be persisted.
-   - The host must store the API key in `context.secrets`, not in files.
-   - No `console.log`/debug logging should print the key or headers.
+**Pass criteria**:
+- The SecretStorage key name includes a stable identifier derived from the normalized server URL (e.g. a hash).
+- The normalized URL logic is understood and documented by the audit:
+  - This repo’s `normalizeServerUrl(...)` supports both `http:` and `https:` and may default to `http://` when no scheme is provided.
+- Migration from any legacy/global key is conservative:
+  - Do not automatically re-bind a legacy key to an arbitrary configured server without explicit user intent.
 
-### D. Confirm profile persistence strips secrets by default
+**Fail examples**:
+- A single `openhands.sessionApiKey` applied to whichever server URL is currently configured.
+- Storing per-server keys using an unnormalized URL (leading to aliasing or unintended reuse).
 
-Profiles can contain inline `apiKey` or `headers` in config, which are high risk if persisted.
+### C. Webview/host boundary: minimize secret exposure
 
-1. Verify profile persistence removes inline secrets unless explicitly opted-in.
-   - Host store wrapper: `src/webview/host/llmProfilesStore.ts`
-   - SDK store: `packages/agent-sdk-ts/src/sdk/llm/profiles.ts`
+**Non-negotiable policy**: the extension host **must never send secret values to the webview**.
 
-2. Expectations:
-   - `includeSecrets` defaults to `false`.
-   - When `includeSecrets=false`, both `apiKey` (if it looks like a real key, not an ENV var name) and `headers` are stripped.
+**Reality check**: the webview may still *see* a secret if the **user types it into a webview input field**. Treat that as the maximum tolerated exposure, not a convenience.
 
-### E. Confirm logs are redacted everywhere secrets may appear
+- Files to inspect:
+  - Webview → host request: `src/webview-src/components/app/useLlmProfilesRequests.ts` (`llmProfileApiKeySetRequest` includes `apiKey`)
+  - Host handler: `src/webview/host/handlers/llmProfiles.ts` (`handleLlmProfileApiKeySetRequest` stores to `context.secrets`)
+  - UI: `src/webview-src/components/LlmProfilesView.tsx`
 
-This repo has multiple logging surfaces. Verify each is covered.
+**Pass criteria**:
+- There are **no host→webview messages** that include secret material (API keys, tokens, Authorization headers, cookies).
+- Webview does not persist secrets:
+  - no `acquireVsCodeApi().setState(...)` (or other persistence) storing `apiKey`, headers, or tokens
+- On submit:
+  - webview sends the key to the host once, host stores it in SecretStorage, and the webview clears local state promptly.
+- No logging on either side:
+  - webview: no `console.log` / error reporting that includes key material
+  - host: no OutputChannel/dev logging of message payloads containing keys
 
-1. Output channel masking
-   - File: `src/extension/devBridgeLogger.ts` (`createMaskedOutputChannel`)
-   - Expectation: any `append/appendLine/replace` path masks via `maskSecretsInText(...)`.
+**Fail examples**:
+- Host echoes a stored key back to the webview for “display”.
+- Webview caches the key in persistent state to “remember” it.
 
-2. Debug JSON channel masking
-   - File: `src/extension/debugJsonOutputChannel.ts`
-   - Expectation: redacts using `maskSecretsInText(...)`.
+### D. Profile persistence: do not write secrets to disk by default
 
-3. Generic string redaction
-   - File: `src/shared/safeStringify.ts`
-   - Expectation: heuristically redacts common patterns (`Authorization: Bearer ...`, `sk-...`, GitHub tokens, etc.).
+Profiles can contain inline `apiKey` or `headers`, which are **high-risk** if persisted.
 
-4. “Known secret value” masking
-   - File: `src/shared/maskSecrets.ts`
-   - Expectation: uses a registry of known secret values (`SecretRegistry`) to replace exact matches.
+- Files to inspect:
+  - Host store wrapper: `src/webview/host/llmProfilesStore.ts`
+  - SDK store: `packages/agent-sdk-ts/src/sdk/llm/profiles.ts`
 
-Audit technique:
+**Check**: profile save paths have a default mode that **excludes secrets**.
 
-- Search for new/unmasked loggers:
-  - `console.log`, `console.warn`, `console.error`
-  - `outputChannel.appendLine` / `append`
-  - any `JSON.stringify(...)` used for logging
+**Pass criteria**:
+- A save option like `includeSecrets` exists and defaults to `false`.
+- When `includeSecrets=false`:
+  - `apiKey` is removed unless it is an explicit non-secret reference (e.g. an env-var indirection supported by this repo).
+  - `headers` are removed (or strictly allowlisted); never persist `Authorization` or cookies.
 
-If you find a logging path that doesn’t go through redaction utilities, flag it.
+**Fail examples**:
+- Persisting literal API keys or Authorization headers into any profile JSON file by default.
+- A heuristic like “strip if it looks like a real key” without a well-defined representation of non-secret references.
 
-### F. Confirm secrets are not placed in URLs
+### E. Logging & error handling: assume redaction is imperfect
 
-Tokens must be sent in headers, never as query parameters.
+**Rule**: the primary defense is **do not log secrets at all**. Redaction is a backstop.
 
-- Search for code that builds URLs with `token=`, `api_key=`, `key=`.
-- Ensure remote calls use `Authorization: Bearer ...` headers.
+- Files to inspect:
+  - Output channel masking: `src/extension/devBridgeLogger.ts` (`createMaskedOutputChannel`)
+  - Debug JSON channel masking: `src/extension/debugJsonOutputChannel.ts`
+  - Generic safe logging: `src/shared/safeStringify.ts`
+  - Known-secret masking registry: `src/shared/maskSecrets.ts`
+
+**Checks**:
+1. All extension-host logging surfaces run through masking utilities.
+2. Any errors posted to OutputChannel / webview / UI are sanitized:
+   - do not include request headers, Authorization, cookies, or full config objects.
+3. Webview-side logging is clean:
+   - no `console.*` printing request payloads that may contain secrets.
+
+**Audit technique**:
+- Search for unmasked loggers:
+  - `console.(log|warn|error)` in both `src/` and `src/webview-src/`
+  - direct `outputChannel.append/appendLine/replace`
+  - `JSON.stringify(...)` used in logs
+- When you find one, trace whether it flows through `maskSecretsInText(...)` or equivalent.
+
+**Fail examples**:
+- Logging the full webview message payload of `llmProfileApiKeySetRequest`.
+- Throwing/printing errors that embed headers or config with inline `apiKey`.
+
+### F. Network requests: keep secrets out of URLs and off the wrong host
+
+**Checks**:
+- No code constructs URLs containing secrets (`token=`, `api_key=`, `key=`, `authorization=`).
+- Secrets are sent via headers, not query params.
+- Ensure Authorization headers are only attached to the intended host:
+  - audit for redirect-following behavior and whether headers are preserved across redirects.
+
+**Repo-specific note**:
+- This repo supports `http:` server URLs (see `src/shared/serverUrls.ts`). If non-HTTPS is allowed, verify:
+  - it is explicit user intent (e.g. localhost/dev)
+  - secrets are not silently sent over `http://` due to scheme defaulting
+
+**Fail examples**:
+- `?token=...` in any URL.
+- Sending session API keys to a server URL that was inferred as `http://...` due to missing scheme.
 
 ---
 
-## 4) Suggested commands (optional, but recommended)
+## 4) Suggested commands (quick checks)
 
-If you have repo access, run quick checks:
+These are **assistive** checks (expect false positives/negatives). The real audit is code-path based.
 
-- Find potential secret patterns committed to code:
-  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}" src packages`
+- Find potential secret patterns committed to code (add context):
+  - `grep -RInEC 2 "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+" src packages`
 
-- Find places secrets might be written:
-  - `grep -RInE "writeFile|appendFile|fs\\." src packages`
-  - `grep -RInE "console\\.(log|warn|error)" src packages`
+- Find code paths that can write to disk (reduce noise):
+  - `grep -RInE "\\.writeFile(Sync)?\\(|\\.appendFile(Sync)?\\(" src packages`
 
-- Run tests that cover redaction and profile persistence:
+- Find obvious logging sites:
+  - `grep -RInE "console\\.(log|warn|error)" src packages src/webview-src`
+
+- Run tests:
   - `npm test`
 
 ---

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -12,7 +12,7 @@ triggers:
 
 # OpenHands-Tab Security Audit (AgentSkill)
 
-This is **not the audit report**. This is a **repeatable checklist** for an agent to run against *this repository*.
+This is a **repeatable checklist** for an agent to run against *this repository*.
 
 When invoked (e.g. the user types `/audit`), follow the checklist below, inspect the referenced code, and then output a short audit report.
 

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -6,8 +6,6 @@ description: >
 license: MIT
 triggers:
   - /audit
-  - audit security
-  - security audit
 ---
 
 # OpenHands-Tab Security Audit (AgentSkill)

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -178,7 +178,7 @@ Tokens must be sent in headers, never as query parameters.
 If you have repo access, run quick checks:
 
 - Find potential secret patterns committed to code:
-  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}" src packages`
+  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}" src packages`
 
 - Find places secrets might be written:
   - `grep -RInE "writeFile|appendFile|fs\\." src packages`

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -132,12 +132,13 @@ Profiles can contain inline `apiKey` or `headers`, which are **high-risk** if pe
 **Pass criteria**:
 - A save option like `includeSecrets` exists and defaults to `false`.
 - When `includeSecrets=false`:
-  - `apiKey` is removed unless it is an explicit non-secret reference (e.g. an env-var indirection supported by this repo).
-  - `headers` are removed (or strictly allowlisted); never persist `Authorization` or cookies.
+  - `headers` are removed by default.
+  - `apiKey` is removed by default **unless** it is a clearly-defined, non-secret reference format supported by this repo.
+    - **Important**: do *not* rely on a regex heuristic like `/^[A-Z0-9_]+$/` to guess “env var name”. Only preserve `apiKey` when it uses an explicit indirection syntax (whatever this repo defines), e.g. `${env:OPENAI_API_KEY}`.
 
 **Fail examples**:
 - Persisting literal API keys or Authorization headers into any profile JSON file by default.
-- A heuristic like “strip if it looks like a real key” without a well-defined representation of non-secret references.
+- Using heuristics (e.g. “keep it if it looks like an env var name”) instead of an explicit indirection format.
 
 ### E. Logging & error handling: assume redaction is imperfect
 

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -34,7 +34,7 @@ Primary risks for this VS Code extension:
 
 - **Persistence leaks**: secrets written to disk (VS Code settings JSON, profile files, workspace/global state, logs, conversation stores)
 - **Logging leaks**: secrets exposed via OutputChannel, debug channels, error strings/stack traces, dev bridge logs, webview console
-- **Webview boundary leaks**: secrets crossing extension-host ↔ webview boundary; secrets persisted in webview state (`acquireVsCodeApi().setState`) or leaked via console
+- **Webview boundary leaks**: host sending secrets to webview (prohibited); user-typed secrets in webview must be sent to host immediately for SecretStorage only and cleared from UI; secrets persisted in webview state (`acquireVsCodeApi().setState`) or leaked via console
 - **Network leaks**: secrets in URLs/query params, secrets sent to wrong host, secrets attached to redirected requests, non-HTTPS when not explicitly intended
 
 ---

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -45,7 +45,7 @@ Primary risks for this VS Code extension:
 
 ### A. Provider API key names and SecretStorage keys
 
-**Do not trust hardcoded lists in docs**. Derive the set of provider key names from code.
+**Do not trust hardcoded lists in docs**. Investigate and find the set of provider key names in the codebase.
 
 - Authoritative code: `src/webview/host/handlers/secretHelpers.ts`
   - Enumerate provider → key name mapping (e.g. `getProviderApiKeyName(...)`).


### PR DESCRIPTION
Adds a new AgentSkills-format skill at `.openhands/skills/audit/SKILL.md`.

The `/audit` skill provides a repo-specific security review checklist for the OpenHands-Tab VS Code extension, focused on:
- secure secret storage (VS Code SecretStorage)
- avoiding persistence of apiKey/headers to disk
- preventing leaks via OutputChannel/dev logging
- webview/host boundary handling

Co-authors included in commits: openhands <openhands@all-hands.dev>, smolpaws <engel@enyst.org>.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a user-facing security audit guide for the VS Code extension, introducing a repo-specific audit skill and how to invoke it (e.g., /audit).
  * Provides a repeatable audit workflow, a concise audit report format (Scope, High/Medium/Low findings, Good practices, Follow-ups), and a step-by-step checklist with pass/fail criteria and example commands.
  * Specifies handling of secrets, per-server key scoping, webview boundaries, profile persistence, logging redaction, network considerations, and domain-specific cautions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->