### PR TITLE
[oh-tab-3sg] Fix total cost overcount with cache token pricing

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/metrics.test.ts
@@ -85,6 +85,29 @@ describe('Metrics', () => {
     expect(m.accumulatedCost).toBeCloseTo(0.21);
   });
 
+  it('adjusts input cost when cache token rates are configured', () => {
+    const m = new Metrics('priced-model', {
+      inputCostPerToken: 0.001,
+      outputCostPerToken: 0.002,
+      cacheReadCostPerToken: 0.0002,
+      cacheWriteCostPerToken: 0.0015,
+    });
+    m.addTokenUsage({
+      promptTokens: 100,
+      completionTokens: 10,
+      cacheReadTokens: 40,
+      cacheWriteTokens: 10,
+      contextWindow: 0,
+      responseId: 'r1',
+    });
+
+    // Base: 100*0.001 + 10*0.002 = 0.12
+    // Cache read adjustment: 40*(0.0002 - 0.001) = -0.032
+    // Cache write adjustment: 10*(0.0015 - 0.001) = +0.005
+    // Total = 0.093
+    expect(m.accumulatedCost).toBeCloseTo(0.093);
+  });
+
   it('does not compute cost when cost rates are not configured', () => {
     const m = new Metrics('model-without-rates');
     m.addTokenUsage({

--- a/packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevPricing.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/__tests__/modelsDevPricing.test.ts
@@ -20,7 +20,7 @@ describe('modelsDevPricing', () => {
       const api = {
         openai: {
           models: {
-            'gpt-5': { cost: { input: 1.25, output: 10 } },
+            'gpt-5': { cost: { input: 1.25, output: 10, cache_read: 0.5, cache_write: 2 } },
           },
         },
       };
@@ -31,6 +31,8 @@ describe('modelsDevPricing', () => {
       });
       expect(pricing).toEqual({
         inputCostPerToken: 1.25 / 1_000_000,
+        cacheReadCostPerToken: 0.5 / 1_000_000,
+        cacheWriteCostPerToken: 2 / 1_000_000,
         outputCostPerToken: 10 / 1_000_000,
         source: 'models.dev',
       });
@@ -40,7 +42,7 @@ describe('modelsDevPricing', () => {
       const api = {
         openai: {
           models: {
-            'gpt-5': { cost: { input: 1.25, output: 10 } },
+            'gpt-5': { cost: { input: 1.25, output: 10, cache_read: 0.5 } },
           },
         },
       };
@@ -50,6 +52,7 @@ describe('modelsDevPricing', () => {
         modelId: 'GPT-5',
       });
       expect(pricing?.inputCostPerToken).toBeCloseTo(1.25 / 1_000_000);
+      expect(pricing?.cacheReadCostPerToken).toBeCloseTo(0.5 / 1_000_000);
       expect(pricing?.outputCostPerToken).toBeCloseTo(10 / 1_000_000);
     });
 
@@ -73,4 +76,3 @@ describe('modelsDevPricing', () => {
     });
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -90,10 +90,14 @@ export class LLMFactory {
 
     const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
 
-    if (
-      (config.inputCostPerToken === null || config.inputCostPerToken === undefined)
-      && (config.outputCostPerToken === null || config.outputCostPerToken === undefined)
-    ) {
+    const needsPricing = (
+      config.inputCostPerToken === null || config.inputCostPerToken === undefined
+      || config.outputCostPerToken === null || config.outputCostPerToken === undefined
+      || config.cacheReadCostPerToken === null || config.cacheReadCostPerToken === undefined
+      || config.cacheWriteCostPerToken === null || config.cacheWriteCostPerToken === undefined
+    );
+
+    if (needsPricing) {
       const normalizedBaseUrl = normalizeUrl(config.baseUrl);
       const normalizedDefaultBaseUrl = normalizeUrl(DEFAULT_PROVIDER_BASE_URLS[provider]);
       const baseUrlMatchesProviderDefault =
@@ -105,8 +109,10 @@ export class LLMFactory {
           if (pricing) {
             config = {
               ...config,
-              inputCostPerToken: pricing.inputCostPerToken,
-              outputCostPerToken: pricing.outputCostPerToken,
+              inputCostPerToken: config.inputCostPerToken ?? pricing.inputCostPerToken,
+              cacheReadCostPerToken: config.cacheReadCostPerToken ?? pricing.cacheReadCostPerToken,
+              cacheWriteCostPerToken: config.cacheWriteCostPerToken ?? pricing.cacheWriteCostPerToken,
+              outputCostPerToken: config.outputCostPerToken ?? pricing.outputCostPerToken,
             };
           }
         } catch {
@@ -210,6 +216,8 @@ export class LLMFactory {
     if (derivedUsageId) {
       const metrics = new Metrics(config.model, {
         inputCostPerToken: config.inputCostPerToken ?? null,
+        cacheReadCostPerToken: config.cacheReadCostPerToken ?? null,
+        cacheWriteCostPerToken: config.cacheWriteCostPerToken ?? null,
         outputCostPerToken: config.outputCostPerToken ?? null,
       });
       const tracked = new TrackedLLMClient({

--- a/packages/agent-sdk-ts/src/sdk/llm/factory.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/factory.ts
@@ -90,12 +90,12 @@ export class LLMFactory {
 
     const provider = config.provider ?? detectProviderFromBaseUrl(config.baseUrl);
 
-    const needsPricing = (
-      config.inputCostPerToken === null || config.inputCostPerToken === undefined
-      || config.outputCostPerToken === null || config.outputCostPerToken === undefined
-      || config.cacheReadCostPerToken === null || config.cacheReadCostPerToken === undefined
-      || config.cacheWriteCostPerToken === null || config.cacheWriteCostPerToken === undefined
-    );
+    const isNil = (value: unknown): boolean => value === null || value === undefined;
+    const needsPricing =
+      isNil(config.inputCostPerToken) ||
+      isNil(config.outputCostPerToken) ||
+      isNil(config.cacheReadCostPerToken) ||
+      isNil(config.cacheWriteCostPerToken);
 
     if (needsPricing) {
       const normalizedBaseUrl = normalizeUrl(config.baseUrl);

--- a/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/metrics.ts
@@ -26,6 +26,8 @@ export class Metrics {
   modelName: string;
   accumulatedCost = 0;
   inputCostPerToken: number | null = null;
+  cacheReadCostPerToken: number | null = null;
+  cacheWriteCostPerToken: number | null = null;
   outputCostPerToken: number | null = null;
   maxBudgetPerTask: number | null = null;
   accumulatedTokenUsage: TokenUsage | null = null;
@@ -34,12 +36,19 @@ export class Metrics {
 
   constructor(
     modelName = 'default',
-    options: { inputCostPerToken?: number | null; outputCostPerToken?: number | null } = {},
+    options: {
+      inputCostPerToken?: number | null;
+      cacheReadCostPerToken?: number | null;
+      cacheWriteCostPerToken?: number | null;
+      outputCostPerToken?: number | null;
+    } = {},
   ) {
     const sanitizeRate = (rate?: number | null) =>
       typeof rate === 'number' && Number.isFinite(rate) ? rate : null;
     this.modelName = modelName;
     this.inputCostPerToken = sanitizeRate(options.inputCostPerToken);
+    this.cacheReadCostPerToken = sanitizeRate(options.cacheReadCostPerToken);
+    this.cacheWriteCostPerToken = sanitizeRate(options.cacheWriteCostPerToken);
     this.outputCostPerToken = sanitizeRate(options.outputCostPerToken);
   }
 
@@ -188,8 +197,21 @@ export class Metrics {
     const outputRate = this.outputCostPerToken;
     // Best-effort: only compute cost when both rates are known.
     if (typeof inputRate !== 'number' || typeof outputRate !== 'number') return;
-    const cost = usage.promptTokens * inputRate + usage.completionTokens * outputRate;
-    if (cost > 0) this.addCost(cost);
+    let cost = usage.promptTokens * inputRate + usage.completionTokens * outputRate;
+
+    // If cache-specific rates are known, adjust the cached token portions to use those rates.
+    // Assumes `cacheReadTokens/cacheWriteTokens` are subsets of `promptTokens` (provider-reported total input tokens).
+    const cacheReadRate = this.cacheReadCostPerToken;
+    if (typeof cacheReadRate === 'number' && usage.cacheReadTokens > 0) {
+      cost += usage.cacheReadTokens * (cacheReadRate - inputRate);
+    }
+    const cacheWriteRate = this.cacheWriteCostPerToken;
+    if (typeof cacheWriteRate === 'number' && usage.cacheWriteTokens > 0) {
+      cost += usage.cacheWriteTokens * (cacheWriteRate - inputRate);
+    }
+
+    const adjustedCost = Math.max(0, cost);
+    if (adjustedCost > 0) this.addCost(adjustedCost);
   }
 
   merge(other: Metrics): void {

--- a/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/modelsDevPricing.ts
@@ -8,6 +8,8 @@ export const MODELS_DEV_API_URL = 'https://models.dev/api.json';
 type ModelsDevCost = {
   input?: unknown;
   output?: unknown;
+  cache_read?: unknown;
+  cache_write?: unknown;
 };
 
 type ModelsDevModel = {
@@ -23,6 +25,8 @@ type ModelsDevApi = Record<string, ModelsDevProvider>;
 export type ModelsDevTokenPricing = {
   inputCostPerToken: number;
   outputCostPerToken: number;
+  cacheReadCostPerToken?: number;
+  cacheWriteCostPerToken?: number;
   source: 'models.dev';
 };
 
@@ -133,9 +137,20 @@ export const extractModelsDevTokenPricing = (params: {
   if (inputPerMillion === null || outputPerMillion === null) return null;
   if (inputPerMillion <= 0 || outputPerMillion <= 0) return null;
 
+  const cacheReadPerMillion = asFiniteNumber(costRaw.cache_read);
+  const cacheWritePerMillion = asFiniteNumber(costRaw.cache_write);
+  const cacheReadCostPerToken = cacheReadPerMillion !== null && cacheReadPerMillion > 0
+    ? cacheReadPerMillion / 1_000_000
+    : undefined;
+  const cacheWriteCostPerToken = cacheWritePerMillion !== null && cacheWritePerMillion > 0
+    ? cacheWritePerMillion / 1_000_000
+    : undefined;
+
   return {
     inputCostPerToken: inputPerMillion / 1_000_000,
     outputCostPerToken: outputPerMillion / 1_000_000,
+    ...(cacheReadCostPerToken !== undefined ? { cacheReadCostPerToken } : {}),
+    ...(cacheWriteCostPerToken !== undefined ? { cacheWriteCostPerToken } : {}),
     source: 'models.dev',
   };
 };

--- a/packages/agent-sdk-ts/src/sdk/llm/types.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/types.ts
@@ -52,6 +52,10 @@ export interface LLMConfiguration {
   headers?: Record<string, string>;
   /** Cost per input token in USD (or base currency). */
   inputCostPerToken?: number | null;
+  /** Cost per cached input token read in USD (or base currency). */
+  cacheReadCostPerToken?: number | null;
+  /** Cost per cached input token write in USD (or base currency). */
+  cacheWriteCostPerToken?: number | null;
   /** Cost per output token in USD (or base currency). */
   outputCostPerToken?: number | null;
   encrypted_reasoning?: string | null;


### PR DESCRIPTION
### Bead
oh-tab-3sg: Verify Total cost display in ConversationView - seems too high
Status: open
Priority: P2
Type: task
Created: 2026-01-17 06:17
Updated: 2026-01-17 06:17

Description:
The 'Total cost:' shown in the webview seems overly high. Possible issues:

1. Caching not accounted for - if provider returns cached token counts, we might be charging full price for cached/discounted tokens
2. Double-counting somewhere in the cost accumulation
3. Wrong pricing data from models.dev

Need to:
- Trace the cost calculation from LLM response usage through to display
- Verify we handle cached_tokens / prompt_cache_hit correctly
- Compare displayed cost against actual provider billing if possible

### Root cause
When token pricing is populated from models.dev we only used `cost.input`/`cost.output` and computed cost as `inputTokens*inputRate + outputTokens*outputRate`, ignoring provider-reported `cacheReadTokens` / `cacheWriteTokens`.

models.dev provides `cost.cache_read` and (for some providers) `cost.cache_write`, so we can avoid charging cached tokens at full input rate.

### What
- Parse `cost.cache_read` / `cost.cache_write` from models.dev and thread them into the LLM config.
- Adjust `Metrics` cost accumulation by applying cache-aware deltas (cached token portions priced at cache_* rates instead of full input rate).

### Testing
- `npm test`
- `npm run typecheck`
- `npm run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cache-aware cost calculations in the Agent SDK's metrics and pricing system
  * Extended pricing configuration to differentiate costs for cached token reads and writes
  * Updated cost calculation logic to properly account for cache-related token expenses

* **Tests**
  * Added comprehensive test coverage for cache cost rate calculations and pricing integration

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->