### PR TITLE
clear up confusion; update docs and UI text for Cloud

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -116,7 +116,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
 - **OpenHands: Set OpenRouter API Key**
 - **OpenHands: Set LiteLLM Proxy API Key**
 - **OpenHands: Set Gemini API Key**
-- **OpenHands: Set Session API Key** - set agent-server auth key
+- **OpenHands: Set Remote API Key** - set the remote auth key (agent-server session key, or Cloud API key for SaaS)
 - **OpenHands: Set GitHub Token**
 - **OpenHands: Set HAL TTS API Key**
 - **OpenHands: Set Custom Secret 1/2/3**

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -16,7 +16,8 @@ The key takeaway: **cloud device-flow returns a user API key / access token for 
 ### A) Cloud device-flow token (aka “cloud API key”, “device link access key”)
 - **Origin:** OAuth 2.0 Device Flow endpoints on the SaaS server
 - **Used to authenticate to:** SaaS server HTTP APIs (e.g. `/api/user/info`, `/api/settings`, cloud conversation creation)
-- **Transport:** `Authorization: Bearer <token>` (or sometimes `X-Session-API-Key: <token>` as a compatibility fallback)
+- **Transport:** `Authorization: Bearer <token>` (clients should treat this as the canonical scheme)
+  - Note: some deployments also accept `X-Session-API-Key: <token>` as a temporary compatibility hack; do not rely on this as the default client behavior.
 - **Storage (CLI):** `~/.openhands/cloud/api_key.txt` (owner-only perms)
 
 ### B) Agent-server session API key (runtime/sandbox scoped)
@@ -202,6 +203,10 @@ Note: this file explicitly labels itself “LEGACY V0 CODE” and warns not to e
   - `${base.replace(/^http/, 'ws')}/sockets/events/${conversationId}?session_api_key=<sessionKey>&resend_all=true`
 
 This is the exact “secret-in-URL” issue from bead `oh-tab-h3g`.
+
+Clarification:
+- The cloud/SaaS device-flow token should be sent as `Authorization: Bearer <cloud_api_key>` to SaaS endpoints.
+- The runtime/sandbox `session_api_key` should be sent as `X-Session-API-Key: <runtime_session_api_key>` to the nested agent-server (and currently as `?session_api_key=...` for WS).
 
 ### 5.3 Why the cloud token vs runtime token confusion matters
 There are multiple server surfaces:

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -17,7 +17,6 @@ The key takeaway: **cloud device-flow returns a user API key / access token for 
 - **Origin:** OAuth 2.0 Device Flow endpoints on the SaaS server
 - **Used to authenticate to:** SaaS server HTTP APIs (e.g. `/api/user/info`, `/api/settings`, cloud conversation creation)
 - **Transport:** `Authorization: Bearer <token>` (clients should treat this as the canonical scheme)
-  - Note: some deployments also accept `X-Session-API-Key: <token>` as a temporary compatibility hack; do not rely on this as the default client behavior.
 - **Storage (CLI):** `~/.openhands/cloud/api_key.txt` (owner-only perms)
 
 ### B) Agent-server session API key (runtime/sandbox scoped)

--- a/docs/cloud_oauth_device_flow.md
+++ b/docs/cloud_oauth_device_flow.md
@@ -4,17 +4,51 @@ Bead: `oh-tab-voc.1` (investigation + design)
 
 ## Goal
 
-Enable **remote** conversations against OpenHands Cloud servers (e.g. `app.all-hands.dev`) by obtaining and storing a **session API key** via **OAuth 2.0 Device Authorization Grant (“Device Flow”)**, matching the existing OpenHands-CLI behavior.
+Enable **remote** conversations against OpenHands Cloud servers (e.g. `app.all-hands.dev`) by obtaining and storing a **cloud API key / SaaS user token** via **OAuth 2.0 Device Authorization Grant (“Device Flow”)**, matching the existing OpenHands-CLI behavior.
 
 Non-goals (for this bead):
 - Implement the flow end-to-end in oh-tab (covered by follow-up beads `oh-tab-voc.2+`).
 - Define cloud-side auth policies or server changes.
 
+Important:
+- The Device Flow `access_token` is a **cloud/SaaS user API key**, not the per-sandbox/runtime **agent-server `session_api_key`**. See `docs/cloud-auth-flow.md`.
+
 ## Current oh-tab behavior (baseline)
 
