### PR TITLE
oh-tab-h4b: Replace apiKey with apiKeyRef

### DIFF
--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -324,8 +324,9 @@ OpenAICompatibleClient  // OpenAI, LiteLLM proxy, OpenRouter
 OpenAIResponsesClient   // OpenAI gpt-5.* with Responses API
 GeminiClient           // Google Gemini with extended thinking
 
-// LLM factory
-createLLMClient(config: LLMConfiguration, options): LLMClient
+	// LLM factory
+	createLLMClient(config: LLMConfiguration, options): LLMClient
+	// API keys are supplied via `config.apiKeyRef` (reference or explicit inline) and resolved via SecretRegistry at request time.
 
 // Router
 createRouterLlmClient({ clients, router }): LLMClient

--- a/packages/agent-sdk-ts/docs/python-parity.md
+++ b/packages/agent-sdk-ts/docs/python-parity.md
@@ -324,9 +324,9 @@ OpenAICompatibleClient  // OpenAI, LiteLLM proxy, OpenRouter
 OpenAIResponsesClient   // OpenAI gpt-5.* with Responses API
 GeminiClient           // Google Gemini with extended thinking
 
-	// LLM factory
-	createLLMClient(config: LLMConfiguration, options): LLMClient
-	// API keys are supplied via `config.apiKeyRef` (reference or explicit inline) and resolved via SecretRegistry at request time.
+// LLM factory
+createLLMClient(config: LLMConfiguration, options): LLMClient
+// API keys are supplied via `config.apiKeyRef` (reference or explicit inline) and resolved via SecretRegistry at request time.
 
 // Router
 createRouterLlmClient({ clients, router }): LLMClient

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profile-selection.test.ts
@@ -25,7 +25,7 @@ describe('LLMFactory profile selection', () => {
           model: 'IGNORED',
           profileId: 'p1',
           usageId: 'default',
-          apiKey: 'sk-inline',
+          apiKeyRef: { kind: 'inline', value: 'sk-inline' },
         },
         { registry, profileStoreOptions: { rootDir: dir } },
       );
@@ -50,7 +50,7 @@ describe('LLMFactory profile selection', () => {
         provider: 'openai',
         model: 'gpt-5-mini',
         usageId: 'default',
-        apiKey: 'sk-inline',
+        apiKeyRef: { kind: 'inline', value: 'sk-inline' },
       },
       { registry },
     );
