### PR TITLE
Fix duplicated tool-call rendering

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -15,14 +15,13 @@ import {
   loadProfile,
   wouldExceedMaxInputTokens,
 } from '../llm';
-import type { ActionEvent, BashEvent, ConversationStateUpdateEvent, Event, Message, MessageEvent, ObservationEvent, ToolCall } from '../types';
+import type { ActionEvent, BashEvent, ConversationStateUpdateEvent, Event, Message, MessageEvent, ObservationEvent, TextContent, ToolCall } from '../types';
 import {
   isActionEvent,
   isAgentErrorEvent,
   isObservationEvent,
   isPauseEvent,
   isSystemPromptEvent,
-  isTextContent,
   isUserRejectObservation,
   type SecurityRisk,
 } from '../types';
@@ -1234,7 +1233,9 @@ export class Agent extends EventEmitter {
     args: Record<string, unknown> | null,
     securityRisk?: SecurityRisk,
   ): ActionEvent {
-    const thought = message.content.filter(isTextContent);
+    // Tool-call assistant messages are already emitted as MessageEvents (user-visible content).
+    // Avoid duplicating that content in ActionEvent.thought, which the UI renders as "Reasoning".
+    const thought: TextContent[] = [];
     const thinkingBlocks =
       message.thinking_signature && typeof message.reasoning_content === 'string' && message.reasoning_content.trim().length
         ? [

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.action-reasoning-metadata.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.action-reasoning-metadata.test.ts
@@ -80,6 +80,7 @@ describe('Agent ActionEvent reasoning metadata', () => {
       const action = actions.find((evt) => evt.tool_call_id === 'call_echo');
       expect(action).toBeDefined();
 
+      expect(action?.thought).toEqual([]);
       expect(action?.thinking_blocks).toEqual([{ type: 'thinking', thinking: 'Thinking...', signature: 'sig_1' }]);
 
       expect(action?.responses_reasoning_item).toMatchObject({ id: 'rs_1', summary: ['short summary'] });
@@ -89,4 +90,3 @@ describe('Agent ActionEvent reasoning metadata', () => {
     }
   });
 });
-

--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -37,6 +37,29 @@ describe('Agent-SDK event rendering', () => {
     expect(await screen.findByText('OpenHands says')).toBeInTheDocument();
   });
 
+  it('does not show Extended Thinking on assistant tool-call messages', async () => {
+    render(<App />);
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'agent',
+      llm_message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Let me check that…' }],
+        reasoning_content: 'internal thinking',
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'terminal', arguments: '{}' } },
+        ],
+      },
+    } as any;
+
+    postToWindow({ type: 'event', event: ev });
+
+    expect(await screen.findByText('Let me check that…')).toBeInTheDocument();
+    expect(await screen.findByText('OpenHands (tool call)')).toBeInTheDocument();
+    expect(screen.queryByText('Extended Thinking')).toBeNull();
+    expect(screen.queryByText('internal thinking')).toBeNull();
+  });
+
   it('renders message markdown (inline code, fenced code, links)', async () => {
     render(<App />);
     const ev: AgentMessageEvent = {

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -20,6 +20,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const message = event.llm_message;
   const isUser = message.role === 'user';
   const isAgent = message.role === 'assistant';
+  const hasToolCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
 
   function truncateEnvironmentInformationForDisplay(text: string): string {
     const lines = text.split(/\r?\n/);
@@ -118,7 +119,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const accentColor = isUser ? USER_ACCENT_COLOR : isAgent ? AGENT_ACCENT_COLOR : DEFAULT_ACCENT_COLOR;
   const icon = isUser ? 'account' : isAgent ? 'hubot' : 'info';
   const roleLabel = message.role === 'assistant'
-    ? 'OpenHands says'
+    ? (hasToolCalls ? 'OpenHands (tool call)' : 'OpenHands says')
     : message.role.charAt(0).toUpperCase() + message.role.slice(1);
   const showRoleLabel = !isUser;
 
@@ -233,6 +234,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
           )}
 
           {(() => {
+            if (isAgent && hasToolCalls) return null;
             // Use reasoning_content if available (Anthropic/OpenAI Chat Completions),
             // otherwise fall back to responses_reasoning_item.summary (OpenAI Responses API / GPT-5)
             const reasoningContent = message.reasoning_content


### PR DESCRIPTION
Fixes oh-tab-48g.

Problem
- Assistant messages that include tool calls could render as both:
  - a normal assistant message ("OpenHands says") with text + Extended Thinking
  - an Agent Action block that repeated the same text under "Reasoning" and repeated Extended Thinking

Changes
- Agent SDK: ActionEvent no longer copies assistant message text into ActionEvent.thought.
- Webview: assistant tool-call messages are labeled "OpenHands (tool call)" and do not render "Extended Thinking" there (it remains on the ActionEvent).

Tests
- 
> @openhands/agent-sdk-ts@0.7.1 test
> vitest run


 RUN  v3.2.4 /Users/enyst/repos/oh-tab/packages/agent-sdk-ts

 ✓ src/tools/__tests__/AskOracleTool.test.ts (5 tests) 229ms
 ✓ src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts (3 tests) 308ms
 ✓ src/sdk/__tests__/remoteConversation.test.ts (33 tests) 191ms
 ✓ src/tools/__tests__/glob-grep.test.ts (17 tests) 198ms
 ✓ src/workspace/__tests__/local.workspace.test.ts (17 tests) 39ms
 ✓ src/sdk/runtime/__tests__/Agent.llm-client-cache-reset.test.ts (2 tests) 77ms
 ✓ src/sdk/__tests__/persistence.test.ts (21 tests) 50ms
 ✓ src/workspace/__tests__/local.workspace.vscodeRemoteRoots.test.ts (2 tests) 7ms
 ✓ src/sdk/__tests__/llm.profile-selection.test.ts (4 tests) 26ms
 ✓ src/tools/__tests__/new-tools.test.ts (13 tests) 58ms
 ✓ src/sdk/__tests__/agent.error-detail.test.ts (2 tests) 16ms
 ✓ src/sdk/runtime/__tests__/AsyncLock.test.ts (9 tests) 49ms
 ✓ src/sdk/__tests__/agent.loop.test.ts (13 tests) 38ms
 ✓ src/sdk/__tests__/agent.condensation-budget.test.ts (1 test) 32ms
 ✓ src/sdk/conversation/LocalConversation.test.ts (13 tests) 29ms
 ✓ src/tools/__tests__/tools.test.ts (28 tests) 844ms
   ✓ FileEditorTool > prunes undo_edit history by byte cap without losing the latest edit  341ms
 ✓ src/sdk/__tests__/llm.profiles.test.ts (9 tests) 18ms
 ✓ src/sdk/runtime/__tests__/Agent.system-prompt.test.ts (3 tests) 11ms
 ✓ src/sdk/context/skills/__tests__/skill.test.ts (46 tests) 30ms
 ✓ src/sdk/runtime/__tests__/Agent.mixed-tool-outcomes.test.ts (2 tests) 10ms
 ✓ src/sdk/llm/__tests__/factory.api-key-precedence.test.ts (3 tests) 11ms
 ✓ src/sdk/runtime/__tests__/toolSummarizer.key-preference.test.ts (2 tests) 15ms
 ✓ src/tools/__tests__/ApplyPatchTool.test.ts (6 tests) 41ms
 ✓ src/sdk/__tests__/registry.test.ts (5 tests) 15ms
 ✓ src/sdk/context/skills/__tests__/agentSkillsFields.test.ts (6 tests) 13ms
 ✓ src/sdk/runtime/__tests__/Agent.hooks.test.ts (3 tests) 13ms
 ✓ src/sdk/context/skills/__tests__/resources.test.ts (15 tests) 10ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-messages.test.ts (11 tests) 19ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-errors.test.ts (6 tests) 22ms
 ✓ src/sdk/context/skills/__tests__/mcp.test.ts (23 tests) 20ms
 ✓ src/sdk/__tests__/llm.streamer.test.ts (21 tests | 1 skipped) 1550ms
   ✓ OpenAICompatibleClient streaming > propagates failure after retries  754ms
   ✓ GeminiClient streaming > propagates failure after retries  752ms
 ✓ src/sdk/conversation/Conversation.factory.test.ts (3 tests) 21ms
 ✓ src/sdk/context/__tests__/agent-context.test.ts (31 tests) 6ms
 ✓ src/tools/__tests__/TerminalTool.session.test.ts (9 tests) 1899ms
   ✓ TerminalTool session behavior > executes a new command even if the previous one completed between calls  503ms
   ✓ TerminalTool session behavior > returns previous metadata when a timed-out command finishes before the next command  506ms
 ✓ src/tools/__tests__/searchUtils.test.ts (35 tests) 18ms
 ✓ src/sdk/llm/__tests__/factory.gemini-profile-generation-config.test.ts (2 tests) 15ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-summaries.test.ts (2 tests) 9ms
 ✓ src/sdk/runtime/__tests__/Agent.debug-mode.test.ts (6 tests) 14ms
 ✓ src/sdk/runtime/__tests__/Agent.llm-payload-logging.test.ts (1 test) 16ms
 ✓ src/sdk/runtime/__tests__/condensation.test.ts (5 tests) 7ms
 ✓ src/sdk/runtime/__tests__/Agent.builtin-tools.test.ts (2 tests) 8ms
 ✓ src/tools/__tests__/zod-tool.test.ts (15 tests) 7ms
 ✓ src/sdk/conversation/RemoteConversation.test.ts (7 tests) 5ms
 ✓ src/sdk/conversation/__tests__/stuckDetector.test.ts (15 tests) 12ms
 ✓ src/sdk/__tests__/agent.security.test.ts (7 tests) 32ms
 ✓ src/sdk/context/condenser/__tests__/llmSummarizingCondenser.test.ts (2 tests) 4ms
 ✓ src/sdk/llm/__tests__/modelsDevApiCache.test.ts (1 test) 9ms
 ✓ src/sdk/llm/__tests__/thinkingBlocks.test.ts (9 tests) 60ms
 ✓ src/tools/__tests__/validation.test.ts (40 tests) 5ms
 ✓ src/sdk/runtime/__tests__/Agent.truncate-observation.test.ts (3 tests) 12ms
 ✓ src/sdk/runtime/__tests__/Agent.terminal-observation-summary.test.ts (2 tests) 10ms
 ✓ src/sdk/runtime/__tests__/EventLog.test.ts (26 tests) 9ms
 ✓ src/sdk/runtime/__tests__/Agent.action-reasoning-metadata.test.ts (1 test) 7ms
 ✓ src/sdk/runtime/__tests__/Agent.file-diff-summary.test.ts (1 test) 8ms
 ✓ src/sdk/runtime/__tests__/ConversationState.test.ts (24 tests) 10ms
 ✓ src/sdk/llm/__tests__/credentials.test.ts (11 tests) 3ms
 ✓ src/sdk/runtime/__tests__/Agent.security-risk.test.ts (4 tests) 12ms
 ✓ src/sdk/conversation/LocalConversation.secretStorage.test.ts (3 tests) 8ms
 ✓ src/sdk/runtime/__tests__/secretMasker.test.ts (22 tests) 7ms
 ✓ src/sdk/llm/__tests__/retryPolicy.test.ts (5 tests) 14ms
 ✓ src/workspace/__tests__/remote.workspace.test.ts (6 tests) 6ms
 ✓ src/sdk/runtime/__tests__/Agent.finish-tool.test.ts (2 tests) 7ms
 ✓ src/sdk/runtime/__tests__/SecretRegistry.test.ts (8 tests) 4ms
 ✓ src/sdk/runtime/__tests__/Agent.redaction.test.ts (2 tests) 9ms
 ✓ src/sdk/security/__tests__/confirmationPolicy.test.ts (22 tests) 3ms
 ✓ src/sdk/runtime/__tests__/Agent.tool-call-redaction.test.ts (1 test) 8ms
 ✓ src/sdk/runtime/__tests__/LlmClientCache.test.ts (5 tests) 4ms
 ✓ src/sdk/runtime/__tests__/Agent.think-tool-parity.test.ts (1 test) 7ms
 ✓ src/sdk/runtime/__tests__/settingsUtils.test.ts (15 tests) 2ms
 ✓ src/sdk/llm/__tests__/errorMapping.test.ts (33 tests) 6ms
 ✓ src/sdk/runtime/__tests__/Agent.workspace.test.ts (1 test) 7ms
 ✓ src/sdk/__tests__/composeCallbacks.test.ts (2 tests) 2ms
 ✓ src/sdk/types/__tests__/typeGuards.test.ts (37 tests) 4ms
 ✓ src/sdk/__tests__/runtime.test.ts (4 tests) 3ms
 ✓ src/sdk/__tests__/conversation-stats.test.ts (5 tests) 4ms
 ✓ src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts (9 tests) 5ms
 ✓ src/tools/delegate/__tests__/DelegateTool.test.ts (6 tests) 6ms
 ✓ src/sdk/__tests__/metrics.test.ts (12 tests) 6ms
 ✓ src/sdk/runtime/__tests__/textSanitizers.test.ts (7 tests) 3ms
 ✓ src/sdk/runtime/__tests__/errorPolicy.test.ts (11 tests) 2ms
 ✓ src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts (9 tests) 4ms
 ✓ src/sdk/__tests__/agent-sdk.guards.test.ts (5 tests) 2ms
 ✓ src/sdk/llm/__tests__/providerQuirks.test.ts (27 tests) 3ms
 ✓ src/sdk/observations/__tests__/observations.format.test.ts (6 tests) 2ms
 ✓ src/sdk/security/__tests__/analyzer.test.ts (12 tests) 3ms
 ✓ src/sdk/conversation/__tests__/ConversationVisualizer.test.ts (1 test) 2ms
 ✓ src/sdk/runtime/__tests__/gitChangeSummarizer.test.ts (4 tests) 8ms
 ✓ src/sdk/runtime/__tests__/toolResultTruncation.test.ts (22 tests) 3ms
 ✓ src/sdk/llm/__tests__/router.test.ts (5 tests) 3ms
 ✓ src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts (3 tests) 2ms
 ✓ src/sdk/runtime/__tests__/truncateError.unit.test.ts (5 tests) 3ms
 ✓ src/sdk/llm/__tests__/gemini.stripUnsupportedSchemaProps.test.ts (7 tests) 4ms
 ✓ src/tools/delegate/__tests__/registration.test.ts (3 tests) 2ms
 ✓ src/sdk/types/__tests__/visualizeConversationErrorEvent.test.ts (3 tests) 1ms
 ✓ src/tools/__tests__/ThinkTool.test.ts (2 tests) 2ms
 ✓ src/sdk/conversation/__tests__/includeDefaultTools.test.ts (6 tests) 5ms
 ✓ src/sdk/llm/__tests__/provider.test.ts (15 tests) 2ms
 ✓ src/sdk/runtime/__tests__/sanitizeChatMessages.test.ts (4 tests) 4ms
 ✓ src/workspace/__tests__/workspace.factory.test.ts (2 tests) 2ms
 ✓ src/sdk/__tests__/remoteUrlNormalization.test.ts (5 tests) 3ms
 ✓ src/sdk/llm/__tests__/contextLimit.test.ts (8 tests) 9ms
 ✓ src/sdk/llm/__tests__/modelsDevPricing.test.ts (5 tests) 2ms
 ✓ src/sdk/__tests__/llmSettingsHelpers.test.ts (2 tests) 3ms
 ✓ src/tools/delegate/__tests__/DelegationVisualizer.test.ts (6 tests) 5ms
 ✓ src/sdk/llm/__tests__/debug.test.ts (7 tests) 2ms
 ✓ src/sdk/context/skills/__tests__/prompt.test.ts (4 tests) 1ms
 ✓ src/sdk/llm/__tests__/timeoutDefaults.test.ts (1 test) 2ms
 ✓ src/sdk/runtime/__tests__/toolCallErrorEvents.test.ts (2 tests) 1ms

 Test Files  108 passed (108)
      Tests  1007 passed | 1 skipped (1008)
   Start at  00:10:48
   Duration  4.82s (transform 1.24s, setup 0ms, collect 9.09s, tests 6.42s, environment 11ms, prepare 5.07s)
- 
 RUN  v3.2.4 /Users/enyst/repos/oh-tab

 ✓ src/webview-src/__tests__/event.rendering.test.tsx (27 tests) 625ms

 Test Files  1 passed (1)
      Tests  27 passed (27)
   Start at  00:10:53
   Duration  1.72s (transform 366ms, setup 46ms, collect 589ms, tests 625ms, environment 290ms, prepare 38ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "OpenHands (tool call)" indicator to distinguish tool-call messages from standard assistant responses.

* **Bug Fixes**
  * Fixed duplication of extended thinking content in tool-call messages by suppressing reasoning display when the assistant performs a tool call.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->