-- Remote mode uses `settings.secrets.sessionApiKey` and sends it as `X-Session-API-Key` for remote agent-server calls (see `packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts` and `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts`).
-- When a remote server returns `401/403`, oh-tab currently shows: “Authentication failed - check your Session API Key in settings.” (see `RemoteConversation.startNewConversation()`).
+- Remote mode uses `settings.secrets.sessionApiKey` (currently a misnomer) as its single “remote auth key” slot (see `packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts` and `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts`).
+- The UI/helptext currently calls this “Session API Key”, even when it is actually a **cloud/SaaS API key** (device-flow output).
 - Tokens are stored in VS Code SecretStorage via `SettingsManager` / `VscodeSettingsAdapter` as `context.secrets` entries (see `src/settings/SettingsManager.ts` + `src/settings/VscodeSettingsAdapter.ts`).
+
+## Clarification: two different keys (very important)
+
+OpenHands Cloud remote mode involves two different secrets:
+
+1) **Cloud API key / SaaS user token** (Device Flow `access_token`)
+   - Used to authenticate requests to the **SaaS/app-server** surface (e.g. `app.all-hands.dev`).
+   - Transport: `Authorization: Bearer <cloud_api_key>`.
+   - This is what the OpenHands-CLI stores in `~/.openhands/cloud/api_key.txt`.
+
+2) **Runtime session API key** (`session_api_key`, sandbox/runtime-scoped)
+   - Used to authenticate requests to the **nested runtime agent-server** (HTTP + WS).
+   - Transport (HTTP): `X-Session-API-Key: <runtime_session_api_key>`.
+   - Transport (WS today): query param `?session_api_key=<runtime_session_api_key>` (see `oh-tab-h3g`).
+
+The cloud API key is **not** the same as the runtime `session_api_key`.
+
+## Target architecture (explicit 2-stage flow)
+
+Goal: after cloud login, use the cloud API key to discover the nested agent-server URL and runtime `session_api_key`, then connect directly to the agent-server.
+
+1) Login (Device Flow) against the SaaS/app-server (e.g. `https://app.all-hands.dev`)
+   - Store the **cloud API key** per server.
+2) Use the cloud API key to call **V1** app-server endpoints to obtain nested runtime connection info:
+   - Prefer `/api/v1/app-conversations*` endpoints that return `AppConversation` records including:
+     - `conversation_url` (contains the nested agent-server base URL)
+     - `session_api_key` (runtime/sandbox credential)
+   - Continue to document legacy `/api/conversations*` for compatibility, but avoid depending on it.
+3) Connect to the nested agent-server directly
+   - Base URL: derived from `conversation_url`
+   - Auth: `X-Session-API-Key: <runtime_session_api_key>` and (today) WS `?session_api_key=...`
 
 ## Reference implementation: OpenHands-CLI
 
@@ -76,27 +110,32 @@ Recommendation:
 ### Token storage model (per-server)
 
 Problem:
-- oh-tab currently stores a single `openhands.sessionApiKey`. But users can have multiple `settings.servers[]`, and cloud tokens are effectively “account/session scoped” (and may differ per environment).
+- oh-tab currently stores a single `openhands.sessionApiKey` and treats it as “the remote auth key”.
+- But cloud mode needs two distinct keys (cloud user token vs runtime `session_api_key`), and users can have multiple `settings.servers[]`.
 
 Recommendation:
-- Store a token **per canonical server URL** in VS Code SecretStorage.
+- Store the **cloud API key** per canonical SaaS server URL in VS Code SecretStorage.
+- Treat runtime `session_api_key` as runtime/sandbox-scoped data (generally obtained from V1 conversation metadata and not reused across unrelated sandboxes).
 
 Suggested secret keys:
-- `openhands.sessionApiKey` (legacy / “effective” key; keep for backwards compatibility)
-- `openhands.sessionApiKey.server.<hash>` (server-specific token)
-- `openhands.sessionApiKey.server.<hash>.meta` (optional JSON metadata; e.g. `{ serverUrl, obtainedAt, tokenType, expiresAt? }`)
+- `openhands.cloudApiKey` (new legacy-ish key for backwards compatibility)
+- `openhands.cloudApiKey.server.<hash>` (server-specific cloud token)
+- `openhands.cloudApiKey.server.<hash>.meta` (optional JSON metadata; e.g. `{ serverUrl, obtainedAt, tokenType, expiresAt? }`)
+
+Compatibility note:
+- Until the schema/code is migrated, oh-tab may temporarily keep storing the cloud API key in `openhands.sessionApiKey*` (misnamed). The UI should still call it “Cloud API Key” for SaaS servers.
 
 Where `<hash>` is a stable hash of the normalized server URL (e.g. SHA-256 hex of `normalizeServerUrl(url).url`).
 
 Lookup rules:
 1. Normalize server URL (`normalizeServerUrl`).
 2. Attempt per-server key first.
