### PR TITLE
Agent: force conservative condensation on context-limit errors

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/credentials.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/credentials.ts
@@ -21,7 +21,7 @@ export class LLMCredentialProvider {
 
     for (const key of orderedKeys) {
       const value = await this.registry.get(key);
-      if (value) return value;
+      if (value && value !== '***') return value;
     }
     return undefined;
   }

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -710,8 +710,16 @@ export class Agent extends EventEmitter {
           }
           break;
         } catch (error) {
-          if (condensationAttempt < MAX_CONDENSATIONS_PER_STEP && isContextLimitError(llmConfig.provider, error)) {
-            const budget = configuredMaxInputTokens ?? FALLBACK_CONDENSATION_MAX_INPUT_TOKENS;
+          if (
+            condensationAttempt < MAX_CONDENSATIONS_PER_STEP &&
+            (isContextLimitError(llmConfig.provider, error) || wouldExceedMaxInputTokens({ request, maxInputTokens: FALLBACK_CONDENSATION_MAX_INPUT_TOKENS }))
+          ) {
+            // On provider context-limit errors (or when the request would exceed a conservative fallback budget),
+            // force a shrink before retry. Large configured limits can cause the condenser to no-op.
+            const budget = Math.min(
+              configuredMaxInputTokens ?? FALLBACK_CONDENSATION_MAX_INPUT_TOKENS,
+              FALLBACK_CONDENSATION_MAX_INPUT_TOKENS,
+            );
             const condensed = await tryCondenseConversationWithDeps({
               maxInputTokens: budget,
               listEvents: () => this.events.list(),


### PR DESCRIPTION
Context: Increasing the default max input tokens caused the condenser to no-op on provider context-limit errors (budget so large that no messages were forgotten), so the Agent never retried after summarizing.

Changes:
- On provider context-limit errors, condense with a conservative budget before retrying: min(configuredMaxInputTokens, 8000).
- Also condense if the request would exceed the fallback budget (8000), even when provider error classification is ambiguous.
- LLMCredentialProvider: ignore masked *** values when resolving API keys (prevents env leakage from breaking tests).

Expected impact:
- Restores the intended behavior: 1) first call fails with context-limit, 2) summarize, 3) retry succeeds.
- Keeps large default profiles but guarantees an actual shrink on retry.

Co-authored-by: smolpaws <engel@enyst.org>
Co-authored-by: openhands <openhands@all-hands.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined credential handling to skip invalid sentinel values during retrieval
  * Enhanced LLM request retry logic to better manage token consumption and prevent context overflow errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->