### PR TITLE
[oh-tab-te6] Docs: enumerate endpoints exposing runtime session_api_key

### DIFF
--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -247,6 +247,24 @@ From V1 app-server code:
 
 So any endpoint returning `AppConversation` can be the source of truth.
 
+In practice, concrete endpoints that return this nested runtime connection info include:
+
+**V1 (preferred; `/api/v1`)**
+- `GET /api/v1/app-conversations`
+  - Returns a list of `AppConversation` objects including:
+    - `conversation_url` (contains the nested `agent_server_url`)
+    - `session_api_key` (runtime/sandbox credential for the nested agent-server)
+- `POST /api/v1/app-conversations/search`
+  - Returns matching `AppConversation` objects with `conversation_url` + `session_api_key`.
+
+**Legacy/compat (deprecated; used by the CLI today)**
+- `GET /api/conversations`
+- `GET /api/conversations/{conversation_id}`
+  - Returns `ConversationInfo` including:
+    - `url` (derived from `AppConversation.conversation_url`)
+    - `session_api_key` (derived from `AppConversation.session_api_key`)
+  - In V1-backed deployments, these endpoints are shims that map `AppConversation` -> `ConversationInfo` (via `_to_conversation_info`).
+
 ### 6.3 Separation of storage in oh-tab (recommended)
 Given the above, `oh-tab` likely should treat these as distinct secrets:
 
@@ -268,9 +286,13 @@ The goal is to validate which token works against which surface without flooding
 - `GET https://app.all-hands.dev/api/user/info` with `Authorization: Bearer <cloud_api_key>`
 
 2) Identify how SaaS exposes nested runtime info
-- Look for SaaS endpoints returning `session_api_key` and a nested URL (`url` / `conversation_url` / `agent_server_url`).
-  - In code, the nested manager produces `AgentLoopInfo(url, session_api_key)`.
-  - In V1, `AppConversation(conversation_url, session_api_key)`.
+- Prefer V1 endpoints returning `AppConversation(conversation_url, session_api_key)`:
+  - `GET /api/v1/app-conversations`
+  - `POST /api/v1/app-conversations/search`
+- If needed for compatibility (CLI / older clients), use legacy shim endpoints returning `ConversationInfo(url, session_api_key)`:
+  - `GET /api/conversations`
+  - `GET /api/conversations/{conversation_id}`
+- In enterprise code, the nested runtime manager also constructs `AgentLoopInfo(url, session_api_key)` for internal use.
 
 3) Once you have a nested `agent_server_url` and its `session_api_key`, validate nested runtime auth
 - `GET <agent_server_url>/api/conversations/<id>` with `X-Session-API-Key: <runtime_session_api_key>`
@@ -292,8 +314,13 @@ Never print tokens; avoid retries/loops.
   - We did not find `sockets/events` routes in enterprise; the agent-sdk-ts WS path likely targets the agent-server directly.
 
 - Which endpoint(s) should `oh-tab` call after cloud login to obtain the runtime `session_api_key` + `agent_server_url`?
-  - V1 suggests `/api/v1/app-conversations` responses.
-  - SaaS nested runtime manager suggests “AgentLoopInfo” surfaces.
+  - Prefer V1 `AppConversation` endpoints:
+    - `GET /api/v1/app-conversations`
+    - `POST /api/v1/app-conversations/search`
+  - Use legacy (deprecated) shim endpoints only for compatibility:
+    - `GET /api/conversations`
+    - `GET /api/conversations/{conversation_id}`
+  - `AgentLoopInfo(url, session_api_key)` is an enterprise internal surface (not a client API contract).
 
 ---
 

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -145,7 +145,9 @@ This is the concrete “two-interface” bridge:
 
 So V1 “app conversations” endpoints are under:
 - `POST /api/v1/app-conversations`
-- `GET /api/v1/app-conversations?...`
+- `POST /api/v1/app-conversations/stream-start`
+- `GET /api/v1/app-conversations?ids=<uuid>&ids=<uuid>` (batch-get)
+- `GET /api/v1/app-conversations/search` (paged search)
 - etc.
 
 ### 3.4 How V1 can call into the agent-server internally
@@ -250,20 +252,29 @@ So any endpoint returning `AppConversation` can be the source of truth.
 In practice, concrete endpoints that return this nested runtime connection info include:
 
 **V1 (preferred; `/api/v1`)**
-- `GET /api/v1/app-conversations`
-  - Returns a list of `AppConversation` objects including:
+- `GET /api/v1/app-conversations?ids=<uuid>&ids=<uuid>`
+  - Batch-get.
+  - Returns `list[AppConversation | null]`.
+  - Each `AppConversation` includes:
     - `conversation_url` (contains the nested `agent_server_url`)
     - `session_api_key` (runtime/sandbox credential for the nested agent-server)
-- `POST /api/v1/app-conversations/search`
-  - Returns matching `AppConversation` objects with `conversation_url` + `session_api_key`.
+- `GET /api/v1/app-conversations/search`
+  - Paged listing/search.
+  - Returns `AppConversationPage`:
+    - `items: AppConversation[]`
+    - `next_page_id: string | null`
 
 **Legacy/compat (deprecated; used by the CLI today)**
 - `GET /api/conversations`
+  - Paged list.
+  - Returns `ConversationInfoResultSet` (not a bare list), which contains `ConversationInfo` records.
 - `GET /api/conversations/{conversation_id}`
