### PR TITLE
Update /audit AgentSkill for current security model

### DIFF
--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -248,7 +248,7 @@ These are **assistive** checks (expect false positives/negatives). The real audi
 > Safety rule: avoid printing raw matching lines (they may contain secrets). Prefer `file:line` only.
 
 - Find potential secret patterns in code (output paths + line numbers only):
-  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+" src packages | cut -d: -f1-2 | sort -u`
+  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]*" src packages | cut -d: -f1-2 | sort -u`
 
 - Find code paths that can write to disk:
   - `grep -RInE "\\.writeFile(Sync)?\\(|\\.appendFile(Sync)?\\(" src packages | cut -d: -f1-2 | sort -u`

--- a/.openhands/skills/audit/SKILL.md
+++ b/.openhands/skills/audit/SKILL.md
@@ -4,6 +4,9 @@ description: >
   AgentSkill: run a repo-specific security audit of the OpenHands-Tab VS Code extension with a focus on
   secret handling, webview/host boundaries, persistence, and logging redaction. Trigger with /audit.
 license: MIT
+metadata:
+  last_updated: "2026-01-17"
+  last_reviewed_commit: "1febfa8"
 triggers:
   - /audit
 ---
@@ -13,6 +16,10 @@ triggers:
 This is a **repeatable checklist** for an agent to run against *this repository*.
 
 When invoked (e.g. the user types `/audit`), follow the checklist below, inspect the referenced code, and then output a short audit report.
+
+> Repo-specific note: This repo supports AgentSkills-style `SKILL.md` directories, but also uses
+> additional OpenHands-specific frontmatter fields like `triggers`. Do not assume every AgentSkills
+> client will understand those extra fields.
 
 ## Output format (required)
 
@@ -26,6 +33,8 @@ Return a report with:
 
 **Never include real secret values** in the report (including partial tokens).
 
+Also: **do not paste raw grep output** that might contain secrets into the report. Prefer file paths + line numbers only.
+
 ---
 
 ## 1) Threat model (repo-specific)
@@ -34,8 +43,9 @@ Primary risks for this VS Code extension:
 
 - **Persistence leaks**: secrets written to disk (VS Code settings JSON, profile files, workspace/global state, logs, conversation stores)
 - **Logging leaks**: secrets exposed via OutputChannel, debug channels, error strings/stack traces, dev bridge logs, webview console
-- **Webview boundary leaks**: host sending secrets to webview (prohibited); user-typed secrets in webview must be sent to host immediately for SecretStorage only and cleared from UI; secrets persisted in webview state (`acquireVsCodeApi().setState`) or leaked via console
+- **Webview boundary leaks**: host sending secrets to webview (prohibited); user-typed secrets in webview must be sent to host immediately for SecretStorage only and cleared from UI; secrets persisted in webview state or leaked via console
 - **Network leaks**: secrets in URLs/query params, secrets sent to wrong host, secrets attached to redirected requests, non-HTTPS when not explicitly intended
+- **Webview surface issues**: XSS / unsafe link openers in the webview can turn “user typed secret” into a real credential leak
 
 ---
 
@@ -72,7 +82,7 @@ Primary risks for this VS Code extension:
 - Any settings written as “status indicators” are non-sensitive (boolean/marker only) and cannot be used to reconstruct the secret.
 
 **Fail examples**:
-- Writing `apiKey`, `token`, `Authorization` headers, or full provider configs into settings JSON.
+- Writing an API key, token, Authorization header, cookie, or full provider config into settings JSON.
 
 ### B. Confirm per-server session API keys are scoped to a specific server
 
@@ -81,14 +91,15 @@ Primary risks for this VS Code extension:
 - Files to inspect:
   - `src/auth/serverSessionApiKeys.ts`
   - `src/shared/serverUrls.ts` (normalization rules)
-  - `src/extension.ts` (migration / usage)
+  - `src/extension/secretCommands.ts` (set/migration behavior)
 
 **Pass criteria**:
 - The SecretStorage key name includes a stable identifier derived from the normalized server URL (e.g. a hash).
 - The normalized URL logic is understood and documented by the audit:
-  - This repo’s `normalizeServerUrl(...)` supports both `http:` and `https:` and may default to `http://` when no scheme is provided.
+  - `normalizeServerUrl(...)` supports both `http:` and `https:`
+  - when no scheme is provided, it defaults to **http for local** (`localhost`, `127.0.0.1`, `::1`) and **https for non-local**
 - Migration from any legacy/global key is conservative:
-  - Do not automatically re-bind a legacy key to an arbitrary configured server without explicit user intent.
+  - do not automatically re-bind a legacy key to an arbitrary configured server without explicit user intent
 
 **Fail examples**:
 - A single `openhands.sessionApiKey` applied to whichever server URL is currently configured.
@@ -108,11 +119,11 @@ Primary risks for this VS Code extension:
 **Pass criteria**:
 - There are **no host→webview messages** that include secret material (API keys, tokens, Authorization headers, cookies).
 - Webview does not persist secrets:
-  - no `acquireVsCodeApi().setState(...)` (or other persistence) storing `apiKey`, headers, or tokens
+  - no `acquireVsCodeApi().setState(...)` storing `apiKey`, headers, or tokens
 - On submit:
   - webview sends the key to the host once, host stores it in SecretStorage, and the webview clears local state promptly.
 - No logging on either side:
-  - webview: no `console.log` / error reporting that includes key material
+  - webview: no `console.*` printing request payloads that may contain secrets
   - host: no OutputChannel/dev logging of message payloads containing keys
 
 **Fail examples**:
@@ -121,11 +132,21 @@ Primary risks for this VS Code extension:
 
 ### D. Profile persistence: do not write secrets to disk by default
 
-Profiles can contain inline `apiKey` or `headers`, which are **high-risk** if persisted.
+In this repo, **LLM profiles are persisted to disk** under `~/.openhands/llm-profiles/*.json`.
+
+Secrets can appear in profiles in two ways:
+
+- `apiKeyRef.kind="inline"` (literal secret value) — **high risk**
+- `headers` (Authorization, x-api-key, etc.) — **high risk**
+
+Non-secret references are expected to use:
+
+- `apiKeyRef.kind="key"` (reference name resolved via SecretRegistry / SecretStorage / env)
 
 - Files to inspect:
   - Host store wrapper: `src/webview/host/llmProfilesStore.ts`
   - SDK store: `packages/agent-sdk-ts/src/sdk/llm/profiles.ts`
+  - Type definition: `packages/agent-sdk-ts/src/sdk/llm/types.ts` (`ApiKeyRef`)
 
 **Check**: profile save paths have a default mode that **excludes secrets**.
 
@@ -133,22 +154,26 @@ Profiles can contain inline `apiKey` or `headers`, which are **high-risk** if pe
 - A save option like `includeSecrets` exists and defaults to `false`.
 - When `includeSecrets=false`:
   - `headers` are removed by default.
-  - `apiKey` is removed by default **unless** it is a clearly-defined, non-secret reference format supported by this repo.
-    - **Important**: do *not* rely on a regex heuristic like `/^[A-Z0-9_]+$/` to guess “env var name”. Only preserve `apiKey` when it uses an explicit indirection syntax (whatever this repo defines), e.g. `${env:OPENAI_API_KEY}`.
+  - `apiKeyRef.kind="inline"` is removed by default.
+  - `apiKeyRef.kind="key"` is preserved (it is a reference name, not the secret value).
+- Host-side "load" paths do not send secrets to the webview:
+  - if profiles on disk contain inline secrets, host must still strip them before returning profile JSON to the webview.
 
 **Fail examples**:
-- Persisting literal API keys or Authorization headers into any profile JSON file by default.
-- Using heuristics (e.g. “keep it if it looks like an env var name”) instead of an explicit indirection format.
+- Persisting literal API keys or Authorization headers into profile JSON by default.
+- Host sending inline secrets/headers to the webview as part of `llmProfileLoadResponse`.
 
 ### E. Logging & error handling: assume redaction is imperfect
 
 **Rule**: the primary defense is **do not log secrets at all**. Redaction is a backstop.
 
+Also: **do not treat allowlists as a security boundary unless enforced in code**. In this repo, `allowed-tools` is parsed for AgentSkills parity but is not used to restrict tool execution.
+
 - Files to inspect:
   - Output channel masking: `src/extension/devBridgeLogger.ts` (`createMaskedOutputChannel`)
   - Debug JSON channel masking: `src/extension/debugJsonOutputChannel.ts`
-  - Generic safe logging: `src/shared/safeStringify.ts`
-  - Known-secret masking registry: `src/shared/maskSecrets.ts`
+  - Structured safe logging: `src/shared/safeStringify.ts`
+  - Secret-value masking: `src/shared/maskSecrets.ts`
 
 **Checks**:
 1. All extension-host logging surfaces run through masking utilities.
