### PR TITLE
[oh-tab-dwq] Centralize env-info collection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,7 @@ import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
-import { collectOpenEditorPaths } from './shared/openEditors';
+import { collectEnvironmentInfo } from './shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import { computeWelcomeSecretStatus } from './shared/welcomeSecretStatus';
@@ -177,10 +177,7 @@ function syncActiveEditorSystemMessageSuffix(editor: vscode.TextEditor | undefin
 
 function buildEnvironmentInfoSuffix(): string | null {
   try {
-    const workspaceRoot = resolvePreferredWorkspaceRoot();
-    const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
-    const openEditorPaths = collectOpenEditorPaths({ activeEditorPath, max: 15 });
-    return formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths });
+    return formatEnvironmentInformation(collectEnvironmentInfo());
   } catch {
     return null;
   }

--- a/src/extension/explainSelectionCommand.ts
+++ b/src/extension/explainSelectionCommand.ts
@@ -1,8 +1,7 @@
 import * as vscode from 'vscode';
 import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import { formatEnvironmentInformation } from '../shared/environmentInformation';
-import { collectOpenEditorPaths } from '../shared/openEditors';
-import { getEffectiveWorkspaceRoot } from '../shared/workspaceRoot';
+import { collectEnvironmentInfo } from '../shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from '../shared/uri';
 
 export function registerExplainSelectionCommand(options: {
@@ -65,10 +64,7 @@ export function registerExplainSelectionCommand(options: {
 
     let finalPrompt = prompt;
     if (getConversationMode() === 'local') {
-      const workspaceRoot = getEffectiveWorkspaceRoot();
-      const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
-      const openEditorPaths = collectOpenEditorPaths({ activeEditorPath, max: 15 });
-      finalPrompt += `\n\n${formatEnvironmentInformation({ workspaceRoot, activeEditorPath, openEditorPaths })}`;
+      finalPrompt += `\n\n${formatEnvironmentInformation(collectEnvironmentInfo())}`;
     }
 
     await conversation.sendUserMessage(finalPrompt);

--- a/src/shared/__tests__/collectEnvironmentInfo.test.ts
+++ b/src/shared/__tests__/collectEnvironmentInfo.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { collectEnvironmentInfo } from '../collectEnvironmentInfo';
+
+describe('collectEnvironmentInfo', () => {
+  beforeEach(() => {
+    (vscode as any).__resetMocks?.();
+  });
+
+  it('collects workspaceRoot, active editor path, and open editor paths', () => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }, { uri: { fsPath: '/test/workspace-b' } }];
+    (vscode.workspace as any).getWorkspaceFolder = vi.fn((uri: { fsPath: string }) => {
+      if (uri.fsPath.startsWith('/test/workspace-b/')) return { uri: { fsPath: '/test/workspace-b' } };
+      if (uri.fsPath.startsWith('/test/workspace-a/')) return { uri: { fsPath: '/test/workspace-a' } };
+      return undefined;
+    });
+
+    (vscode.window as any).activeTextEditor = {
+      document: { uri: { scheme: 'file', fsPath: '/test/workspace-b/src/a.ts' } },
+    };
+    (vscode.window as any).visibleTextEditors = [
+      { document: { uri: { scheme: 'file', fsPath: '/test/workspace-b/src/a.ts' } } },
+      { document: { uri: { scheme: 'file', fsPath: '/test/workspace-b/src/b.ts' } } },
+    ];
+
+    expect(collectEnvironmentInfo()).toEqual({
+      workspaceRoot: '/test/workspace-b',
+      activeEditorPath: '/test/workspace-b/src/a.ts',
+      openEditorPaths: ['/test/workspace-b/src/b.ts'],
+    });
+  });
+
+  it('treats untitled active editor as no active path', () => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }];
+    (vscode.workspace as any).getWorkspaceFolder = vi.fn(() => undefined);
+    (vscode.window as any).activeTextEditor = {
+      document: { uri: { scheme: 'untitled', fsPath: '/tmp/Untitled-1' } },
+    };
+    (vscode.window as any).visibleTextEditors = [
+      { document: { uri: { scheme: 'file', fsPath: '/test/workspace-a/src/b.ts' } } },
+    ];
+
+    expect(collectEnvironmentInfo()).toEqual({
+      workspaceRoot: '/test/workspace-a',
+      activeEditorPath: null,
+      openEditorPaths: ['/test/workspace-a/src/b.ts'],
+    });
+  });
+
+  it('treats vscode-remote active editor as file-backed', () => {
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace-a' } }];
+    (vscode.workspace as any).getWorkspaceFolder = vi.fn((uri: { fsPath: string }) => {
+      if (uri.fsPath.startsWith('/test/workspace-a/')) return { uri: { fsPath: '/test/workspace-a' } };
+      return undefined;
+    });
+
+    (vscode.window as any).activeTextEditor = {
+      document: { uri: { scheme: 'vscode-remote', fsPath: '/test/workspace-a/src/remote.ts' } },
+    };
+    (vscode.window as any).visibleTextEditors = [
+      { document: { uri: { scheme: 'vscode-remote', fsPath: '/test/workspace-a/src/remote.ts' } } },
+      { document: { uri: { scheme: 'file', fsPath: '/test/workspace-a/src/other.ts' } } },
+    ];
+
+    expect(collectEnvironmentInfo()).toEqual({
+      workspaceRoot: '/test/workspace-a',
+      activeEditorPath: '/test/workspace-a/src/remote.ts',
+      openEditorPaths: ['/test/workspace-a/src/other.ts'],
+    });
+  });
+});
+

