### PR TITLE
[oh-tab-8c6] Default to https for non-local server URLs

### DIFF
--- a/src/shared/__tests__/serverUrls.test.ts
+++ b/src/shared/__tests__/serverUrls.test.ts
@@ -25,6 +25,8 @@ describe('server URL normalization', () => {
     expect(normalizeServerUrl('localhost')).toEqual({ ok: true, url: 'http://localhost' });
     expect(normalizeServerUrl('localhost:3000')).toEqual({ ok: true, url: 'http://localhost:3000' });
     expect(normalizeServerUrl('127.0.0.1:3000')).toEqual({ ok: true, url: 'http://127.0.0.1:3000' });
+    expect(normalizeServerUrl('::1')).toEqual({ ok: true, url: 'http://[::1]' });
+    expect(normalizeServerUrl('::1:3000')).toEqual({ ok: true, url: 'http://[::1]:3000' });
     expect(normalizeServerUrl('[::1]:3000')).toEqual({ ok: true, url: 'http://[::1]:3000' });
   });
 

--- a/src/shared/__tests__/serverUrls.test.ts
+++ b/src/shared/__tests__/serverUrls.test.ts
@@ -17,10 +17,19 @@ describe('server URL normalization', () => {
     expect(normalizeServerUrl('wss://').ok).toBe(false);
   });
 
-  it('preserves existing http/https normalization behavior', () => {
-    expect(normalizeServerUrl('example.com')).toEqual({ ok: true, url: 'http://example.com' });
+  it('defaults to https:// for non-local hostnames without a scheme', () => {
+    expect(normalizeServerUrl('example.com')).toEqual({ ok: true, url: 'https://example.com' });
+  });
+
+  it('defaults to http:// for local hostnames without a scheme', () => {
+    expect(normalizeServerUrl('localhost')).toEqual({ ok: true, url: 'http://localhost' });
+    expect(normalizeServerUrl('localhost:3000')).toEqual({ ok: true, url: 'http://localhost:3000' });
+    expect(normalizeServerUrl('127.0.0.1:3000')).toEqual({ ok: true, url: 'http://127.0.0.1:3000' });
+    expect(normalizeServerUrl('[::1]:3000')).toEqual({ ok: true, url: 'http://[::1]:3000' });
+  });
+
+  it('preserves existing http/https normalization behavior when the scheme is provided', () => {
     expect(normalizeServerUrl('http:example.com')).toEqual({ ok: true, url: 'http://example.com' });
     expect(normalizeServerUrl('https:example.com')).toEqual({ ok: true, url: 'https://example.com' });
   });
 });
-

--- a/src/shared/serverUrls.ts
+++ b/src/shared/serverUrls.ts
@@ -11,15 +11,27 @@ export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
   }
 
   const hasLocalHostnamePrefix =
-    /^localhost([/:]|$)/i.test(trimmed) ||
-    /^127\.0\.0\.1([/:]|$)/.test(trimmed) ||
-    /^(?:\[::1\]|::1)([/:]|$)/.test(trimmed);
+    /^localhost([/:?#]|$)/i.test(trimmed) ||
+    /^127\.0\.0\.1([/:?#]|$)/.test(trimmed) ||
+    /^(?:\[::1\]|::1)([/:?#]|$)/.test(trimmed);
 
   let candidate = trimmed;
   if (/^(https?|wss?):/i.test(candidate) && !/^(https?|wss?):\/\//i.test(candidate)) {
     candidate = candidate.replace(/^(https?|wss?):/i, (match) => `${match}//`);
   } else if (!HAS_EXPLICIT_SCHEME.test(candidate)) {
-    candidate = `${hasLocalHostnamePrefix ? 'http' : 'https'}://${candidate}`;
+    const scheme = hasLocalHostnamePrefix ? 'http' : 'https';
+    let host = candidate;
+
+    if (!host.startsWith('[') && /^::1($|[/?#])/.test(host)) {
+      host = host.replace(/^::1/, '[::1]');
+    } else if (!host.startsWith('[')) {
+      const match = host.match(/^::1:(\d+)($|[/?#])/);
+      if (match) {
+        host = host.replace(/^::1:(\d+)/, '[::1]:$1');
+      }
+    }
+
+    candidate = `${scheme}://${host}`;
   }
 
   if (/^ws:\/\//i.test(candidate)) {

--- a/src/shared/serverUrls.ts
+++ b/src/shared/serverUrls.ts
@@ -10,11 +10,16 @@ export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
     return { ok: false, error: 'Server URL is required' };
   }
 
+  const hasLocalHostnamePrefix =
+    /^localhost([/:]|$)/i.test(trimmed) ||
+    /^127\.0\.0\.1([/:]|$)/.test(trimmed) ||
+    /^(?:\[::1\]|::1)([/:]|$)/.test(trimmed);
+
   let candidate = trimmed;
   if (/^(https?|wss?):/i.test(candidate) && !/^(https?|wss?):\/\//i.test(candidate)) {
     candidate = candidate.replace(/^(https?|wss?):/i, (match) => `${match}//`);
   } else if (!HAS_EXPLICIT_SCHEME.test(candidate)) {
-    candidate = `http://${candidate}`;
+    candidate = `${hasLocalHostnamePrefix ? 'http' : 'https'}://${candidate}`;
   }
 
   if (/^ws:\/\//i.test(candidate)) {


### PR DESCRIPTION
Summary\n- Default missing scheme to https:// for non-local hosts; keep http:// for localhost/loopback.\n- Update unit tests for new defaulting behavior.\n\nTests\n- npm run typecheck\n- npm run lint\n- npm test\n\n### Bead\n\n
oh-tab-8c6: Security: avoid implicit http:// for serverUrl normalization
Status: open
Priority: P1
Type: bug
Created: 2026-01-17 17:55
Updated: 2026-01-17 17:55

Description:
Problem
- normalizeServerUrl() currently defaults to http:// when the user enters a host without an explicit scheme (e.g. app.all-hands.dev -> http://app.all-hands.dev).
- This can lead to sending session API keys / provider tokens over cleartext HTTP if the server supports it or if the user intended HTTPS but omitted the scheme.

Audit context
- /audit (oh-tab-0h9) flagged this as a high-risk network leak risk.

Acceptance criteria
- When the user provides no explicit scheme, do not silently default to cleartext HTTP for non-local hosts.
- Preferred behavior: default to https:// unless hostname is localhost / 127.0.0.1 / ::1 (or prompt user explicitly).
- Update unit tests in src/shared/__tests__/serverUrls.test.ts to cover the new behavior and keep existing ws/wss normalization behavior.
- Ensure callsites that display/validate server URLs behave correctly (server selector, tools list fetch, auth commands).

Acceptance Criteria:
- No implicit http:// normalization for non-local hosts
- Tests updated/added for server URL normalization
- No regressions for localhost/dev http workflows

Labels: [audit network security]\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default URL scheme now defaults to HTTPS for remote hostnames and HTTP for local development hosts.
  * Improved handling and normalization of IPv6 localhost addresses and ports to ensure consistent URL parsing.
  * Preserved existing behavior when an explicit URL scheme is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->