### PR TITLE
[oh-tab-u6k] Normalize explicit-scheme bare ::1

### DIFF
--- a/src/shared/__tests__/serverUrls.test.ts
+++ b/src/shared/__tests__/serverUrls.test.ts
@@ -5,11 +5,15 @@ describe('server URL normalization', () => {
   it('accepts ws:// inputs by normalizing to http://', () => {
     expect(normalizeServerUrl('ws://example.com')).toEqual({ ok: true, url: 'http://example.com' });
     expect(normalizeServerUrl('ws://example.com/')).toEqual({ ok: true, url: 'http://example.com' });
+    expect(normalizeServerUrl('ws://::1')).toEqual({ ok: true, url: 'http://[::1]' });
+    expect(normalizeServerUrl('ws://::1:3000')).toEqual({ ok: true, url: 'http://[::1]:3000' });
   });
 
   it('accepts wss:// inputs by normalizing to https://', () => {
     expect(normalizeServerUrl('wss://example.com')).toEqual({ ok: true, url: 'https://example.com' });
     expect(normalizeServerUrl('wss://example.com/')).toEqual({ ok: true, url: 'https://example.com' });
+    expect(normalizeServerUrl('wss://::1')).toEqual({ ok: true, url: 'https://[::1]' });
+    expect(normalizeServerUrl('wss://::1:3000')).toEqual({ ok: true, url: 'https://[::1]:3000' });
   });
 
   it('rejects invalid ws/wss hosts', () => {
@@ -33,5 +37,11 @@ describe('server URL normalization', () => {
   it('preserves existing http/https normalization behavior when the scheme is provided', () => {
     expect(normalizeServerUrl('http:example.com')).toEqual({ ok: true, url: 'http://example.com' });
     expect(normalizeServerUrl('https:example.com')).toEqual({ ok: true, url: 'https://example.com' });
+    expect(normalizeServerUrl('http://::1')).toEqual({ ok: true, url: 'http://[::1]' });
+    expect(normalizeServerUrl('http://::1:3000')).toEqual({ ok: true, url: 'http://[::1]:3000' });
+    expect(normalizeServerUrl('https://::1')).toEqual({ ok: true, url: 'https://[::1]' });
+    expect(normalizeServerUrl('https://::1:3000')).toEqual({ ok: true, url: 'https://[::1]:3000' });
+    expect(normalizeServerUrl('http://[::1]:3000')).toEqual({ ok: true, url: 'http://[::1]:3000' });
+    expect(normalizeServerUrl('https://[::1]:3000')).toEqual({ ok: true, url: 'https://[::1]:3000' });
   });
 });

--- a/src/shared/serverUrls.ts
+++ b/src/shared/serverUrls.ts
@@ -40,6 +40,8 @@ export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
     candidate = candidate.replace(/^wss:/i, 'https:');
   }
 
+  candidate = candidate.replace(/^(https?:\/\/)::1(?=[:/?#]|$)/i, '$1[::1]');
+
   let parsed: URL;
   try {
     parsed = new URL(candidate);

--- a/src/shared/serverUrls.ts
+++ b/src/shared/serverUrls.ts
@@ -40,7 +40,7 @@ export function normalizeServerUrl(raw: string): NormalizeServerUrlResult {
     candidate = candidate.replace(/^wss:/i, 'https:');
   }
 
-  candidate = candidate.replace(/^(https?:\/\/)::1(?=[:/?#]|$)/i, '$1[::1]');
+  candidate = candidate.replace(/^(https?:\/\/)([^/?#]*@)?::1(?=[:/?#]|$)/i, '$1$2[::1]');
 
   let parsed: URL;
   try {


### PR DESCRIPTION
Summary
- Accept explicit-scheme bare IPv6 loopback inputs (e.g. http://::1, ws://::1:3000) by rewriting to bracketed form before parsing.
- Add unit coverage for http/https/ws/wss + host-only + host:port.

Tests
- npx vitest run src/shared/__tests__/serverUrls.test.ts
- npm run typecheck
- npm run lint

### Bead

oh-tab-u6k: Fix normalizeServerUrl for explicit-scheme bare ::1
Status: closed
Priority: P2
Type: bug
Created: 2026-01-17T18:53:31.450283+01:00
Updated: 2026-01-17T19:06:51.499909+01:00
Closed: 2026-01-17T19:06:51.499909+01:00

Description:
Problem
- src/shared/serverUrls.ts normalizes bare IPv6 loopback (::1 and ::1:PORT) only when the input has no explicit scheme.
- Inputs like http://::1, https://::1, ws://::1, wss://::1 are invalid URL syntax (IPv6 literal must be bracketed) and currently fail validation/URL parsing.

Acceptance criteria
- normalizeServerUrl() accepts explicit-scheme inputs containing bare ::1 or ::1:PORT and rewrites them to bracketed form (e.g. http://[::1], https://[::1], ws://[::1], wss://[::1], and port-aware variants).
- Unit tests cover explicit schemes + bare IPv6 (http/https/ws/wss) for both host-only and host:port.
- Keep existing behavior for already-bracketed IPv6 unchanged.

Labels: [ipv6 url]