@@ -158,32 +183,61 @@ Profiles can contain inline `apiKey` or `headers`, which are **high-risk** if pe
    - no `console.*` printing request payloads that may contain secrets.
 
 **Audit technique**:
-- Search for unmasked loggers:
+- Search for risky logging sites:
   - `console.(log|warn|error)` in both `src/` and `src/webview-src/`
   - direct `outputChannel.append/appendLine/replace`
   - `JSON.stringify(...)` used in logs
-- When you find one, trace whether it flows through `maskSecretsInText(...)` or equivalent.
+- When you find one, trace whether it flows through `maskSecretsInText(...)` and/or `safeStringify(...)`.
 
 **Fail examples**:
 - Logging the full webview message payload of `llmProfileApiKeySetRequest`.
-- Throwing/printing errors that embed headers or config with inline `apiKey`.
+- Throwing/printing errors that embed headers or config with inline secrets.
 
 ### F. Network requests: keep secrets out of URLs and off the wrong host
 
 **Checks**:
 - No code constructs URLs containing secrets (`token=`, `api_key=`, `key=`, `authorization=`).
 - Secrets are sent via headers, not query params.
-- Ensure Authorization headers are only attached to the intended host:
-  - audit for redirect-following behavior and whether headers are preserved across redirects.
+- Ensure Authorization / session headers are only attached to the intended host:
+  - audit for redirect behavior and whether headers are preserved across redirects.
 
 **Repo-specific note**:
-- This repo supports `http:` server URLs (see `src/shared/serverUrls.ts`). If non-HTTPS is allowed, verify:
-  - it is explicit user intent (e.g. localhost/dev)
+- This repo supports `http:` server URLs (see `src/shared/serverUrls.ts`). Verify:
+  - non-HTTPS is only used by explicit user intent (e.g. localhost/dev)
   - secrets are not silently sent over `http://` due to scheme defaulting
 
 **Fail examples**:
 - `?token=...` in any URL.
 - Sending session API keys to a server URL that was inferred as `http://...` due to missing scheme.
+
+### G. Conversation persistence: do not leak secrets to disk
+
+Conversation stores are a persistence risk because they can contain:
+
+- user messages (which may contain secrets)
+- tool results / logs
+- LLM request/response payloads (which may include headers)
+
+- Files to inspect:
+  - `src/extension/conversationStoreRoot.ts`
+  - `src/webview/host/conversationHistory.ts`
+
+**Pass criteria**:
+- Directories created for conversation storage are restricted (e.g. `0700`) and files are restricted (e.g. `0600`) when the platform supports it.
+- No code explicitly writes SecretStorage values (API keys, session keys) into conversation files.
+
+### H. Webview surface hardening (CSP + link openers)
+
+Because secrets may exist transiently in webview JS memory, treat webview XSS and unsafe openers as **credential leak** vectors.
+
+- Files to inspect:
+  - CSP: `src/webview/getWebviewHtml.ts`
+  - Markdown link opener allowlist: `src/webview/host/handlers/openers.ts` (`handleOpenMarkdownLink`)
+  - Tests: `src/__tests__/openMarkdownLink.security.test.ts`
+
+**Pass criteria**:
+- Webview CSP is restrictive (no remote scripts; `default-src 'none'` pattern).
+- Link openers reject unsafe schemes (`javascript:`, `file://`) and block path traversal outside the workspace.
 
 ---
 
@@ -191,14 +245,16 @@ Profiles can contain inline `apiKey` or `headers`, which are **high-risk** if pe
 
 These are **assistive** checks (expect false positives/negatives). The real audit is code-path based.
 
-- Find potential secret patterns committed to code (add context):
-  - `grep -RInEC 2 "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+" src packages`
+> Safety rule: avoid printing raw matching lines (they may contain secrets). Prefer `file:line` only.
 
-- Find code paths that can write to disk (reduce noise):
-  - `grep -RInE "\\.writeFile(Sync)?\\(|\\.appendFile(Sync)?\\(" src packages`
+- Find potential secret patterns in code (output paths + line numbers only):
+  - `grep -RInE "sk-[A-Za-z0-9_-]{12,}|gh[pousr]_[A-Za-z0-9]{12,}|github_pat_[A-Za-z0-9_]{12,}|AIza[A-Za-z0-9_-]{12,}|(AKIA|ASIA)[A-Z0-9]{16}|eyJ[A-Za-z0-9_-]+\\.eyJ[A-Za-z0-9_-]+" src packages | cut -d: -f1-2 | sort -u`
+
+- Find code paths that can write to disk:
+  - `grep -RInE "\\.writeFile(Sync)?\\(|\\.appendFile(Sync)?\\(" src packages | cut -d: -f1-2 | sort -u`
 
 - Find obvious logging sites:
-  - `grep -RInE "console\\.(log|warn|error)" src packages src/webview-src`
+  - `grep -RInE "console\\.(log|warn|error)" src packages src/webview-src | cut -d: -f1-2 | sort -u`
 
 - Run tests:
   - `npm test`
@@ -210,45 +266,46 @@ These are **assistive** checks (expect false positives/negatives). The real audi
 These patterns are considered good practice in this repo; if present, explicitly list them under “Good practices already present”:
 
 - Secrets stored using **VS Code SecretStorage** (`context.secrets.*`) and never written to settings JSON.
-- Per-server session API keys keyed by a **hash of the server URL** to reduce accidental cross-server reuse.
+- Per-server session API keys keyed by a **hash of the normalized server URL** to reduce accidental cross-server reuse.
 - Centralized masking utilities (`maskSecretsInText`, `safeStringify`) used for every logging surface.
-- Profile persistence defaults to **not** saving inline `apiKey`/`headers`.
+- Profile persistence defaults to **not** saving inline secrets (`apiKeyRef.kind="inline"`) or `headers`.
+- Conversation persistence uses restrictive file permissions (best-effort) for conversation stores.
+- Webview CSP and opener allowlists reduce webview-based secret exfiltration risk.
 
 ---
 
 ## 6) Common pitfalls (flag if you see them)
 
 - Any secret value written to:
-  - `globalState`, `workspaceState`, `workspace.getConfiguration()`, or any JSON file under the repo
+  - `globalState`, `workspaceState`, `workspace.getConfiguration()`, or any JSON file
 - Any secret printed in logs or thrown in error messages without masking
 - Webview messages that echo secrets back to the UI or store them in persistent webview state
 - Tokens included in URLs, query strings, or file paths
-
+- Assuming a tool allowlist (`allowed-tools`) is enforced when it is not
 
 ---
 
 ## ATTENTION: FOOTGUNS
 
-This section documents **current reality (today)** in this repo: the name `apiKey` is used across multiple domains and does **not** always mean the same thing.
+This section documents **current reality (today)** in this repo: the name `apiKey` appears in multiple domains and does **not** always mean the same thing.
 
-This is a source of audit mistakes and security regressions. We should **improve this over time** (clearer naming and explicit types/formats), but in the meantime we must be careful to **not make it worse** (no new ambiguous `apiKey` uses; avoid copying patterns blindly).
+This is a source of audit mistakes and security regressions. We should **improve this over time** (clearer naming and explicit types/formats), but in the meantime we must be careful to **not make it worse**.
 
-### `apiKey` flows (source → sink) — verify each independently
+### Key credential flows (source → sink) — verify each independently
 
 | Domain / meaning | Where it lives (structure) | Typical source (where it comes from) | Sinks (where it ends up) | What can go wrong |
 |---|---|---|---|---|
