### PR TITLE
[oh-tab-1s6] Show user messages immediately after Stop

### DIFF
--- a/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
+++ b/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { App } from '../components/App';
+import { postToWindow } from './testUtils';
+import type { ConversationStateUpdateEvent, MessageEvent } from '@openhands/agent-sdk-ts';
+
+describe('App - optimistic user MessageEvent rendering', () => {
+  const mockApi = { postMessage: vi.fn() };
+
+  beforeEach(() => {
+    // @ts-expect-error -- VS Code API is injected by host environment during runtime
+    window.acquireVsCodeApi = () => mockApi;
+    mockApi.postMessage.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows an optimistic user message immediately and keeps queued badge until the real event arrives', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    });
+
+    postToWindow({ type: 'status', status: 'online', mode: 'remote' });
+
+    const running: ConversationStateUpdateEvent = {
+      kind: 'ConversationStateUpdateEvent',
+      agent_status: 'RUNNING',
+    } as ConversationStateUpdateEvent;
+    postToWindow({ type: 'event', event: running });
+
+    const input = screen.getByPlaceholderText('Ask OpenHands anything...') as HTMLTextAreaElement;
+    const user = userEvent.setup();
+    await user.type(input, 'hello{enter}');
+
+    expect(mockApi.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'send', text: 'hello' }));
+
+    const optimistic: MessageEvent = {
+      kind: 'MessageEvent',
+      id: 'optimistic:test',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: optimistic });
+
+    expect(screen.getByText('hello')).toBeInTheDocument();
+    expect(screen.getByTestId('queued-messages-badge')).toHaveTextContent('1');
+
+    const persisted: MessageEvent = {
+      ...optimistic,
+      id: 'server:test',
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: persisted });
+
+    expect(screen.getAllByText('hello')).toHaveLength(1);
+    expect(screen.queryByTestId('queued-messages-badge')).toBeNull();
+  });
+});
+

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -12,6 +12,7 @@ import {
   isUserRejectObservation,
   type ActionEvent,
   type Event,
+  type MessageEvent,
 } from '@openhands/agent-sdk-ts';
 import { initialLlmStreamingState, reduceLlmStreamingState } from '../../../shared/llmStreaming';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS } from '../../../shared/webviewMessages';
@@ -47,6 +48,25 @@ type UseConversationEventsOptions = {
 };
 
 const isRenderableEvent = (event: Event) => !isConversationStateUpdateEvent(event);