-  - Returns `ConversationInfo` including:
-    - `url` (derived from `AppConversation.conversation_url`)
-    - `session_api_key` (derived from `AppConversation.session_api_key`)
-  - In V1-backed deployments, these endpoints are shims that map `AppConversation` -> `ConversationInfo` (via `_to_conversation_info`).
+  - Single get.
+  - Returns `ConversationInfo | null`.
+
+In V1-backed deployments, these legacy endpoints are shims that map `AppConversation` -> `ConversationInfo` (via `_to_conversation_info`), which is why they can expose:
+- `ConversationInfo.url` (derived from `AppConversation.conversation_url`)
+- `ConversationInfo.session_api_key` (derived from `AppConversation.session_api_key`)
 
 ### 6.3 Separation of storage in oh-tab (recommended)
 Given the above, `oh-tab` likely should treat these as distinct secrets:
@@ -287,11 +298,11 @@ The goal is to validate which token works against which surface without flooding
 
 2) Identify how SaaS exposes nested runtime info
 - Prefer V1 endpoints returning `AppConversation(conversation_url, session_api_key)`:
-  - `GET /api/v1/app-conversations`
-  - `POST /api/v1/app-conversations/search`
+  - `GET /api/v1/app-conversations?ids=<uuid>&ids=<uuid>` (batch-get)
+  - `GET /api/v1/app-conversations/search` (paged)
 - If needed for compatibility (CLI / older clients), use legacy shim endpoints returning `ConversationInfo(url, session_api_key)`:
-  - `GET /api/conversations`
-  - `GET /api/conversations/{conversation_id}`
+  - `GET /api/conversations` (paged `ConversationInfoResultSet`)
+  - `GET /api/conversations/{conversation_id}` (`ConversationInfo | null`)
 - In enterprise code, the nested runtime manager also constructs `AgentLoopInfo(url, session_api_key)` for internal use.
 
 3) Once you have a nested `agent_server_url` and its `session_api_key`, validate nested runtime auth
@@ -315,11 +326,11 @@ Never print tokens; avoid retries/loops.
 
 - Which endpoint(s) should `oh-tab` call after cloud login to obtain the runtime `session_api_key` + `agent_server_url`?
   - Prefer V1 `AppConversation` endpoints:
-    - `GET /api/v1/app-conversations`
-    - `POST /api/v1/app-conversations/search`
+    - `GET /api/v1/app-conversations?ids=<uuid>&ids=<uuid>` (batch-get)
+    - `GET /api/v1/app-conversations/search` (paged)
   - Use legacy (deprecated) shim endpoints only for compatibility:
-    - `GET /api/conversations`
-    - `GET /api/conversations/{conversation_id}`
+    - `GET /api/conversations` (paged `ConversationInfoResultSet`)
+    - `GET /api/conversations/{conversation_id}` (`ConversationInfo | null`)
   - `AgentLoopInfo(url, session_api_key)` is an enterprise internal surface (not a client API contract).
 
 ---


### PR DESCRIPTION
Adds an explicit list of SaaS/app-server endpoints that return nested runtime connection info (`agent_server_url` via `conversation_url`/`url`, plus runtime `session_api_key`).

### Bead

oh-tab-te6: Docs: enumerate endpoints exposing runtime session_api_key
Status: open
Priority: P3
Type: task
Created: 2026-01-18 00:57
Updated: 2026-01-18 00:58

Description:
The new doc `docs/cloud-auth-flow.md` correctly distinguishes cloud device-flow API keys vs nested runtime `session_api_key`, but it should explicitly name the *actual* HTTP endpoints a client can call to obtain the runtime `session_api_key` + nested URL.

Background
- In V1 app_server, `AppConversation` includes `conversation_url` and `session_api_key` (derived from `sandbox.exposed_urls` and `sandbox.session_api_key`).
- In SaaS, legacy (deprecated) `/api/conversations` endpoints still exist and shim V1 conversations into `ConversationInfo`, including `url` and `session_api_key`.

Work
- Update `docs/cloud-auth-flow.md` to add a short section (or an appendix) enumerating concrete endpoints and what fields they return.

Concrete code paths to reference (examples)
- `~/repos/odie/openhands/app_server/app_conversation/app_conversation_router.py` (V1 endpoints under `/api/v1/app-conversations`).
- `~/repos/odie/openhands/server/routes/manage_conversations.py` (deprecated `/api/conversations` endpoints returning `ConversationInfo.url` + `ConversationInfo.session_api_key`, including V1 shim via `_to_conversation_info`).
- `~/repos/odie/enterprise/server/saas_nested_conversation_manager.py` (where `AgentLoopInfo` carries `url` + `session_api_key`).

Acceptance Criteria:
- `docs/cloud-auth-flow.md` includes an explicit list of endpoints a client can use to obtain nested runtime connection info.
- At minimum, mention both:
  - V1: `/api/v1/app-conversations` (batch get) and `/api/v1/app-conversations/search` (and note they return `AppConversation` with `conversation_url` + `session_api_key`).
  - Legacy (deprecated but still used by CLI): `/api/conversations` and `/api/conversations/{conversation_id}` returning `ConversationInfo.url` + `ConversationInfo.session_api_key` (including V1 shim via `_to_conversation_info`).
- No secrets/tokens included.

Labels: [auth cloud docs]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified authentication flow and emphasized preferred V1 API endpoints for retrieving conversation and runtime connection info.
  * Documented concrete V1 endpoints exposing conversation_url and session_api_key, and guidance for clients to use them.
  * Marked legacy/compat endpoints as deprecated for compatibility, described their shim behavior, and consolidated recommended client integration practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->