### PR TITLE
oh-tab-mmn: Rename RemoteWorkspace apiKey to sessionApiKey

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -178,8 +178,8 @@ export class RemoteConversation extends EventEmitter {
     if (!this.workspaceClient) {
       const rawWorkingDir = this.workspace?.['working_dir'];
       const workingDir = typeof rawWorkingDir === 'string' ? rawWorkingDir : this.workspaceRoot;
-      const apiKey = this.settings?.secrets.sessionApiKey;
-      this.workspaceClient = new RemoteWorkspace({ host: this.serverUrl, apiKey, workingDir });
+      const sessionApiKey = this.settings?.secrets.sessionApiKey;
+      this.workspaceClient = new RemoteWorkspace({ host: this.serverUrl, sessionApiKey, workingDir });
     }
     return this.workspaceClient;
   }

--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -32,7 +32,8 @@ const normalizeEncoding = (encoding: WorkspaceEncoding): NodeBufferEncoding => {
 
 export interface RemoteWorkspaceOptions {
   host: string;
-  apiKey?: string;
+  /** Session API key for authenticating with the OpenHands server. */
+  sessionApiKey?: string;
   workingDir?: string;
   pollIntervalMs?: number;
   httpTimeoutMs?: number;
@@ -94,7 +95,7 @@ export class RemoteWorkspace implements BaseWorkspace {
   readonly root: string;
 
   private readonly host: string;
-  private readonly apiKey?: string;
+  private readonly sessionApiKey?: string;
   private readonly pollIntervalMs: number;
   private readonly httpTimeoutMs: number;
 
@@ -107,7 +108,9 @@ export class RemoteWorkspace implements BaseWorkspace {
 
   constructor(options: RemoteWorkspaceOptions) {
     this.host = normalizeRemoteHostUrl(options.host);
-    this.apiKey = typeof options.apiKey === 'string' && options.apiKey.trim() ? options.apiKey.trim() : undefined;
+    this.sessionApiKey = typeof options.sessionApiKey === 'string' && options.sessionApiKey.trim()
+      ? options.sessionApiKey.trim()
+      : undefined;
     this.root = normalizePosixRoot(options.workingDir ?? '/workspace');
     this.pollIntervalMs = typeof options.pollIntervalMs === 'number' ? Math.max(0, options.pollIntervalMs) : 100;
     this.httpTimeoutMs = typeof options.httpTimeoutMs === 'number' ? Math.max(0, options.httpTimeoutMs) : 60_000;
@@ -420,9 +423,9 @@ export class RemoteWorkspace implements BaseWorkspace {
 
   private getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
     const headers: Record<string, string> = { ...extra };
-    if (this.apiKey) {
-      headers['X-Session-API-Key'] = this.apiKey;
-      headers['Authorization'] = `Bearer ${this.apiKey}`;
+    if (this.sessionApiKey) {
+      headers['X-Session-API-Key'] = this.sessionApiKey;
+      headers['Authorization'] = `Bearer ${this.sessionApiKey}`;
     }
     return headers;
   }

--- a/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
@@ -100,7 +100,7 @@ describe('RemoteWorkspace', () => {
     const ws = new RemoteWorkspace({
       host: 'http://localhost:3000',
       workingDir: '/workspace/project',
-      apiKey: 'session-key',
+      sessionApiKey: 'session-key',
       pollIntervalMs: 0,
     });
 
@@ -138,7 +138,7 @@ describe('RemoteWorkspace', () => {
     const ws = new RemoteWorkspace({
       host: 'http://localhost:3000',
       workingDir: '/workspace/project',
-      apiKey: 'session-key',
+      sessionApiKey: 'session-key',
     });
 
     await ws.writeFile('hello.txt', 'hello');

--- a/packages/agent-sdk-ts/src/workspace/index.ts
+++ b/packages/agent-sdk-ts/src/workspace/index.ts
@@ -12,7 +12,7 @@ export type WorkspaceFactoryOptions =
   | {
     kind: 'remote';
     serverUrl: string;
-    apiKey?: string;
+    sessionApiKey?: string;
     workingDir?: string;
     workspaceRoot?: string;
     runtimeApiUrl?: string;
@@ -28,7 +28,7 @@ export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
   const workingDir = options.workingDir ?? options.workspaceRoot;
   return new RemoteWorkspace({
     host: options.serverUrl,
-    apiKey: options.apiKey,
+    sessionApiKey: options.sessionApiKey,
     workingDir,
     runtimeApiUrl: options.runtimeApiUrl,
     runtimeApiKey: options.runtimeApiKey,


### PR DESCRIPTION
### Bead

```text

oh-tab-mmn: Rename apiKey to session_api_key in RemoteWorkspace.ts
Status: open
Priority: P2
Type: task
Created: 2026-01-17 04:44
Updated: 2026-01-17 04:44

Description:
In `packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts`, the `apiKey` parameter is confusingly named.

**Problem:**
- This `apiKey` is the **session API key** for authenticating with the OpenHands server
- It's sent as `session_api_key` in requests
- But it shares the name `apiKey` with the LLM provider API key, which is a completely different credential

**Fix:**
Rename `apiKey` to `session_api_key` (or `sessionApiKey`) throughout RemoteWorkspace to match:
1. What it's actually sent as in the protocol
2. Distinguish it clearly from LLM provider keys

This reduces confusion when reading the code.

```

### Summary
- Renames RemoteWorkspace's server auth key from `apiKey` to `sessionApiKey` to avoid confusion with LLM API keys.

### Testing
- npm run build -w @openhands/agent-sdk-ts
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Remote workspace session authentication configuration has been updated: the `apiKey` parameter is now named `sessionApiKey` across the SDK for improved naming clarity and consistency. This is a breaking change—any applications or code initializing remote workspaces must update their configuration to use the new `sessionApiKey` parameter name instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->