### PR TITLE
Fix user message duplicates + image attachments

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -48,6 +48,7 @@ export interface LocalConversationOptions {
   persistenceDir?: string;
   persistence?: ConversationPersistence;
   agentContext?: AgentContext;
+  pastedImagesBaseDir?: string;
   hooks?: AgentHook | AgentHook[];
 }
 
@@ -67,6 +68,7 @@ export class LocalConversation extends EventEmitter {
   private readonly persistenceDir?: string;
   private persistence?: ConversationPersistence;
   private readonly agentContext?: AgentContext;
+  private readonly pastedImagesBaseDir?: string;
   private readonly hooks?: AgentHook | AgentHook[];
   private agent: Agent;
   private readonly llmRegistry: LLMRegistry;
@@ -88,6 +90,7 @@ export class LocalConversation extends EventEmitter {
     this.tools = this.resolveTools(this.hasToolsOption ? (options.tools ?? []) : undefined);
     this.secrets = options.secrets ?? new SecretRegistry(options.secretStorage);
     this.agentContext = options.agentContext;
+    this.pastedImagesBaseDir = options.pastedImagesBaseDir;
     this.hooks = options.hooks;
     this.llmRegistry = new LLMRegistry();
     this.stats = new ConversationStats();
@@ -312,6 +315,7 @@ export class LocalConversation extends EventEmitter {
       state: this.state,
       secrets: this.secrets,
       agentContext: this.agentContext,
+      pastedImagesBaseDir: this.pastedImagesBaseDir,
       hooks: this.hooks,
       onTerminalEvent: (event) => this.emit('terminal', event),
       registry: this.llmRegistry,

--- a/packages/agent-sdk-ts/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/index.ts
@@ -24,6 +24,11 @@ export interface ConversationFactoryOptions {
   secretStorage?: SecretStorage;
   persistenceDir?: string;
   agentContext?: AgentContext;
+  /**
+   * Base directory for OpenHands-Tab persisted images (used to resolve `openhands-image://...` references
+   * into data URLs for multimodal LLM requests in local mode).
+   */
+  pastedImagesBaseDir?: string;
   hooks?: AgentHook | AgentHook[];
 }
 
@@ -48,6 +53,7 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     secretStorage: options.secretStorage,
     persistenceDir: options.persistenceDir,
     agentContext: options.agentContext,
+    pastedImagesBaseDir: options.pastedImagesBaseDir,
     hooks: options.hooks,
   }) as ConversationInstance;
 }

--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -39,7 +39,17 @@ type AnthropicToolResultBlock = {
   content: string;
 };
 
-type AnthropicContentBlock = AnthropicThinkingBlock | AnthropicTextBlock | AnthropicToolUseBlock | AnthropicToolResultBlock;
+type AnthropicImageBlock = {
+  type: 'image';
+  source: { type: 'base64'; media_type: string; data: string };
+};
+
+type AnthropicContentBlock =
+  | AnthropicThinkingBlock
+  | AnthropicTextBlock
+  | AnthropicImageBlock
+  | AnthropicToolUseBlock
+  | AnthropicToolResultBlock;
 
 interface AnthropicMessage {
   role: 'user' | 'assistant';
@@ -130,16 +140,39 @@ class AnthropicToolCallAccumulator implements ToolCallAccumulator {
   }
 }
 
