### PR TITLE
[oh-tab-e2e-tmpdir] Shorten E2E --user-data-dir on macOS

### DIFF
--- a/tests/e2e/testHelpers.ts
+++ b/tests/e2e/testHelpers.ts
@@ -1,4 +1,5 @@
 import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { mkdtempSync } from 'fs';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
@@ -58,7 +59,7 @@ export function createE2EUserDataDir(testName: string): string {
   // Keep basename + base dir short to avoid macOS IPC handle path warnings.
   // On macOS, os.tmpdir() can be a very long /var/folders path, so prefer /tmp.
   const baseDir = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
-  const userDataDir = path.join(baseDir, `oh-e2e-${slug}-${Date.now().toString(36)}`);
+  const userDataDir = mkdtempSync(path.join(baseDir, `oh-e2e-${slug}-`));
 
   after(async () => {
     await fs.rm(userDataDir, { recursive: true, force: true });

--- a/tests/e2e/testHelpers.ts
+++ b/tests/e2e/testHelpers.ts
@@ -55,8 +55,10 @@ function sanitizeTestNameForPath(raw: string): string {
 
 export function createE2EUserDataDir(testName: string): string {
   const slug = sanitizeTestNameForPath(testName);
-  // Keep basename short to avoid macOS IPC handle path warnings.
-  const userDataDir = path.join(os.tmpdir(), `vscode-t-${slug}-${Date.now().toString(36)}`);
+  // Keep basename + base dir short to avoid macOS IPC handle path warnings.
+  // On macOS, os.tmpdir() can be a very long /var/folders path, so prefer /tmp.
+  const baseDir = process.platform === 'darwin' ? '/tmp' : os.tmpdir();
+  const userDataDir = path.join(baseDir, `oh-e2e-${slug}-${Date.now().toString(36)}`);
 
   after(async () => {
     await fs.rm(userDataDir, { recursive: true, force: true });


### PR DESCRIPTION
### Bead
oh-tab-e2e-tmpdir: E2E: shorten --user-data-dir to avoid IPC path length warnings
Status: open
Priority: P4
Type: chore
Created: 2026-01-16 00:24
Updated: 2026-01-16 00:24

Description:
On macOS, vscode/test-electron logs 'IPC handle ... is longer than 103 chars' when we use os.tmpdir() (which can be a very long /var/folders path) plus long test-specific folder names. This is noisy and could become flaky on some environments.

Seen in: tests/e2e/deviceFlowAuth.test.ts, tests/e2e/lastUserMessage.test.ts.

Idea: prefer a shorter base dir (e.g. '/tmp' on darwin) and/or shorter prefix names (e.g. 'oh-e2e-<ts>').

Acceptance Criteria:
- E2E tests no longer emit IPC path-length warnings on macOS.
- Change is cross-platform safe (darwin-specific override ok; windows unaffected).

Depends on:
- oh-tab-e2e-cleanup: (tech debt) E2E: always cleanup user-data-dir temp folders [P3]

### What
- Use `/tmp` as the base directory for E2E `--user-data-dir` on macOS (instead of `os.tmpdir()`), keeping the directory name short.
- Use `mkdtempSync()` to create the per-test user-data-dir atomically (avoids `Date.now()` collisions under parallel runs).

### Testing
- `npm run lint`
- E2E smoke: `mocha tests/e2e/out/open.test.js` (via `npm exec`, after `npm run compile` + e2e `tsc`)
