### PR TITLE
oh-tab-y6b: Fix @ context picker trigger and focus

### DIFF
--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -941,7 +941,7 @@ describe('App - Advanced Test Coverage', () => {
       const textarea = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
       expect(textarea).toBeTruthy();
 
-      const initial = 'Please read@rethen';
+      const initial = 'Please read @rethen';
       const caret = initial.indexOf('@') + 1 + 2; // after "@re"
 
       Object.defineProperty(textarea, 'selectionStart', { value: caret, configurable: true });

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -557,22 +557,6 @@ describe('App toolbar interactions', () => {
     expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
   });
 
-  it('does not open the context picker when @ is mid-word (email address)', async () => {
-    render(<App />);
-    const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
-    expect(input).toBeTruthy();
-
-    const value = 'engel@gmail.com';
-    input.setSelectionRange(value.length, value.length);
-    fireEvent.select(input);
-    fireEvent.change(input, { target: { value } });
-
-    await waitFor(() => {
-      expect(mockApi.postMessage).not.toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
-    });
-    expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
-  });
-
   it('requests skills and opens selected skill file', async () => {
     render(<App />);
     fireEvent.click(screen.getAllByLabelText('Skills')[0]);

--- a/src/webview-src/__tests__/App.toolbar.test.tsx
+++ b/src/webview-src/__tests__/App.toolbar.test.tsx
@@ -7,10 +7,12 @@ const mockApi = { postMessage: vi.fn() };
 
 describe('App toolbar interactions', () => {
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
   beforeEach(() => {
+    vi.useRealTimers();
     // @ts-expect-error mock VS Code API
     window.acquireVsCodeApi = () => mockApi;
     mockApi.postMessage.mockClear();
@@ -427,6 +429,96 @@ describe('App toolbar interactions', () => {
     expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
   });
 
+  it('does not open the context picker for email addresses', async () => {
+    render(<App />);
+    const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+    expect(input).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
+      }));
+    });
+
+    mockApi.postMessage.mockClear();
+    input.focus();
+    fireEvent.change(input, { target: { value: 'engel@gmail.com' } });
+    input.setSelectionRange(input.value.length, input.value.length);
+    fireEvent.select(input);
+
+    expect(mockApi.postMessage).not.toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
+    expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
+  });
+
+  it('does not steal focus when opening the mention context picker', async () => {
+    render(<App />);
+    const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+    expect(input).toBeTruthy();
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
+      }));
+    });
+
+    mockApi.postMessage.mockClear();
+    input.focus();
+    fireEvent.change(input, { target: { value: '@' } });
+    input.setSelectionRange(1, 1);
+    fireEvent.select(input);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'workspaceFiles', files: ['src/index.ts', 'README.md'] }
+      }));
+    });
+
+    expect(await screen.findByPlaceholderText('Search files...')).toBeInTheDocument();
+    expect(document.activeElement).toBe(input);
+  });
+
+  it('closes the mention context picker when clicking back into the input', async () => {
+    vi.useFakeTimers();
+    try {
+      render(<App />);
+      const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+      expect(input).toBeTruthy();
+
+      await act(async () => {
+        window.dispatchEvent(new MessageEvent('message', {
+          data: { type: 'status', status: 'online', mode: 'local', llmProfileLabel: 'gpt-4.1' }
+        }));
+      });
+
+      mockApi.postMessage.mockClear();
+      act(() => {
+        input.focus();
+        fireEvent.change(input, { target: { value: '@' } });
+        input.setSelectionRange(1, 1);
+        fireEvent.select(input);
+      });
+
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
+      expect(screen.getByPlaceholderText('Search files...')).toBeInTheDocument();
+
+      // Wait for the close handler to be attached (100ms delay in useCloseOnEscapeAndOutsideClick)
+      act(() => { vi.advanceTimersByTime(150); });
+
+      act(() => {
+        fireEvent.click(input);
+      });
+
+      expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
+      expect(document.activeElement).toBe(input);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('closes the context picker on Esc and returns focus to the input', async () => {
     render(<App />);
     const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
@@ -452,22 +544,6 @@ describe('App toolbar interactions', () => {
       }));
     });
 
-    expect(await screen.findByPlaceholderText('Search files...')).toBeInTheDocument();
-
-    fireEvent.click(screen.getByText('src/index.ts'));
-
-    await waitFor(() => {
-      expect(input.value).toContain('@src/index.ts');
-    });
-
-    // Blur input (user clicked elsewhere)
-    input.blur();
-
-    // Clicking back into the input near the mention re-opens the picker.
-    input.setSelectionRange(input.value.length, input.value.length);
-    input.focus();
-    fireEvent.select(input);
-
     const searchInput = await screen.findByPlaceholderText('Search files...');
     fireEvent.keyDown(searchInput, { key: 'Escape' });
 
@@ -475,6 +551,26 @@ describe('App toolbar interactions', () => {
     expect(document.activeElement).toBe(input);
     expect(input.selectionStart).toBe(input.value.length);
     expect(input.selectionEnd).toBe(input.value.length);
+
+    // Selecting/focusing the input should not immediately reopen the picker and steal focus back.
+    fireEvent.select(input);
+    expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
+  });
+
+  it('does not open the context picker when @ is mid-word (email address)', async () => {
+    render(<App />);
+    const input = document.getElementById('openhands-chat-input') as HTMLTextAreaElement;
+    expect(input).toBeTruthy();
+
+    const value = 'engel@gmail.com';
+    input.setSelectionRange(value.length, value.length);
+    fireEvent.select(input);
+    fireEvent.change(input, { target: { value } });
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).not.toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });
+    });
+    expect(screen.queryByPlaceholderText('Search files...')).not.toBeInTheDocument();
   });
 
   it('requests skills and opens selected skill file', async () => {

--- a/src/webview-src/components/App.tsx
+++ b/src/webview-src/components/App.tsx
@@ -73,7 +73,7 @@ export function App() {
   const [selectedContextFiles, setSelectedContextFiles] = useState<string[]>([]);
   const [isMentionActive, setIsMentionActive] = useState(false);
   const mentionStartRef = useRef<number | null>(null);
-  const suppressMentionOnceRef = useRef(false);
+  const dismissedMentionStartRef = useRef<number | null>(null);
 
   // Skills state
   const [showSkillsPopover, setShowSkillsPopover] = useState(false);
@@ -348,17 +348,26 @@ export function App() {
     const before = text.slice(0, caret);
     const at = before.lastIndexOf('@');
 
-    // If we intentionally closed the picker (e.g. Esc), avoid reopening immediately on the focus/selection event.
-    if (suppressMentionOnceRef.current) {
-      suppressMentionOnceRef.current = false;
-      if (at !== -1 && !/\s/.test(before.slice(at + 1))) {
-        return;
-      }
-    }
+    const hasWhitespaceAfterAt = at !== -1 && /\s/.test(before.slice(at + 1));
+    const isAtTriggerPosition = at === 0 || (at > 0 && /\s/.test(before.charAt(at - 1)));
+    const shouldActivateMention = at !== -1 && isAtTriggerPosition && !hasWhitespaceAfterAt;
 
     // Clear mention if no @ or whitespace after @
-    if (at === -1 || /\s/.test(before.slice(at + 1))) {
+    if (!shouldActivateMention) {
       if (isMentionActive) {
+        setIsMentionActive(false);
+        setShowContextPicker(false);
+        setContextQuery('');
+        mentionStartRef.current = null;
+      }
+      dismissedMentionStartRef.current = null;
+      return;
+    }
+
+    if (dismissedMentionStartRef.current === at) {
+      // User dismissed the picker while the caret was in this mention token; keep it closed
+      // so it doesn't immediately steal focus back from the textarea.
+      if (isMentionActive || showContextPicker) {
         setIsMentionActive(false);
         setShowContextPicker(false);
         setContextQuery('');
@@ -370,6 +379,7 @@ export function App() {
     // Activate mention mode
     const afterAt = before.slice(at + 1);
     mentionStartRef.current = at;
+    dismissedMentionStartRef.current = null;
     setIsMentionActive(true);
     setShowSkillsPopover(false);
     setShowToolsPopover(false);
@@ -505,17 +515,19 @@ export function App() {
   const handleCloseContextPicker = useCallback((reason: 'escape' | 'outside') => {
     setShowContextPicker(false);
 
-    if (reason !== 'escape') {
-      return;
+    if (isMentionActive && mentionStartRef.current !== null) {
+      // Prevent immediate re-open while the caret remains in the same mention token.
+      dismissedMentionStartRef.current = mentionStartRef.current;
+      setIsMentionActive(false);
+      setContextQuery('');
+      mentionStartRef.current = null;
     }
 
-    // When Esc closes the picker, return focus to the input and prevent the mention logic from reopening it.
-    setIsMentionActive(false);
-    setContextQuery('');
-    mentionStartRef.current = null;
-    suppressMentionOnceRef.current = true;
-    focusInputAtEnd();
-  }, [focusInputAtEnd]);
+    if (reason === 'escape') {
+      // When Esc closes the picker, return focus to the input.
+      focusInputAtEnd();
+    }
+  }, [focusInputAtEnd, isMentionActive]);
 
   // Attachments handlers
   const handleOpenAttachments = useCallback(() => {
@@ -790,6 +802,7 @@ export function App() {
             contextQuery,
             onContextQueryChange: setContextQuery,
             onCloseContextPicker: handleCloseContextPicker,
+            contextPickerAutoFocusSearch: !isMentionActive,
             onOpenSkills: handleOpenSkills,
             skillsCount: skills.length,
             showSkillsPopover,

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -28,6 +28,7 @@ interface InputAreaProps {
   contextQuery?: string;
   onContextQueryChange?: (query: string) => void;
   onCloseContextPicker?: (reason: CloseReason) => void;
+  contextPickerAutoFocusSearch?: boolean;
   // Skills
   onOpenSkills: () => void;
   skillsCount?: number;
@@ -84,6 +85,7 @@ export function InputArea({
   contextQuery = '',
   onContextQueryChange,
   onCloseContextPicker,
+  contextPickerAutoFocusSearch = true,
   onOpenSkills,
   skillsCount = 0,
   showSkillsPopover = false,
@@ -327,6 +329,7 @@ export function InputArea({
                 onToggleFile={onToggleContextFile}
                 searchQuery={contextQuery}
                 onSearchChange={onContextQueryChange}
+                autoFocusSearch={contextPickerAutoFocusSearch}
               />
             )}
           </div>

--- a/src/webview-src/components/inputArea/ContextPicker.tsx
+++ b/src/webview-src/components/inputArea/ContextPicker.tsx
@@ -9,6 +9,7 @@ interface ContextPickerProps {
   onToggleFile: (file: string) => void;
   searchQuery: string;
   onSearchChange: (query: string) => void;
+  autoFocusSearch?: boolean;
 }
 
 export function ContextPicker({
@@ -19,6 +20,7 @@ export function ContextPicker({
   onToggleFile,
   searchQuery,
   onSearchChange,
+  autoFocusSearch = true,
 }: ContextPickerProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -86,7 +88,7 @@ export function ContextPicker({
           aria-controls={listboxId}
           aria-activedescendant={activeOptionId}
           className="w-full px-3 py-2 bg-black/30 border border-white/[0.08] rounded-lg text-sm text-stone-200 placeholder:text-stone-500 focus:outline-none focus:ring-0 focus:border-white/[0.08] focus:shadow-[0_0_0_1px_rgba(232,166,66,0.08)] oh-focus-outline"
-          autoFocus
+          autoFocus={autoFocusSearch}
         />
       </div>
 


### PR DESCRIPTION
### Bead

```text

oh-tab-y6b: @ symbol triggers context picker incorrectly and steals focus
Status: closed
Priority: P1
Type: task
Assignee: BlackCastle
Created: 2026-01-16 18:19
Updated: 2026-01-17 06:43

Description:
Two issues with @ symbol handling in the input prompt box:

**Issue 1: @ triggers context picker mid-word**
- Typing an email like engel@gmail.com triggers the Add Context Files dialogue
- The @ should only trigger context picker when:
  - At the beginning of the prompt/line
  - After a whitespace character
- Mid-word @ (like in email addresses) should be typed normally

**Issue 2: Cannot regain focus in input box**
- When @ triggers the context picker and it opens
- Clicking back inside the input box should:
  - Close the context picker dialogue
  - Return focus to the input box
  - Let the user continue typing their prompt
- Currently the context picker stays open and blocks normal input

```

### Summary
- Fixes @ mention trigger/focus behavior in context picker.

### Testing
- npm test
- npm run build -w @openhands/agent-sdk-ts
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mention picker from incorrectly triggering on email-like strings.
  * Improved focus restoration when interacting with the context picker.

* **Tests**
  * Expanded test coverage for mention picker behavior and focus management across user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->