--- a/src/shared/__tests__/collectEnvironmentInfo.test.ts
+++ b/src/shared/__tests__/collectEnvironmentInfo.test.ts
@@ -68,5 +68,16 @@ describe('collectEnvironmentInfo', () => {
       openEditorPaths: ['/test/workspace-a/src/other.ts'],
     });
   });
-});
 
+  it('handles no workspace root and no active editor', () => {
+    (vscode.workspace as any).workspaceFolders = [];
+    (vscode.window as any).activeTextEditor = undefined;
+    (vscode.window as any).visibleTextEditors = [];
+
+    expect(collectEnvironmentInfo()).toEqual({
+      workspaceRoot: undefined,
+      activeEditorPath: null,
+      openEditorPaths: [],
+    });
+  });
+});

--- a/src/shared/__tests__/collectEnvironmentInfo.test.ts
+++ b/src/shared/__tests__/collectEnvironmentInfo.test.ts
@@ -80,4 +80,16 @@ describe('collectEnvironmentInfo', () => {
       openEditorPaths: [],
     });
   });
+
+  it('handles workspaceFolders being undefined', () => {
+    (vscode.workspace as any).workspaceFolders = undefined;
+    (vscode.window as any).activeTextEditor = undefined;
+    (vscode.window as any).visibleTextEditors = [];
+
+    expect(collectEnvironmentInfo()).toEqual({
+      workspaceRoot: undefined,
+      activeEditorPath: null,
+      openEditorPaths: [],
+    });
+  });
 });

--- a/src/shared/collectEnvironmentInfo.ts
+++ b/src/shared/collectEnvironmentInfo.ts
@@ -1,0 +1,19 @@
+import * as vscode from 'vscode';
+import { collectOpenEditorPaths } from './openEditors';
+import { getFileBackedFsPath } from './uri';
+import { resolvePreferredWorkspaceRoot } from './workspaceRoot';
+
+export type CollectedEnvironmentInfo = {
+  workspaceRoot?: string;
+  activeEditorPath: string | null;
+  openEditorPaths: string[];
+};
+
+export function collectEnvironmentInfo(params?: { maxOpenEditorPaths?: number }): CollectedEnvironmentInfo {
+  const workspaceRoot = resolvePreferredWorkspaceRoot();
+  const activeEditorPath = getFileBackedFsPath(vscode.window.activeTextEditor?.document?.uri) ?? null;
+  const openEditorPaths = collectOpenEditorPaths({ activeEditorPath, max: params?.maxOpenEditorPaths ?? 15 });
+
+  return { workspaceRoot, activeEditorPath, openEditorPaths };
+}
+


### PR DESCRIPTION
### Bead
oh-tab-dwq: (tech debt) Centralize environment info collection (workspaceRoot + file-backed URIs)
Status: open
Priority: P3
Type: chore
Created: 2026-01-15 06:49
Updated: 2026-01-15 06:49

Description:
Problem
- Env-info collection (workspaceRoot + active/open editors) is reimplemented in multiple places with inconsistent rules (workspaceFolders[0], scheme===file only, etc.).
- Multi-root + VS Code Remote require consistent workspaceRoot and file-backed URI logic.

Goal
- Add a shared helper that collects environment info inputs deterministically (workspaceRoot, activeEditorPath, openEditorPaths) using the agreed workspaceRoot strategy and file-backed URI helper.

Proposed approach
- Add `src/shared/collectEnvironmentInfo.ts` exporting something like `collectEnvironmentInfo()` that:
  - uses the fixed workspaceRoot resolver (per oh-tab-exx)
  - uses `getFileBackedFsPath(uri)` (per oh-tab-jqs) to gather active + visible editors
- Update callsites that currently duplicate this logic:
  - `src/extension.ts` (buildEnvironmentInfoSuffix)
  - `src/extension/explainSelectionCommand.ts`
  - `src/webview/host/createWebviewMessageHandler.ts` (send)

Acceptance
- One shared collector used by all callsites.
- Unit tests cover multi-root-ish cases (active editor within workspace vs outside, file vs vscode-remote vs untitled).
- No behavior regressions; existing tests remain green.

Acceptance Criteria:
- Duplicated env-info collection code removed from callsites.
- WorkspaceRoot + file-backed URI rules are consistent.
- Unit tests added for the collector.
- Existing unit/e2e remain green.

Labels: [env-info tech-debt vscode workspace]

Depends on (3):
  → oh-tab-exx: Fix workspaceRoot resolution to follow active editor (remove global cache) [P2]
  → oh-tab-jqs: (tech debt) VS Code: centralize file-backed URI detection (file vs vscode-remote) [P3]
  → oh-tab-usi: Env info userMessageSuffix is stale after active editor changes [P3]

### What
- Add `src/shared/collectEnvironmentInfo.ts` to centralize env-info inputs (workspace root, active editor path, open editors).
- Use the shared collector in `buildEnvironmentInfoSuffix()` and the local-mode explain-selection flow.

### Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a unified environment-info collector API for the extension.

* **Refactor**
  * Consolidated environment information gathering to use the new unified collector across commands.

* **Tests**
  * Added comprehensive unit tests covering typical workspaces, untitled editors, remote sessions, and absent-workspace scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->