### PR TITLE
[oh-tab-ztb] Expand agent-server E2E test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -515,7 +515,7 @@
     "vscode:prepublish": "npm run build",
     "package": "node scripts/run-vsce-package.cjs",
     "e2e": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/**/*.test.js",
-    "e2e:agent-server": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha tests/e2e/out/agentServerRemote.test.js",
+    "e2e:agent-server": "node -e \"require('fs').rmSync('tests/e2e/out', { recursive: true, force: true })\" && npm run compile && tsc -p tests/e2e/tsconfig.suite.json && tsc -p tsconfig.e2e.json && mocha \"tests/e2e/out/agentServerRemote*.test.js\"",
     "test": "npm test -w @openhands/agent-sdk-ts && vitest run --dir src",
     "test:watch": "vitest",
     "typecheck": "tsc -p . && tsc -p tsconfig.webview.json",

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -18,9 +18,14 @@ function getDefaultAgentSdkDir(): string {
 }
 
 function resolveUvPath(): string | null {
-  const found = spawnSync('which', ['uv'], { encoding: 'utf8' });
-  const uvPath = typeof found.stdout === 'string' ? found.stdout.trim() : '';
-  return uvPath.length > 0 ? uvPath : null;
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  const found = spawnSync(cmd, ['uv'], { encoding: 'utf8' });
+  if (found.error || found.status !== 0) {
+    return null;
+  }
+  const stdout = typeof found.stdout === 'string' ? found.stdout.trim() : '';
+  const firstLine = stdout.split(/\r?\n/)[0]?.trim() ?? '';
+  return firstLine.length > 0 ? firstLine : null;
 }
 
 type OutputTail = {

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -75,7 +75,9 @@ async function waitForHealthOrExit(proc: ReturnType<typeof spawn>, url: string, 
       throw new Error(`Agent-server exited before reporting healthy (exit=${String(proc.exitCode)} signal=${String(proc.signalCode)})`);
     }
     try {
-      const res = await fetch(url, { method: 'GET' });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
+      const res = await fetch(url, { method: 'GET', signal: controller.signal }).finally(() => clearTimeout(timer));
       if (res.ok) return;
       lastError = new Error(`HTTP ${res.status}`);
     } catch (err) {

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -207,8 +207,6 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
 
     const env: Record<string, string | undefined> = {
       ...process.env,
-      // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
       // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
       OH_ENABLE_VSCODE: '0',
@@ -219,6 +217,11 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       OH_CONVERSATIONS_PATH: agentServerConversationsPath,
       OH_BASH_EVENTS_DIR: agentServerBashEventsDir,
     };
+    // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
+    // Note: keep PATH intact on Windows.
+    if (process.platform !== 'win32') {
+      env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+    }
     if (env.SESSION_API_KEY === undefined) {
       // Default to no auth for CI, but allow authenticated runs by setting
       // SESSION_API_KEY in the environment.

--- a/tests/e2e/agentServerRemote.test.ts
+++ b/tests/e2e/agentServerRemote.test.ts
@@ -175,6 +175,10 @@ async function startAgentServerWithRetry(
 describe('OpenHands-Tab Remote Agent-Server E2E', function () {
   this.timeout(180000);
 
+  after(async () => {
+    await fs.promises.rm(agentServerStateDir, { recursive: true, force: true });
+  });
+
   it('connects to a live python agent-server and streams events', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();

--- a/tests/e2e/agentServerRemoteErrorHandling.test.ts
+++ b/tests/e2e/agentServerRemoteErrorHandling.test.ts
@@ -134,6 +134,10 @@ async function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
 describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
   this.timeout(180000);
 
+  after(async () => {
+    await fs.promises.rm(agentServerStateDir, { recursive: true, force: true });
+  });
+
   it('renders an error event when the LLM endpoint returns 400', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();

--- a/tests/e2e/agentServerRemoteErrorHandling.test.ts
+++ b/tests/e2e/agentServerRemoteErrorHandling.test.ts
@@ -174,7 +174,9 @@ describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
       // Make the default LLM config point at the mock server even if the client omits fields.
       LLM_MODEL: 'gpt-4o-mini',
       LLM_BASE_URL: `${mock.baseUrl}/v1`,
-      LLM_API_KEY: 'sk-e2e',
+      // LiteLLM expects provider-specific env vars when api_key isn't explicitly provided
+      // in the StartConversation payload.
+      OPENAI_API_KEY: 'sk-e2e',
     };
     if (env.SESSION_API_KEY === undefined) {
       env.SESSION_API_KEY = '';

--- a/tests/e2e/agentServerRemoteErrorHandling.test.ts
+++ b/tests/e2e/agentServerRemoteErrorHandling.test.ts
@@ -73,7 +73,9 @@ async function waitForHealthOrExit(proc: ReturnType<typeof spawn>, url: string, 
       throw new Error(`Agent-server exited before reporting healthy (exit=${String(proc.exitCode)} signal=${String(proc.signalCode)})`);
     }
     try {
-      const res = await fetch(url, { method: 'GET' });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
+      const res = await fetch(url, { method: 'GET', signal: controller.signal }).finally(() => clearTimeout(timer));
       if (res.ok) return;
       lastError = new Error(`HTTP ${res.status}`);
     } catch (err) {

--- a/tests/e2e/agentServerRemoteErrorHandling.test.ts
+++ b/tests/e2e/agentServerRemoteErrorHandling.test.ts
@@ -5,8 +5,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { startMockLlmServer, type MockLlmScript } from './suite/mockLlmServer';
 
-const userDataDir = createE2EUserDataDir('agentServerRemote');
+const userDataDir = createE2EUserDataDir('agentServerRemoteErrorHandling');
 const agentServerStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oh-e2e-agent-server-'));
 const agentServerConversationsPath = path.join(agentServerStateDir, 'conversations');
 const agentServerBashEventsDir = path.join(agentServerStateDir, 'bash_events');
@@ -47,8 +48,6 @@ function createOutputTail(maxChars: number = 20000): OutputTail {
 }
 
 function pickPortForAgentServer(triedPorts: Set<number>): number {
-  // Avoid the bind+close+rebind race: pick a candidate port and retry on failure.
-  // (Similar to how we now bind the mock LLM server to port 0.)
   const min = 20_000;
   const max = 60_000;
   for (let attempts = 0; attempts < 50; attempts += 1) {
@@ -58,7 +57,6 @@ function pickPortForAgentServer(triedPorts: Set<number>): number {
       return port;
     }
   }
-  // Extremely unlikely; just return a candidate.
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
@@ -99,7 +97,6 @@ async function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
 
   if (process.platform === 'win32') {
     try {
-      // Best effort: terminate the entire process tree.
       spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
     } catch {
       // ignore
@@ -134,74 +131,39 @@ async function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
   await waitForExit(2000);
 }
 
-async function startAgentServerWithRetry(
-  agentSdkDir: string,
-  uvPath: string,
-  env: Record<string, string | undefined>,
-  maxAttempts: number = 3
-): Promise<{ child: ReturnType<typeof spawn>; serverUrl: string; output: OutputTail }> {
-  const failures: string[] = [];
-  const triedPorts = new Set<number>();
-  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-    const port = pickPortForAgentServer(triedPorts);
-    const serverUrl = `http://127.0.0.1:${port}`;
-    const output = createOutputTail();
-    const child = spawn(
-      uvPath,
-      ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
-      {
-        cwd: agentSdkDir,
-        env,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: process.platform !== 'win32',
-      }
-    );
-
-    child.stdout?.on('data', output.append);
-    child.stderr?.on('data', output.append);
-
-    try {
-      await waitForHealthOrExit(child, `${serverUrl}/health`, 45000);
-      return { child, serverUrl, output };
-    } catch (err) {
-      failures.push(`Attempt ${attempt}/${maxAttempts} (${serverUrl}): ${String(err)}\n${output.dump()}`);
-      await killProcessTree(child);
-    }
-  }
-
-  throw new Error(`Failed to start agent-server after ${maxAttempts} attempts.\n\n${failures.join('\n\n')}`);
-}
-
-describe('OpenHands-Tab Remote Agent-Server E2E', function () {
+describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
   this.timeout(180000);
 
-  it('connects to a live python agent-server and streams events', async function () {
+  it('renders an error event when the LLM endpoint returns 400', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();
     }
 
     const agentSdkDir = process.env.AGENT_SDK_DIR || process.env.OPENHANDS_AGENT_SDK_DIR || getDefaultAgentSdkDir();
-    if (!agentSdkDir) {
-      this.skip();
-    }
-    if (!fs.existsSync(agentSdkDir)) {
-      this.skip();
-    }
+    if (!agentSdkDir) this.skip();
+    if (!fs.existsSync(agentSdkDir)) this.skip();
     const uvPath = resolveUvPath();
-    if (!uvPath) {
-      this.skip();
-    }
+    if (!uvPath) this.skip();
     const uvCheck = spawnSync(uvPath, ['--version'], { stdio: 'ignore' });
-    if (uvCheck.error || uvCheck.status !== 0) {
-      this.skip();
-    }
+    if (uvCheck.error || uvCheck.status !== 0) this.skip();
+
+    const errorResponses = Array.from({ length: 25 }, () => ({
+      type: 'json' as const,
+      status: 400,
+      body: { error: { message: 'E2E forced error', type: 'e2e_error' } },
+    }));
+    const scripts: MockLlmScript[] = [
+      { path: '/chat/completions', responses: errorResponses },
+      { path: '/responses', responses: errorResponses },
+    ];
+
+    const mock = await startMockLlmServer({ scripts });
 
     const env: Record<string, string | undefined> = {
       ...process.env,
       // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
       PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
-      // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
       OH_ENABLE_VSCODE: '0',
       OH_ENABLE_VNC: '0',
       OH_PRELOAD_TOOLS: '0',
@@ -209,14 +171,45 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       // conversations in ~/repos/agent-sdk/workspace/conversations.
       OH_CONVERSATIONS_PATH: agentServerConversationsPath,
       OH_BASH_EVENTS_DIR: agentServerBashEventsDir,
+      // Make the default LLM config point at the mock server even if the client omits fields.
+      LLM_MODEL: 'gpt-4o-mini',
+      LLM_BASE_URL: `${mock.baseUrl}/v1`,
+      LLM_API_KEY: 'sk-e2e',
     };
     if (env.SESSION_API_KEY === undefined) {
-      // Default to no auth for CI, but allow authenticated runs by setting
-      // SESSION_API_KEY in the environment.
       env.SESSION_API_KEY = '';
     }
 
-    const { child, serverUrl, output } = await startAgentServerWithRetry(agentSdkDir, uvPath, env, 3);
+    const { child, serverUrl, output } = await (async () => {
+      // Inline wrapper so we can spawn uv by absolute path.
+      const failures: string[] = [];
+      const triedPorts = new Set<number>();
+      for (let attempt = 1; attempt <= 3; attempt += 1) {
+        const port = pickPortForAgentServer(triedPorts);
+        const candidateUrl = `http://127.0.0.1:${port}`;
+        const outputTail = createOutputTail();
+        const childProc = spawn(
+          uvPath,
+          ['run', 'python', '-m', 'openhands.agent_server', '--host', '127.0.0.1', '--port', String(port)],
+          {
+            cwd: agentSdkDir,
+            env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            detached: process.platform !== 'win32',
+          }
+        );
+        childProc.stdout?.on('data', outputTail.append);
+        childProc.stderr?.on('data', outputTail.append);
+        try {
+          await waitForHealthOrExit(childProc, `${candidateUrl}/health`, 45000);
+          return { child: childProc, serverUrl: candidateUrl, output: outputTail };
+        } catch (err) {
+          failures.push(`Attempt ${attempt}/3 (${candidateUrl}): ${String(err)}\n${outputTail.dump()}`);
+          await killProcessTree(childProc);
+        }
+      }
+      throw new Error(`Failed to start agent-server after 3 attempts.\n\n${failures.join('\n\n')}`);
+    })();
 
     try {
       const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
@@ -235,12 +228,13 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
           '--disable-gpu',
           '--disable-dev-shm-usage',
           '--disable-software-rasterizer',
-          extensionDevelopmentPath
+          extensionDevelopmentPath,
         ],
         extensionTestsEnv: {
-          TEST_NAME: 'agentServerRemote',
+          TEST_NAME: 'agentServerRemoteErrorHandling',
           AGENT_SERVER_URL: serverUrl,
-        }
+          MOCK_LLM_BASE_URL: mock.baseUrl,
+        },
       });
 
       assert.ok(true);
@@ -249,6 +243,7 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       throw err;
     } finally {
       await killProcessTree(child);
+      await mock.close();
     }
   });
 });

--- a/tests/e2e/agentServerRemoteErrorHandling.test.ts
+++ b/tests/e2e/agentServerRemoteErrorHandling.test.ts
@@ -170,8 +170,6 @@ describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
 
     const env: Record<string, string | undefined> = {
       ...process.env,
-      // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
       OH_ENABLE_VSCODE: '0',
       OH_ENABLE_VNC: '0',
@@ -187,11 +185,20 @@ describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
       // in the StartConversation payload.
       OPENAI_API_KEY: 'sk-e2e',
     };
+    // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
+    // Note: keep PATH intact on Windows.
+    if (process.platform !== 'win32') {
+      env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+    }
     if (env.SESSION_API_KEY === undefined) {
       env.SESSION_API_KEY = '';
     }
 
-    const { child, serverUrl, output } = await (async () => {
+    let child: ReturnType<typeof spawn> | null = null;
+    let serverUrl = '';
+    let output: OutputTail | null = null;
+
+    try {
       // Inline wrapper so we can spawn uv by absolute path.
       const failures: string[] = [];
       const triedPorts = new Set<number>();
@@ -213,16 +220,20 @@ describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
         childProc.stderr?.on('data', outputTail.append);
         try {
           await waitForHealthOrExit(childProc, `${candidateUrl}/health`, 45000);
-          return { child: childProc, serverUrl: candidateUrl, output: outputTail };
+          child = childProc;
+          serverUrl = candidateUrl;
+          output = outputTail;
+          break;
         } catch (err) {
           failures.push(`Attempt ${attempt}/3 (${candidateUrl}): ${String(err)}\n${outputTail.dump()}`);
           await killProcessTree(childProc);
         }
       }
-      throw new Error(`Failed to start agent-server after 3 attempts.\n\n${failures.join('\n\n')}`);
-    })();
 
-    try {
+      if (!child) {
+        throw new Error(`Failed to start agent-server after 3 attempts.\n\n${failures.join('\n\n')}`);
+      }
+
       const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
       const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
       const extensionTestsPath = path.resolve(__dirname, './suite');
@@ -250,10 +261,14 @@ describe('OpenHands-Tab Remote Agent-Server E2E (error handling)', function () {
 
       assert.ok(true);
     } catch (err) {
-      console.error('agent-server output (tail):\n', output.dump());
+      if (output) {
+        console.error('agent-server output (tail):\n', output.dump());
+      }
       throw err;
     } finally {
-      await killProcessTree(child);
+      if (child) {
+        await killProcessTree(child);
+      }
       await mock.close();
     }
   });

--- a/tests/e2e/agentServerRemoteErrorHandling.test.ts
+++ b/tests/e2e/agentServerRemoteErrorHandling.test.ts
@@ -19,9 +19,14 @@ function getDefaultAgentSdkDir(): string {
 }
 
 function resolveUvPath(): string | null {
-  const found = spawnSync('which', ['uv'], { encoding: 'utf8' });
-  const uvPath = typeof found.stdout === 'string' ? found.stdout.trim() : '';
-  return uvPath.length > 0 ? uvPath : null;
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  const found = spawnSync(cmd, ['uv'], { encoding: 'utf8' });
+  if (found.error || found.status !== 0) {
+    return null;
+  }
+  const stdout = typeof found.stdout === 'string' ? found.stdout.trim() : '';
+  const firstLine = stdout.split(/\r?\n/)[0]?.trim() ?? '';
+  return firstLine.length > 0 ? firstLine : null;
 }
 
 type OutputTail = {

--- a/tests/e2e/agentServerRemoteHistory.test.ts
+++ b/tests/e2e/agentServerRemoteHistory.test.ts
@@ -172,6 +172,10 @@ async function startAgentServerWithRetry(
 describe('OpenHands-Tab Remote Agent-Server E2E (history-ish)', function () {
   this.timeout(180000);
 
+  after(async () => {
+    await fs.promises.rm(agentServerStateDir, { recursive: true, force: true });
+  });
+
   it('starts two remote conversations and resets rendered event backlog', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();

--- a/tests/e2e/agentServerRemoteHistory.test.ts
+++ b/tests/e2e/agentServerRemoteHistory.test.ts
@@ -5,8 +5,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { startMockLlmServer } from './suite/mockLlmServer';
 
-const userDataDir = createE2EUserDataDir('agentServerRemote');
+const userDataDir = createE2EUserDataDir('agentServerRemoteHistory');
 const agentServerStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oh-e2e-agent-server-'));
 const agentServerConversationsPath = path.join(agentServerStateDir, 'conversations');
 const agentServerBashEventsDir = path.join(agentServerStateDir, 'bash_events');
@@ -47,8 +48,6 @@ function createOutputTail(maxChars: number = 20000): OutputTail {
 }
 
 function pickPortForAgentServer(triedPorts: Set<number>): number {
-  // Avoid the bind+close+rebind race: pick a candidate port and retry on failure.
-  // (Similar to how we now bind the mock LLM server to port 0.)
   const min = 20_000;
   const max = 60_000;
   for (let attempts = 0; attempts < 50; attempts += 1) {
@@ -58,7 +57,6 @@ function pickPortForAgentServer(triedPorts: Set<number>): number {
       return port;
     }
   }
-  // Extremely unlikely; just return a candidate.
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
@@ -99,7 +97,6 @@ async function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
 
   if (process.platform === 'win32') {
     try {
-      // Best effort: terminate the entire process tree.
       spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
     } catch {
       // ignore
@@ -172,36 +169,29 @@ async function startAgentServerWithRetry(
   throw new Error(`Failed to start agent-server after ${maxAttempts} attempts.\n\n${failures.join('\n\n')}`);
 }
 
-describe('OpenHands-Tab Remote Agent-Server E2E', function () {
+describe('OpenHands-Tab Remote Agent-Server E2E (history-ish)', function () {
   this.timeout(180000);
 
-  it('connects to a live python agent-server and streams events', async function () {
+  it('starts two remote conversations and resets rendered event backlog', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();
     }
 
     const agentSdkDir = process.env.AGENT_SDK_DIR || process.env.OPENHANDS_AGENT_SDK_DIR || getDefaultAgentSdkDir();
-    if (!agentSdkDir) {
-      this.skip();
-    }
-    if (!fs.existsSync(agentSdkDir)) {
-      this.skip();
-    }
+    if (!agentSdkDir) this.skip();
+    if (!fs.existsSync(agentSdkDir)) this.skip();
     const uvPath = resolveUvPath();
-    if (!uvPath) {
-      this.skip();
-    }
+    if (!uvPath) this.skip();
     const uvCheck = spawnSync(uvPath, ['--version'], { stdio: 'ignore' });
-    if (uvCheck.error || uvCheck.status !== 0) {
-      this.skip();
-    }
+    if (uvCheck.error || uvCheck.status !== 0) this.skip();
+
+    const mock = await startMockLlmServer();
 
     const env: Record<string, string | undefined> = {
       ...process.env,
       // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
       PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
-      // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
       OH_ENABLE_VSCODE: '0',
       OH_ENABLE_VNC: '0',
       OH_PRELOAD_TOOLS: '0',
@@ -209,10 +199,11 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       // conversations in ~/repos/agent-sdk/workspace/conversations.
       OH_CONVERSATIONS_PATH: agentServerConversationsPath,
       OH_BASH_EVENTS_DIR: agentServerBashEventsDir,
+      LLM_MODEL: 'gpt-4o-mini',
+      LLM_BASE_URL: `${mock.baseUrl}/v1`,
+      LLM_API_KEY: 'sk-e2e',
     };
     if (env.SESSION_API_KEY === undefined) {
-      // Default to no auth for CI, but allow authenticated runs by setting
-      // SESSION_API_KEY in the environment.
       env.SESSION_API_KEY = '';
     }
 
@@ -235,12 +226,13 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
           '--disable-gpu',
           '--disable-dev-shm-usage',
           '--disable-software-rasterizer',
-          extensionDevelopmentPath
+          extensionDevelopmentPath,
         ],
         extensionTestsEnv: {
-          TEST_NAME: 'agentServerRemote',
+          TEST_NAME: 'agentServerRemoteHistory',
           AGENT_SERVER_URL: serverUrl,
-        }
+          MOCK_LLM_BASE_URL: mock.baseUrl,
+        },
       });
 
       assert.ok(true);
@@ -249,6 +241,7 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       throw err;
     } finally {
       await killProcessTree(child);
+      await mock.close();
     }
   });
 });

--- a/tests/e2e/agentServerRemoteHistory.test.ts
+++ b/tests/e2e/agentServerRemoteHistory.test.ts
@@ -201,7 +201,7 @@ describe('OpenHands-Tab Remote Agent-Server E2E (history-ish)', function () {
       OH_BASH_EVENTS_DIR: agentServerBashEventsDir,
       LLM_MODEL: 'gpt-4o-mini',
       LLM_BASE_URL: `${mock.baseUrl}/v1`,
-      LLM_API_KEY: 'sk-e2e',
+      OPENAI_API_KEY: 'sk-e2e',
     };
     if (env.SESSION_API_KEY === undefined) {
       env.SESSION_API_KEY = '';

--- a/tests/e2e/agentServerRemoteHistory.test.ts
+++ b/tests/e2e/agentServerRemoteHistory.test.ts
@@ -73,7 +73,9 @@ async function waitForHealthOrExit(proc: ReturnType<typeof spawn>, url: string, 
       throw new Error(`Agent-server exited before reporting healthy (exit=${String(proc.exitCode)} signal=${String(proc.signalCode)})`);
     }
     try {
-      const res = await fetch(url, { method: 'GET' });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
+      const res = await fetch(url, { method: 'GET', signal: controller.signal }).finally(() => clearTimeout(timer));
       if (res.ok) return;
       lastError = new Error(`HTTP ${res.status}`);
     } catch (err) {

--- a/tests/e2e/agentServerRemoteHistory.test.ts
+++ b/tests/e2e/agentServerRemoteHistory.test.ts
@@ -198,8 +198,6 @@ describe('OpenHands-Tab Remote Agent-Server E2E (history-ish)', function () {
 
     const env: Record<string, string | undefined> = {
       ...process.env,
-      // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
       OH_ENABLE_VSCODE: '0',
       OH_ENABLE_VNC: '0',
@@ -212,13 +210,25 @@ describe('OpenHands-Tab Remote Agent-Server E2E (history-ish)', function () {
       LLM_BASE_URL: `${mock.baseUrl}/v1`,
       OPENAI_API_KEY: 'sk-e2e',
     };
+    // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
+    // Note: keep PATH intact on Windows.
+    if (process.platform !== 'win32') {
+      env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+    }
     if (env.SESSION_API_KEY === undefined) {
       env.SESSION_API_KEY = '';
     }
 
-    const { child, serverUrl, output } = await startAgentServerWithRetry(agentSdkDir, uvPath, env, 3);
+    let child: ReturnType<typeof spawn> | null = null;
+    let serverUrl = '';
+    let output: OutputTail | null = null;
 
     try {
+      const started = await startAgentServerWithRetry(agentSdkDir, uvPath, env, 3);
+      child = started.child;
+      serverUrl = started.serverUrl;
+      output = started.output;
+
       const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
       const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
       const extensionTestsPath = path.resolve(__dirname, './suite');
@@ -246,10 +256,14 @@ describe('OpenHands-Tab Remote Agent-Server E2E (history-ish)', function () {
 
       assert.ok(true);
     } catch (err) {
-      console.error('agent-server output (tail):\n', output.dump());
+      if (output) {
+        console.error('agent-server output (tail):\n', output.dump());
+      }
       throw err;
     } finally {
-      await killProcessTree(child);
+      if (child) {
+        await killProcessTree(child);
+      }
       await mock.close();
     }
   });

--- a/tests/e2e/agentServerRemoteHistory.test.ts
+++ b/tests/e2e/agentServerRemoteHistory.test.ts
@@ -19,9 +19,14 @@ function getDefaultAgentSdkDir(): string {
 }
 
 function resolveUvPath(): string | null {
-  const found = spawnSync('which', ['uv'], { encoding: 'utf8' });
-  const uvPath = typeof found.stdout === 'string' ? found.stdout.trim() : '';
-  return uvPath.length > 0 ? uvPath : null;
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  const found = spawnSync(cmd, ['uv'], { encoding: 'utf8' });
+  if (found.error || found.status !== 0) {
+    return null;
+  }
+  const stdout = typeof found.stdout === 'string' ? found.stdout.trim() : '';
+  const firstLine = stdout.split(/\r?\n/)[0]?.trim() ?? '';
+  return firstLine.length > 0 ? firstLine : null;
 }
 
 type OutputTail = {

--- a/tests/e2e/agentServerRemoteMessaging.test.ts
+++ b/tests/e2e/agentServerRemoteMessaging.test.ts
@@ -5,8 +5,9 @@ import * as os from 'os';
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 import { createE2EUserDataDir, downloadVSCodeWithRetry, ensureVsCodeArgvJson } from './testHelpers';
+import { startMockLlmServer } from './suite/mockLlmServer';
 
-const userDataDir = createE2EUserDataDir('agentServerRemote');
+const userDataDir = createE2EUserDataDir('agentServerRemoteMessaging');
 const agentServerStateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'oh-e2e-agent-server-'));
 const agentServerConversationsPath = path.join(agentServerStateDir, 'conversations');
 const agentServerBashEventsDir = path.join(agentServerStateDir, 'bash_events');
@@ -47,8 +48,6 @@ function createOutputTail(maxChars: number = 20000): OutputTail {
 }
 
 function pickPortForAgentServer(triedPorts: Set<number>): number {
-  // Avoid the bind+close+rebind race: pick a candidate port and retry on failure.
-  // (Similar to how we now bind the mock LLM server to port 0.)
   const min = 20_000;
   const max = 60_000;
   for (let attempts = 0; attempts < 50; attempts += 1) {
@@ -58,7 +57,6 @@ function pickPortForAgentServer(triedPorts: Set<number>): number {
       return port;
     }
   }
-  // Extremely unlikely; just return a candidate.
   return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 
@@ -99,7 +97,6 @@ async function killProcessTree(proc: ReturnType<typeof spawn>): Promise<void> {
 
   if (process.platform === 'win32') {
     try {
-      // Best effort: terminate the entire process tree.
       spawnSync('taskkill', ['/PID', String(pid), '/T', '/F'], { stdio: 'ignore' });
     } catch {
       // ignore
@@ -172,36 +169,29 @@ async function startAgentServerWithRetry(
   throw new Error(`Failed to start agent-server after ${maxAttempts} attempts.\n\n${failures.join('\n\n')}`);
 }
 
-describe('OpenHands-Tab Remote Agent-Server E2E', function () {
+describe('OpenHands-Tab Remote Agent-Server E2E (messaging)', function () {
   this.timeout(180000);
 
-  it('connects to a live python agent-server and streams events', async function () {
+  it('sends two messages and observes LLM requests via the mock server log', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();
     }
 
     const agentSdkDir = process.env.AGENT_SDK_DIR || process.env.OPENHANDS_AGENT_SDK_DIR || getDefaultAgentSdkDir();
-    if (!agentSdkDir) {
-      this.skip();
-    }
-    if (!fs.existsSync(agentSdkDir)) {
-      this.skip();
-    }
+    if (!agentSdkDir) this.skip();
+    if (!fs.existsSync(agentSdkDir)) this.skip();
     const uvPath = resolveUvPath();
-    if (!uvPath) {
-      this.skip();
-    }
+    if (!uvPath) this.skip();
     const uvCheck = spawnSync(uvPath, ['--version'], { stdio: 'ignore' });
-    if (uvCheck.error || uvCheck.status !== 0) {
-      this.skip();
-    }
+    if (uvCheck.error || uvCheck.status !== 0) this.skip();
+
+    const mock = await startMockLlmServer();
 
     const env: Record<string, string | undefined> = {
       ...process.env,
       // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
       PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
-      // Keep server startup lightweight for CI (no VSCode/VNC, no tool preload).
       OH_ENABLE_VSCODE: '0',
       OH_ENABLE_VNC: '0',
       OH_PRELOAD_TOOLS: '0',
@@ -209,10 +199,12 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       // conversations in ~/repos/agent-sdk/workspace/conversations.
       OH_CONVERSATIONS_PATH: agentServerConversationsPath,
       OH_BASH_EVENTS_DIR: agentServerBashEventsDir,
+      // Make the default LLM config point at the mock server even if the client omits fields.
+      LLM_MODEL: 'gpt-4o-mini',
+      LLM_BASE_URL: `${mock.baseUrl}/v1`,
+      LLM_API_KEY: 'sk-e2e',
     };
     if (env.SESSION_API_KEY === undefined) {
-      // Default to no auth for CI, but allow authenticated runs by setting
-      // SESSION_API_KEY in the environment.
       env.SESSION_API_KEY = '';
     }
 
@@ -235,12 +227,13 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
           '--disable-gpu',
           '--disable-dev-shm-usage',
           '--disable-software-rasterizer',
-          extensionDevelopmentPath
+          extensionDevelopmentPath,
         ],
         extensionTestsEnv: {
-          TEST_NAME: 'agentServerRemote',
+          TEST_NAME: 'agentServerRemoteMessaging',
           AGENT_SERVER_URL: serverUrl,
-        }
+          MOCK_LLM_BASE_URL: mock.baseUrl,
+        },
       });
 
       assert.ok(true);
@@ -249,6 +242,7 @@ describe('OpenHands-Tab Remote Agent-Server E2E', function () {
       throw err;
     } finally {
       await killProcessTree(child);
+      await mock.close();
     }
   });
 });

--- a/tests/e2e/agentServerRemoteMessaging.test.ts
+++ b/tests/e2e/agentServerRemoteMessaging.test.ts
@@ -202,7 +202,7 @@ describe('OpenHands-Tab Remote Agent-Server E2E (messaging)', function () {
       // Make the default LLM config point at the mock server even if the client omits fields.
       LLM_MODEL: 'gpt-4o-mini',
       LLM_BASE_URL: `${mock.baseUrl}/v1`,
-      LLM_API_KEY: 'sk-e2e',
+      OPENAI_API_KEY: 'sk-e2e',
     };
     if (env.SESSION_API_KEY === undefined) {
       env.SESSION_API_KEY = '';

--- a/tests/e2e/agentServerRemoteMessaging.test.ts
+++ b/tests/e2e/agentServerRemoteMessaging.test.ts
@@ -73,7 +73,9 @@ async function waitForHealthOrExit(proc: ReturnType<typeof spawn>, url: string, 
       throw new Error(`Agent-server exited before reporting healthy (exit=${String(proc.exitCode)} signal=${String(proc.signalCode)})`);
     }
     try {
-      const res = await fetch(url, { method: 'GET' });
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 3000);
+      const res = await fetch(url, { method: 'GET', signal: controller.signal }).finally(() => clearTimeout(timer));
       if (res.ok) return;
       lastError = new Error(`HTTP ${res.status}`);
     } catch (err) {

--- a/tests/e2e/agentServerRemoteMessaging.test.ts
+++ b/tests/e2e/agentServerRemoteMessaging.test.ts
@@ -172,6 +172,10 @@ async function startAgentServerWithRetry(
 describe('OpenHands-Tab Remote Agent-Server E2E (messaging)', function () {
   this.timeout(180000);
 
+  after(async () => {
+    await fs.promises.rm(agentServerStateDir, { recursive: true, force: true });
+  });
+
   it('sends two messages and observes LLM requests via the mock server log', async function () {
     if (process.env.E2E_AGENT_SERVER !== '1') {
       this.skip();

--- a/tests/e2e/agentServerRemoteMessaging.test.ts
+++ b/tests/e2e/agentServerRemoteMessaging.test.ts
@@ -19,9 +19,14 @@ function getDefaultAgentSdkDir(): string {
 }
 
 function resolveUvPath(): string | null {
-  const found = spawnSync('which', ['uv'], { encoding: 'utf8' });
-  const uvPath = typeof found.stdout === 'string' ? found.stdout.trim() : '';
-  return uvPath.length > 0 ? uvPath : null;
+  const cmd = process.platform === 'win32' ? 'where' : 'which';
+  const found = spawnSync(cmd, ['uv'], { encoding: 'utf8' });
+  if (found.error || found.status !== 0) {
+    return null;
+  }
+  const stdout = typeof found.stdout === 'string' ? found.stdout.trim() : '';
+  const firstLine = stdout.split(/\r?\n/)[0]?.trim() ?? '';
+  return firstLine.length > 0 ? firstLine : null;
 }
 
 type OutputTail = {

--- a/tests/e2e/agentServerRemoteMessaging.test.ts
+++ b/tests/e2e/agentServerRemoteMessaging.test.ts
@@ -198,8 +198,6 @@ describe('OpenHands-Tab Remote Agent-Server E2E (messaging)', function () {
 
     const env: Record<string, string | undefined> = {
       ...process.env,
-      // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
-      PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
       PYTHONUNBUFFERED: '1',
       OH_ENABLE_VSCODE: '0',
       OH_ENABLE_VNC: '0',
@@ -213,13 +211,25 @@ describe('OpenHands-Tab Remote Agent-Server E2E (messaging)', function () {
       LLM_BASE_URL: `${mock.baseUrl}/v1`,
       OPENAI_API_KEY: 'sk-e2e',
     };
+    // Avoid tmux-based terminal sessions in E2E (tmux can be flaky / unavailable in CI).
+    // Note: keep PATH intact on Windows.
+    if (process.platform !== 'win32') {
+      env.PATH = '/usr/bin:/bin:/usr/sbin:/sbin';
+    }
     if (env.SESSION_API_KEY === undefined) {
       env.SESSION_API_KEY = '';
     }
 
-    const { child, serverUrl, output } = await startAgentServerWithRetry(agentSdkDir, uvPath, env, 3);
+    let child: ReturnType<typeof spawn> | null = null;
+    let serverUrl = '';
+    let output: OutputTail | null = null;
 
     try {
+      const started = await startAgentServerWithRetry(agentSdkDir, uvPath, env, 3);
+      child = started.child;
+      serverUrl = started.serverUrl;
+      output = started.output;
+
       const vscodeExecutablePath = await downloadVSCodeWithRetry('stable');
       const extensionDevelopmentPath = path.resolve(__dirname, '../../..');
       const extensionTestsPath = path.resolve(__dirname, './suite');
@@ -247,10 +257,14 @@ describe('OpenHands-Tab Remote Agent-Server E2E (messaging)', function () {
 
       assert.ok(true);
     } catch (err) {
-      console.error('agent-server output (tail):\n', output.dump());
+      if (output) {
+        console.error('agent-server output (tail):\n', output.dump());
+      }
       throw err;
     } finally {
-      await killProcessTree(child);
+      if (child) {
+        await killProcessTree(child);
+      }
       await mock.close();
     }
   });

--- a/tests/e2e/suite/agentServerRemoteErrorHandling.ts
+++ b/tests/e2e/suite/agentServerRemoteErrorHandling.ts
@@ -1,0 +1,106 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
+
+type RenderedEventsInfo = {
+  count?: number;
+  eventTypes?: unknown[];
+};
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+async function resetMock(baseUrl: string): Promise<void> {
+  await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+}
+
+async function getMockRequestCount(baseUrl: string): Promise<number> {
+  const res = await fetch(`${baseUrl}/__log`, { method: 'GET' });
+  if (!res.ok) return 0;
+  const json = await res.json() as { requests?: unknown };
+  const requests = Array.isArray(json.requests) ? json.requests : [];
+  return requests.length;
+}
+
+export async function run(): Promise<void> {
+  const serverUrl = process.env.AGENT_SERVER_URL;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) {
+    throw new Error('Missing required env var: AGENT_SERVER_URL');
+  }
+  const mockBaseUrl = process.env.MOCK_LLM_BASE_URL;
+  if (typeof mockBaseUrl !== 'string' || mockBaseUrl.trim().length === 0) {
+    throw new Error('Missing required env var: MOCK_LLM_BASE_URL');
+  }
+
+  await resetMock(mockBaseUrl);
+
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  const profileId = `e2e-agent-server-remote-openai-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  await vscode.commands.executeCommand('openhands._createProfile', {
+    profileId,
+    profile: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      baseUrl: `${mockBaseUrl}/v1`,
+      openaiApiMode: 'responses',
+    },
+  });
+  await vscode.workspace.getConfiguration().update('openhands.llm.profileId', profileId, vscode.ConfigurationTarget.Global);
+
+  // Configure remote server and keep the run short.
+  await vscode.commands.executeCommand('openhands._serversSet', { servers: [serverUrl], serverUrl: '' });
+  await vscode.workspace.getConfiguration().update(
+    'openhands.conversation.maxIterations',
+    1,
+    vscode.ConfigurationTarget.Global
+  );
+
+  const selectServer = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'selectServer',
+    payload: { url: serverUrl },
+  });
+  if (!selectServer?.sent) {
+    throw new Error(`selectServer action was not sent: ${JSON.stringify(selectServer)}`);
+  }
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
+  }, 45000);
+
+  const before = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+  const beforeCount = typeof before?.count === 'number' ? before.count : 0;
+  const beforeRequests = await getMockRequestCount(mockBaseUrl);
+
+  const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text: 'E2E: force LLM error and ensure ConversationErrorEvent renders.' }
+  });
+  if (!send?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+  }
+
+  await pollUntil(async () => {
+    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+    const count = typeof rendered?.count === 'number' ? rendered.count : 0;
+    const types = Array.isArray(rendered?.eventTypes) ? rendered.eventTypes : [];
+    if (count <= beforeCount) return false;
+    return types.includes('ConversationErrorEvent') || types.includes('AgentErrorEvent');
+  }, 120000);
+
+  await pollUntil(async () => (await getMockRequestCount(mockBaseUrl)) > beforeRequests, 60000);
+}

--- a/tests/e2e/suite/agentServerRemoteErrorHandling.ts
+++ b/tests/e2e/suite/agentServerRemoteErrorHandling.ts
@@ -12,12 +12,19 @@ type WebviewActionResult = {
 };
 
 async function resetMock(baseUrl: string): Promise<void> {
-  await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+  const res = await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to reset mock server (HTTP ${res.status})${body ? `: ${body}` : ''}`);
+  }
 }
 
 async function getMockRequestCount(baseUrl: string): Promise<number> {
   const res = await fetch(`${baseUrl}/__log`, { method: 'GET' });
-  if (!res.ok) return 0;
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to fetch mock log (HTTP ${res.status})${body ? `: ${body}` : ''}`);
+  }
   const json = await res.json() as { requests?: unknown };
   const requests = Array.isArray(json.requests) ? json.requests : [];
   return requests.length;

--- a/tests/e2e/suite/agentServerRemoteHistory.ts
+++ b/tests/e2e/suite/agentServerRemoteHistory.ts
@@ -1,0 +1,126 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
+
+type RenderedEventsInfo = {
+  count?: number;
+  eventTypes?: unknown[];
+};
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+async function resetMock(baseUrl: string): Promise<void> {
+  await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+}
+
+async function getMockRequestCount(baseUrl: string): Promise<number> {
+  const res = await fetch(`${baseUrl}/__log`, { method: 'GET' });
+  if (!res.ok) return 0;
+  const json = await res.json() as { requests?: unknown };
+  const requests = Array.isArray(json.requests) ? json.requests : [];
+  return requests.length;
+}
+
+export async function run(): Promise<void> {
+  const serverUrl = process.env.AGENT_SERVER_URL;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) {
+    throw new Error('Missing required env var: AGENT_SERVER_URL');
+  }
+  const mockBaseUrl = process.env.MOCK_LLM_BASE_URL;
+  if (typeof mockBaseUrl !== 'string' || mockBaseUrl.trim().length === 0) {
+    throw new Error('Missing required env var: MOCK_LLM_BASE_URL');
+  }
+
+  await resetMock(mockBaseUrl);
+
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  const profileId = `e2e-agent-server-remote-openai-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  await vscode.commands.executeCommand('openhands._createProfile', {
+    profileId,
+    profile: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      baseUrl: `${mockBaseUrl}/v1`,
+      openaiApiMode: 'responses',
+    },
+  });
+  await vscode.workspace.getConfiguration().update('openhands.llm.profileId', profileId, vscode.ConfigurationTarget.Global);
+
+  await vscode.commands.executeCommand('openhands._serversSet', { servers: [serverUrl], serverUrl: '' });
+  await vscode.workspace.getConfiguration().update(
+    'openhands.conversation.maxIterations',
+    1,
+    vscode.ConfigurationTarget.Global
+  );
+
+  const selectServer = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'selectServer',
+    payload: { url: serverUrl },
+  });
+  if (!selectServer?.sent) {
+    throw new Error(`selectServer action was not sent: ${JSON.stringify(selectServer)}`);
+  }
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
+  }, 45000);
+
+  const firstConversationId = (await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics'))?.conversationId;
+  const beforeRequests = await getMockRequestCount(mockBaseUrl);
+
+  const send = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text: 'E2E: first remote conversation message.' }
+  });
+  if (!send?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(send)}`);
+  }
+
+  await pollUntil(async () => {
+    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+    const types = Array.isArray(rendered?.eventTypes)
+      ? rendered.eventTypes.filter((t): t is string => typeof t === 'string')
+      : [];
+    const messageEvents = types.filter((t) => t === 'MessageEvent').length;
+    return messageEvents >= 2; // user + assistant
+  }, 60000);
+
+  await pollUntil(async () => (await getMockRequestCount(mockBaseUrl)) > beforeRequests, 60000);
+
+  const backlogBeforeReset = (await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics'))?.eventBacklog?.size ?? 0;
+  if (backlogBeforeReset < 2) {
+    throw new Error(`Expected eventBacklog.size >= 2 after remote send, got ${backlogBeforeReset}`);
+  }
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
+  }, 45000);
+
+  const secondConversationId = (await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics'))?.conversationId;
+  if (firstConversationId && secondConversationId && firstConversationId === secondConversationId) {
+    throw new Error(`Expected conversationId to change after startNewConversation (still ${secondConversationId})`);
+  }
+
+  const backlogAfterReset = (await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics'))?.eventBacklog?.size ?? 0;
+  if (backlogAfterReset >= backlogBeforeReset) {
+    throw new Error(`Expected eventBacklog.size to reset after new conversation (before=${backlogBeforeReset}, after=${backlogAfterReset})`);
+  }
+}

--- a/tests/e2e/suite/agentServerRemoteHistory.ts
+++ b/tests/e2e/suite/agentServerRemoteHistory.ts
@@ -12,12 +12,19 @@ type WebviewActionResult = {
 };
 
 async function resetMock(baseUrl: string): Promise<void> {
-  await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+  const res = await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to reset mock server (HTTP ${res.status})${body ? `: ${body}` : ''}`);
+  }
 }
 
 async function getMockRequestCount(baseUrl: string): Promise<number> {
   const res = await fetch(`${baseUrl}/__log`, { method: 'GET' });
-  if (!res.ok) return 0;
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to fetch mock log (HTTP ${res.status})${body ? `: ${body}` : ''}`);
+  }
   const json = await res.json() as { requests?: unknown };
   const requests = Array.isArray(json.requests) ? json.requests : [];
   return requests.length;

--- a/tests/e2e/suite/agentServerRemoteMessaging.ts
+++ b/tests/e2e/suite/agentServerRemoteMessaging.ts
@@ -12,12 +12,19 @@ type RenderedEventsInfo = {
 };
 
 async function resetMock(baseUrl: string): Promise<void> {
-  await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+  const res = await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to reset mock server (HTTP ${res.status})${body ? `: ${body}` : ''}`);
+  }
 }
 
 async function getMockRequestCount(baseUrl: string): Promise<number> {
   const res = await fetch(`${baseUrl}/__log`, { method: 'GET' });
-  if (!res.ok) return 0;
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Failed to fetch mock log (HTTP ${res.status})${body ? `: ${body}` : ''}`);
+  }
   const json = await res.json() as { requests?: unknown };
   const requests = Array.isArray(json.requests) ? json.requests : [];
   return requests.length;

--- a/tests/e2e/suite/agentServerRemoteMessaging.ts
+++ b/tests/e2e/suite/agentServerRemoteMessaging.ts
@@ -1,0 +1,126 @@
+import * as vscode from 'vscode';
+import { pollUntil } from './pollUntil';
+import type { DiagnosticsInfo } from './helpers/diagnosticsInfo';
+
+type WebviewActionResult = {
+  sent?: boolean;
+};
+
+type RenderedEventsInfo = {
+  count?: number;
+  eventTypes?: unknown[];
+};
+
+async function resetMock(baseUrl: string): Promise<void> {
+  await fetch(`${baseUrl}/__reset`, { method: 'POST' });
+}
+
+async function getMockRequestCount(baseUrl: string): Promise<number> {
+  const res = await fetch(`${baseUrl}/__log`, { method: 'GET' });
+  if (!res.ok) return 0;
+  const json = await res.json() as { requests?: unknown };
+  const requests = Array.isArray(json.requests) ? json.requests : [];
+  return requests.length;
+}
+
+export async function run(): Promise<void> {
+  const serverUrl = process.env.AGENT_SERVER_URL;
+  if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) {
+    throw new Error('Missing required env var: AGENT_SERVER_URL');
+  }
+  const mockBaseUrl = process.env.MOCK_LLM_BASE_URL;
+  if (typeof mockBaseUrl !== 'string' || mockBaseUrl.trim().length === 0) {
+    throw new Error('Missing required env var: MOCK_LLM_BASE_URL');
+  }
+
+  await resetMock(mockBaseUrl);
+
+  await vscode.commands.executeCommand('openhands.open');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
+  }, 15000);
+
+  const profileId = `e2e-agent-server-remote-openai-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  await vscode.commands.executeCommand('openhands._createProfile', {
+    profileId,
+    profile: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+      baseUrl: `${mockBaseUrl}/v1`,
+      // Prefer responses when available, but mock server supports both.
+      openaiApiMode: 'responses',
+    },
+  });
+  await vscode.workspace.getConfiguration().update('openhands.llm.profileId', profileId, vscode.ConfigurationTarget.Global);
+
+  // Configure remote server and keep the run short.
+  await vscode.commands.executeCommand('openhands._serversSet', { servers: [serverUrl], serverUrl: '' });
+  await vscode.workspace.getConfiguration().update(
+    'openhands.conversation.maxIterations',
+    2,
+    vscode.ConfigurationTarget.Global
+  );
+
+  const selectServer = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'selectServer',
+    payload: { url: serverUrl },
+  });
+  if (!selectServer?.sent) {
+    throw new Error(`selectServer action was not sent: ${JSON.stringify(selectServer)}`);
+  }
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.serverUrl === serverUrl;
+  }, 15000);
+
+  await vscode.commands.executeCommand('openhands.startNewConversation');
+
+  await pollUntil(async () => {
+    const diag = await vscode.commands.executeCommand<DiagnosticsInfo>('openhands._diagnostics');
+    return diag?.mode === 'remote' && diag?.status === 'online' && typeof diag?.conversationId === 'string';
+  }, 45000);
+
+  const beforeRequests = await getMockRequestCount(mockBaseUrl);
+
+  const sendFirst = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text: 'E2E: first message via remote agent-server.' }
+  });
+  if (!sendFirst?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(sendFirst)}`);
+  }
+
+  await pollUntil(async () => {
+    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+    const types = Array.isArray(rendered?.eventTypes)
+      ? rendered.eventTypes.filter((t): t is string => typeof t === 'string')
+      : [];
+    const messageEvents = types.filter((t) => t === 'MessageEvent').length;
+    return messageEvents >= 2; // user + assistant
+  }, 60000);
+
+  await pollUntil(async () => (await getMockRequestCount(mockBaseUrl)) > beforeRequests, 60000);
+  const afterFirstRequests = await getMockRequestCount(mockBaseUrl);
+
+  const sendSecond = await vscode.commands.executeCommand<WebviewActionResult>('openhands._webviewAction', {
+    action: 'sendMessage',
+    payload: { text: 'E2E: second message via remote agent-server.' }
+  });
+  if (!sendSecond?.sent) {
+    throw new Error(`sendMessage action was not sent: ${JSON.stringify(sendSecond)}`);
+  }
+
+  await pollUntil(async () => {
+    const rendered = await vscode.commands.executeCommand<RenderedEventsInfo>('openhands._queryRenderedEvents');
+    const types = Array.isArray(rendered?.eventTypes)
+      ? rendered.eventTypes.filter((t): t is string => typeof t === 'string')
+      : [];
+    const messageEvents = types.filter((t) => t === 'MessageEvent').length;
+    return messageEvents >= 4; // 2 user + 2 assistant
+  }, 60000);
+
+  await pollUntil(async () => (await getMockRequestCount(mockBaseUrl)) > afterFirstRequests, 60000);
+}

--- a/tests/e2e/suite/index.ts
+++ b/tests/e2e/suite/index.ts
@@ -50,6 +50,21 @@ export async function run(): Promise<void> {
     return runAgentServerRemoteTest();
   }
 
+  if (testName === 'agentServerRemoteMessaging') {
+    const { run: runAgentServerRemoteMessagingTest } = await import('./agentServerRemoteMessaging');
+    return runAgentServerRemoteMessagingTest();
+  }
+
+  if (testName === 'agentServerRemoteErrorHandling') {
+    const { run: runAgentServerRemoteErrorHandlingTest } = await import('./agentServerRemoteErrorHandling');
+    return runAgentServerRemoteErrorHandlingTest();
+  }
+
+  if (testName === 'agentServerRemoteHistory') {
+    const { run: runAgentServerRemoteHistoryTest } = await import('./agentServerRemoteHistory');
+    return runAgentServerRemoteHistoryTest();
+  }
+
   if (testName === 'terminalLog') {
     const { run: runTerminalLogTest } = await import('./terminalLog');
     return runTerminalLogTest();

--- a/tests/e2e/suite/mockLlmServer.ts
+++ b/tests/e2e/suite/mockLlmServer.ts
@@ -73,15 +73,30 @@ function sendOpenAiChatCompletionsSse(res: http.ServerResponse, text: string): v
     'Cache-Control': 'no-cache',
     Connection: 'keep-alive',
   });
-  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: [{ type: 'text', text }] } }] })}\n`);
+  res.write(`data: ${JSON.stringify({ choices: [{ delta: { content: text } }] })}\n\n`);
   res.write(
     `data: ${JSON.stringify({
       choices: [{ delta: {}, finish_reason: 'stop' }],
       usage: { prompt_tokens: 1, completion_tokens: 1, prompt_tokens_details: { cached_tokens: 0 } },
-    })}\n`,
+    })}\n\n`,
   );
-  res.write('data: [DONE]\n');
+  res.write('data: [DONE]\n\n');
   res.end();
+}
+
+function sendOpenAiChatCompletionsJson(res: http.ServerResponse, text: string): void {
+  const payload = {
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: text },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2, prompt_tokens_details: { cached_tokens: 0 } },
+  };
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
 }
 
 function sendAnthropicMessagesSse(res: http.ServerResponse, text: string): void {
@@ -248,7 +263,12 @@ export async function startMockLlmServer(options?: { scripts?: MockLlmScript[] }
       }
 
       if (normalizedPath === '/chat/completions') {
-        sendOpenAiChatCompletionsSse(res, 'OK (chat_completions)');
+        const shouldStream = Boolean((json as { stream?: unknown } | undefined)?.stream);
+        if (shouldStream) {
+          sendOpenAiChatCompletionsSse(res, 'OK (chat_completions)');
+        } else {
+          sendOpenAiChatCompletionsJson(res, 'OK (chat_completions)');
+        }
         return;
       }
 


### PR DESCRIPTION
### Bead
oh-tab-ztb: Expand agent-server E2E test coverage
Status: open
Priority: P2
Type: task
Created: 2026-01-17 06:12
Updated: 2026-01-17 06:12

Description:
Currently only 1 E2E test (agentServerRemote.test.ts) runs against the real Python agent-server, while 25 other tests run only in local/mock mode.

Tests to port to agent-server E2E:
- messaging (basic send/receive)
- error handling
- history
- context limit retry / condensation
- terminal events
- confirmation flows
- diagnostics

Skip for now (agent-server doesn't support yet):
- LLM profiles (separate deferred bead)
- HAL/oracle tests (local-only feature)
- device-flow auth (cloud-specific)

### What
- Add agent-server-backed E2E suites for messaging, error handling, and “history-ish” coverage.
- Run all agent-server E2E tests via `npm run e2e:agent-server` (pattern: `agentServerRemote*.test.js`).
- Stabilize agent-server E2E by isolating server state dirs and avoiding tmux terminals.
- Cleanup per-run agent-server state dirs after each suite to avoid tmp bloat.

### Testing
- `npm run lint`
- `npm run typecheck`
- `E2E_AGENT_SERVER=1 npm run e2e:agent-server`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive E2E suites for remote agent-server messaging, history, and error-handling with startup retries, health checks, port selection, log tailing, and per-test isolated state and cleanup.
* **Mock & Tools**
  * Enhanced mock LLM to support both streaming SSE and JSON responses and improved diagnostic output.
* **Chores**
  * Broadened E2E test invocation to run multiple related agent-server tests via a glob pattern.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