-| **LLM provider API key** (OpenAI/Anthropic/Gemini/etc.) | `LLMConfiguration.apiKey` (`packages/agent-sdk-ts/src/sdk/llm/types.ts`) and on-disk profile JSON (`~/.openhands/llm-profiles/*.json` when `includeSecrets=true`) | From SecretStorage / SecretRegistry, or inline config, or (today) sometimes “env-var-shaped” strings treated as references | Network requests to provider clients (`Authorization`, `x-api-key`, `x-goog-api-key`) | Easy to accidentally persist to disk, log, or treat a reference as a secret (or vice versa). **Do not add new heuristics.** Prefer explicit formats.
-| **Webview → host payload secret** (user typed key) | Webview message: `llmProfileApiKeySetRequest.apiKey` (`src/shared/webviewMessages.ts`) | User types into webview UI (`src/webview-src/components/LlmProfilesView.tsx`) | Stored in `context.secrets.store(...)` and optionally `secretRegistry.set(...)` (`src/webview/host/handlers/llmProfiles.ts`) | Webview JS memory is a leak surface (console logs, devtools, XSS, persistence via `acquireVsCodeApi().setState`). Host must **never** echo secrets back to webview.
-| **Agent-server session API key** (auth to OpenHands server) | `RemoteWorkspaceOptions.apiKey` / `RemoteWorkspace.apiKey` (`packages/agent-sdk-ts/src/workspace/*`) | `settings.secrets.sessionApiKey` (remote conversation setup) | Network requests to agent-server via `X-Session-API-Key` / `Authorization: Bearer ...` | Confusing it with provider keys can cause wrong-host leakage. Ensure per-server scoping and never attach to unintended hosts/redirects.
+| **LLM provider credential** (OpenAI/Anthropic/Gemini/etc.) | `LLMConfiguration.apiKeyRef` (`packages/agent-sdk-ts/src/sdk/llm/types.ts`) and on-disk profile JSON (`~/.openhands/llm-profiles/*.json` when `includeSecrets=true`) | From SecretStorage / SecretRegistry, or explicit inline opt-in (`apiKeyRef.kind="inline"`) | Network requests to provider clients (`Authorization`, `x-api-key`, `x-goog-api-key`) | Easy to accidentally persist to disk or log. Treat `apiKeyRef.kind="inline"` as a secret; treat `apiKeyRef.kind="key"` as a reference name.
+| **Webview → host payload secret** (user typed key) | Webview message: `llmProfileApiKeySetRequest.apiKey` (`src/shared/webviewMessages.ts`) | User types into webview UI (`src/webview-src/components/LlmProfilesView.tsx`) | Stored in `context.secrets.store(...)` and optionally `secretRegistry.set(...)` (`src/webview/host/handlers/llmProfiles.ts`) | Webview JS memory is a leak surface (console logs, devtools, XSS, persistence). Host must **never** echo secrets back to webview.
+| **Agent-server session API key** (auth to OpenHands server) | `RemoteWorkspaceOptions.sessionApiKey` (`packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts`) and SecretStorage keys derived from normalized server URL (`src/auth/serverSessionApiKeys.ts`) | `settings.secrets.sessionApiKey` (remote conversation setup) | Network requests to agent-server via `X-Session-API-Key` / `Authorization: Bearer ...` | Confusing it with provider credentials can cause wrong-host leakage. Ensure per-server scoping and never attach to unintended hosts/redirects.
 | **HAL / auxiliary service keys** (Gemini classifier, ElevenLabs, etc.) | Feature params objects (e.g. `src/hal/gemini/decisionClassifier.ts`, `src/hal/elevenlabs/ttsClient.ts`) | From SecretStorage-backed settings / secrets | Outbound requests to those services | Same logging/persistence risks, plus accidental reuse in unrelated contexts.
 
 ### Audit guidance
 
-- Treat each `apiKey` occurrence as **domain-specific**. During audit, always answer: *“which system is this key for?”* before evaluating risk.
-- **Do not assume** an `apiKey` string is a literal secret value. Today, some code paths treat `/^[A-Z0-9_]+$/` values as “env-var / key-name references”. This ambiguity is a known footgun.
+- Treat each credential-bearing field as **domain-specific**. During audit, always answer: *“which system is this credential for?”* before evaluating risk.
 - When modifying code:
-  - do not introduce new `apiKey` fields/messages without strong justification
-  - prefer explicit names (`sessionApiKey`, `providerApiKey`, `ttsApiKey`, etc.) and explicit reference formats (e.g. `${env:NAME}`) over heuristics
+  - do not introduce new ambiguous `apiKey` fields/messages without strong justification
+  - prefer explicit names (`sessionApiKey`, `providerApiKey`, `ttsApiKey`, etc.) and explicit reference types (`apiKeyRef`) over heuristics
   - ensure secrets never cross host → webview boundaries
 
 If you suspect a leak but cannot prove it, write it as a **risk hypothesis** and point to the exact file + code region to inspect next.


### PR DESCRIPTION
This updates `.openhands/skills/audit/SKILL.md` to reflect the current security-relevant architecture and recent changes.

Key updates:
- Aligns the skill with `apiKeyRef` (inline vs key reference) and `sessionApiKey` naming.
- Updates server URL normalization expectations (https default for non-local, http for local).
- Adds explicit checks for:
  - conversation persistence file permissions
  - webview CSP and link opener allowlisting
- Makes the suggested grep commands safer by default (paths + line numbers only; avoid printing matching lines that may include secrets).

No code behavior changes; skill/checklist only.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced security audit guidelines with comprehensive threat model coverage, including webview boundary and surface security issues.
  * Clarified credential handling with explicit distinction between inline and reference-based API key types.
  * Strengthened webview/host boundary security guidance with specific logging, error handling, and persistence recommendations.
  * Added conversation persistence security requirements and webview surface hardening standards with inspection criteria.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->