-3. Fall back to `openhands.sessionApiKey` (so existing manual workflows keep working).
+3. Fall back to the legacy key (so existing manual workflows keep working).
 
 Write rules:
 - Whenever a token is obtained for a server, always store it in the per-server key.
-- Do **not** silently clobber `openhands.sessionApiKey` (legacy) if it already contains a different value.
-  - If `openhands.sessionApiKey` is empty/unset, or already matches the per-server token for the currently-selected server, it is OK to write it for backwards compatibility.
+- Do **not** silently clobber the legacy key if it already contains a different value.
+  - If the legacy key is empty/unset, or already matches the per-server token for the currently-selected server, it is OK to write it for backwards compatibility.
   - Otherwise leave it unchanged and rely on the per-server key as the authoritative source.
 
 ### CLI token reuse (optional)
@@ -168,16 +207,13 @@ The host should remain the source of truth for token storage; webview should nev
 ### Header compatibility (Bearer vs X-Session-API-Key)
 
 CLI uses `Authorization: Bearer <token>` for `/api/*` calls.
-oh-tab’s remote agent-server currently uses `X-Session-API-Key: <token>`.
 
-Open question:
-- Whether OpenHands Cloud accepts both headers for all relevant endpoints.
+Important:
+- For OpenHands Cloud/SaaS calls, **do not** send the cloud API key as `X-Session-API-Key`.
+- Use `Authorization: Bearer <cloud_api_key>` for SaaS/app-server APIs.
+- Reserve `X-Session-API-Key` for the runtime/sandbox `session_api_key` when calling the nested agent-server.
 
-Recommendation:
-- In follow-up implementation, consider sending **both headers** (same token) for remote agent-server API calls to maximize compatibility:
-  - `Authorization: Bearer <token>`
-  - `X-Session-API-Key: <token>`
-This can be done in `RemoteConversation.getAuthHeaders()` and `RemoteWorkspace.getAuthHeaders()`.
+If a cloud deployment only works with `X-Session-API-Key` for SaaS endpoints, treat that as a server-side compatibility quirk and document it explicitly (do not make it the default client behavior).
 
 ## Sequence diagrams
 
@@ -214,17 +250,16 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
   participant Host as Extension Host
-  participant SDK as RemoteConversation
-  participant Cloud as Cloud Server
+  participant Cloud as SaaS/App-Server
+  participant Agent as Nested Agent-Server
 
-  Host->>SDK: startNewConversation()
-  SDK->>Cloud: POST /api/conversations (auth headers)
-  Cloud-->>SDK: 401/403
-  SDK-->>Host: emits an auth-shaped error/event (e.g. 401/403 from remote)
+  Host->>Cloud: POST /api/v1/app-conversations (Authorization: Bearer cloud_api_key)
+  Cloud-->>Host: 401/403
   Host->>Host: prompt user to login (host-side UX)
   Host->>Cloud: OAuth device flow (as above)
-  Host->>SDK: setSettings({ secrets: { sessionApiKey: token } })
-  Host->>SDK: startNewConversation() retry
+  Host->>Cloud: retry POST /api/v1/app-conversations (Authorization: Bearer cloud_api_key)
+  Cloud-->>Host: AppConversation { conversation_url, session_api_key, ... }
+  Host->>Agent: connect to conversation_url (X-Session-API-Key: session_api_key, WS ?session_api_key=...)
 ```
 
 ## Threat model (extension-side)
@@ -250,4 +285,4 @@ Suggested coverage to unblock implementation:
 1. **Settings sync parity:** Should oh-tab fetch `/api/settings` after login (like CLI) and update local UI defaults for remote mode?
 2. **Token expiry:** If the access token expires, what is the expected renewal mechanism (re-login vs refresh token)?
 3. **Multi-server tokens:** Should UI expose “Logged in as …” per server and allow per-server logout?
-4. **Header scheme:** Confirm whether cloud accepts `X-Session-API-Key` for all endpoints used by remote mode, or if Bearer is required.
+4. **Header scheme:** Confirm that OpenHands Cloud (SaaS) accepts `Authorization: Bearer <cloud_api_key>` for all endpoints used by remote mode.

--- a/docs/vscode_local_setup.md
+++ b/docs/vscode_local_setup.md
@@ -166,7 +166,7 @@ npm run agent-server
 ```
 
 Notes:
