### PR TITLE
oh-tab-tf8: Improve open editors context + condensation

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
@@ -63,13 +63,16 @@ describe('condensation helpers', () => {
     expect(userMessage.content).toEqual([{ type: 'text', text: 'Hello' }, { type: 'text', text: 'Context' }]);
   });
 
-  it('only attaches extended_content to the most recent user message', () => {
+  it('only keeps <environment information> for the most recent user message', () => {
     const message1 = {
       kind: 'MessageEvent',
       id: 'm1',
       source: 'user',
       llm_message: { role: 'user', content: [{ type: 'text', text: 'First' }] },
-      extended_content: [{ type: 'text', text: 'Env 1' }],
+      extended_content: [
+        { type: 'text', text: '<environment information>\nActive editor: a.ts\n</environment information>' },
+        { type: 'text', text: 'Environment note: user edited file:\n/tmp/a.txt' },
+      ],
     } satisfies Extract<Event, { kind: 'MessageEvent' }>;
 
     const message2 = {
@@ -77,7 +80,7 @@ describe('condensation helpers', () => {
       id: 'm2',
       source: 'user',
       llm_message: { role: 'user', content: [{ type: 'text', text: 'Second' }] },
-      extended_content: [{ type: 'text', text: 'Env 2' }],
+      extended_content: [{ type: 'text', text: '<environment information>\nActive editor: b.ts\n</environment information>' }],
     } satisfies Extract<Event, { kind: 'MessageEvent' }>;
 
     const tools: LLMToolDefinition[] = [];
@@ -88,8 +91,14 @@ describe('condensation helpers', () => {
     });
 
     expect(request.messages.map((m) => m.role)).toEqual(['user', 'user']);
-    expect(request.messages[0]?.content).toEqual([{ type: 'text', text: 'First' }]);
-    expect(request.messages[1]?.content).toEqual([{ type: 'text', text: 'Second' }, { type: 'text', text: 'Env 2' }]);
+    expect(request.messages[0]?.content).toEqual([
+      { type: 'text', text: 'First' },
+      { type: 'text', text: 'Environment note: user edited file:\n/tmp/a.txt' },
+    ]);
+    expect(request.messages[1]?.content).toEqual([
+      { type: 'text', text: 'Second' },
+      { type: 'text', text: '<environment information>\nActive editor: b.ts\n</environment information>' },
+    ]);
   });
 
   it('tryCondenseConversation emits a Condensation event using injected condense()', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
@@ -63,6 +63,35 @@ describe('condensation helpers', () => {
     expect(userMessage.content).toEqual([{ type: 'text', text: 'Hello' }, { type: 'text', text: 'Context' }]);
   });
 
+  it('only attaches extended_content to the most recent user message', () => {
+    const message1 = {
+      kind: 'MessageEvent',
+      id: 'm1',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'First' }] },
+      extended_content: [{ type: 'text', text: 'Env 1' }],
+    } satisfies Extract<Event, { kind: 'MessageEvent' }>;
+
+    const message2 = {
+      kind: 'MessageEvent',
+      id: 'm2',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'Second' }] },
+      extended_content: [{ type: 'text', text: 'Env 2' }],
+    } satisfies Extract<Event, { kind: 'MessageEvent' }>;
+
+    const tools: LLMToolDefinition[] = [];
+    const request = buildChatRequestWithCondensation({
+      events: [message1, message2],
+      systemPrompt: 'SYS',
+      tools,
+    });
+
+    expect(request.messages.map((m) => m.role)).toEqual(['user', 'user']);
+    expect(request.messages[0]?.content).toEqual([{ type: 'text', text: 'First' }]);
+    expect(request.messages[1]?.content).toEqual([{ type: 'text', text: 'Second' }, { type: 'text', text: 'Env 2' }]);
+  });
+
   it('tryCondenseConversation emits a Condensation event using injected condense()', async () => {
     const events: Event[] = [
       { kind: 'MessageEvent', id: 'a', source: 'user', llm_message: { role: 'user', content: [{ type: 'text', text: 'a' }] } },
@@ -105,4 +134,3 @@ describe('condensation helpers', () => {
     });
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
@@ -42,15 +42,25 @@ export const buildChatRequestWithCondensation = (params: {
     systemPrompt += `\n\n<CONVERSATION SUMMARY>\n${condensationState.summary}\n</CONVERSATION SUMMARY>`;
   }
 
-  const rawMessages = params.events
+  const messageEvents = params.events
     .filter(isMessageEvent)
-    .filter((event) => !condensationState.forgottenEventIds.has(event.id ?? ''))
-    .map((event) => {
-      if (event.source === 'user' && event.extended_content?.length) {
-        return { ...event.llm_message, content: [...event.llm_message.content, ...event.extended_content] };
-      }
-      return event.llm_message;
-    });
+    .filter((event) => !condensationState.forgottenEventIds.has(event.id ?? ''));
+
+  const lastUserMessageIndex = (() => {
+    for (let i = messageEvents.length - 1; i >= 0; i -= 1) {
+      if (messageEvents[i]?.source === 'user') return i;
+    }
+    return -1;
+  })();
+
+  const rawMessages = messageEvents.map((event, idx) => {
+    // Only attach extended_content to the most recent user message so stale environment info
+    // from earlier turns doesn't pollute the request context.
+    if (idx === lastUserMessageIndex && event.source === 'user' && event.extended_content?.length) {
+      return { ...event.llm_message, content: [...event.llm_message.content, ...event.extended_content] };
+    }
+    return event.llm_message;
+  });
   const messages = sanitizeChatMessages(rawMessages);
 
   return { systemPrompt, messages, tools: params.tools };

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
@@ -53,11 +53,22 @@ export const buildChatRequestWithCondensation = (params: {
     return -1;
   })();
 
+  const isEnvironmentInfoBlock = (text: string): boolean =>
+    text.trimStart().toLowerCase().startsWith('<environment information>');
+
   const rawMessages = messageEvents.map((event, idx) => {
-    // Only attach extended_content to the most recent user message so stale environment info
-    // from earlier turns doesn't pollute the request context.
-    if (idx === lastUserMessageIndex && event.source === 'user' && event.extended_content?.length) {
-      return { ...event.llm_message, content: [...event.llm_message.content, ...event.extended_content] };
+    if (event.source === 'user' && event.extended_content?.length) {
+      // Environment info is ephemeral and should reflect the latest editor state only.
+      // Keep other extended content (e.g. watched-file notes, skill suffixes) attached to its
+      // original message so it remains in conversation history.
+      const extendedContent =
+        idx === lastUserMessageIndex
+          ? event.extended_content
+          : event.extended_content.filter((c) => !(c.type === 'text' && isEnvironmentInfoBlock(c.text)));
+
+      if (extendedContent.length > 0) {
+        return { ...event.llm_message, content: [...event.llm_message.content, ...extendedContent] };
+      }
     }
     return event.llm_message;
   });

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -920,7 +920,7 @@ describe('Chat view behavior', () => {
     expect(agentContext.userMessageSuffix).toContain('<environment information>');
     expect(agentContext.userMessageSuffix).toContain('Active editor: initial.ts');
     expect(agentContext.userMessageSuffix).toContain('Open editors:');
-    expect(agentContext.userMessageSuffix).toContain('- initial.ts');
+    expect(agentContext.userMessageSuffix).toContain('- none');
     expect(agentContext.userMessageSuffix).toContain('</environment information>');
 
     const nextEditor = {
@@ -935,13 +935,54 @@ describe('Chat view behavior', () => {
     (vscode.window as any).visibleTextEditors = [nextEditor];
     (vscode as any).__triggerActiveTextEditorChange(nextEditor);
     expect(agentContext.userMessageSuffix).toContain('Active editor: next.ts');
-    expect(agentContext.userMessageSuffix).toContain('- next.ts');
+    expect(agentContext.userMessageSuffix).toContain('- none');
 
     (vscode.window as any).activeTextEditor = undefined;
     (vscode.window as any).visibleTextEditors = [];
     (vscode as any).__triggerActiveTextEditorChange(undefined);
     expect(agentContext.userMessageSuffix).toContain('Active editor: none');
     expect(agentContext.userMessageSuffix).toContain('- none');
+  });
+
+  it('lists other open tabs (excluding the active editor) in the local environment info suffix', async () => {
+    mockSettings = { ...mockSettings, serverUrl: '' as any };
+    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', '');
+
+    const initialEditor = {
+      document: {
+        uri: {
+          scheme: 'file',
+          fsPath: '/test/workspace/src/initial.ts',
+        },
+      },
+    };
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace' } }];
+    (vscode.window as any).activeTextEditor = initialEditor;
+    (vscode.window as any).visibleTextEditors = [initialEditor];
+    (vscode.window as any).tabGroups = {
+      all: [
+        {
+          tabs: [
+            { input: { uri: { scheme: 'file', fsPath: '/test/workspace/src/initial.ts' } } },
+            { input: { uri: { scheme: 'file', fsPath: '/test/workspace/src/other.ts' } } },
+            { input: { uri: { scheme: 'file', fsPath: '/test/workspace/README.md' } } },
+          ],
+        },
+      ],
+    };
+
+    await resolveChatView(mockContext);
+
+    const { Conversation } = await import('@openhands/agent-sdk-ts');
+    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
+    expect(options?.agentContext).toBeTruthy();
+    const agentContext = options.agentContext as any;
+
+    expect(agentContext.userMessageSuffix).toContain('Active editor: initial.ts');
+    expect(agentContext.userMessageSuffix).toContain('Open editors:');
+    expect(agentContext.userMessageSuffix).toContain('- other.ts');
+    expect(agentContext.userMessageSuffix).toContain('- README.md');
+    expect(agentContext.userMessageSuffix).not.toContain('- initial.ts');
   });
 
   it('auto-disables tool-call summarization when Gemini key is missing (local mode)', async () => {
@@ -1040,7 +1081,7 @@ describe('Command handlers', () => {
     expect(message).toContain('<environment information>');
     expect(message).toContain('Active editor: example.ts');
     expect(message).toContain('Open editors:');
-    expect(message).toContain('- example.ts');
+    expect(message).toContain('- none');
     expect(message).toContain('</environment information>');
   });
 
@@ -1077,7 +1118,7 @@ describe('Command handlers', () => {
     expect(message).toContain('<environment information>');
     expect(message).toContain('Active editor: ralph.md');
     expect(message).toContain('Open editors:');
-    expect(message).toContain('- ralph.md');
+    expect(message).toContain('- none');
     expect(message).toContain('</environment information>');
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
+import { collectOpenEditorPaths } from './shared/openEditors';
 import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import { computeWelcomeSecretStatus } from './shared/welcomeSecretStatus';
@@ -178,9 +179,7 @@ function buildEnvironmentInfoSuffix(): string | null {
   try {
     const workspaceRoot = resolvePreferredWorkspaceRoot();
     const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
-    const openEditorPaths = (vscode.window.visibleTextEditors ?? [])
-      .map((e) => getFileBackedFsPath(e?.document?.uri))
-      .filter((p): p is string => typeof p === 'string' && p.length > 0);
+    const openEditorPaths = collectOpenEditorPaths({ activeEditorPath, max: 15 });
     return formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths });
   } catch {
     return null;

--- a/src/extension/explainSelectionCommand.ts
+++ b/src/extension/explainSelectionCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import { formatEnvironmentInformation } from '../shared/environmentInformation';
+import { collectOpenEditorPaths } from '../shared/openEditors';
 import { getEffectiveWorkspaceRoot } from '../shared/workspaceRoot';
 import { getFileBackedFsPath } from '../shared/uri';
 
@@ -66,9 +67,7 @@ export function registerExplainSelectionCommand(options: {
     if (getConversationMode() === 'local') {
       const workspaceRoot = getEffectiveWorkspaceRoot();
       const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
-      const openEditorPaths = (vscode.window.visibleTextEditors ?? [])
-        .map((e) => getFileBackedFsPath(e?.document?.uri))
-        .filter((p): p is string => typeof p === 'string' && p.length > 0);
+      const openEditorPaths = collectOpenEditorPaths({ activeEditorPath, max: 15 });
       finalPrompt += `\n\n${formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths })}`;
     }
 

--- a/src/shared/__tests__/environmentInformation.test.ts
+++ b/src/shared/__tests__/environmentInformation.test.ts
@@ -7,7 +7,6 @@ describe('formatEnvironmentInformation', () => {
       workspaceRoot: '/ws',
       activeEditorPath: '/ws/src/foo.ts',
       openEditorPaths: [
-        '/ws/src/foo.ts',
         '/ws/test/foo.ts',
         '/outside/bar.ts',
       ],
@@ -18,7 +17,6 @@ describe('formatEnvironmentInformation', () => {
 
     // duplicate basenames inside workspace are disambiguated
     expect(text).toContain('Active editor: foo.ts — src');
-    expect(text).toContain('- foo.ts — src');
     expect(text).toContain('- foo.ts — test');
 
     // outside-workspace paths remain absolute

--- a/src/shared/openEditors.ts
+++ b/src/shared/openEditors.ts
@@ -1,0 +1,73 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { getFileBackedFsPath } from './uri';
+
+function isUriLike(value: unknown): value is vscode.Uri {
+  return Boolean(value)
+    && typeof value === 'object'
+    && typeof (value as { scheme?: unknown }).scheme === 'string'
+    && typeof (value as { fsPath?: unknown }).fsPath === 'string';
+}
+
+function extractUriFromTabInput(input: unknown): vscode.Uri | undefined {
+  if (!input || typeof input !== 'object') return undefined;
+
+  const maybeUri = (input as { uri?: unknown }).uri;
+  if (isUriLike(maybeUri)) return maybeUri;
+
+  const maybeModified = (input as { modified?: unknown }).modified;
+  if (isUriLike(maybeModified)) return maybeModified;
+
+  const maybeResource = (input as { resource?: unknown }).resource;
+  if (isUriLike(maybeResource)) return maybeResource;
+
+  return undefined;
+}
+
+function collectOpenEditorPathsFromTabs(): string[] {
+  const groups = vscode.window.tabGroups?.all;
+  if (!Array.isArray(groups)) return [];
+
+  const paths: string[] = [];
+  for (const group of groups) {
+    const tabs = (group as { tabs?: unknown }).tabs;
+    if (!Array.isArray(tabs)) continue;
+    for (const tab of tabs) {
+      const uri = extractUriFromTabInput((tab as { input?: unknown }).input);
+      const fsPath = getFileBackedFsPath(uri);
+      if (fsPath) paths.push(fsPath);
+    }
+  }
+  return paths;
+}
+
+function collectOpenEditorPathsFromVisibleEditors(): string[] {
+  return (vscode.window.visibleTextEditors ?? [])
+    .map((e) => getFileBackedFsPath(e?.document?.uri))
+    .filter((p): p is string => typeof p === 'string' && p.length > 0);
+}
+
+export function collectOpenEditorPaths(params: {
+  activeEditorPath?: string | null;
+  max?: number;
+}): string[] {
+  const max = params.max ?? Number.POSITIVE_INFINITY;
+  const activeEditorPath = typeof params.activeEditorPath === 'string' ? params.activeEditorPath : null;
+  const resolvedActive = activeEditorPath ? path.resolve(activeEditorPath) : null;
+
+  const candidates = collectOpenEditorPathsFromTabs();
+  const raw = candidates.length > 0 ? candidates : collectOpenEditorPathsFromVisibleEditors();
+
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const p of raw) {
+    const resolved = path.resolve(p);
+    if (resolvedActive && resolved === resolvedActive) continue;
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    result.push(p);
+    if (result.length >= max) break;
+  }
+
+  return result;
+}

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -156,6 +156,44 @@ describe('Agent-SDK event rendering', () => {
     expect(screen.queryByText(/open editors:/i)).toBeNull();
   });
 
+  it('truncates long open editors lists in Extended Context', async () => {
+    render(<App />);
+
+    const env = [
+      '<environment information>',
+      'Active editor: a.ts',
+      'Open editors:',
+      '- b1.ts',
+      '- b2.ts',
+      '- b3.ts',
+      '- b4.ts',
+      '- b5.ts',
+      '- b6.ts',
+      '</environment information>',
+    ].join('\n');
+
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+      extended_content: [{ type: 'text', text: env }],
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText('hello')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Extended Context'));
+
+    expect(await screen.findByText(/- b1\.ts/)).toBeInTheDocument();
+    expect(screen.getByText(/- b5\.ts/)).toBeInTheDocument();
+    expect(screen.getByText(/- \.\.\./)).toBeInTheDocument();
+    expect(screen.queryByText(/b6\.ts/)).toBeNull();
+  });
+
   it('renders agent error events', async () => {
     render(<App />);
     const ev: AgentErrorEvent = {

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -169,6 +169,7 @@ describe('Agent-SDK event rendering', () => {
       '- b4.ts',
       '- b5.ts',
       '- b6.ts',
+      'Other info: should stay',
       '</environment information>',
     ].join('\n');
 
@@ -192,6 +193,7 @@ describe('Agent-SDK event rendering', () => {
     expect(screen.getByText(/- b5\.ts/)).toBeInTheDocument();
     expect(screen.getByText(/- \.\.\./)).toBeInTheDocument();
     expect(screen.queryByText(/b6\.ts/)).toBeNull();
+    expect(screen.getByText(/Other info: should stay/)).toBeInTheDocument();
   });
 
   it('renders agent error events', async () => {

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -21,6 +21,32 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const isUser = message.role === 'user';
   const isAgent = message.role === 'assistant';
 
+  function truncateEnvironmentInformationForDisplay(text: string): string {
+    const lines = text.split(/\r?\n/);
+    const startIndex = lines.findIndex((line) => line.trim().toLowerCase() === '<environment information>');
+    if (startIndex === -1) return text;
+
+    const endIndex = lines.findIndex((line, idx) => idx > startIndex && line.trim().toLowerCase() === '</environment information>');
+    if (endIndex === -1) return text;
+
+    const openEditorsIndex = lines.findIndex((line, idx) => idx > startIndex && idx < endIndex && line.trim().toLowerCase() === 'open editors:');
+    if (openEditorsIndex === -1) return text;
+
+    const listStartIndex = openEditorsIndex + 1;
+    const listLines = lines.slice(listStartIndex, endIndex);
+    const editorLines = listLines.filter((line) => line.trimStart().startsWith('- '));
+    if (editorLines.length <= 5) return text;
+
+    const truncated = [
+      ...lines.slice(0, listStartIndex),
+      ...editorLines.slice(0, 5),
+      '- ...',
+      ...lines.slice(endIndex),
+    ];
+
+    return truncated.join('\n');
+  }
+
   const rawText = message.content.filter(isTextContent).map((c) => c.text).join('\n');
   const sanitizedText = stripEnvironmentInformationBlocks(rawText);
   const CONTEXT_HEADER = 'User has selected the following files for you to read:';
@@ -243,7 +269,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
               <div className="mt-2 space-y-1">
                 {event.extended_content.filter(isTextContent).map((content, idx) => (
                   <pre key={idx} className="bg-black/20 border border-white/[0.04] rounded-lg p-2 font-mono text-stone-400 whitespace-pre-wrap break-words">
-                    {content.text}
+                    {truncateEnvironmentInformationForDisplay(content.text)}
                   </pre>
                 ))}
               </div>

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -33,15 +33,19 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
     if (openEditorsIndex === -1) return text;
 
     const listStartIndex = openEditorsIndex + 1;
-    const listLines = lines.slice(listStartIndex, endIndex);
-    const editorLines = listLines.filter((line) => line.trimStart().startsWith('- '));
+    let listEndIndex = listStartIndex;
+    while (listEndIndex < endIndex && lines[listEndIndex]?.trimStart().startsWith('- ')) {
+      listEndIndex += 1;
+    }
+
+    const editorLines = lines.slice(listStartIndex, listEndIndex);
     if (editorLines.length <= 5) return text;
 
     const truncated = [
       ...lines.slice(0, listStartIndex),
       ...editorLines.slice(0, 5),
       '- ...',
-      ...lines.slice(endIndex),
+      ...lines.slice(listEndIndex),
     ];
 
     return truncated.join('\n');

--- a/test/__mocks__/vscode.ts
+++ b/test/__mocks__/vscode.ts
@@ -202,6 +202,9 @@ export function __resetMocks() {
   mockSaveTextDocumentListeners.length = 0;
   mockConfigValues.clear();
   mockWebviewViewProviders.clear();
+  (window as any).activeTextEditor = undefined;
+  (window as any).visibleTextEditors = [];
+  (window as any).tabGroups = undefined;
   // Reset common spies to default implementations
   ;(workspace.getConfiguration as any).mockClear();
   ;(mockConfiguration.get as any).mockClear();


### PR DESCRIPTION
### Bead

```text

oh-tab-tf8: Open editors list in extended context only shows active file
Status: closed
Priority: P1
Type: task
Created: 2026-01-16 18:13
Updated: 2026-01-17 06:47

Description:
Extended context attached to user messages includes 'environment information' with:
- Active editor (works correctly)
- Open editors list (broken - only repeats the active file)

Expected behavior:
1. Open editors list should NOT repeat the active editor
2. Open editors list should include all other files currently open in VS Code editors

Display limits:
- Backend: send up to 15 open files in the extended context
- Webview UI: show max 5 open files, append '...' after the last file if there are more

LLM request behavior change:
- Currently: condensation.ts appends extended_content to ALL user messages (line 49-50)
- Problem: old environment info (open files from previous turns) is stale/noise
- Fix: Only attach extended_content to the LAST user message, not previous ones
- Location: buildChatRequestWithCondensation in packages/agent-sdk-ts/src/sdk/runtime/condensation.ts

Need to investigate VS Code API to get the actual list of open editors (e.g., vscode.window.tabGroups or vscode.window.visibleTextEditors).

```

### Summary
- Adds a shared open-editors collector and uses it in environment info.
- Truncates open editors UI output and tightens condensation to the latest user message only.

### Testing
- npm run build -w @openhands/agent-sdk-ts
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Long open editor lists in Extended Context are now truncated to the first 5 items with an ellipsis indicator for improved readability.

* **Bug Fixes**
  * Open editors display and listing behavior improved for clarity in environment information.
  * Refined extended content attachment in chat requests to ensure proper organization of message content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->