### PR TITLE
[oh-tab-h3g] Remove session_api_key from RemoteConversation WS URL

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -18,12 +18,14 @@ class MockWS {
   static CLOSED = 3;
 
   url: string;
+  options?: unknown;
   handlers: Record<string, Handler[]> = {};
   readyState = MockWS.CONNECTING;
   sent: string[] = [];
 
-  constructor(url: string) {
+  constructor(url: string, options?: unknown) {
     this.url = url;
+    this.options = options;
     wsInstances.push(this);
   }
 
@@ -85,6 +87,38 @@ describe('RemoteConversation', () => {
     vi.clearAllMocks();
     wsInstances = [];
     (globalThis as any).fetch = undefined as any;
+  });
+
+  it('authenticates WebSocket via headers only (no session_api_key query param)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(url).toContain('/events/search');
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ items: [], next_page_id: null }),
+        text: async () => '',
+      } as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key' } },
+    });
+
+    await conversation.restoreConversation('abc');
+
+    const ws = getEventWS();
+    expect(ws.url).toContain('/sockets/events/abc?');
+    expect(ws.url).toContain('resend_all=true');
+    expect(ws.url).not.toContain('session_api_key');
+    expect(ws.url).not.toContain('session-key');
+
+    const headers = (ws.options as any)?.headers;
+    expect(headers?.['X-Session-API-Key']).toBe('session-key');
+    expect(headers?.Authorization).toBe('Bearer session-key');
+    expect(headers?.['Content-Type']).toBeUndefined();
   });
 
   it('times out if the WebSocket never connects', async () => {

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -781,9 +781,7 @@ export class RemoteConversation extends EventEmitter {
   private connect() {
     if (!this.conversationId) return;
     const base = this.serverUrl.replace(/\/$/, '');
-    const sessionKey = this.settings?.secrets.sessionApiKey || '';
     const params = new URLSearchParams();
-    if (sessionKey) params.set('session_api_key', sessionKey);
     params.set('resend_all', 'true');
     const qs = params.toString();
     const wsUrl = `${base.replace(/^http/, 'ws')}/sockets/events/${this.conversationId}?${qs}`;


### PR DESCRIPTION
Summary\n- Stop including session API keys in WebSocket URLs; authenticate via headers only.\n- Add test to ensure no secret appears in the WS URL and headers carry auth.\n\nTests\n- npm run typecheck\n- npm run lint\n- npm test\n\n### Bead\n\n
oh-tab-h3g: Security: remove session_api_key from RemoteConversation WebSocket URL
Status: open
Priority: P1
Type: bug
Created: 2026-01-17 17:53
Updated: 2026-01-17 17:53

Description:
Finding (audit): packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts currently includes the session API key in the WebSocket URL query string via session_api_key. This leaks a secret into URLs (logs/proxies/etc.) and violates our security posture.

Goal: never include session keys/tokens in URLs. Use headers only (X-Session-API-Key and Authorization: Bearer ... are already sent in the WS client options).

Implementation notes:
- Remove the session_api_key query param entirely.
- Ensure agent-server websocket auth still works using headers-only.
- Add/adjust tests to assert no secrets are present in constructed URLs.

Acceptance Criteria:
- RemoteConversation.connect() no longer includes session_api_key (or any secret) in the WebSocket URL.
- Remote websocket connection authenticates via headers only.
- Unit test coverage asserts the constructed WS URL does not include session_api_key.
- npm test remains green.

Labels: [auth security websocket]\n