@@ -115,14 +115,14 @@ describe('LLMFactory profile selection', () => {
       registry.subscribe((event) => stats.registerLlm(event));
 
       const first = await new LLMFactory(
-        { provider: 'openai', model: 'IGNORED', profileId: 'gpt-5', usageId: 'agent', apiKey: 'sk-inline' },
+        { provider: 'openai', model: 'IGNORED', profileId: 'gpt-5', usageId: 'agent', apiKeyRef: { kind: 'inline', value: 'sk-inline' } },
         { registry, profileStoreOptions: { rootDir: dir } },
       ).createClient();
       expect(first).toBeInstanceOf(TrackedLLMClient);
       (first as TrackedLLMClient).metrics.addTokenUsage({ promptTokens: 10, completionTokens: 1, responseId: 'r1' });
 
       const second = await new LLMFactory(
-        { provider: 'openai', model: 'IGNORED', profileId: 'sonnet-45', usageId: 'agent', apiKey: 'sk-inline' },
+        { provider: 'openai', model: 'IGNORED', profileId: 'sonnet-45', usageId: 'agent', apiKeyRef: { kind: 'inline', value: 'sk-inline' } },
         { registry, profileStoreOptions: { rootDir: dir } },
       ).createClient();
       expect(second).toBeInstanceOf(TrackedLLMClient);

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.profiles.test.ts
@@ -11,8 +11,8 @@ describe('LLM profiles', () => {
   it('saves, loads, and lists profiles', () => {
     const dir = makeTempDir();
     try {
-      const configA: LLMConfiguration = { provider: 'openai', model: 'gpt-5', apiKey: 'OPENAI_API_KEY' };
-      const configB: LLMConfiguration = { provider: 'anthropic', model: 'claude', apiKey: 'ANTHROPIC_API_KEY' };
+      const configA: LLMConfiguration = { provider: 'openai', model: 'gpt-5', apiKeyRef: { kind: 'key', name: 'OPENAI_API_KEY' } };
+      const configB: LLMConfiguration = { provider: 'anthropic', model: 'claude', apiKeyRef: { kind: 'key', name: 'ANTHROPIC_API_KEY' } };
       saveProfile('b', configB, { rootDir: dir });
       saveProfile('a', configA, { rootDir: dir });
 
@@ -27,7 +27,7 @@ describe('LLM profiles', () => {
     }
   });
 
-  it('omits inline apiKey and headers when includeSecrets=false', () => {
+  it('omits inline apiKeyRef and headers when includeSecrets=false', () => {
     const dir = makeTempDir();
     try {
       saveProfile(
@@ -35,7 +35,7 @@ describe('LLM profiles', () => {
         {
           provider: 'openai',
           model: 'gpt-5',
-          apiKey: 'sk-secret',
+          apiKeyRef: { kind: 'inline', value: 'sk-secret' },
           headers: { Authorization: 'Bearer sk-secret', 'X-Title': 'not-a-secret' },
         },
         { rootDir: dir },
@@ -43,28 +43,28 @@ describe('LLM profiles', () => {
       const filePath = path.join(dir, 'no-secrets.json');
       const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
 
-      expect(payload.apiKey).toBeUndefined();
+      expect(payload.apiKeyRef).toBeUndefined();
       expect(payload.headers).toBeUndefined();
       const loaded = loadProfile('no-secrets', { rootDir: dir }).config;
-      expect(loaded.apiKey).toBeUndefined();
+      expect(loaded.apiKeyRef).toBeUndefined();
       expect(loaded.headers).toBeUndefined();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  it('persists inline apiKey when includeSecrets=true', () => {
+  it('persists inline apiKeyRef when includeSecrets=true', () => {
     const dir = makeTempDir();
     try {
       saveProfile(
         'with-secrets',
-        { provider: 'openai', model: 'gpt-5', apiKey: 'sk-secret' },
+        { provider: 'openai', model: 'gpt-5', apiKeyRef: { kind: 'inline', value: 'sk-secret' } },
         { rootDir: dir, includeSecrets: true },
       );
       const filePath = path.join(dir, 'with-secrets.json');
       const payload = JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
 
-      expect(payload.apiKey).toBe('sk-secret');
+      expect(payload.apiKeyRef).toMatchObject({ kind: 'inline', value: 'sk-secret' });
       if (process.platform !== 'win32') {
         expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
       }

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llm.streamer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llm.streamer.test.ts
@@ -426,7 +426,7 @@ describe('OpenAIResponsesClient (non-stream)', () => {
 describe('LLMFactory integration', () => {
   it('uses inline apiKey without registry lookup', async () => {
     const spy = vi.spyOn(LLMCredentialProvider.prototype, 'getApiKey');
-    const factory = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', apiKey: 'sk-inline' });
+    const factory = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', apiKeyRef: { kind: 'inline', value: 'sk-inline' } });
 
     const client = await factory.createClient();
 
@@ -447,13 +447,13 @@ describe('LLMFactory integration', () => {
   });
 
   it('routes GPT-5 models through Responses API', async () => {
-    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline' });
+    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKeyRef: { kind: 'inline', value: 'sk-inline' } });
     const client = await factory.createClient();
     expect(client).toBeInstanceOf(OpenAIResponsesClient);
   });
 
   it('honors openaiApiMode=chat_completions for GPT-5 models', async () => {
-    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', openaiApiMode: 'chat_completions', apiKey: 'sk-inline' });
+    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', openaiApiMode: 'chat_completions', apiKeyRef: { kind: 'inline', value: 'sk-inline' } });
     const client = await factory.createClient();
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });
@@ -464,14 +464,14 @@ describe('LLMFactory integration', () => {
       provider: 'openai',
       baseUrl: 'http://localhost:4000',
       openaiApiMode: 'responses',
-      apiKey: 'sk-inline',
+      apiKeyRef: { kind: 'inline', value: 'sk-inline' },
     });
     const client = await factory.createClient();
     expect(client).toBeInstanceOf(OpenAIResponsesClient);
   });
 
   it('does not route GPT-5 models through Responses API when baseUrl is custom', async () => {
-    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', baseUrl: 'http://localhost:4000', apiKey: 'sk-inline' });
+    const factory = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', baseUrl: 'http://localhost:4000', apiKeyRef: { kind: 'inline', value: 'sk-inline' } });
     const client = await factory.createClient();
     expect(client).toBeInstanceOf(OpenAICompatibleClient);
   });

--- a/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/registry.test.ts
@@ -51,11 +51,11 @@ describe('LLMRegistry and TrackedLLMClient', () => {
     const events: string[] = [];
     registry.subscribe((e) => events.push(`${e.llm.usageId}:${e.llm.modelName}`));
 
-    const factory1 = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline', usageId: 'default-llm' }, { registry });
+    const factory1 = new LLMFactory({ model: 'gpt-5-mini', provider: 'openai', apiKeyRef: { kind: 'inline', value: 'sk-inline' }, usageId: 'default-llm' }, { registry });
     const c1 = await factory1.createClient();
     expect(registry.get('default-llm')).toBe(c1);
 
-    const factory2 = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', apiKey: 'sk-inline2', usageId: 'default-llm' }, { registry });
+    const factory2 = new LLMFactory({ model: 'gpt-4o-mini', provider: 'openai', apiKeyRef: { kind: 'inline', value: 'sk-inline2' }, usageId: 'default-llm' }, { registry });
     const c2 = await factory2.createClient();
     expect(c2).not.toBe(c1);
     expect(registry.get('default-llm')).toBe(c2);
@@ -66,12 +66,12 @@ describe('LLMRegistry and TrackedLLMClient', () => {
   it('registers tracked clients under provider/model registry keys', async () => {
     const registry = new LLMRegistry();
     const factory = new LLMFactory(
-      { model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline', usageId: 'default-llm' },
+      { model: 'gpt-5-mini', provider: 'openai', apiKeyRef: { kind: 'inline', value: 'sk-inline' }, usageId: 'default-llm' },
       { registry },
     );
     const client = await factory.createClient();
     expect(
-      registry.getByConfig({ model: 'gpt-5-mini', provider: 'openai', apiKey: 'sk-inline', usageId: 'default-llm' }),
+      registry.getByConfig({ model: 'gpt-5-mini', provider: 'openai' }),
     ).toBe(client);
   });
 

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -721,7 +721,7 @@ describe('RemoteConversation', () => {
       maxLength: 12,
       llm: {
         model: 'custom-model',
-        apiKey: 'llm-key',
+        apiKeyRef: { kind: 'inline', value: 'llm-key' },
         baseUrl: 'https://llm.example',
         apiVersion: '2025-01-01',
         timeoutSeconds: 10,

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -575,16 +575,16 @@ export class RemoteConversation extends EventEmitter {
       : 50;
 
     const llm = options?.llm;
-    const llmPayload = llm ? {
-      usage_id: llm.usageId ?? 'agent',
-      model: llm.model,
-      ...(llm.baseUrl ? { base_url: llm.baseUrl } : {}),
-      ...(llm.apiVersion ? { api_version: llm.apiVersion } : {}),
-      ...(llm.apiKey ? { api_key: llm.apiKey } : {}),
-      ...(typeof llm.timeoutSeconds === 'number' ? { timeout: llm.timeoutSeconds } : {}),
-      ...(typeof llm.temperature === 'number' ? { temperature: llm.temperature } : {}),
-      ...(typeof llm.topP === 'number' ? { top_p: llm.topP } : {}),
-      ...(typeof llm.topK === 'number' ? { top_k: llm.topK } : {}),
+      const llmPayload = llm ? {
+        usage_id: llm.usageId ?? 'agent',
+        model: llm.model,
+        ...(llm.baseUrl ? { base_url: llm.baseUrl } : {}),
+        ...(llm.apiVersion ? { api_version: llm.apiVersion } : {}),
+        ...(llm.apiKeyRef?.kind === 'inline' ? { api_key: llm.apiKeyRef.value } : {}),
+        ...(typeof llm.timeoutSeconds === 'number' ? { timeout: llm.timeoutSeconds } : {}),
+        ...(typeof llm.temperature === 'number' ? { temperature: llm.temperature } : {}),
+        ...(typeof llm.topP === 'number' ? { top_p: llm.topP } : {}),
+        ...(typeof llm.topK === 'number' ? { top_k: llm.topK } : {}),
       ...(typeof llm.maxInputTokens === 'number' ? { max_input_tokens: llm.maxInputTokens } : {}),
       ...(typeof llm.maxOutputTokens === 'number' ? { max_output_tokens: llm.maxOutputTokens } : {}),
       ...(typeof llm.reasoningEffort === 'string' ? { reasoning_effort: llm.reasoningEffort } : {}),

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -4,7 +4,7 @@ import { AnthropicClient } from './anthropic';
 import { OpenAICompatibleClient } from './openai-compatible';
 import { OpenAIResponsesClient } from './openai-responses';
 import { GeminiClient } from './gemini';
-import type { ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
+import type { ApiKeyRef, ChatCompletionRequest, LLMClient, LLMConfiguration, LLMProvider } from './types';
 import type { LLMProfileStoreOptions } from './profiles';
 import { loadProfile } from './profiles';
 import { normalizeGenerationParamsForModel } from './providerQuirks';
@@ -42,6 +42,19 @@ export class LLMFactory {
       const trimmed = typeof value === 'string' ? value.trim() : '';
       return trimmed.length ? trimmed : undefined;
     };
+    const normalizeApiKeyRef = (value: unknown): ApiKeyRef | undefined => {
+      if (!value || typeof value !== 'object') return undefined;
+      const kind = (value as { kind?: unknown }).kind;
+      if (kind === 'inline') {
+        const inline = normalizeOptionalString((value as { value?: unknown }).value);
+        return inline ? { kind: 'inline', value: inline } : undefined;
+      }
+      if (kind === 'key') {
+        const name = normalizeOptionalString((value as { name?: unknown }).name);
+        return name ? { kind: 'key', name } : undefined;
+      }
+      return undefined;
+    };
     const hashString = (input: string): string => createHash('sha256').update(input).digest('hex');
     const stableStringifyHeaders = (headers: Record<string, string> | undefined): string | undefined => {
       if (!headers) return undefined;
@@ -63,8 +76,8 @@ export class LLMFactory {
       // set for runtime bookkeeping/secrets.
       const requestedUsageId = normalizeOptionalString(this.config.usageId);
       if (requestedUsageId) merged.usageId = requestedUsageId;
-      const requestedApiKey = normalizeOptionalString(this.config.apiKey);
-      if (requestedApiKey) merged.apiKey = requestedApiKey;
+      const requestedApiKeyRef = normalizeApiKeyRef(this.config.apiKeyRef);
+      if (requestedApiKeyRef) merged.apiKeyRef = requestedApiKeyRef;
       return merged;
     })();
     config = normalizeGenerationParamsForModel(config);
@@ -102,12 +115,11 @@ export class LLMFactory {
       }
     }
 
-    const inlineApiKey =
-      typeof config.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(config.apiKey)
-        ? config.apiKey
-        : undefined;
+    const normalizedApiKeyRef = normalizeApiKeyRef(config.apiKeyRef);
+    const inlineApiKey = normalizedApiKeyRef?.kind === 'inline' ? normalizedApiKeyRef.value : undefined;
+    const preferredApiKeyName = normalizedApiKeyRef?.kind === 'key' ? normalizedApiKeyRef.name : undefined;
     const defaultApiKeyName = this.getDefaultApiKeyName(provider);
-    const preferredApiKeys = config.apiKey ?? this.preferredKeys;
+    const preferredApiKeys = preferredApiKeyName ?? this.preferredKeys;
     const apiKeyLookup = (() => {
       const llmGlobalKey = 'openhands.llmApiKey';
       if (Array.isArray(preferredApiKeys)) {

--- a/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/profiles.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import type { LLMConfiguration, LLMProvider, OpenAIChatApi, ReasoningSummary } from './types';
+import type { ApiKeyRef, LLMConfiguration, LLMProvider, OpenAIChatApi, ReasoningSummary } from './types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 
 export const DEFAULT_LLM_PROFILES_DIR = path.join(os.homedir(), '.openhands', 'llm-profiles');
@@ -114,10 +114,32 @@ const validateHeaders = (headers: unknown): void => {
   }
 };
 
+const validateApiKeyRef = (value: unknown): void => {
+  if (!isObjectRecord(value)) {
+    throw new LLMProfileValidationError('apiKeyRef must be an object');
+  }
+  const kind = value.kind;
+  if (kind === 'inline') {
+    if (typeof value.value !== 'string' || !value.value.trim()) {
+      throw new LLMProfileValidationError('apiKeyRef.value must be a non-empty string when kind="inline"');
+    }
+    return;
+  }
+  if (kind === 'key') {
+    if (typeof value.name !== 'string' || !value.name.trim()) {
+      throw new LLMProfileValidationError('apiKeyRef.name must be a non-empty string when kind="key"');
+    }
+    return;
+  }
+  throw new LLMProfileValidationError('apiKeyRef.kind must be "key" or "inline"');
+};
+
 export const validateProfile = (payload: unknown): LLMConfiguration => {
   if (!isObjectRecord(payload)) {
     throw new LLMProfileValidationError('Profile payload must be an object');
   }
+
+  const config = payload;
 
   if (typeof payload.model !== 'string' || !payload.model.trim()) {
     throw new LLMProfileValidationError('Profile must include a non-empty "model" string');
@@ -156,10 +178,19 @@ export const validateProfile = (payload: unknown): LLMConfiguration => {
     }
   }
 
-  if ('apiKey' in payload && payload.apiKey !== undefined) {
-    if (typeof payload.apiKey !== 'string') {
+  if ('apiKeyRef' in config && config.apiKeyRef !== undefined && config.apiKeyRef !== null) {
+    validateApiKeyRef(config.apiKeyRef);
+  }
+  // Backward-compat: treat legacy `apiKey` as a reference name, not an inline secret value.
+  if ('apiKey' in config && config.apiKey !== undefined) {
+    if (typeof config.apiKey !== 'string') {
       throw new LLMProfileValidationError('apiKey must be a string');
     }
+    const name = config.apiKey.trim();
+    if (name && config.apiKeyRef === undefined) {
+      config.apiKeyRef = { kind: 'key', name } satisfies ApiKeyRef;
+    }
+    delete config.apiKey;
   }
 
   for (const key of ['timeoutSeconds', 'temperature', 'topP', 'topK'] as const) {
@@ -209,13 +240,13 @@ export const validateProfile = (payload: unknown): LLMConfiguration => {
     }
   }
 
-  return payload as unknown as LLMConfiguration;
+  return config as unknown as LLMConfiguration;
 };
 
 const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
   const sanitized: LLMConfiguration = { ...config };
-  if (typeof sanitized.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(sanitized.apiKey)) {
-    delete sanitized.apiKey;
+  if (sanitized.apiKeyRef?.kind === 'inline') {
+    delete sanitized.apiKeyRef;
   }
   // Headers can plausibly contain auth material (Authorization, x-api-key, etc.).
   // In "no secrets" mode, be conservative and do not persist headers.

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -6,6 +6,20 @@ export type OpenAIChatApi = 'chat_completions' | 'responses';
 
 export type ReasoningSummary = 'auto' | 'concise' | 'detailed';
 
+/**
+ * Reference (or explicit inline value) for resolving an LLM provider API key.
+ *
+ * - Prefer `{ kind: 'key', name: 'OPENAI_API_KEY' }` (or any other SecretRegistry key name).
+ *   This keeps secrets out of profile JSON and allows resolution at request time via SecretRegistry
+ *   (SecretStorage/env/in-memory).
+ * - `{ kind: 'inline', value: 'sk-...' }` is supported for explicit opt-in cases where the caller
+ *   wants to provide the raw credential directly. Avoid persisting this to disk unless you
+ *   understand the security trade-offs.
+ */
+export type ApiKeyRef =
+  | { kind: 'key'; name: string }
+  | { kind: 'inline'; value: string };
+
 export interface LLMToolDefinition {
   type: 'function';
   function: {
@@ -24,7 +38,7 @@ export interface LLMConfiguration {
   /** Only applies to OpenAI provider. */
   openaiApiMode?: OpenAIChatApi | null;
   baseUrl?: string | null;
-  apiKey?: string;
+  apiKeyRef?: ApiKeyRef | null;
   apiVersion?: string | null;
   timeoutSeconds?: number | null;
   temperature?: number | null;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1032,9 +1032,7 @@ export class Agent extends EventEmitter {
       const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
       const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
       const configuredApiKey = toOptionalNonEmptyString(this.options.settings?.secrets?.llmApiKey);
-      const hasInlineApiKey =
-        typeof configuredApiKey === 'string' && !/^[A-Z0-9_]+$/.test(configuredApiKey);
-      const apiKeyStatus = configuredApiKey ? (hasInlineApiKey ? 'inline' : 'reference') : 'unset';
+      const apiKeyStatus = configuredApiKey ? 'set' : 'unset';
       const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
       const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
 
@@ -1044,7 +1042,7 @@ export class Agent extends EventEmitter {
         `llm.provider=${provider}`,
         `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
         `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
-        `llm.apiKey=${apiKeyStatus}`,
+        `llm.apiKeyStatus=${apiKeyStatus}`,
       ];
       if (profileId) {
         contextParts.push(`llm.profileId=${profileId}`);

--- a/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
@@ -26,9 +26,8 @@ export function createLlmClientFromSettings(params: {
   const effectiveUsageId = 'agent';
 
   const configuredApiKey = toOptionalNonEmptyString(s.secrets?.llmApiKey);
-  if (configuredApiKey) {
-    secrets.set('openhands.llmApiKey', configuredApiKey);
-  }
+  // Always write through so clearing settings also clears any previously registered value.
+  secrets.set('openhands.llmApiKey', configuredApiKey);
 
   const preferredApiKeys = (() => {
     if (!profileId || !isSafeProfileId(profileId)) return undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/createLlmClientFromSettings.ts
@@ -1,4 +1,4 @@
-import type { LLMClient, LLMProfileStoreOptions } from '../llm';
+import type { ApiKeyRef, LLMClient, LLMConfiguration, LLMProfileStoreOptions } from '../llm';
 import { LLMFactory } from '../llm';
 import type { LLMRegistry } from '../llm/registry';
 import type { OpenHandsSettings } from '../types/settings';
@@ -26,28 +26,27 @@ export function createLlmClientFromSettings(params: {
   const effectiveUsageId = 'agent';
 
   const configuredApiKey = toOptionalNonEmptyString(s.secrets?.llmApiKey);
-  const configuredApiKeyIsReference =
-    typeof configuredApiKey === 'string' && /^[A-Z0-9_]+$/.test(configuredApiKey);
-  const configuredApiKeyInline = configuredApiKeyIsReference ? undefined : configuredApiKey;
-  secrets.set('openhands.llmApiKey', configuredApiKeyInline);
+  if (configuredApiKey) {
+    secrets.set('openhands.llmApiKey', configuredApiKey);
+  }
 
   const preferredApiKeys = (() => {
     if (!profileId || !isSafeProfileId(profileId)) return undefined;
-    const keys: string[] = [`openhands.llmProfileApiKey.${profileId}`];
-    if (configuredApiKeyIsReference && configuredApiKey) {
-      keys.push(configuredApiKey);
-    }
-    return keys;
+    return [`openhands.llmProfileApiKey.${profileId}`];
   })();
 
-  const config = {
+  const apiKeyRef = configuredApiKey
+    ? ({ kind: 'key', name: 'openhands.llmApiKey' } satisfies ApiKeyRef)
+    : undefined;
+
+  const config: LLMConfiguration = {
     profileId,
     provider: s.llm.provider ?? undefined,
     model: model ?? '',
     openaiApiMode: s.llm.openaiApiMode ?? undefined,
     usageId: effectiveUsageId,
     baseUrl: s.llm.baseUrl ?? undefined,
-    apiKey: profileId ? undefined : configuredApiKey,
+    apiKeyRef: profileId ? undefined : apiKeyRef,
     apiVersion: s.llm.apiVersion ?? undefined,
     timeoutSeconds: s.llm.timeout ?? undefined,
     temperature: s.llm.temperature ?? undefined,

--- a/src/__tests__/llmProfilesStore.test.ts
+++ b/src/__tests__/llmProfilesStore.test.ts
@@ -81,7 +81,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       {
         provider: 'openai',
         model: 'gpt-5-mini',
-        apiKey: 'sk-test-inline',
+        apiKeyRef: { kind: 'inline', value: 'sk-test-inline' },
         headers: { Authorization: 'Bearer secret' },
       },
       { rootDir: tmpDir, includeSecrets: true },
@@ -101,7 +101,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       profileId: 'secret',
     });
     expect(response.profile.model).toBe('gpt-5-mini');
-    expect(response.profile.apiKey).toBeUndefined();
+    expect(response.profile.apiKeyRef).toBeUndefined();
     expect(response.profile.headers).toBeUndefined();
   });
 
@@ -115,7 +115,7 @@ describe('LLM profile host CRUD (llm-profiles store)', () => {
       profile: {
         provider: 'openai',
         model: 'gpt-5-mini',
-        apiKey: 'sk-test-inline',
+        apiKeyRef: { kind: 'inline', value: 'sk-test-inline' },
         headers: { Authorization: 'Bearer secret' },
       },
     });

--- a/src/webview/host/llmProfilesStore.ts
+++ b/src/webview/host/llmProfilesStore.ts
@@ -10,14 +10,14 @@ import {
 } from '@openhands/agent-sdk-ts';
 
 export type HostLlmProfileSaveOptions = LLMProfileStoreOptions & {
-  /** When true, allow inline secrets (apiKey/headers) to be persisted to disk. */
+  /** When true, allow inline secrets (apiKeyRef.kind="inline"/headers) to be persisted to disk. */
   includeSecrets?: boolean;
 };
 
 const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
   const sanitized: LLMConfiguration = { ...config };
-  if (typeof sanitized.apiKey === 'string' && !/^[A-Z0-9_]+$/.test(sanitized.apiKey)) {
-    delete sanitized.apiKey;
+  if (sanitized.apiKeyRef?.kind === 'inline') {
+    delete sanitized.apiKeyRef;
   }
   // Headers can plausibly contain auth material (Authorization, x-api-key, etc.).
   // In "no secrets" mode, be conservative and do not send/persist headers.


### PR DESCRIPTION
### Bead

```text

oh-tab-h4b: Replace LLMConfiguration.apiKey with explicit apiKeyRef
Status: closed
Priority: P1
Type: task
Created: 2026-01-17 05:16
Updated: 2026-01-17 07:10

Description:
GitHub issue #836. Security: apiKey is ambiguous (literal vs env-var reference). Replace with apiKeyRef, resolve secrets only at request time. Remove heuristics from factory.ts, profiles.ts, llmProfilesStore.ts. Requires documentation at type definition, resolution points, webview boundary, and python-parity.md.

```

### Summary
- Replaces `apiKey` with explicit `apiKeyRef` to avoid persisting/inferencing API keys.

### Testing
- npm run build -w @openhands/agent-sdk-ts
- npm test
- npm run typecheck
- npm run lint