+
+const isOptimisticUserMessageEvent = (event: Event): boolean => (
+  isMessageEvent(event)
+  && event.source === 'user'
+  && typeof event.id === 'string'
+  && event.id.startsWith('optimistic:')
+);
+
+const fingerprintMessageEvent = (event: MessageEvent): string => {
+  const role = event.llm_message?.role ?? '';
+  const content = Array.isArray(event.llm_message?.content) ? event.llm_message.content : [];
+  const extended = Array.isArray(event.extended_content) ? event.extended_content : [];
+  try {
+    return JSON.stringify({ role, content, extended });
+  } catch {
+    const firstText = content.find((c) => c?.type === 'text' && typeof (c as { text?: unknown }).text === 'string') as { text?: string } | undefined;
+    return `${role}:${firstText?.text ?? ''}`;
+  }
+};
 
 export function useConversationEvents(options: UseConversationEventsOptions) {
   const {
@@ -212,12 +232,24 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
 
-    if (isMessageEvent(event) && event.source === 'user') {
+    if (isMessageEvent(event) && event.source === 'user' && !isOptimisticUserMessageEvent(event)) {
       setQueuedMessagesCount((prev) => Math.max(0, prev - 1));
     }
 
     setEvents((ev) => {
-      const next = [...ev, { id: eventId.current++, event }];
+      let base = ev;
+      if (isMessageEvent(event) && event.source === 'user' && !isOptimisticUserMessageEvent(event)) {
+        const incomingFingerprint = fingerprintMessageEvent(event);
+        const optimisticIndex = base.findIndex(({ event: existing }) => (
+          isOptimisticUserMessageEvent(existing)
+          && fingerprintMessageEvent(existing as MessageEvent) === incomingFingerprint
+        ));
+        if (optimisticIndex !== -1) {
+          base = [...base.slice(0, optimisticIndex), ...base.slice(optimisticIndex + 1)];
+        }
+      }
+
+      const next = [...base, { id: eventId.current++, event }];
       return next.length > MAX_RENDERED_EVENTS ? next.slice(-MAX_RENDERED_EVENTS) : next;
     });
   }, [eventId, setEvents, setQueuedMessagesCount]);

--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -288,7 +288,7 @@ export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDep
       }
       case 'send': {
         if (!conversation) break;
-        await handleSend({ context, deps, conversation, message, outputChannel });
+        await handleSend({ context, deps, host, conversation, message, outputChannel });
         break;
       }
       case 'halTtsRequest': {

--- a/src/webview/host/handlers/send.ts
+++ b/src/webview/host/handlers/send.ts
@@ -3,10 +3,12 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { MessageEvent } from '@openhands/agent-sdk-ts';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../../shared/pastedImages';
 import { MAX_PASTED_IMAGE_BYTES } from '../../../shared/pasteLimits';
 import { buildAttachmentBlocks, safeParseUri } from '../attachments';
 import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+import type { WebviewHost } from '../createWebviewMessageHandler';
 
 async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
   const filePath = getPastedImagePath(baseDir, imageId);
@@ -17,6 +19,7 @@ async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8
 export async function handleSend(args: {
   context: vscode.ExtensionContext;
   deps: CreateWebviewMessageHandlerDeps;
+  host: WebviewHost;
   conversation: ConversationInstance;
   message: Extract<WebviewToHostMessage, { type: 'send' }>;
   outputChannel: vscode.OutputChannel | undefined;
@@ -77,6 +80,24 @@ export async function handleSend(args: {
     .filter((note) => typeof note === 'string' && note.trim().length > 0)
     .map((note) => note.trimEnd())
     .join('\n\n');
+
+  // Optimistically render the user message in the webview immediately, even if the remote runtime
+  // is currently paused / blocked on an in-flight LLM request (common right after "Stop").
+  // The webview deduplicates this optimistic event once the real persisted MessageEvent arrives.
+  const optimisticId = typeof globalThis.crypto?.randomUUID === 'function'
+    ? `optimistic:${globalThis.crypto.randomUUID()}`
+    : `optimistic:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+  const optimisticEvent: MessageEvent = {
+    kind: 'MessageEvent',
+    id: optimisticId,
+    source: 'user',
+    llm_message: {
+      role: 'user',
+      content: [{ type: 'text', text: finalText }],
+    },
+    extended_content: queuedNotesText ? [{ type: 'text', text: queuedNotesText }] : undefined,
+  };
+  await args.host.postMessage({ type: 'event', event: optimisticEvent });
 
   if (queuedNotesText) {
     await args.conversation.sendUserMessage(finalText, { extendedContent: [{ type: 'text', text: queuedNotesText }] });


### PR DESCRIPTION
### Bead
oh-tab-1s6: User message not visible until LLM response after Stop
Status: open
Priority: P2
Type: task
Created: 2026-01-17 05:20
Updated: 2026-01-17 05:20

Description:
UX issue: When agent is working and user presses red Stop button, conversation pauses (OK). But when user sends a new message, it's not visible in the conversation until the LLM request returns. Should be visible immediately. Note: Verify actual behavior before modifying - this observation may be outdated.

### Repro (before/after)
- Before: if the runtime is paused / blocked right after **Stop**, the webview can wait for the next persisted `MessageEvent` before rendering the user message (so it appears only after the in-flight LLM request returns).
- After: the host posts an optimistic user `MessageEvent` immediately on send, so the message renders right away; when the persisted `MessageEvent` arrives later it replaces the optimistic one (no duplicates).

### What
- Post an optimistic user `MessageEvent` to the webview immediately when handling `send` (using the fully-sanitized final message text).
- Deduplicate the optimistic event when the real persisted `MessageEvent` arrives; keep the queued badge behavior consistent while the agent is still `RUNNING`.
- Add unit coverage in `src/webview-src/__tests__/App.optimisticUserMessage.test.tsx`.

### Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`
