### PR TITLE
oh-tab-24l: HAL uses LLM profile apiKeyRef for voice_confirm

### DIFF
--- a/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
@@ -137,4 +137,76 @@ describe('createWebviewMessageHandler (HAL voice_confirm profile)', () => {
       apiKey: 'profile-secret',
     }));
   });
+
+  it('uses apiKeyRef.name from the profile config when set', async () => {
+    const cfg = {
+      get: vi.fn((key: string, defaultValue?: unknown) => defaultValue),
+      inspect: vi.fn(() => ({})),
+      update: vi.fn(async () => undefined),
+    };
+
+    (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
+
+    const context = {
+      secrets: {
+        get: vi.fn(async () => undefined),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      },
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    const { loadProfile } = await import('../llmProfilesStore');
+    (loadProfile as any).mockReturnValueOnce({
+      profileId: 'gemini-flash-hal',
+      config: {
+        provider: 'gemini',
+        model: 'gemini-2.5-flash',
+        baseUrl: 'https://profiles.example/v1beta',
+        apiKeyRef: { kind: 'key', name: 'HAL_GEMINI_KEY' },
+      },
+    });
+
+    const secretRegistryGet = vi.fn(async (key: string) => {
+      if (key === 'HAL_GEMINI_KEY') return 'apiKeyRef-secret';
+      if (key === 'openhands.llmProfileApiKey.gemini-flash-hal') return 'profile-secret';
+      if (key === 'GEMINI_API_KEY') return 'provider-secret';
+      return undefined;
+    });
+
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context,
+      host: { postMessage },
+      secretRegistry: { get: secretRegistryGet } as any,
+      getQueuedUserEditNotes: () => [],
+      clearQueuedUserEditNotes: () => {},
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp/openhands-conversations',
+      setWebviewReadyState: () => undefined,
+      setLastKnownLlmLabel: () => undefined,
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => undefined,
+      onRenderedEventsResponse: () => undefined,
+      onUiStateResponse: () => undefined,
+      onHalStateResponse: () => undefined,
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => undefined,
+    });
+
+    await handler({
+      type: 'halVoiceConfirmRequest',
+      requestId: 'r1',
+      mimeType: 'audio/wav',
+      audioBase64: 'Zm9v',
+    });
+
+    const { classifyHalVoiceDecision } = await import('../../../hal/gemini/decisionClassifier');
+    expect(classifyHalVoiceDecision).toHaveBeenCalledWith(expect.objectContaining({
+      apiKey: 'apiKeyRef-secret',
+    }));
+  });
 });

--- a/src/webview/host/handlers/hal.ts
+++ b/src/webview/host/handlers/hal.ts
@@ -167,12 +167,15 @@ export async function handleHalVoiceConfirmRequest(args: {
 
   const { getStoredSecret } = createStoredSecretHelpers({ context: args.context, secretRegistry: args.deps.secretRegistry });
 
+  const apiKeyRefName = halProfile.config.apiKeyRef?.kind === 'key' ? halProfile.config.apiKeyRef.name : undefined;
+
   const keyOrder = [
+    ...(typeof apiKeyRefName === 'string' && apiKeyRefName.trim() ? [apiKeyRefName.trim()] : []),
     getProfileApiKeySecretKey(halProfileId),
     getProviderApiKeyName(provider),
     'openhands.llmApiKey',
     'LLM_API_KEY',
-  ];
+  ].filter((key, idx, arr) => arr.indexOf(key) === idx);
   let halGeminiKey: string | undefined;
   for (const key of keyOrder) {
     const candidate = await getStoredSecret(key);


### PR DESCRIPTION
### Bead

```text

oh-tab-24l: HAL should use LLMProfiles instead of separate Gemini classifier
Status: open
Priority: P2
Type: task
Created: 2026-01-17 04:48
Updated: 2026-01-17 04:48

Description:
**Tech debt**

**Current state:**
HAL uses a separate Gemini decision classifier with its own configuration and apiKey storage.

**Problem:**
- Duplicates LLM configuration logic that LLMProfiles already handles
- Stores apiKey separately - why, if we could have a gemini-hal profile?
- Any other LLM services within HAL likely have the same issue

**Desired state:**
1. HAL should use LLMProfiles system with a dedicated profile (e.g. gemini-hal)
2. Remove separate apiKey storage for HAL - use the profile credentials
3. Audit other LLM services within HAL for the same pattern

**Benefits:**
- Single source of truth for LLM configuration
- Consistent credential management via SecretStorage
- Users can configure HAL LLM the same way they configure other profiles

```

### Summary
- HAL `voice_confirm` now honors `apiKeyRef` from the selected HAL LLM profile (instead of hard-coding the profile secret name first).

### Testing
- npm test
- npm run typecheck
- npm run lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HAL voice assistant now supports explicitly configured API key references in profile settings for flexible secret management.

* **Tests**
  * Added test coverage for API key reference resolution when configured in profile settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->