-- If you set `SESSION_API_KEY`, you must also set it in VS Code via “OpenHands: Set Session API Key”.
+- If you set `SESSION_API_KEY`, you must also set it in VS Code via “OpenHands: Set Remote API Key”.
 - Avoid `DEBUG_LLM=1` unless you know what you’re doing: it prompts for confirmation and may expose secrets in logs.
 
 ## Logs and Diagnostics

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
       },
       {
         "command": "openhands.setSessionApiKey",
-        "title": "OpenHands: Set Session API Key"
+        "title": "OpenHands: Set Remote API Key"
       },
       {
         "command": "openhands.cloudLogin",
@@ -419,7 +419,7 @@
             "default": "",
             "order": 1,
             "editPresentation": "singlelineText",
-            "markdownDescription": "**To set your Session API Key securely:**\n\n[🔑 Configure Session API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json. Used to authenticate to agent-server.)_"
+            "markdownDescription": "**To set your remote auth key securely:**\n\n[🔑 Configure Remote API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json.)_\n\nNotes:\n- **OpenHands Cloud/SaaS**: this is your **Cloud API Key** (Device Flow `access_token`), used as `Authorization: Bearer ...`.\n- **Nested runtime agent-server**: this is the runtime **session API key** (`session_api_key`), used as `X-Session-API-Key: ...`."
           },
           "openhands.secrets.githubToken": {
             "type": "string",

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -14,6 +14,7 @@ import type { BaseWorkspace } from '../../workspace/BaseWorkspace';
 import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from '../../workspace/types';
 import { resolveToolsWithDefaultTools } from './includeDefaultTools';
 import { normalizeRemoteUrl } from '../../shared/remoteUrl';
+import { getRemoteAuthKeyLabelForServerUrl, isOpenHandsCloudServerUrl } from '../../shared/cloudServers';
 
 
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
@@ -392,7 +393,7 @@ export class RemoteConversation extends EventEmitter {
         const status = res.status;
         let userMessage = `Failed to start conversation (HTTP ${status})`;
         if (status === 401 || status === 403) {
-          userMessage += '. Authentication failed - check your Session API Key in settings.';
+          userMessage += `. Authentication failed - check your ${getRemoteAuthKeyLabelForServerUrl(this.serverUrl)} in settings.`;
         } else if (status === 404) {
           userMessage += `. Server not found at ${this.serverUrl}. Check the server URL in settings.`;
         } else if (status >= 500) {
@@ -732,8 +733,12 @@ export class RemoteConversation extends EventEmitter {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     const sessionKey = this.settings?.secrets.sessionApiKey || '';
     if (sessionKey) {
-      headers['X-Session-API-Key'] = sessionKey;
-      headers['Authorization'] = `Bearer ${sessionKey}`;
+      if (isOpenHandsCloudServerUrl(this.serverUrl)) {
+        headers['Authorization'] = `Bearer ${sessionKey}`;
+      } else {
+        headers['X-Session-API-Key'] = sessionKey;
+        headers['Authorization'] = `Bearer ${sessionKey}`;
+      }
     }
     return headers;
   }
@@ -783,7 +788,7 @@ export class RemoteConversation extends EventEmitter {
     const base = this.serverUrl.replace(/\/$/, '');
     const sessionKey = this.settings?.secrets.sessionApiKey || '';
     const params = new URLSearchParams();
-    if (sessionKey) params.set('session_api_key', sessionKey);
+    if (sessionKey && !isOpenHandsCloudServerUrl(this.serverUrl)) params.set('session_api_key', sessionKey);
     params.set('resend_all', 'true');
     const qs = params.toString();
     const wsUrl = `${base.replace(/^http/, 'ws')}/sockets/events/${this.conversationId}?${qs}`;

--- a/packages/agent-sdk-ts/src/shared/cloudServers.ts
+++ b/packages/agent-sdk-ts/src/shared/cloudServers.ts
@@ -1,0 +1,18 @@
+import { normalizeRemoteUrl } from './remoteUrl';
+
+export function isOpenHandsCloudServerUrl(raw: string): boolean {
+  const normalized = normalizeRemoteUrl(raw);
+  if (!normalized) return false;
+
+  try {
+    const url = new URL(normalized);
+    return url.hostname.toLowerCase() === 'app.all-hands.dev';
+  } catch {
+    return false;
+  }
+}
+
+export function getRemoteAuthKeyLabelForServerUrl(raw: string): string {
+  return isOpenHandsCloudServerUrl(raw) ? 'Cloud API Key' : 'Session API Key';
+}
+

--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceEncoding,
 } from './types';
 import { normalizeRemoteUrl } from '../shared/remoteUrl';
+import { isOpenHandsCloudServerUrl } from '../shared/cloudServers';
 
 const normalizeRemoteHostUrl = normalizeRemoteUrl;
 
@@ -32,7 +33,12 @@ const normalizeEncoding = (encoding: WorkspaceEncoding): NodeBufferEncoding => {
 
 export interface RemoteWorkspaceOptions {
   host: string;
-  /** Session API key for authenticating with the OpenHands server. */
+  /**
+   * Authentication token for the remote host.
+   *
+   * - OpenHands Cloud/SaaS: cloud API key (device-flow `access_token`), used as `Authorization: Bearer ...`
+   * - Nested runtime agent-server: runtime `session_api_key`, used as `X-Session-API-Key: ...`
+   */
   sessionApiKey?: string;
   workingDir?: string;
   pollIntervalMs?: number;
@@ -424,8 +430,12 @@ export class RemoteWorkspace implements BaseWorkspace {
   private getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
     const headers: Record<string, string> = { ...extra };
     if (this.sessionApiKey) {
-      headers['X-Session-API-Key'] = this.sessionApiKey;
-      headers['Authorization'] = `Bearer ${this.sessionApiKey}`;
+      if (isOpenHandsCloudServerUrl(this.host)) {
+        headers['Authorization'] = `Bearer ${this.sessionApiKey}`;
+      } else {
+        headers['X-Session-API-Key'] = this.sessionApiKey;
+        headers['Authorization'] = `Bearer ${this.sessionApiKey}`;
+      }
     }
     return headers;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import { computeWelcomeSecretStatus } from './shared/welcomeSecretStatus';
 import { getServerSessionApiKeySecretKey } from './auth/serverSessionApiKeys';
+import { getRemoteAuthKeyLabelForServerUrl } from './shared/cloudServers';
 import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
 import { registerCloudLogoutCommand } from './extension/cloudLogoutCommand';
 import {
@@ -521,7 +522,7 @@ export function activate(context: vscode.ExtensionContext) {
             })();
 
             const action = await vscode.window.showWarningMessage(
-              `OpenHands: A legacy Session API Key is set. Use it for ${serverLabel}?`,
+              `OpenHands: A legacy ${getRemoteAuthKeyLabelForServerUrl(settings.serverUrl)} is set. Use it for ${serverLabel}?`,
               { modal: true },
               'Use key for this server',
               'Not now',

--- a/src/extension/cloudLoginCommand.ts
+++ b/src/extension/cloudLoginCommand.ts
@@ -147,7 +147,7 @@ export function registerCloudLoginCommand(options: {
       await context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmedToken);
     }
 
-    output?.appendLine(`[auth] Stored session API key for ${keyInfo.normalizedServerUrl}.`);
+    output?.appendLine(`[auth] Stored cloud API key for ${keyInfo.normalizedServerUrl}.`);
     if (!canUpdateLegacy && legacyValue) {
       output?.appendLine('[auth] Legacy openhands.sessionApiKey was not overwritten (different value already set).');
     }

--- a/src/extension/secretCommands.ts
+++ b/src/extension/secretCommands.ts
@@ -3,6 +3,7 @@ import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsMan
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import type { ConversationInstance, SecretRegistry } from '@openhands/agent-sdk-ts';
 import { getServerSessionApiKeySecretKey, LEGACY_SESSION_API_KEY_SECRET_KEY } from '../auth/serverSessionApiKeys';
+import { getRemoteAuthKeyLabelForServerUrl, isOpenHandsCloudServerUrl } from '../shared/cloudServers';
 
 type SecretKey = keyof OpenHandsSettings['secrets'];
 
@@ -272,18 +273,23 @@ export function registerSecretCommands(params: {
   });
 
   const setSessionApiKey = vscode.commands.registerCommand('openhands.setSessionApiKey', async () => {
-    const title = 'Session API Key';
-    const prompt = 'Enter your Session API key. It will be stored securely in VS Code SecretStorage.';
-    const successMessage = 'Session API Key saved securely.';
-    const clearedMessage = 'Session API Key cleared.';
-    const errorPrefix = 'Failed to save Session API Key';
-
     const trimOrEmpty = (value: unknown): string => typeof value === 'string' ? value.trim() : '';
+    let errorPrefix = 'Failed to save Remote API Key';
 
     try {
       const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(params.context));
       const existing = await settingsMgr.get();
       const serverUrl = typeof existing.serverUrl === 'string' ? existing.serverUrl.trim() : '';
+      const authKeyLabel = getRemoteAuthKeyLabelForServerUrl(serverUrl);
+      const isCloud = Boolean(serverUrl) && isOpenHandsCloudServerUrl(serverUrl);
+
+      const title = authKeyLabel;
+      const prompt = isCloud
+        ? 'Enter your OpenHands Cloud API key. It will be stored securely in VS Code SecretStorage.'
+        : 'Enter your Session API key for the remote agent-server. It will be stored securely in VS Code SecretStorage.';
+      const successMessage = `${authKeyLabel} saved securely.`;
+      const clearedMessage = `${authKeyLabel} cleared.`;
+      errorPrefix = `Failed to save ${authKeyLabel}`;
 
       const keyInfo = serverUrl ? getServerSessionApiKeySecretKey(serverUrl) : null;
       const storageKey = keyInfo?.ok ? keyInfo.secretKey : LEGACY_SESSION_API_KEY_SECRET_KEY;
@@ -336,7 +342,7 @@ export function registerSecretCommands(params: {
         title,
         password: true,
         prompt,
-        placeHolder: 'sk-...',
+        placeHolder: isCloud ? 'paste token...' : 'sk-...',
       });
 
       if (value === undefined) return;

--- a/src/shared/cloudServers.ts
+++ b/src/shared/cloudServers.ts
@@ -1,0 +1,20 @@
+import { normalizeServerUrl } from './serverUrls';
+
+export function isOpenHandsCloudServerUrl(raw: string): boolean {
+  const normalized = normalizeServerUrl(raw);
+  if (!normalized.ok) return false;
+
+  try {
+    const url = new URL(normalized.url);
+    // Keep this conservative: only treat the known SaaS host as “cloud”.
+    // If we need to support additional enterprise cloud hosts, expand this list explicitly.
+    return url.hostname.toLowerCase() === 'app.all-hands.dev';
+  } catch {
+    return false;
+  }
+}
+
+export function getRemoteAuthKeyLabelForServerUrl(raw: string): string {
+  return isOpenHandsCloudServerUrl(raw) ? 'Cloud API Key' : 'Session API Key';
+}
+

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -1,6 +1,7 @@
 import type * as vscode from 'vscode';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools, type LocalToolId } from '../../../shared/localTools';
+import { isOpenHandsCloudServerUrl } from '../../../shared/cloudServers';
 import { normalizeServerUrl } from '../../../shared/serverUrls';
 import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
 
@@ -48,7 +49,11 @@ async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[
   const url = `${normalized.url}/api/tools/`;
   const headers: Record<string, string> = {};
   if (params.sessionApiKey) {
-    headers['X-Session-API-Key'] = params.sessionApiKey;
+    if (isOpenHandsCloudServerUrl(normalized.url)) {
+      headers['Authorization'] = `Bearer ${params.sessionApiKey}`;
+    } else {
+      headers['X-Session-API-Key'] = params.sessionApiKey;
+    }
   }
 
   const fetchFn = globalThis.fetch;
@@ -142,4 +147,3 @@ export async function handleSetEnabledTools(args: {
 
   await args.postToolsList();
 }
-


### PR DESCRIPTION
clear up confusion; update docs and UI text for Cloud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated authentication documentation to clarify Cloud API Key usage for OpenHands Cloud versus Session API Key for remote runtime servers.
  * Renamed command label from "Session API Key" to "Remote API Key" for improved clarity.

* **Improvements**
  * Enhanced authentication handling to use appropriate authentication methods based on server type.
  * Improved error messages and prompts to reference the correct key type for your configured server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->