### PR TITLE
[oh-tab-dkj] Harden conversation store permissions

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -83,6 +83,29 @@ describe('FileStore', () => {
       temperature: 0.25,
     });
   });
+
+  it('creates directories and files with restrictive permissions', () => {
+    if (process.platform === 'win32') return;
+
+    const dir = makeTempDir('conversation-perms-');
+    const conversationId = 'conv-perms';
+    const persistence = new FileStore({ rootDir: dir, conversationId });
+
+    persistence.appendEvent({
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: 'hi' }] },
+    } as Event);
+
+    persistence.writeState({ status: 'idle', iteration: 0, values: {} } as any);
+    persistence.writeLlmConfig?.({ profileId: 'test-profile' });
+
+    const conversationDir = path.join(dir, conversationId);
+    expect(fs.statSync(conversationDir).mode & 0o777).toBe(0o700);
+    expect(fs.statSync(path.join(conversationDir, 'events.jsonl')).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.join(conversationDir, 'state.json')).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.join(conversationDir, 'llm.json')).mode & 0o777).toBe(0o600);
+  });
 });
 
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
@@ -39,6 +39,15 @@ const OPENAI_API_MODES: readonly OpenAIChatApi[] = ['chat_completions', 'respons
 const REASONING_SUMMARIES: readonly ReasoningSummary[] = ['auto', 'concise', 'detailed'];
 const REASONING_EFFORTS: readonly PersistedLlmConfig['reasoningEffort'][] = ['low', 'medium', 'high', 'none'];
 
+const bestEffortChmodSync = (targetPath: string, mode: number) => {
+  if (process.platform === 'win32') return;
+  try {
+    fs.chmodSync(targetPath, mode);
+  } catch (error) {
+    void error;
+  }
+};
+
 const toOptionalProvider = (value: unknown): LLMProvider | undefined =>
   typeof value === 'string' && PROVIDERS.includes(value as LLMProvider) ? (value as LLMProvider) : undefined;
 
@@ -121,6 +130,7 @@ export class FileStore implements ConversationPersistence {
   private readonly eventsFile: string;
   private readonly stateFile: string;
   private readonly llmFile: string;
+  private readonly openhandsRootDir?: string;
 
   constructor(options: FileStoreOptions) {
     this.rootDir = options.rootDir ?? path.join(os.homedir(), '.openhands', 'conversations');
@@ -129,11 +139,26 @@ export class FileStore implements ConversationPersistence {
     this.eventsFile = path.join(this.conversationDir, 'events.jsonl');
     this.stateFile = path.join(this.conversationDir, 'state.json');
     this.llmFile = path.join(this.conversationDir, 'llm.json');
-    fs.mkdirSync(this.conversationDir, { recursive: true });
+    this.openhandsRootDir = (() => {
+      try {
+        const candidate = path.join(os.homedir(), '.openhands');
+        const resolvedCandidate = path.resolve(candidate);
+        const resolvedRoot = path.resolve(this.rootDir);
+        return resolvedRoot === resolvedCandidate || resolvedRoot.startsWith(`${resolvedCandidate}${path.sep}`) ? candidate : undefined;
+      } catch (error) {
+        void error;
+        return undefined;
+      }
+    })();
+    fs.mkdirSync(this.conversationDir, { recursive: true, mode: 0o700 });
+    if (this.openhandsRootDir) bestEffortChmodSync(this.openhandsRootDir, 0o700);
+    bestEffortChmodSync(this.rootDir, 0o700);
+    bestEffortChmodSync(this.conversationDir, 0o700);
   }
 
   appendEvent(event: Event): void {
-    fs.appendFileSync(this.eventsFile, `${JSON.stringify(event)}\n`, 'utf8');
+    fs.appendFileSync(this.eventsFile, `${JSON.stringify(event)}\n`, { encoding: 'utf8', mode: 0o600 });
+    bestEffortChmodSync(this.eventsFile, 0o600);
   }
 
   readEvents(): Event[] {
@@ -154,7 +179,8 @@ export class FileStore implements ConversationPersistence {
   }
 
   writeState(state: AgentState): void {
-    fs.writeFileSync(this.stateFile, JSON.stringify(state), 'utf8');
+    fs.writeFileSync(this.stateFile, JSON.stringify(state), { encoding: 'utf8', mode: 0o600 });
+    bestEffortChmodSync(this.stateFile, 0o600);
   }
 
   readState(): AgentState | undefined {
@@ -171,6 +197,7 @@ export class FileStore implements ConversationPersistence {
   writeLlmConfig(config: PersistedLlmConfig): void {
     try {
       fs.writeFileSync(this.llmFile, `${JSON.stringify(config)}\n`, { encoding: 'utf8', mode: 0o600 });
+      bestEffortChmodSync(this.llmFile, 0o600);
     } catch (error) {
       console.error(`[FileStore] Failed to write llm config: ${String(error)}`);
     }

--- a/src/extension/conversationStoreRoot.ts
+++ b/src/extension/conversationStoreRoot.ts
@@ -20,10 +20,32 @@ function resolveConfiguredPath(p: string): string {
   return path.resolve(os.homedir(), raw);
 }
 
+async function bestEffortChmod(targetPath: string, mode: number): Promise<void> {
+  if (process.platform === 'win32') return;
+  try {
+    await fs.chmod(targetPath, mode);
+  } catch (err) {
+    void err;
+  }
+}
+
 async function ensureWritableDirectory(dir: string): Promise<void> {
-  await fs.mkdir(dir, { recursive: true });
+  await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+
+  try {
+    const openhandsRoot = path.join(os.homedir(), '.openhands');
+    const resolvedRoot = path.resolve(openhandsRoot);
+    const resolvedDir = path.resolve(dir);
+    if (resolvedDir === resolvedRoot || resolvedDir.startsWith(`${resolvedRoot}${path.sep}`)) {
+      await bestEffortChmod(openhandsRoot, 0o700);
+    }
+  } catch (err) {
+    void err;
+  }
+
+  await bestEffortChmod(dir, 0o700);
   const probe = path.join(dir, `.openhands-write-probe-${process.pid}-${Date.now()}`);
-  await fs.writeFile(probe, 'ok', 'utf8');
+  await fs.writeFile(probe, 'ok', { encoding: 'utf8', mode: 0o600 });
   await fs.unlink(probe);
 }
 

--- a/src/webview/host/__tests__/conversationHistory.test.ts
+++ b/src/webview/host/__tests__/conversationHistory.test.ts
@@ -84,6 +84,12 @@ describe('conversationHistory', () => {
     await persistConversationTitle(tmpRoot, id, 'New title');
     const updated = await getConversationHistoryList(tmpRoot);
     expect(updated.find((x) => x.id === id)?.title).toBe('New title');
+
+    if (process.platform !== 'win32') {
+      const dirStat = await fs.stat(dir);
+      expect(dirStat.mode & 0o777).toBe(0o700);
+      const baseStat = await fs.stat(path.join(dir, 'conversation.json'));
+      expect(baseStat.mode & 0o777).toBe(0o600);
+    }
   });
 });
-

--- a/src/webview/host/conversationHistory.ts
+++ b/src/webview/host/conversationHistory.ts
@@ -19,6 +19,15 @@ const CONVERSATION_BASE_JSON = 'conversation.json';
 const isRecord = (candidate: unknown): candidate is Record<string, unknown> =>
   !!candidate && typeof candidate === 'object' && !Array.isArray(candidate);
 
+async function bestEffortChmod(targetPath: string, mode: number): Promise<void> {
+  if (process.platform === 'win32') return;
+  try {
+    await fs.chmod(targetPath, mode);
+  } catch (err) {
+    void err;
+  }
+}
+
 const toNonNegativeInt = (value: unknown): number | null => {
   const num = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
   if (!Number.isFinite(num)) return null;
@@ -93,6 +102,13 @@ export async function persistConversationTitle(
   const dir = path.join(conversationStoreRoot, conversationId);
   const filePath = path.join(dir, CONVERSATION_BASE_JSON);
 
+  try {
+    await fs.mkdir(dir, { recursive: true, mode: 0o700 });
+    await bestEffortChmod(dir, 0o700);
+  } catch (err) {
+    void err;
+  }
+
   let next: Record<string, unknown> = { title: trimmed };
   try {
     const content = await fs.readFile(filePath, 'utf8');
@@ -105,7 +121,8 @@ export async function persistConversationTitle(
   }
 
   try {
-    await fs.writeFile(filePath, JSON.stringify(next), 'utf8');
+    await fs.writeFile(filePath, JSON.stringify(next), { encoding: 'utf8', mode: 0o600 });
+    await bestEffortChmod(filePath, 0o600);
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     outputChannel?.appendLine(`[history] Failed to persist title for ${conversationId}: ${reason}`);


### PR DESCRIPTION
Summary\n- Force restrictive permissions for conversation persistence dirs/files (best-effort; skipped on win32).\n- Add unit coverage for FileStore + conversation.json persistence permissions.\n\nTests\n- npm run typecheck\n- npm run lint\n- npm test\n\n### Bead\n\n
oh-tab-dkj: Security: restrict permissions for ~/.openhands conversation store files
Status: open
Priority: P1
Type: bug
Created: 2026-01-17 17:55
Updated: 2026-01-17 17:55

Description:
Problem
- Conversation persistence under ~/.openhands (and related conversation store roots) writes events/state/title JSON using default filesystem permissions.
- On some multi-user systems, defaults (e.g. 0755 dirs / 0644 files) can allow other local users to read sensitive conversation content (user prompts, tool args, file paths).

Audit context
- /audit (oh-tab-0h9) flagged persistence/permission hardening as high-risk.

Scope candidates
- packages/agent-sdk-ts/src/sdk/runtime/persistence.ts (FileStore: conversationDir + events.jsonl/state.json/llm.json)
- src/extension/conversationStoreRoot.ts (directory creation)
- src/webview/host/conversationHistory.ts (conversation.json title write)

Acceptance criteria
- Ensure newly-created ~/.openhands directories used for persistence are created with 0700 (best-effort on platforms that support chmod).
- Ensure persisted conversation files (events/state/conversation base JSON) are created/forced to 0600.
- Add unit coverage (where feasible) to verify permission-setting code paths are invoked (skip or best-effort on Windows).
- No behavior regressions for existing stores; best-effort chmod on existing files is acceptable.

Acceptance Criteria:
- New persistence dirs default to 0700
- New persistence files default to 0600
- Tests added/updated for permission hardening
- No regressions on Windows/CI

Labels: [audit persistence security]\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened file and directory permissions for stored conversation data and configuration files on non-Windows systems.
  * Conversation directories and related data files now restrict access to the owner only, improving data protection and confidentiality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->