+const parseBase64DataUrl = (url: string): { mediaType: string; base64: string } | null => {
+  const raw = typeof url === 'string' ? url.trim() : '';
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/=]+)$/.exec(raw);
+  if (!match) return null;
+  return { mediaType: match[1].toLowerCase(), base64: match[2] };
+};
+
 const toAnthropicMessages = (request: ChatCompletionRequest): AnthropicMessage[] => {
   const result: AnthropicMessage[] = [];
 
   for (const message of request.messages) {
     if (message.role === 'user') {
-      // User messages: simple text content
-      result.push({
-        role: 'user',
-        content: [{ type: 'text', text: reduceTextContent(message) }],
-      });
+      const contentBlocks: AnthropicContentBlock[] = [];
+      for (const part of message.content) {
+        if (part.type === 'text') {
+          contentBlocks.push({ type: 'text', text: part.text });
+          continue;
+        }
+        if (part.type === 'image' && Array.isArray(part.image_urls)) {
+          for (const url of part.image_urls) {
+            const parsed = parseBase64DataUrl(url);
+            if (!parsed) continue;
+            contentBlocks.push({
+              type: 'image',
+              source: { type: 'base64', media_type: parsed.mediaType, data: parsed.base64 },
+            });
+          }
+        }
+      }
+      if (contentBlocks.length === 0) {
+        contentBlocks.push({ type: 'text', text: '' });
+      }
+      result.push({ role: 'user', content: contentBlocks });
     } else if (message.role === 'assistant') {
       // Assistant messages: may have thinking + tool_use
       const contentBlocks: AnthropicContentBlock[] = [];

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -37,6 +37,7 @@ type GeminiRole = 'user' | 'model';
 
 type GeminiPart =
   | { text: string; thoughtSignature?: string }
+  | { inlineData: { mimeType: string; data: string } }
   | { functionCall: { name: string; args?: unknown }; thoughtSignature?: string }
   | { functionResponse: { name: string; response?: unknown } };
 
@@ -103,6 +104,13 @@ const reduceTextContent = (content: Content[]): string =>
     .map((item) => item.text)
     .join('\n');
 
+const parseBase64DataUrl = (url: string): { mimeType: string; base64: string } | null => {
+  const raw = typeof url === 'string' ? url.trim() : '';
+  const match = /^data:([^;,]+);base64,([A-Za-z0-9+/=]+)$/.exec(raw);
+  if (!match) return null;
+  return { mimeType: match[1].toLowerCase(), base64: match[2] };
+};
+
 const toGeminiPartsForMessage = (message: Message): GeminiPart[] => {
   if (message.role === 'tool') {
     const toolName = (message.name ?? '').trim() || 'unknown_tool';
@@ -132,6 +140,14 @@ const toGeminiPartsForMessage = (message: Message): GeminiPart[] => {
         part.thoughtSignature = message.thinking_signature;
       }
       parts.push(part);
+    }
+
+    if (item.type === 'image' && Array.isArray(item.image_urls)) {
+      for (const url of item.image_urls) {
+        const parsed = parseBase64DataUrl(url);
+        if (!parsed) continue;
+        parts.push({ inlineData: { mimeType: parsed.mimeType, data: parsed.base64 } });
+      }
     }
   }
 

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -31,6 +31,11 @@ type OpenAITextContentBlock = {
   text: string;
 };
 
+type OpenAIImageUrlContentBlock = {
+  type: 'image_url';
+  image_url: { url: string; detail?: string };
+};
+
 type OpenAIToolUseContentBlock = {
   type: 'tool_use';
   id: string;
@@ -38,7 +43,7 @@ type OpenAIToolUseContentBlock = {
   input: unknown;
 };
 
-type OpenAIContentBlock = OpenAIThinkingContentBlock | OpenAITextContentBlock | OpenAIToolUseContentBlock;
+type OpenAIContentBlock = OpenAIThinkingContentBlock | OpenAITextContentBlock | OpenAIImageUrlContentBlock | OpenAIToolUseContentBlock;
 
 type OpenAIChatMessage = {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -133,6 +138,28 @@ const toOpenAIMessage = (message: ChatCompletionRequest['messages'][number], con
       ...(message.tool_calls?.length ? { tool_calls: message.tool_calls } : {}),
     };
     return result;
+  }
+
+  // User messages: include image_url blocks when present.
+  if (message.role === 'user') {
+    const blocks: OpenAIContentBlock[] = [];
+    for (const part of message.content) {
+      if (part.type === 'text') {
+        blocks.push({ type: 'text', text: part.text });
+        continue;
+      }
+      if (part.type === 'image' && Array.isArray(part.image_urls)) {
+        for (const url of part.image_urls) {
+          blocks.push({ type: 'image_url', image_url: { url, detail: part.detail ?? 'auto' } });
+        }
+      }
+    }
+    if (blocks.some((b) => b.type === 'image_url')) {
+      if (!blocks.some((b) => b.type === 'text')) {
+        blocks.unshift({ type: 'text', text: '' });
+      }
+      return { role: 'user', content: blocks };
+    }
   }
 
   // Standard case: plain text content (for non-Anthropic models or messages without thinking)

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -88,6 +88,11 @@ export interface AgentOptions {
   state?: ConversationState;
   secrets?: SecretRegistry;
   agentContext?: AgentContext;
+  /**
+   * Base directory for OpenHands-Tab persisted images (used to resolve `openhands-image://...` references
+   * into data URLs for multimodal LLM requests).
+   */
+  pastedImagesBaseDir?: string;
   profileStoreOptions?: LLMProfileStoreOptions;
   onTerminalEvent?: (event: BashEvent) => void;
   registry?: import('../llm').LLMRegistry;
@@ -618,6 +623,7 @@ export class Agent extends EventEmitter {
           events: this.events.list(),
           systemPrompt: this.buildSystemPrompt(),
           tools: this.getToolDefinitions(),
+          pastedImagesBaseDir: this.options.pastedImagesBaseDir,
         });
 
         // Emit a lightweight debug/state event so hosts can log what tools are actually sent

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Event } from '../../types';
 import type { LLMToolDefinition } from '../../llm';
 import { buildChatRequestWithCondensation, getCondensationState, tryCondenseConversation } from '../condensation';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 describe('condensation helpers', () => {
   it('getCondensationState unions forgotten ids and keeps latest non-empty summary', () => {
@@ -99,6 +102,35 @@ describe('condensation helpers', () => {
       { type: 'text', text: 'Second' },
       { type: 'text', text: '<environment information>\nActive editor: b.ts\n</environment information>' },
     ]);
+  });
+
+  it('expands openhands-image markdown to image content when pastedImagesBaseDir is provided', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'condensation-images-'));
+    const pastedDir = path.join(tmp, 'pasted-images');
+    fs.mkdirSync(pastedDir, { recursive: true });
+
+    const imageId = '0123456789abcdef.png';
+    fs.writeFileSync(path.join(pastedDir, imageId), Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG signature prefix
+
+    const message: Extract<Event, { kind: 'MessageEvent' }> = {
+      kind: 'MessageEvent',
+      id: 'm1',
+      source: 'user',
+      llm_message: { role: 'user', content: [{ type: 'text', text: `see this\n\n![shot](openhands-image://${imageId})` }] },
+    };
+
+    const tools: LLMToolDefinition[] = [];
+    const request = buildChatRequestWithCondensation({
+      events: [message],
+      systemPrompt: 'SYS',
+      tools,
+      pastedImagesBaseDir: tmp,
+    });
+
+    const userMessage = request.messages[0]!;
+    expect(userMessage.role).toBe('user');
+    const imagePart = userMessage.content.find((c) => c.type === 'image') as { image_urls?: string[] } | undefined;
+    expect(imagePart?.image_urls?.[0]).toMatch(/^data:image\/png;base64,/);
   });
 
   it('tryCondenseConversation emits a Condensation event using injected condense()', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/condensation.test.ts
@@ -106,31 +106,35 @@ describe('condensation helpers', () => {
 
   it('expands openhands-image markdown to image content when pastedImagesBaseDir is provided', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'condensation-images-'));
-    const pastedDir = path.join(tmp, 'pasted-images');
-    fs.mkdirSync(pastedDir, { recursive: true });
+    try {
+      const pastedDir = path.join(tmp, 'pasted-images');
+      fs.mkdirSync(pastedDir, { recursive: true });
 
-    const imageId = '0123456789abcdef.png';
-    fs.writeFileSync(path.join(pastedDir, imageId), Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG signature prefix
+      const imageId = '0123456789abcdef.png';
+      fs.writeFileSync(path.join(pastedDir, imageId), Buffer.from([0x89, 0x50, 0x4e, 0x47])); // PNG signature prefix
 
-    const message: Extract<Event, { kind: 'MessageEvent' }> = {
-      kind: 'MessageEvent',
-      id: 'm1',
-      source: 'user',
-      llm_message: { role: 'user', content: [{ type: 'text', text: `see this\n\n![shot](openhands-image://${imageId})` }] },
-    };
+      const message: Extract<Event, { kind: 'MessageEvent' }> = {
+        kind: 'MessageEvent',
+        id: 'm1',
+        source: 'user',
+        llm_message: { role: 'user', content: [{ type: 'text', text: `see this\n\n![shot](openhands-image://${imageId})` }] },
+      };
 
-    const tools: LLMToolDefinition[] = [];
-    const request = buildChatRequestWithCondensation({
-      events: [message],
-      systemPrompt: 'SYS',
-      tools,
-      pastedImagesBaseDir: tmp,
-    });
+      const tools: LLMToolDefinition[] = [];
+      const request = buildChatRequestWithCondensation({
+        events: [message],
+        systemPrompt: 'SYS',
+        tools,
+        pastedImagesBaseDir: tmp,
+      });
 
-    const userMessage = request.messages[0]!;
-    expect(userMessage.role).toBe('user');
-    const imagePart = userMessage.content.find((c) => c.type === 'image') as { image_urls?: string[] } | undefined;
-    expect(imagePart?.image_urls?.[0]).toMatch(/^data:image\/png;base64,/);
+      const userMessage = request.messages[0]!;
+      expect(userMessage.role).toBe('user');
+      const imagePart = userMessage.content.find((c) => c.type === 'image') as { image_urls?: string[] } | undefined;
+      expect(imagePart?.image_urls?.[0]).toMatch(/^data:image\/png;base64,/);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
   });
 
   it('tryCondenseConversation emits a Condensation event using injected condense()', async () => {

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
@@ -1,8 +1,10 @@
 import type { LLMClient, LLMToolDefinition } from '../llm';
-import type { Event, Message } from '../types';
+import type { Content, Event, Message } from '../types';
 import { isCondensation, isMessageEvent } from '../types';
 import { LLMSummarizingCondenser } from '../context';
 import { sanitizeChatMessages } from './sanitizeChatMessages';
+import fs from 'fs';
+import path from 'path';
 
 export type CondensationState = {
   summary: string | null;
@@ -34,6 +36,7 @@ export const buildChatRequestWithCondensation = (params: {
   events: Event[];
   systemPrompt: string;
   tools: LLMToolDefinition[];
+  pastedImagesBaseDir?: string;
 }): { systemPrompt: string; messages: Message[]; tools: LLMToolDefinition[] } => {
   const condensationState = getCondensationState(params.events);
 
@@ -56,6 +59,95 @@ export const buildChatRequestWithCondensation = (params: {
   const isEnvironmentInfoBlock = (text: string): boolean =>
     text.trimStart().toLowerCase().startsWith('<environment information>');
 
+  const OPENHANDS_IMAGE_URL_PREFIX = 'openhands-image://';
+  const IMAGE_ID_REGEX = /^[a-f0-9]{16}\.[a-z0-9]+$/;
+
+  const EXT_TO_MIME: Record<string, string> = {
+    '.png': 'image/png',
+    '.jpg': 'image/jpeg',
+    '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif',
+    '.webp': 'image/webp',
+  };
+
+  const toDataUrlFromOpenHandsImageId = (imageId: string): string | undefined => {
+    const baseDir = typeof params.pastedImagesBaseDir === 'string' ? params.pastedImagesBaseDir : '';
+    if (!baseDir) return undefined;
+    if (!IMAGE_ID_REGEX.test(imageId)) return undefined;
+
+    const ext = path.extname(imageId).toLowerCase();
+    const mime = EXT_TO_MIME[ext];
+    if (!mime) return undefined;
+
+    try {
+      const filePath = path.join(baseDir, 'pasted-images', imageId);
+      const bytes = fs.readFileSync(filePath);
+      const base64 = bytes.toString('base64');
+      return `data:${mime};base64,${base64}`;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const expandOpenHandsImagesInText = (text: string): Content[] => {
+    const raw = typeof text === 'string' ? text : '';
+    if (!raw.includes(OPENHANDS_IMAGE_URL_PREFIX)) return [{ type: 'text', text: raw }];
+
+    const imageRegex = /!\[([^\]]*)\]\(openhands-image:\/\/([a-f0-9]{16}\.[a-z0-9]+)\)/gi;
+    const out: Content[] = [];
+    let last = 0;
+
+    let match: RegExpExecArray | null;
+    while ((match = imageRegex.exec(raw)) !== null) {
+      const start = match.index;
+      const full = match[0] ?? '';
+      const alt = (match[1] ?? '').trim();
+      const imageId = (match[2] ?? '').toLowerCase();
+      const dataUrl = toDataUrlFromOpenHandsImageId(imageId);
+
+      if (start > last) {
+        out.push({ type: 'text', text: raw.slice(last, start) });
+      }
+
+      if (dataUrl) {
+        const label = alt || imageId;
+        out.push({ type: 'text', text: `\n\n[Image: ${label}]\n\n` });
+        out.push({ type: 'image', image_urls: [dataUrl], detail: 'auto' });
+      } else {
+        out.push({ type: 'text', text: full });
+      }
+
+      last = start + full.length;
+    }
+
+    if (last < raw.length) {
+      out.push({ type: 'text', text: raw.slice(last) });
+    }
+
+    if (out.length === 0) return [{ type: 'text', text: raw }];
+    return out;
+  };
+
+  const maybeExpandOpenHandsImages = (message: Message): Message => {
+    const baseDir = typeof params.pastedImagesBaseDir === 'string' ? params.pastedImagesBaseDir : '';
+    if (!baseDir) return message;
+    if (message.role !== 'user') return message;
+
+    const nextContent: Content[] = [];
+    for (const part of message.content) {
+      if (part.type !== 'text') {
+        nextContent.push(part);
+        continue;
+      }
+      nextContent.push(...expandOpenHandsImagesInText(part.text));
+    }
+
+    // Avoid churn if no image expansion occurred.
+    const changed = nextContent.some((p) => p.type === 'image') || nextContent.length !== message.content.length;
+    if (!changed) return message;
+    return { ...message, content: nextContent };
+  };
+
   const rawMessages = messageEvents.map((event, idx) => {
     if (event.source === 'user' && event.extended_content?.length) {
       // Environment info is ephemeral and should reflect the latest editor state only.
@@ -71,7 +163,7 @@ export const buildChatRequestWithCondensation = (params: {
       }
     }
     return event.llm_message;
-  });
+  }).map(maybeExpandOpenHandsImages);
   const messages = sanitizeChatMessages(rawMessages);
 
   return { systemPrompt, messages, tools: params.tools };

--- a/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/condensation.ts
@@ -61,6 +61,8 @@ export const buildChatRequestWithCondensation = (params: {
 
   const OPENHANDS_IMAGE_URL_PREFIX = 'openhands-image://';
   const IMAGE_ID_REGEX = /^[a-f0-9]{16}\.[a-z0-9]+$/;
+  // Keep in sync with OpenHands-Tab's per-image attachment cap (host-side).
+  const MAX_OPENHANDS_IMAGE_BYTES = 5 * 1024 * 1024;
 
   const EXT_TO_MIME: Record<string, string> = {
     '.png': 'image/png',
@@ -81,6 +83,9 @@ export const buildChatRequestWithCondensation = (params: {
 
     try {
       const filePath = path.join(baseDir, 'pasted-images', imageId);
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile()) return undefined;
+      if (stat.size > MAX_OPENHANDS_IMAGE_BYTES) return undefined;
       const bytes = fs.readFileSync(filePath);
       const base64 = bytes.toString('base64');
       return `data:${mime};base64,${base64}`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -659,6 +659,7 @@ export function activate(context: vscode.ExtensionContext) {
         secrets,
         persistenceDir,
         agentContext,
+        pastedImagesBaseDir,
       };
 
       // Populate user environment info suffix for local mode (after agentContext is created & system message synced)

--- a/src/shared/pasteLimits.ts
+++ b/src/shared/pasteLimits.ts
@@ -1,3 +1,2 @@
-export const MAX_PASTED_IMAGE_BYTES = 350 * 1024;
+export const MAX_PASTED_IMAGE_BYTES = 5 * 1024 * 1024;
 export const MAX_PASTED_IMAGES = 4;
-

--- a/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
+++ b/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
@@ -63,5 +63,51 @@ describe('App - optimistic user MessageEvent rendering', () => {
     expect(screen.getAllByText('hello')).toHaveLength(1);
     expect(screen.queryByTestId('queued-messages-badge')).toBeNull();
   });
-});
 
+  it('deduplicates an optimistic user message when the persisted event adds <environment information> extended content', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    });
+
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const running: ConversationStateUpdateEvent = {
+      kind: 'ConversationStateUpdateEvent',
+      agent_status: 'RUNNING',
+    } as ConversationStateUpdateEvent;
+    postToWindow({ type: 'event', event: running });
+
+    const input = screen.getByPlaceholderText('Ask OpenHands anything...') as HTMLTextAreaElement;
+    const user = userEvent.setup();
+    await user.type(input, 'hello{enter}');
+
+    const optimistic: MessageEvent = {
+      kind: 'MessageEvent',
+      id: 'optimistic:test',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: optimistic });
+
+    expect(screen.getAllByText('hello')).toHaveLength(1);
+
+    const persisted: MessageEvent = {
+      ...optimistic,
+      id: 'server:test',
+      extended_content: [
+        {
+          type: 'text',
+          text: '<environment information>\nActive editor: /tmp/a.ts\n</environment information>',
+        },
+      ],
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: persisted });
+
+    expect(screen.getAllByText('hello')).toHaveLength(1);
+  });
+});

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -56,10 +56,15 @@ const isOptimisticUserMessageEvent = (event: Event): boolean => (
   && event.id.startsWith('optimistic:')
 );
 
+const isEnvironmentInfoBlock = (text: string): boolean =>
+  text.trimStart().toLowerCase().startsWith('<environment information>');
+
 const fingerprintMessageEvent = (event: MessageEvent): string => {
   const role = event.llm_message?.role ?? '';
   const content = Array.isArray(event.llm_message?.content) ? event.llm_message.content : [];
-  const extended = Array.isArray(event.extended_content) ? event.extended_content : [];
+  const extended = Array.isArray(event.extended_content)
+    ? event.extended_content.filter((c) => !(c?.type === 'text' && typeof c.text === 'string' && isEnvironmentInfoBlock(c.text)))
+    : [];
   try {
     return JSON.stringify({ role, content, extended });
   } catch {

--- a/src/webview-src/components/app/useInlineImageAttachments.ts
+++ b/src/webview-src/components/app/useInlineImageAttachments.ts
@@ -59,7 +59,9 @@ export function useInlineImageAttachments({
     }
 
     if (didSkipLarge) {
-      showStatusMessage('warn', `Some images were too large to paste (max ${Math.trunc(maxBytesPerImage / 1024)}KB).`);
+      const mb = maxBytesPerImage / (1024 * 1024);
+      const limitLabel = mb >= 1 ? `${mb.toFixed(1).replace(/\.0$/, '')}MB` : `${Math.trunc(maxBytesPerImage / 1024)}KB`;
+      showStatusMessage('warn', `Some images were too large to paste (max ${limitLabel}).`);
     }
     if (didSkipSvg) {
       showStatusMessage('warn', 'SVG images are not supported for pasted images.');

--- a/src/webview/host/attachments.ts
+++ b/src/webview/host/attachments.ts
@@ -23,7 +23,7 @@ function isProbablyBinary(bytes: Uint8Array): boolean {
 }
 
 function escapeMarkdownAltText(value: string): string {
-  return value.replaceAll('[', '\\[').replaceAll(']', '\\]');
+  return value.replace(/\\/g, '\\\\').replace(/\]/g, '\\]').replace(/[\r\n]+/g, ' ').trim();
 }
 
 export function toAttachmentLabel(uri: vscode.Uri): string {

--- a/src/webview/host/attachments.ts
+++ b/src/webview/host/attachments.ts
@@ -1,9 +1,18 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { TextDecoder } from 'util';
+import { MAX_PASTED_IMAGE_BYTES, MAX_PASTED_IMAGES } from '../../shared/pasteLimits';
 
 const MAX_ATTACHMENT_BYTES_PER_FILE = 200 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES = 500 * 1024;
+
+const IMAGE_EXT_TO_MIME: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+};
 
 function isProbablyBinary(bytes: Uint8Array): boolean {
   // Heuristic: treat NUL bytes as binary.
@@ -11,6 +20,10 @@ function isProbablyBinary(bytes: Uint8Array): boolean {
     if (bytes[i] === 0) return true;
   }
   return false;
+}
+
+function escapeMarkdownAltText(value: string): string {
+  return value.replaceAll('[', '\\[').replaceAll(']', '\\]');
 }
 
 export function toAttachmentLabel(uri: vscode.Uri): string {
@@ -38,6 +51,7 @@ export async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promi
   const decoder = new TextDecoder('utf-8', { fatal: false });
   const blocks: string[] = [];
   let totalIncluded = 0;
+  let imageCount = 0;
 
   for (const uri of attachmentUris) {
     const label = toAttachmentLabel(uri);
@@ -46,6 +60,26 @@ export async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promi
 
     try {
       const bytes = await vscode.workspace.fs.readFile(uri);
+
+      const ext = path.extname(uri.fsPath ?? '').toLowerCase();
+      const mime = IMAGE_EXT_TO_MIME[ext];
+      if (mime) {
+        if (imageCount >= MAX_PASTED_IMAGES) {
+          blocks.push(`\n\n${begin}\n(attachment skipped: too many images; max ${MAX_PASTED_IMAGES} images)\n${end}`);
+          continue;
+        }
+        if (bytes.length > MAX_PASTED_IMAGE_BYTES) {
+          const mb = MAX_PASTED_IMAGE_BYTES / (1024 * 1024);
+          blocks.push(`\n\n${begin}\n(attachment skipped: image too large; max ${mb}MB)\n${end}`);
+          continue;
+        }
+
+        imageCount += 1;
+        const base64 = Buffer.from(bytes).toString('base64');
+        const alt = escapeMarkdownAltText(label);
+        blocks.push(`\n\n${begin}\n![${alt}](data:${mime};base64,${base64})\n${end}`);
+        continue;
+      }
 
       if (isProbablyBinary(bytes)) {
         blocks.push(`\n\n${begin}\n(attachment skipped: binary file)\n${end}`);
@@ -74,4 +108,3 @@ export async function buildAttachmentBlocks(attachmentUris: vscode.Uri[]): Promi
 
   return blocks.join('');
 }
-

--- a/src/webview/host/handlers/send.ts
+++ b/src/webview/host/handlers/send.ts
@@ -5,7 +5,7 @@ import type { ConversationInstance } from '@openhands/agent-sdk-ts';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import type { MessageEvent } from '@openhands/agent-sdk-ts';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../../shared/pastedImages';
-import { MAX_PASTED_IMAGE_BYTES } from '../../../shared/pasteLimits';
+import { MAX_PASTED_IMAGE_BYTES, MAX_PASTED_IMAGES } from '../../../shared/pasteLimits';
 import { buildAttachmentBlocks, safeParseUri } from '../attachments';
 import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
 import type { WebviewHost } from '../createWebviewMessageHandler';
@@ -47,10 +47,15 @@ export async function handleSend(args: {
 
   const globalStorageBaseDir = getGlobalStorageBaseDir(args.context.globalStorageUri?.fsPath);
   const pastedImages = new Map<string, Uint8Array>();
+  let didSkipImageCap = false;
   const rewriteResult = rewriteDataImageMarkdown(combinedText, (dataUrl) => {
     const parsed = parseBase64DataImageUrl(dataUrl);
     if (!parsed) return { url: '' };
     if (parsed.bytes.length > MAX_PASTED_IMAGE_BYTES) return { url: '' };
+    if (pastedImages.size >= MAX_PASTED_IMAGES) {
+      didSkipImageCap = true;
+      return { url: '' };
+    }
     pastedImages.set(parsed.imageId, parsed.bytes);
     return { url: `${OPENHANDS_IMAGE_URL_PREFIX}${parsed.imageId}` };
   });
@@ -71,8 +76,14 @@ export async function handleSend(args: {
       finalText = rewriteOpenHandsImageUrls(finalText, (imageId) => (failed.has(imageId) ? '' : undefined));
       void vscode.window.showWarningMessage(`Some pasted images could not be saved (${failed.size}). They were omitted from the message.`);
     }
+    if (didSkipImageCap) {
+      void vscode.window.showWarningMessage(`Some images were omitted (max ${MAX_PASTED_IMAGES} images per message).`);
+    }
   } else if (rewriteResult.rewritten > 0) {
     void vscode.window.showWarningMessage('Some pasted images were not supported and were omitted from the message.');
+    if (didSkipImageCap) {
+      void vscode.window.showWarningMessage(`Some images were omitted (max ${MAX_PASTED_IMAGES} images per message).`);
+    }
   }
 
   const queuedNotes = args.deps.getQueuedUserEditNotes();

--- a/src/webview/host/handlers/send.ts
+++ b/src/webview/host/handlers/send.ts
@@ -35,9 +35,19 @@ export async function handleSend(args: {
       .filter((u): u is vscode.Uri => u !== undefined)
     : [];
 
+  const attachmentsText = await buildAttachmentBlocks(attachmentUris);
+
+  let combinedText = baseText;
+  if (attachmentsText) {
+    combinedText += attachmentsText;
+  }
+  if (contextFiles.length > 0) {
+    combinedText += `\n\nUser has selected the following files for you to read:\n${contextFiles.join('\n')}`;
+  }
+
   const globalStorageBaseDir = getGlobalStorageBaseDir(args.context.globalStorageUri?.fsPath);
   const pastedImages = new Map<string, Uint8Array>();
-  const rewriteResult = rewriteDataImageMarkdown(baseText, (dataUrl) => {
+  const rewriteResult = rewriteDataImageMarkdown(combinedText, (dataUrl) => {
     const parsed = parseBase64DataImageUrl(dataUrl);
     if (!parsed) return { url: '' };
     if (parsed.bytes.length > MAX_PASTED_IMAGE_BYTES) return { url: '' };
@@ -45,7 +55,7 @@ export async function handleSend(args: {
     return { url: `${OPENHANDS_IMAGE_URL_PREFIX}${parsed.imageId}` };
   });
 
-  let sanitizedText = rewriteResult.text;
+  let finalText = rewriteResult.text;
   if (pastedImages.size > 0) {
     const failed = new Set<string>();
     for (const [imageId, bytes] of pastedImages.entries()) {
@@ -58,21 +68,11 @@ export async function handleSend(args: {
       }
     }
     if (failed.size > 0) {
-      sanitizedText = rewriteOpenHandsImageUrls(sanitizedText, (imageId) => (failed.has(imageId) ? '' : undefined));
+      finalText = rewriteOpenHandsImageUrls(finalText, (imageId) => (failed.has(imageId) ? '' : undefined));
       void vscode.window.showWarningMessage(`Some pasted images could not be saved (${failed.size}). They were omitted from the message.`);
     }
   } else if (rewriteResult.rewritten > 0) {
     void vscode.window.showWarningMessage('Some pasted images were not supported and were omitted from the message.');
-  }
-
-  const attachmentsText = await buildAttachmentBlocks(attachmentUris);
-
-  let finalText = sanitizedText;
-  if (attachmentsText) {
-    finalText += attachmentsText;
-  }
-  if (contextFiles.length > 0) {
-    finalText += `\n\nUser has selected the following files for you to read:\n${contextFiles.join('\n')}`;
   }
 
   const queuedNotes = args.deps.getQueuedUserEditNotes();


### PR DESCRIPTION
Fixes
- `oh-tab-3le`: De-dupe optimistic user messages even when the persisted event adds `<environment information>` extended content.
- `oh-tab-cc1`: Allow image attachments up to 5MB; include image attachments (png/jpg/gif/webp) and resolve `openhands-image://…` into multimodal LLM image parts in local mode.

Notes
- Local-mode LLM request building expands OpenHands-Tab persisted image references into data URLs for providers that support images.

Verification
- `npm test`
- `npm run typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embed pasted images directly into conversations (inline, base64-encoded) and resolve local pasted images via a configurable base directory.
  * Increased maximum pasted image size to 5 MB and enforced per-message image limits.

* **Bug Fixes**
  * Improved message deduplication to ignore environment-info blocks so optimistic and persisted messages match.

* **Tests**
  * Added tests covering filesystem image expansion and deduplication scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->