### PR TITLE
Split cloud API key vs runtime session API key

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -141,7 +141,7 @@ LocalConversation supports persistent conversations through the `persistenceDir`
 - Real-time event streaming
 - HTTP fallback for message delivery
 - Automatic reconnection with exponential backoff
-- Session API key authentication
+- Runtime session API key authentication
 - Conversation lifecycle management via REST API
 
 **Connection Strategy**:
@@ -1469,11 +1469,13 @@ function resolveWorkspaceRoot(): string {
 
 // Create conversation (auto-detects local vs remote)
 const serverUrl = settings.serverUrl ?? undefined; // undefined = local mode
-const cloudApiKey = serverUrl && isOpenHandsCloudServerUrl(serverUrl)
-  ? await context.secrets.get(getServerCloudApiKeySecretKey(serverUrl).secretKey)
+const cloudKeyInfo = serverUrl ? getServerCloudApiKeySecretKey(serverUrl) : null;
+const cloudApiKey = serverUrl && isOpenHandsCloudServerUrl(serverUrl) && cloudKeyInfo?.ok
+  ? await context.secrets.get(cloudKeyInfo.secretKey)
   : undefined;
-const runtimeSessionApiKey = serverUrl
-  ? await context.secrets.get(getServerRuntimeSessionApiKeySecretKey(serverUrl).secretKey)
+const runtimeKeyInfo = serverUrl ? getServerRuntimeSessionApiKeySecretKey(serverUrl) : null;
+const runtimeSessionApiKey = serverUrl && runtimeKeyInfo?.ok
+  ? await context.secrets.get(runtimeKeyInfo.secretKey)
   : undefined;
 
 const conversation: ConversationInstance = Conversation({

--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -169,7 +169,7 @@ const conversation = Conversation({
   settings: {
     llm: { model: 'claude-sonnet-4-20250514', usageId: 'remote' },
     secrets: {
-      sessionApiKey: 'sk_session_xxx',
+      runtimeSessionApiKey: 'sk_session_xxx',
       llmApiKey: process.env.ANTHROPIC_API_KEY,
     },
   },
@@ -1449,6 +1449,9 @@ import {
   isActionEvent,
   isObservationEvent
 } from '@openhands/agent-sdk-ts';
+import { isOpenHandsCloudServerUrl } from '../src/shared/cloudServers';
+import { getServerCloudApiKeySecretKey } from '../src/auth/serverCloudApiKeys';
+import { getServerRuntimeSessionApiKeySecretKey } from '../src/auth/serverRuntimeSessionApiKeys';
 
 // Workspace root selection (multi-root-safe):
 // Prefer the workspace folder containing the active editor, fall back only when the workspace has a single folder.
@@ -1465,8 +1468,16 @@ function resolveWorkspaceRoot(): string {
 }
 
 // Create conversation (auto-detects local vs remote)
+const serverUrl = settings.serverUrl ?? undefined; // undefined = local mode
+const cloudApiKey = serverUrl && isOpenHandsCloudServerUrl(serverUrl)
+  ? await context.secrets.get(getServerCloudApiKeySecretKey(serverUrl).secretKey)
+  : undefined;
+const runtimeSessionApiKey = serverUrl
+  ? await context.secrets.get(getServerRuntimeSessionApiKeySecretKey(serverUrl).secretKey)
+  : undefined;
+
 const conversation: ConversationInstance = Conversation({
-  serverUrl: settings.serverUrl ?? undefined, // undefined = local mode
+  serverUrl,
   settings: {
     llm: {
       model: 'claude-sonnet-4-20250514',
@@ -1477,7 +1488,8 @@ const conversation: ConversationInstance = Conversation({
       maxIterations: 50,
     },
     secrets: {
-      sessionApiKey: await context.secrets.get('openhands.sessionApiKey'),
+      cloudApiKey,
+      runtimeSessionApiKey,
       llmApiKey: await context.secrets.get('openhands.llmApiKey'),
     },
   },

--- a/docs/agent_server_test_matrix.md
+++ b/docs/agent_server_test_matrix.md
@@ -71,7 +71,7 @@ curl -fsS http://127.0.0.1:8001/health
 | Server down | Select server while not running | `offline` + clear error message (no hang) |
 | Wrong port | Select `http://127.0.0.1:9999` | Same as “Server down” |
 | WebSocket blocked | Allow HTTP but break WS (if reproducible) | Start conversation via HTTP; WS reconnect/backoff behavior is sensible; errors surface |
-| Auth required (optional) | Set/clear `sessionApiKey` (if server enforces) | 401/403 surfaced with helpful message |
+| Auth required (optional) | Set/clear `runtimeSessionApiKey` (if server enforces) | 401/403 surfaced with helpful message |
 
 ### Conversation flow (remote)
 
@@ -99,4 +99,3 @@ curl -fsS http://127.0.0.1:8001/health
   - conversationStarted received
   - event stream is non-empty after sending a message
 - Always include teardown with timeouts to avoid hung CI runs.
-

--- a/docs/auth/device-flow-test-plan.md
+++ b/docs/auth/device-flow-test-plan.md
@@ -43,11 +43,9 @@ It is a **porting plan** derived from the OpenHands-CLI Python tests listed in t
 ## Token storage
 
 - Per-server token storage uses a canonical server URL key.
-- Legacy compatibility:
-  - Does not silently clobber `openhands.sessionApiKey` when it differs.
-  - Writes `openhands.sessionApiKey` when empty or already matches the per-server token.
+- Device flow stores the **cloud API key** only (device-flow `access_token`) under `openhands.cloudApiKey.server.<hash>`.
 - Delete token:
-  - Clears per-server token and (when applicable) legacy token.
+  - Clears the per-server cloud token and leaves other servers untouched.
 - Metadata storage:
   - Stores non-secret metadata (e.g. obtainedAt/expiresAt/tokenType) separately from the secret.
 
@@ -70,6 +68,4 @@ It is a **porting plan** derived from the OpenHands-CLI Python tests listed in t
 ## Logout command
 
 - Logout clears per-server token and leaves other servers untouched.
-- Logout clears legacy `openhands.sessionApiKey` only when it matches the cleared server token.
 - Logout updates UI state (logged-in indicator) without leaking tokens.
-

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -22,7 +22,7 @@ The key takeaway: **cloud device-flow returns a user API key / access token for 
 ### B) Agent-server session API key (runtime/sandbox scoped)
 - **Origin:** Sandbox/runtime creation (generated per sandbox/runtime)
 - **Used to authenticate to:** the **nested runtime / agent-server** HTTP APIs and its WebSocket/event stream
-- **Transport (HTTP):** `X-Session-API-Key: <session_api_key>` (and sometimes also `Authorization: Bearer …` in TS client)
+- **Transport (HTTP):** `X-Session-API-Key: <session_api_key>`
 - **Transport (WS):** currently frequently appears as a **query param** `?session_api_key=…` for browser WS constraints (this is the `oh-tab-h3g` security concern)
 
 ---
@@ -95,7 +95,7 @@ So although it’s shaped like OAuth, the “access token” is effectively an *
 
 - Requests to most `/api/*` and `/mcp/*` paths require credentials.
 - It treats `Authorization: Bearer …` as the primary API credential.
-- It also treats `X-Session-API-Key` as an acceptable substitute when Authorization is absent.
+- It also treats `X-Session-API-Key` as an acceptable substitute when Authorization is absent (oh-tab should not rely on this fallback).
 
 ### 2.4 SaaS nested runtime manager: returns a *separate* `session_api_key` for the nested runtime
 **File:** `~/repos/odie/enterprise/server/saas_nested_conversation_manager.py`

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -182,24 +182,23 @@ Note: this file explicitly labels itself “LEGACY V0 CODE” and warns not to e
 
 ## 5) OpenHands-Tab (`oh-tab`) / agent-sdk-ts: current client behavior
 
-### 5.1 VS Code extension cloud login stores the device-flow access token as “session API key”
+### 5.1 VS Code extension cloud login stores the device-flow access token as “Cloud API Key”
 **File:** `src/extension/cloudLoginCommand.ts`
 
 - Runs device flow against the currently selected `settings.serverUrl`.
-- Stores returned `access_token` in VS Code SecretStorage under the per-server key.
-- Logs: `[auth] Stored session API key for <normalizedServerUrl>.`
+- Stores returned `access_token` in VS Code SecretStorage under a per-server **cloud API key** slot.
+- Logs: `[auth] Stored cloud API key for <normalizedServerUrl>.`
 
-**Important:** naming aside, this means the device-flow API key is stored in the same slot used by agent-sdk-ts RemoteConversation as `settings.secrets.sessionApiKey`.
-
-### 5.2 RemoteConversation uses that `sessionApiKey` for both HTTP headers and WS URL query
+### 5.2 RemoteConversation uses distinct keys for SaaS vs nested runtime
 **File:** `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts`
 
-- `getAuthHeaders()` sets:
-  - `X-Session-API-Key: <sessionApiKey>`
-  - `Authorization: Bearer <sessionApiKey>`
+- For cloud/SaaS hosts, `getAuthHeaders()` uses:
+  - `Authorization: Bearer <cloudApiKey>`
+- For non-cloud agent-servers, `getAuthHeaders()` uses:
+  - `X-Session-API-Key: <runtimeSessionApiKey>`
 
 - `connect()` constructs WS URL:
-  - `${base.replace(/^http/, 'ws')}/sockets/events/${conversationId}?session_api_key=<sessionKey>&resend_all=true`
+  - `${base.replace(/^http/, 'ws')}/sockets/events/${conversationId}?session_api_key=<runtimeSessionApiKey>&resend_all=true` (non-cloud only)
 
 This is the exact “secret-in-URL” issue from bead `oh-tab-h3g`.
 
@@ -289,7 +288,7 @@ Given the above, `oh-tab` likely should treat these as distinct secrets:
 - **Runtime session API key** (per-sandbox)
   - used to call the agent-server and open WS connections
 
-Today, `oh-tab` uses a single `sessionApiKey` slot for both, which creates ambiguity.
+`oh-tab` stores these separately (`cloudApiKey` vs `runtimeSessionApiKey`) to avoid ambiguity.
 
 ---
 

--- a/docs/cloud_oauth_device_flow.md
+++ b/docs/cloud_oauth_device_flow.md
@@ -15,9 +15,10 @@ Important:
 
 ## Current oh-tab behavior (baseline)
 
-- Remote mode uses `settings.secrets.sessionApiKey` (currently a misnomer) as its single “remote auth key” slot (see `packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts` and `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts`).
-- The UI/helptext currently calls this “Session API Key”, even when it is actually a **cloud/SaaS API key** (device-flow output).
-- Tokens are stored in VS Code SecretStorage via `SettingsManager` / `VscodeSettingsAdapter` as `context.secrets` entries (see `src/settings/SettingsManager.ts` + `src/settings/VscodeSettingsAdapter.ts`).
+- Remote mode uses two distinct fields:
+  - `settings.secrets.cloudApiKey` for **SaaS/app-server** calls (Bearer).
+  - `settings.secrets.runtimeSessionApiKey` for **nested agent-server** calls (X-Session-API-Key / WS query param).
+- Tokens are stored in VS Code SecretStorage as per-server entries (see `src/auth/serverCloudApiKeys.ts` and `src/auth/serverRuntimeSessionApiKeys.ts`).
 
 ## Clarification: two different keys (very important)
 
@@ -105,38 +106,22 @@ Recommendation:
 - Keep auth orchestration in **extension host** (needs VS Code APIs + SecretStorage + safe UX):
   - new module(s) under `src/auth/`
 - Keep only small, pure helpers in `src/shared/` (e.g. server URL normalization already lives there).
-- Avoid putting auth logic into `packages/agent-sdk-ts` for now; the SDK should remain transport-agnostic and accept “sessionApiKey” as an input.
+- Avoid putting auth orchestration into `packages/agent-sdk-ts` for now; the SDK should remain transport-agnostic and accept explicit auth inputs (cloud vs runtime) from the host.
 
 ### Token storage model (per-server)
 
 Problem:
-- oh-tab currently stores a single `openhands.sessionApiKey` and treats it as “the remote auth key”.
-- But cloud mode needs two distinct keys (cloud user token vs runtime `session_api_key`), and users can have multiple `settings.servers[]`.
+- Cloud mode needs two distinct keys (cloud user token vs runtime `session_api_key`), and users can have multiple `settings.servers[]`.
 
 Recommendation:
 - Store the **cloud API key** per canonical SaaS server URL in VS Code SecretStorage.
-- Treat runtime `session_api_key` as runtime/sandbox-scoped data (generally obtained from V1 conversation metadata and not reused across unrelated sandboxes).
+- Store the latest **runtime `session_api_key`** per SaaS server URL as well (useful for reconnect/debug; it is still runtime-scoped and expected to change across sandboxes/conversations).
 
 Suggested secret keys:
-- `openhands.cloudApiKey` (new legacy-ish key for backwards compatibility)
 - `openhands.cloudApiKey.server.<hash>` (server-specific cloud token)
-- `openhands.cloudApiKey.server.<hash>.meta` (optional JSON metadata; e.g. `{ serverUrl, obtainedAt, tokenType, expiresAt? }`)
-
-Compatibility note:
-- Until the schema/code is migrated, oh-tab may temporarily keep storing the cloud API key in `openhands.sessionApiKey*` (misnamed). The UI should still call it “Cloud API Key” for SaaS servers.
+- `openhands.runtimeSessionApiKey.server.<hash>` (server-specific runtime session key)
 
 Where `<hash>` is a stable hash of the normalized server URL (e.g. SHA-256 hex of `normalizeServerUrl(url).url`).
-
-Lookup rules:
-1. Normalize server URL (`normalizeServerUrl`).
-2. Attempt per-server key first.
-3. Fall back to the legacy key (so existing manual workflows keep working).
-
-Write rules:
-- Whenever a token is obtained for a server, always store it in the per-server key.
-- Do **not** silently clobber the legacy key if it already contains a different value.
-  - If the legacy key is empty/unset, or already matches the per-server token for the currently-selected server, it is OK to write it for backwards compatibility.
-  - Otherwise leave it unchanged and rely on the per-server key as the authoritative source.
 
 ### CLI token reuse (optional)
 
@@ -266,7 +251,7 @@ sequenceDiagram
 
 Primary risks and mitigations:
 - **Token leakage via logs/UI**: never print tokens to OutputChannel, toasts, or webview messages. Keep the token in extension host only and persist it only in VS Code SecretStorage.
-- **Accidental token overwrite**: avoid silently replacing `openhands.sessionApiKey` when it differs (per “Write rules”); prefer server-scoped secrets as authoritative.
+- **Accidental token overwrite**: avoid silently replacing per-server secrets (e.g. `openhands.cloudApiKey.server.<hash>` / `openhands.runtimeSessionApiKey.server.<hash>`) without explicit user intent.
 - **Phishing / malicious serverUrl**: show the canonical server URL being logged into and the exact verification URL opened; require explicit user action to start login. Avoid auto-login loops without user confirmation.
 - **Replay / long-lived tokens**: treat access tokens as sensitive long-lived secrets; if the server provides expiry metadata (`expires_in`) or refresh tokens, store metadata (not secrets) separately and plan for re-auth / refresh.
 - **Compromised machine / extension host**: SecretStorage reduces accidental exposure but cannot defend against a fully compromised host; keep scope minimal (no additional token replication beyond SecretStorage).
@@ -275,7 +260,7 @@ Primary risks and mitigations:
 
 Suggested coverage to unblock implementation:
 - **Unit (host)**: device-flow polling state machine (`authorization_pending`, `slow_down` backoff, `expired_token`, `access_denied`, timeout, cancel).
-- **Unit (storage)**: per-server secret key selection, and the “do not clobber legacy key” write rules.
+- **Unit (storage)**: per-server secret key selection and explicit overwrite behavior (no implicit migration/compat keys).
 - **E2E (VS Code)**:
   - Login command opens browser + persists per-server token.
   - Remote connect with missing/invalid token shows a host-side prompt; after login, the connection retries and succeeds.

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -15,9 +15,13 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
   - If `serverUrl` is set, it is always injected into the saved server list.
 
 ### Secrets
-- `openhands.sessionApiKey` (VS Code SecretStorage)
-  - HTTP header: `X-Session-API-Key`
-  - WebSocket query param: `?session_api_key=...`
+- `openhands.cloudApiKey.server.<hash>` (VS Code SecretStorage; per-server)
+  - Used only for OpenHands Cloud/SaaS servers (e.g. `https://app.all-hands.dev`).
+  - HTTP header: `Authorization: Bearer <cloudApiKey>`
+- `openhands.runtimeSessionApiKey.server.<hash>` (VS Code SecretStorage; per-server)
+  - Used for agent-server endpoints (local python server or nested cloud runtime agent-server).
+  - HTTP header: `X-Session-API-Key: <runtimeSessionApiKey>`
+  - WebSocket query param: `?session_api_key=<runtimeSessionApiKey>`
 
 ## 2) Conversation lifecycle & persistence
 
@@ -98,7 +102,8 @@ These values map directly to the SDK confirmation policy and drive the confirmat
 Secrets are stored in VS Code SecretStorage and never in `settings.json`:
 
 **Extension-scoped secrets (SecretStorage keys)**
-- `openhands.sessionApiKey`
+- `openhands.cloudApiKey.server.<hash>`
+- `openhands.runtimeSessionApiKey.server.<hash>`
 - `openhands.llmApiKey` (global fallback LLM API key)
 - `openhands.awsAccessKeyId`, `openhands.awsSecretAccessKey` (plumbed but no dedicated UI)
 - `openhands.githubToken`
@@ -111,7 +116,7 @@ Secrets are stored in VS Code SecretStorage and never in `settings.json`:
 
 **Important: “secrets” settings are *status indicators only***
 The following VS Code settings exist only to display ✓/blank status in the Settings UI:
-- `openhands.secrets.*` (`sessionApiKey`, `githubToken`, provider keys, custom secrets)
+- `openhands.secrets.*` (`cloudApiKey`, `runtimeSessionApiKey`, `githubToken`, provider keys, custom secrets)
 
 These do **not** store secrets; they are updated automatically when SecretStorage changes.
 
@@ -121,8 +126,8 @@ These do **not** store secrets; they are updated automatically when SecretStorag
 - **Secret commands** prompt for values and store them securely:
   - `OpenHands: Set API Key` (global fallback key: `openhands.llmApiKey`)
   - Provider-specific keys: OpenAI, Anthropic, OpenRouter, LiteLLM, Gemini
-  - Session API key, GitHub token, HAL TTS key, Custom secrets 1–3
-- **LLM Profiles view** (webview slide-over) for profile CRUD and per-profile keys.
+  - Cloud API key, Runtime Session API key, GitHub token, HAL TTS key, Custom secrets 1–3
+  - **LLM Profiles view** (webview slide-over) for profile CRUD and per-profile keys.
 
 ## 9) Runtime mapping
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "onCommand:openhands.setOpenRouterApiKey",
     "onCommand:openhands.setLiteLlmApiKey",
     "onCommand:openhands.setGeminiLlmApiKey",
-    "onCommand:openhands.setSessionApiKey",
+    "onCommand:openhands.setCloudApiKey",
+    "onCommand:openhands.setRuntimeSessionApiKey",
     "onCommand:openhands.cloudLogin",
     "onCommand:openhands.cloudLogout",
     "onCommand:openhands.setGithubToken",
@@ -93,8 +94,12 @@
         "title": "OpenHands: Set Gemini API Key"
       },
       {
-        "command": "openhands.setSessionApiKey",
-        "title": "OpenHands: Set Remote API Key"
+        "command": "openhands.setCloudApiKey",
+        "title": "OpenHands: Set Cloud API Key"
+      },
+      {
+        "command": "openhands.setRuntimeSessionApiKey",
+        "title": "OpenHands: Set Runtime Session API Key"
       },
       {
         "command": "openhands.cloudLogin",
@@ -414,52 +419,59 @@
         "title": "OpenHands: Secrets",
         "order": 9,
         "properties": {
-          "openhands.secrets.sessionApiKey": {
+          "openhands.secrets.cloudApiKey": {
             "type": "string",
             "default": "",
             "order": 1,
             "editPresentation": "singlelineText",
-            "markdownDescription": "**To set your remote auth key securely:**\n\n[🔑 Configure Remote API Key](command:openhands.setSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json.)_\n\nNotes:\n- **OpenHands Cloud/SaaS**: this is your **Cloud API Key** (Device Flow `access_token`), used as `Authorization: Bearer ...`.\n- **Nested runtime agent-server**: this is the runtime **session API key** (`session_api_key`), used as `X-Session-API-Key: ...`."
+            "markdownDescription": "**OpenHands Cloud API Key**\n\n[🔑 Configure Cloud API Key](command:openhands.setCloudApiKey)\n\n_(Stored in secure system keychain, not in settings.json.)_\n\nNotes:\n- This is your **Cloud API Key / SaaS user token** (Device Flow `access_token`).\n- Used to authenticate to the **SaaS/app-server** as `Authorization: Bearer ...`."
+          },
+          "openhands.secrets.runtimeSessionApiKey": {
+            "type": "string",
+            "default": "",
+            "order": 2,
+            "editPresentation": "singlelineText",
+            "markdownDescription": "**Runtime session API key (nested agent-server)**\n\n[🔑 Configure Runtime Session API Key](command:openhands.setRuntimeSessionApiKey)\n\n_(Stored in secure system keychain, not in settings.json.)_\n\nNotes:\n- This is the runtime/sandbox `session_api_key`.\n- Used to authenticate to the **nested agent-server** as `X-Session-API-Key: ...` (and currently as WS `?session_api_key=...`)."
           },
           "openhands.secrets.githubToken": {
             "type": "string",
             "default": "",
-            "order": 2,
+            "order": 3,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your GitHub token securely:**\n\n[🔑 Configure GitHub Token](command:openhands.setGithubToken)\n\n_(Tokens are stored in secure system keychain, not in settings.json)_"
           },
           "openhands.secrets.openaiApiKey": {
             "type": "string",
             "default": "",
-            "order": 3,
+            "order": 4,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your OpenAI API key securely:**\n\n[🔑 Configure OpenAI API Key](command:openhands.setOpenAiApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `OPENAI_API_KEY`.)_"
           },
           "openhands.secrets.anthropicApiKey": {
             "type": "string",
             "default": "",
-            "order": 4,
+            "order": 5,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your Anthropic API key securely:**\n\n[🔑 Configure Anthropic API Key](command:openhands.setAnthropicApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `ANTHROPIC_API_KEY`.)_"
           },
           "openhands.secrets.openrouterApiKey": {
             "type": "string",
             "default": "",
-            "order": 5,
+            "order": 6,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your OpenRouter API key securely:**\n\n[🔑 Configure OpenRouter API Key](command:openhands.setOpenRouterApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `OPENROUTER_API_KEY`.)_"
           },
           "openhands.secrets.litellmApiKey": {
             "type": "string",
             "default": "",
-            "order": 6,
+            "order": 7,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your LiteLLM Proxy API key securely:**\n\n[🔑 Configure LiteLLM Proxy API Key](command:openhands.setLiteLlmApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `LITELLM_API_KEY`.)_"
           },
           "openhands.secrets.geminiLlmApiKey": {
             "type": "string",
             "default": "",
-            "order": 7,
+            "order": 8,
             "editPresentation": "singlelineText",
             "markdownDescription": "**To set your Gemini API key securely:**\n\n[🔑 Configure Gemini API Key](command:openhands.setGeminiLlmApiKey)\n\n_(Keys are stored in secure system keychain, not in settings.json. Stored as `GEMINI_API_KEY`.)_"
           },

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -981,7 +981,6 @@ describe('RemoteConversation', () => {
       if (url.includes('/confirmation_policy')) {
         expect(init?.method).toBe('POST');
         expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
-        expect(init?.headers?.Authorization).toBe('Bearer session-key');
         const body = JSON.parse(init?.body ?? '{}');
         expect(body).toEqual({
           policy: { kind: 'ConfirmRisky', threshold: 'HIGH', confirm_unknown: false },
@@ -1001,7 +1000,7 @@ describe('RemoteConversation', () => {
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
     const conversation = new RemoteConversation({
       serverUrl: 'http://localhost:3000',
-      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key' } },
+      settings: { ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key' } },
     });
 
     await conversation.restoreConversation('abc');
@@ -1035,7 +1034,6 @@ describe('RemoteConversation', () => {
         call += 1;
         expect(init?.method).toBe('POST');
         expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
-        expect(init?.headers?.Authorization).toBe('Bearer session-key');
         const body = JSON.parse(init?.body ?? '{}');
         if (call === 1) {
           expect(body).toEqual({ security_analyzer: { kind: 'LLMSecurityAnalyzer' } });
@@ -1057,7 +1055,7 @@ describe('RemoteConversation', () => {
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
     const conversation = new RemoteConversation({
       serverUrl: 'http://localhost:3000',
-      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key' } },
+      settings: { ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key' } },
     });
 
     await conversation.restoreConversation('abc');
@@ -1076,14 +1074,13 @@ describe('RemoteConversation', () => {
     );
   });
 
-  it('getWorkspace exposes a RemoteWorkspace using sessionApiKey and invalidates on key change', async () => {
+  it('getWorkspace exposes a RemoteWorkspace using runtimeSessionApiKey and invalidates on key change', async () => {
     let uploadCalls = 0;
     const fetchMock = vi.fn(async (url: string, init?: any) => {
       if (url.includes('/api/file/upload')) {
         expect(init?.method).toBe('POST');
         uploadCalls += 1;
         expect(init?.headers?.['X-Session-API-Key']).toBe(uploadCalls === 1 ? 'session-key-1' : 'session-key-2');
-        expect(init?.headers?.Authorization).toBe(uploadCalls === 1 ? 'Bearer session-key-1' : 'Bearer session-key-2');
         return {
           ok: true,
           status: 200,
@@ -1099,7 +1096,7 @@ describe('RemoteConversation', () => {
     const conversation = new RemoteConversation({
       serverUrl: 'http://localhost:3000',
       workspaceRoot: '/workspace',
-      settings: { ...baseSettings, secrets: { sessionApiKey: 'session-key-1' } },
+      settings: { ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key-1' } },
     });
 
     const w1 = conversation.getWorkspace();
@@ -1110,7 +1107,7 @@ describe('RemoteConversation', () => {
 
     await w1.writeFile('notes.txt', 'hello');
 
-    conversation.setSettings({ ...baseSettings, secrets: { sessionApiKey: 'session-key-2' } });
+    conversation.setSettings({ ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key-2' } });
     const w3 = conversation.getWorkspace();
     expect(w3).not.toBe(w1);
 

--- a/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts
@@ -179,8 +179,13 @@ export class RemoteConversation extends EventEmitter {
     if (!this.workspaceClient) {
       const rawWorkingDir = this.workspace?.['working_dir'];
       const workingDir = typeof rawWorkingDir === 'string' ? rawWorkingDir : this.workspaceRoot;
-      const sessionApiKey = this.settings?.secrets.sessionApiKey;
-      this.workspaceClient = new RemoteWorkspace({ host: this.serverUrl, sessionApiKey, workingDir });
+      const secrets = this.settings?.secrets;
+      this.workspaceClient = new RemoteWorkspace({
+        host: this.serverUrl,
+        cloudApiKey: secrets?.cloudApiKey,
+        runtimeSessionApiKey: secrets?.runtimeSessionApiKey,
+        workingDir,
+      });
     }
     return this.workspaceClient;
   }
@@ -228,8 +233,15 @@ export class RemoteConversation extends EventEmitter {
   getStatus(): ConversationStatus { return this.status; }
 
   setSettings(settings: OpenHandsSettings) {
-    const oldApiKey = this.settings?.secrets.sessionApiKey;
-    const newApiKey = settings?.secrets.sessionApiKey;
+    const getWorkspaceAuthKey = (serverUrl: string, s: OpenHandsSettings | undefined): string | undefined => {
+      const secrets = s?.secrets;
+      return isOpenHandsCloudServerUrl(serverUrl)
+        ? secrets?.cloudApiKey
+        : secrets?.runtimeSessionApiKey;
+    };
+
+    const oldApiKey = getWorkspaceAuthKey(this.serverUrl, this.settings);
+    const newApiKey = getWorkspaceAuthKey(this.serverUrl, settings);
     this.settings = settings;
     if (this.workspaceClient && oldApiKey !== newApiKey) {
       this.workspaceClient = undefined;
@@ -731,15 +743,15 @@ export class RemoteConversation extends EventEmitter {
 
   private getAuthHeaders(): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    const sessionKey = this.settings?.secrets.sessionApiKey || '';
-    if (sessionKey) {
-      if (isOpenHandsCloudServerUrl(this.serverUrl)) {
-        headers['Authorization'] = `Bearer ${sessionKey}`;
-      } else {
-        headers['X-Session-API-Key'] = sessionKey;
-        headers['Authorization'] = `Bearer ${sessionKey}`;
-      }
+    const secrets = this.settings?.secrets;
+    const isCloud = isOpenHandsCloudServerUrl(this.serverUrl);
+    if (isCloud) {
+      const cloudApiKey = secrets?.cloudApiKey ?? '';
+      if (cloudApiKey) headers['Authorization'] = `Bearer ${cloudApiKey}`;
+      return headers;
     }
+    const runtimeSessionApiKey = secrets?.runtimeSessionApiKey ?? '';
+    if (runtimeSessionApiKey) headers['X-Session-API-Key'] = runtimeSessionApiKey;
     return headers;
   }
 
@@ -786,7 +798,7 @@ export class RemoteConversation extends EventEmitter {
   private connect() {
     if (!this.conversationId) return;
     const base = this.serverUrl.replace(/\/$/, '');
-    const sessionKey = this.settings?.secrets.sessionApiKey || '';
+    const sessionKey = this.settings?.secrets.runtimeSessionApiKey || '';
     const params = new URLSearchParams();
     if (sessionKey && !isOpenHandsCloudServerUrl(this.serverUrl)) params.set('session_api_key', sessionKey);
     params.set('resend_all', 'true');

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -26,6 +26,8 @@ const SENSITIVE_KEYS = new Set([
   'password', 'pass', 'pwd',
   'secret', 'secret_key', 'secretKey', 'client_secret', 'clientSecret', 'private_key', 'privateKey',
   'awsAccessKeyId', 'awsSecretAccessKey',
+  'cloudApiKey', 'cloud_api_key',
+  'runtimeSessionApiKey', 'runtime_session_api_key',
   'sessionApiKey', 'session_api_key', 'x_api_key', 'x-api-key',
 ]);
 

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -84,7 +84,7 @@ export function redactStringHeuristics(text: string): string {
     t = t.replace(pattern, '***');
   });
   // Common key=value or key: value patterns
-  const keyPattern = /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret)/gi;
+  const keyPattern = /(api[_-]?key|cloud[_-]?api[_-]?key|runtime[_-]?session[_-]?api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret)/gi;
   t = t.replace(
     new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'),
     (_m, p1, _p2) => `${p1}: ***`,

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -118,7 +118,8 @@ export type OpenHandsSettings = ServerSettings & {
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
   secrets: {
-    sessionApiKey?: string;
+    cloudApiKey?: string;
+    runtimeSessionApiKey?: string;
     llmApiKey?: string;
     awsAccessKeyId?: string;
     awsSecretAccessKey?: string;

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -118,6 +118,11 @@ export type OpenHandsSettings = ServerSettings & {
   conversation: ConversationSettings;
   confirmation: ConfirmationSettings;
   secrets: {
+    /**
+     * Remote-mode credentials are injected by the host application at runtime.
+     *
+     * In OpenHands-Tab, these values come from per-server VS Code SecretStorage slots.
+     */
     cloudApiKey?: string;
     runtimeSessionApiKey?: string;
     llmApiKey?: string;

--- a/packages/agent-sdk-ts/src/shared/cloudServers.ts
+++ b/packages/agent-sdk-ts/src/shared/cloudServers.ts
@@ -13,6 +13,5 @@ export function isOpenHandsCloudServerUrl(raw: string): boolean {
 }
 
 export function getRemoteAuthKeyLabelForServerUrl(raw: string): string {
-  return isOpenHandsCloudServerUrl(raw) ? 'Cloud API Key' : 'Session API Key';
+  return isOpenHandsCloudServerUrl(raw) ? 'Cloud API Key' : 'Runtime Session API Key';
 }
-

--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -36,10 +36,11 @@ export interface RemoteWorkspaceOptions {
   /**
    * Authentication token for the remote host.
    *
-   * - OpenHands Cloud/SaaS: cloud API key (device-flow `access_token`), used as `Authorization: Bearer ...`
-   * - Nested runtime agent-server: runtime `session_api_key`, used as `X-Session-API-Key: ...`
+   * - OpenHands Cloud/SaaS: `cloudApiKey` (device-flow `access_token`), used as `Authorization: Bearer ...`
+   * - Nested runtime agent-server: `runtimeSessionApiKey` (runtime `session_api_key`), used as `X-Session-API-Key: ...`
    */
-  sessionApiKey?: string;
+  cloudApiKey?: string;
+  runtimeSessionApiKey?: string;
   workingDir?: string;
   pollIntervalMs?: number;
   httpTimeoutMs?: number;
@@ -101,7 +102,8 @@ export class RemoteWorkspace implements BaseWorkspace {
   readonly root: string;
 
   private readonly host: string;
-  private readonly sessionApiKey?: string;
+  private readonly cloudApiKey?: string;
+  private readonly runtimeSessionApiKey?: string;
   private readonly pollIntervalMs: number;
   private readonly httpTimeoutMs: number;
 
@@ -114,8 +116,11 @@ export class RemoteWorkspace implements BaseWorkspace {
 
   constructor(options: RemoteWorkspaceOptions) {
     this.host = normalizeRemoteHostUrl(options.host);
-    this.sessionApiKey = typeof options.sessionApiKey === 'string' && options.sessionApiKey.trim()
-      ? options.sessionApiKey.trim()
+    this.cloudApiKey = typeof options.cloudApiKey === 'string' && options.cloudApiKey.trim()
+      ? options.cloudApiKey.trim()
+      : undefined;
+    this.runtimeSessionApiKey = typeof options.runtimeSessionApiKey === 'string' && options.runtimeSessionApiKey.trim()
+      ? options.runtimeSessionApiKey.trim()
       : undefined;
     this.root = normalizePosixRoot(options.workingDir ?? '/workspace');
     this.pollIntervalMs = typeof options.pollIntervalMs === 'number' ? Math.max(0, options.pollIntervalMs) : 100;
@@ -429,14 +434,11 @@ export class RemoteWorkspace implements BaseWorkspace {
 
   private getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
     const headers: Record<string, string> = { ...extra };
-    if (this.sessionApiKey) {
-      if (isOpenHandsCloudServerUrl(this.host)) {
-        headers['Authorization'] = `Bearer ${this.sessionApiKey}`;
-      } else {
-        headers['X-Session-API-Key'] = this.sessionApiKey;
-        headers['Authorization'] = `Bearer ${this.sessionApiKey}`;
-      }
+    if (isOpenHandsCloudServerUrl(this.host)) {
+      if (this.cloudApiKey) headers['Authorization'] = `Bearer ${this.cloudApiKey}`;
+      return headers;
     }
+    if (this.runtimeSessionApiKey) headers['X-Session-API-Key'] = this.runtimeSessionApiKey;
     return headers;
   }
 

--- a/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
+++ b/packages/agent-sdk-ts/src/workspace/__tests__/remote.workspace.test.ts
@@ -100,7 +100,7 @@ describe('RemoteWorkspace', () => {
     const ws = new RemoteWorkspace({
       host: 'http://localhost:3000',
       workingDir: '/workspace/project',
-      sessionApiKey: 'session-key',
+      runtimeSessionApiKey: 'session-key',
       pollIntervalMs: 0,
     });
 
@@ -129,7 +129,6 @@ describe('RemoteWorkspace', () => {
       expect(url).toContain('/workspace/project/hello.txt');
       expect(init?.method).toBe('POST');
       expect(init?.headers?.['X-Session-API-Key']).toBe('session-key');
-      expect(init?.headers?.Authorization).toBe('Bearer session-key');
       expect(init?.body).toBeInstanceOf(FormData);
       return okJson({ ok: true }) as any;
     });
@@ -138,7 +137,7 @@ describe('RemoteWorkspace', () => {
     const ws = new RemoteWorkspace({
       host: 'http://localhost:3000',
       workingDir: '/workspace/project',
-      sessionApiKey: 'session-key',
+      runtimeSessionApiKey: 'session-key',
     });
 
     await ws.writeFile('hello.txt', 'hello');

--- a/packages/agent-sdk-ts/src/workspace/index.ts
+++ b/packages/agent-sdk-ts/src/workspace/index.ts
@@ -12,7 +12,8 @@ export type WorkspaceFactoryOptions =
   | {
     kind: 'remote';
     serverUrl: string;
-    sessionApiKey?: string;
+    cloudApiKey?: string;
+    runtimeSessionApiKey?: string;
     workingDir?: string;
     workspaceRoot?: string;
     runtimeApiUrl?: string;
@@ -28,7 +29,8 @@ export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
   const workingDir = options.workingDir ?? options.workspaceRoot;
   return new RemoteWorkspace({
     host: options.serverUrl,
-    sessionApiKey: options.sessionApiKey,
+    cloudApiKey: options.cloudApiKey,
+    runtimeSessionApiKey: options.runtimeSessionApiKey,
     workingDir,
     runtimeApiUrl: options.runtimeApiUrl,
     runtimeApiKey: options.runtimeApiKey,

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -26,7 +26,7 @@ const defaultMockSettings = {
   },
   secrets: {
     llmApiKey: 'test-llm-key',
-    sessionApiKey: 'test-session-key',
+    runtimeSessionApiKey: 'test-session-key',
   },
 };
 
@@ -216,9 +216,8 @@ describe('Extension Activation', () => {
     expect(vscode.commands.registerCommand).toHaveBeenCalled();
   });
 
-  it('cloudLogin stores a per-server session key without clobbering legacy when different', async () => {
+  it('cloudLogin stores a per-server cloud API key', async () => {
     const secretStorage = new Map<string, string>();
-    secretStorage.set('openhands.sessionApiKey', 'legacy-key');
 
     mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
     mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
@@ -239,50 +238,23 @@ describe('Extension Activation', () => {
     await extension.activate(mockContext);
     await vscode.commands.executeCommand('openhands.cloudLogin');
 
-    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
-    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    const { getServerCloudApiKeySecretKey } = await import('../auth/serverCloudApiKeys');
+    const keyInfo = getServerCloudApiKeySecretKey(defaultMockSettings.serverUrl);
     expect(keyInfo.ok).toBe(true);
     if (!keyInfo.ok) return;
 
     expect(secretStorage.get(keyInfo.secretKey)).toBe('server-token');
-    expect(secretStorage.get('openhands.sessionApiKey')).toBe('legacy-key');
   });
 
-  it('cloudLogin updates legacy openhands.sessionApiKey when unset', async () => {
+  it('cloudLogout clears the per-server cloud API key', async () => {
     const secretStorage = new Map<string, string>();
 
-    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
-    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
-      secretStorage.set(key, value);
-    });
-
-    startDeviceAuthorizationMock.mockResolvedValue({
-      deviceCode: 'dev',
-      userCode: 'ABC-123',
-      verificationUri: 'https://example.com/verify',
-      verificationUriComplete: 'https://example.com/verify?user_code=ABC-123',
-      intervalMs: 1000,
-    });
-    pollDeviceTokenMock.mockResolvedValue({ accessToken: 'server-token' });
-    (vscode.env.openExternal as Mock).mockResolvedValue(true);
-    (vscode.window.showInformationMessage as Mock).mockResolvedValue(undefined);
-
-    await extension.activate(mockContext);
-    await vscode.commands.executeCommand('openhands.cloudLogin');
-
-    expect(secretStorage.get('openhands.sessionApiKey')).toBe('server-token');
-  });
-
-  it('cloudLogout clears the per-server session key and legacy when they match', async () => {
-    const secretStorage = new Map<string, string>();
-
-    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
-    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    const { getServerCloudApiKeySecretKey } = await import('../auth/serverCloudApiKeys');
+    const keyInfo = getServerCloudApiKeySecretKey(defaultMockSettings.serverUrl);
     expect(keyInfo.ok).toBe(true);
     if (!keyInfo.ok) return;
 
     secretStorage.set(keyInfo.secretKey, 'server-token');
-    secretStorage.set('openhands.sessionApiKey', 'server-token');
 
     mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
     mockContext.secrets.delete = vi.fn(async (key: string) => {
@@ -295,57 +267,6 @@ describe('Extension Activation', () => {
     await vscode.commands.executeCommand('openhands.cloudLogout');
 
     expect(secretStorage.has(keyInfo.secretKey)).toBe(false);
-    expect(secretStorage.has('openhands.sessionApiKey')).toBe(false);
-  });
-
-  it('cloudLogout clears the per-server session key without clobbering legacy when different', async () => {
-    const secretStorage = new Map<string, string>();
-
-    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
-    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
-    expect(keyInfo.ok).toBe(true);
-    if (!keyInfo.ok) return;
-
-    secretStorage.set(keyInfo.secretKey, 'server-token');
-    secretStorage.set('openhands.sessionApiKey', 'legacy-key');
-
-    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
-    mockContext.secrets.delete = vi.fn(async (key: string) => {
-      secretStorage.delete(key);
-    });
-
-    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Log out');
-
-    await extension.activate(mockContext);
-    await vscode.commands.executeCommand('openhands.cloudLogout');
-
-    expect(secretStorage.has(keyInfo.secretKey)).toBe(false);
-    expect(secretStorage.get('openhands.sessionApiKey')).toBe('legacy-key');
-  });
-
-  it('cloudLogout clears legacy openhands.sessionApiKey when empty', async () => {
-    const secretStorage = new Map<string, string>();
-
-    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
-    const keyInfo = getServerSessionApiKeySecretKey(defaultMockSettings.serverUrl);
-    expect(keyInfo.ok).toBe(true);
-    if (!keyInfo.ok) return;
-
-    secretStorage.set(keyInfo.secretKey, 'server-token');
-    secretStorage.set('openhands.sessionApiKey', '');
-
-    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
-    mockContext.secrets.delete = vi.fn(async (key: string) => {
-      secretStorage.delete(key);
-    });
-
-    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Log out');
-
-    await extension.activate(mockContext);
-    await vscode.commands.executeCommand('openhands.cloudLogout');
-
-    expect(secretStorage.has(keyInfo.secretKey)).toBe(false);
-    expect(secretStorage.has('openhands.sessionApiKey')).toBe(false);
   });
 
   it('does not create a conversation until the chat view resolves', async () => {
@@ -423,7 +344,16 @@ describe('Secret indicator sync', () => {
     extension?.deactivate?.();
   });
 
-  it('writes a non-secret status marker for settings-backed secrets', async () => {
+  it('writes a non-secret status marker for runtimeSessionApiKey', async () => {
+    const secretStorage = new Map<string, string>();
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+
+    const { getServerRuntimeSessionApiKeySecretKey } = await import('../auth/serverRuntimeSessionApiKeys');
+    const keyInfo = getServerRuntimeSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    expect(keyInfo.ok).toBe(true);
+    if (!keyInfo.ok) return;
+    secretStorage.set(keyInfo.secretKey, 'runtime-token');
+
     await extension.activate(mockContext);
 
     const cfg = vscode.workspace.getConfiguration();
@@ -433,10 +363,10 @@ describe('Secret indicator sync', () => {
       await new Promise((r) => setTimeout(r, 0));
     }
 
-    expect(cfg.update).toHaveBeenCalledWith('openhands.secrets.sessionApiKey', '✓ set', vscode.ConfigurationTarget.Global);
+    expect(cfg.update).toHaveBeenCalledWith('openhands.secrets.runtimeSessionApiKey', '✓ set', vscode.ConfigurationTarget.Global);
     expect(cfg.update).not.toHaveBeenCalledWith(
-      'openhands.secrets.sessionApiKey',
-      defaultMockSettings.secrets.sessionApiKey,
+      'openhands.secrets.runtimeSessionApiKey',
+      'runtime-token',
       vscode.ConfigurationTarget.Global
     );
   });
@@ -598,109 +528,33 @@ describe('Chat view behavior', () => {
     expect(__getLastConversation()).toBeTruthy();
   });
 
-  it('does not send legacy sessionApiKey to a server when the per-server key is missing', async () => {
+  it('injects a per-server runtimeSessionApiKey when present', async () => {
     const secretStorage = new Map<string, string>();
     mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
-    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
-      secretStorage.set(key, value);
-    });
 
-    mockSettings = {
-      ...mockSettings,
-      serverUrl: 'http://localhost:3000',
-      secrets: {
-        ...mockSettings.secrets,
-        sessionApiKey: 'legacy-token',
-      },
-    };
-
-    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Not now');
-
-    await resolveChatView(mockContext);
-
-    const { Conversation } = await import('@openhands/agent-sdk-ts');
-    const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
-    expect(options?.settings?.secrets?.sessionApiKey).toBeUndefined();
-
-    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
-    const keyInfo = getServerSessionApiKeySecretKey(mockSettings.serverUrl);
+    const { getServerRuntimeSessionApiKeySecretKey } = await import('../auth/serverRuntimeSessionApiKeys');
+    const keyInfo = getServerRuntimeSessionApiKeySecretKey(mockSettings.serverUrl);
     expect(keyInfo.ok).toBe(true);
     if (!keyInfo.ok) return;
 
-    expect(mockContext.secrets.store).not.toHaveBeenCalledWith(keyInfo.secretKey, expect.anything());
-  });
-
-  it('migrates legacy sessionApiKey to the per-server secret key after confirmation', async () => {
-    const secretStorage = new Map<string, string>();
-    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
-    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
-      secretStorage.set(key, value);
-    });
-
-    mockSettings = {
-      ...mockSettings,
-      serverUrl: 'http://localhost:3000',
-      secrets: {
-        ...mockSettings.secrets,
-        sessionApiKey: 'legacy-token',
-      },
-    };
-
-    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Use key for this server');
+    secretStorage.set(keyInfo.secretKey, 'runtime-token');
 
     await resolveChatView(mockContext);
 
-    const { getServerSessionApiKeySecretKey } = await import('../auth/serverSessionApiKeys');
-    const keyInfo = getServerSessionApiKeySecretKey(mockSettings.serverUrl);
-    expect(keyInfo.ok).toBe(true);
-    if (!keyInfo.ok) return;
-
-    expect(secretStorage.get(keyInfo.secretKey)).toBe('legacy-token');
-
     const { Conversation } = await import('@openhands/agent-sdk-ts');
     const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
-    expect(options?.settings?.secrets?.sessionApiKey).toBe('legacy-token');
+    expect(options?.settings?.secrets?.runtimeSessionApiKey).toBe('runtime-token');
   });
 
-  it('does not reuse legacy sessionApiKey when switching servers without a per-server key', async () => {
+  it('does not inject runtimeSessionApiKey when missing', async () => {
     const secretStorage = new Map<string, string>();
     mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
-    mockContext.secrets.store = vi.fn(async (key: string, value: string) => {
-      secretStorage.set(key, value);
-    });
-
-    mockSettings = {
-      ...mockSettings,
-      serverUrl: 'http://server-a.test:3000',
-      secrets: {
-        ...mockSettings.secrets,
-        sessionApiKey: 'legacy-token',
-      },
-    };
-
-    (vscode.window.showWarningMessage as Mock)
-      .mockResolvedValueOnce('Not now')
-      .mockResolvedValueOnce('Not now');
 
     await resolveChatView(mockContext);
 
-    mockSettings = { ...mockSettings, serverUrl: 'http://server-b.test:3000' };
-    (vscode as any).__getMockConfigValues().set('openhands.serverUrl', mockSettings.serverUrl);
-    (vscode as any).__triggerConfigChange({
-      affectsConfiguration: (key: string) => key === 'openhands.serverUrl',
-    });
-
     const { Conversation } = await import('@openhands/agent-sdk-ts');
-    const beforeCalls = (Conversation as unknown as Mock).mock.calls.length;
-
-    const deadline = Date.now() + 2000;
-    while (Date.now() < deadline) {
-      if ((Conversation as unknown as Mock).mock.calls.length > beforeCalls) break;
-      await new Promise((r) => setTimeout(r, 0));
-    }
-
     const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
-    expect(options?.settings?.secrets?.sessionApiKey).toBeUndefined();
+    expect(options?.settings?.secrets?.runtimeSessionApiKey).toBeUndefined();
   });
 
   it('does not auto-restore saved conversation on first chat view resolve', async () => {
@@ -762,6 +616,12 @@ describe('Chat view behavior', () => {
   });
 
   it('refreshes the active conversation when LLM settings change', async () => {
+    const secretStorage = new Map<string, string>();
+    const { getServerRuntimeSessionApiKeySecretKey } = await import('../auth/serverRuntimeSessionApiKeys');
+    const runtimeKeyInfo = getServerRuntimeSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    secretStorage.set(runtimeKeyInfo.secretKey, defaultMockSettings.secrets.runtimeSessionApiKey);
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+
     const view = await resolveChatView(mockContext);
     expect(view).toBeTruthy();
 
@@ -791,6 +651,12 @@ describe('Chat view behavior', () => {
   });
 
   it('refreshes the active conversation when confirmation settings change', async () => {
+    const secretStorage = new Map<string, string>();
+    const { getServerRuntimeSessionApiKeySecretKey } = await import('../auth/serverRuntimeSessionApiKeys');
+    const runtimeKeyInfo = getServerRuntimeSessionApiKeySecretKey(defaultMockSettings.serverUrl);
+    secretStorage.set(runtimeKeyInfo.secretKey, defaultMockSettings.secrets.runtimeSessionApiKey);
+    mockContext.secrets.get = vi.fn(async (key: string) => secretStorage.get(key));
+
     const view = await resolveChatView(mockContext);
     expect(view).toBeTruthy();
 

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -557,6 +557,51 @@ describe('Chat view behavior', () => {
     expect(options?.settings?.secrets?.runtimeSessionApiKey).toBeUndefined();
   });
 
+  it('prompts to set runtimeSessionApiKey on remote auth failure for non-cloud servers', async () => {
+    await resolveChatView(mockContext);
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const conv = __getLastConversation();
+    expect(conv).toBeTruthy();
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Set Key');
+
+    conv.emit('error', new Error('Authentication failed (HTTP 401)'));
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const calls = (vscode.commands.executeCommand as Mock).mock.calls;
+      if (calls.some((c) => c?.[0] === 'openhands.setRuntimeSessionApiKey')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('openhands.setRuntimeSessionApiKey');
+  });
+
+  it('prompts to cloudLogin on remote auth failure for cloud servers', async () => {
+    mockSettings = { ...mockSettings, serverUrl: 'https://app.all-hands.dev' as any };
+    await resolveChatView(mockContext);
+
+    const { __getLastConversation } = await import('@openhands/agent-sdk-ts');
+    const conv = __getLastConversation();
+    expect(conv).toBeTruthy();
+
+    (vscode.window.showWarningMessage as Mock).mockResolvedValue('Login');
+
+    conv.emit('error', new Error('Authentication failed (HTTP 403)'));
+
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      const calls = (vscode.commands.executeCommand as Mock).mock.calls;
+      if (calls.some((c) => c?.[0] === 'openhands.cloudLogin')) break;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalled();
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('openhands.cloudLogin');
+  });
+
   it('does not auto-restore saved conversation on first chat view resolve', async () => {
     // Intentionally does not restore on first open - users may return after weeks
     // and won't remember what the conversation was about

--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -99,7 +99,7 @@ describe('Tools picker host messages', () => {
 
     const conversation = {
       serverUrl: 'http://localhost:3000',
-      settings: { secrets: { sessionApiKey: 'test-key-123' } },
+      settings: { secrets: { runtimeSessionApiKey: 'test-key-123' } },
     };
 
     const { handler, postMessage } = createRemoteHandler(conversation);

--- a/src/auth/serverCloudApiKeys.ts
+++ b/src/auth/serverCloudApiKeys.ts
@@ -1,0 +1,20 @@
+import { createHash } from 'crypto';
+import { normalizeServerUrl } from '../shared/serverUrls';
+
+export const CLOUD_API_KEY_SECRET_KEY = 'openhands.cloudApiKey';
+
+export type ServerCloudApiKeySecretKeyResult =
+  | { ok: true; normalizedServerUrl: string; secretKey: string }
+  | { ok: false; error: string };
+
+export function getServerCloudApiKeySecretKey(serverUrl: string): ServerCloudApiKeySecretKeyResult {
+  const normalized = normalizeServerUrl(serverUrl);
+  if (!normalized.ok) return { ok: false, error: normalized.error };
+
+  const hash = createHash('sha256').update(normalized.url).digest('hex');
+  return {
+    ok: true,
+    normalizedServerUrl: normalized.url,
+    secretKey: `${CLOUD_API_KEY_SECRET_KEY}.server.${hash}`,
+  };
+}

--- a/src/auth/serverRuntimeSessionApiKeys.ts
+++ b/src/auth/serverRuntimeSessionApiKeys.ts
@@ -1,13 +1,13 @@
 import { createHash } from 'crypto';
 import { normalizeServerUrl } from '../shared/serverUrls';
 
-export const LEGACY_SESSION_API_KEY_SECRET_KEY = 'openhands.sessionApiKey';
+export const RUNTIME_SESSION_API_KEY_SECRET_KEY = 'openhands.runtimeSessionApiKey';
 
-export type ServerSessionApiKeySecretKeyResult =
+export type ServerRuntimeSessionApiKeySecretKeyResult =
   | { ok: true; normalizedServerUrl: string; secretKey: string }
   | { ok: false; error: string };
 
-export function getServerSessionApiKeySecretKey(serverUrl: string): ServerSessionApiKeySecretKeyResult {
+export function getServerRuntimeSessionApiKeySecretKey(serverUrl: string): ServerRuntimeSessionApiKeySecretKeyResult {
   const normalized = normalizeServerUrl(serverUrl);
   if (!normalized.ok) return { ok: false, error: normalized.error };
 
@@ -15,7 +15,7 @@ export function getServerSessionApiKeySecretKey(serverUrl: string): ServerSessio
   return {
     ok: true,
     normalizedServerUrl: normalized.url,
-    secretKey: `${LEGACY_SESSION_API_KEY_SECRET_KEY}.server.${hash}`,
+    secretKey: `${RUNTIME_SESSION_API_KEY_SECRET_KEY}.server.${hash}`,
   };
 }
 

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -7,7 +7,8 @@ import { maskSecretsInText } from '../shared/maskSecrets';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
-import { getServerSessionApiKeySecretKey, LEGACY_SESSION_API_KEY_SECRET_KEY } from '../auth/serverSessionApiKeys';
+import { getServerCloudApiKeySecretKey } from '../auth/serverCloudApiKeys';
+import { getServerRuntimeSessionApiKeySecretKey } from '../auth/serverRuntimeSessionApiKeys';
 import * as llmProfilesStore from '../webview/host/llmProfilesStore';
 import { OpenHandsTerminalLogPseudoterminal } from '../terminal/OpenHandsTerminalLogPseudoterminal';
 import { isBashEvent, isTextContent, type BashEvent, type ConversationInstance, type Event, type SecretRegistry } from '@openhands/agent-sdk-ts';
@@ -228,30 +229,28 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
 
         if (!serverUrl) return { ok: false, error: 'Missing serverUrl' };
 
-        const keyInfo = getServerSessionApiKeySecretKey(serverUrl);
-        if (!keyInfo.ok) return { ok: false, error: keyInfo.error };
+        const cloudKeyInfo = getServerCloudApiKeySecretKey(serverUrl);
+        if (!cloudKeyInfo.ok) return { ok: false, error: cloudKeyInfo.error };
+        const runtimeKeyInfo = getServerRuntimeSessionApiKeySecretKey(serverUrl);
+        if (!runtimeKeyInfo.ok) return { ok: false, error: runtimeKeyInfo.error };
 
-        let stored: string | undefined;
-        try {
-          stored = await deps.context.secrets.get(keyInfo.secretKey);
-        } catch {
-          stored = undefined;
-        }
-        const token = typeof stored === 'string' ? stored.trim() : '';
+        const readTrimmed = async (key: string): Promise<string> => {
+          try {
+            const raw = await deps.context.secrets.get(key);
+            return typeof raw === 'string' ? raw.trim() : '';
+          } catch {
+            return '';
+          }
+        };
 
-        let legacyRaw: string | undefined;
-        try {
-          legacyRaw = await deps.context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
-        } catch {
-          legacyRaw = undefined;
-        }
-        const legacy = typeof legacyRaw === 'string' ? legacyRaw.trim() : '';
+        const cloudToken = await readTrimmed(cloudKeyInfo.secretKey);
+        const runtimeToken = await readTrimmed(runtimeKeyInfo.secretKey);
 
         return {
           ok: true,
-          normalizedServerUrl: keyInfo.normalizedServerUrl,
-          hasSessionApiKey: Boolean(token),
-          hasLegacySessionApiKey: Boolean(legacy),
+          normalizedServerUrl: cloudKeyInfo.normalizedServerUrl,
+          hasCloudApiKey: Boolean(cloudToken),
+          hasRuntimeSessionApiKey: Boolean(runtimeToken),
         };
       })
     : undefined;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -968,6 +968,7 @@ export function deactivate() {
   chatLastSeenSeq = undefined;
   conversationStoreRoot = undefined;
   lastRemoteAuthPromptAtMs = 0;
+  lastRemoteServerUrl = undefined;
   resetConversationEventBacklog(undefined);
   receivedTerminalEvents.length = 0;
   sentTestEvents.length = 0;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,8 +31,9 @@ import { collectEnvironmentInfo } from './shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from './shared/uri';
 import { resolvePreferredWorkspaceRoot } from './shared/workspaceRoot';
 import { computeWelcomeSecretStatus } from './shared/welcomeSecretStatus';
-import { getServerSessionApiKeySecretKey } from './auth/serverSessionApiKeys';
-import { getRemoteAuthKeyLabelForServerUrl } from './shared/cloudServers';
+import { getServerCloudApiKeySecretKey } from './auth/serverCloudApiKeys';
+import { getServerRuntimeSessionApiKeySecretKey } from './auth/serverRuntimeSessionApiKeys';
+import { isOpenHandsCloudServerUrl } from './shared/cloudServers';
 import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
 import { registerCloudLogoutCommand } from './extension/cloudLogoutCommand';
 import {
@@ -472,77 +473,41 @@ export function activate(context: vscode.ExtensionContext) {
 
     const trimOrEmpty = (value: unknown): string => typeof value === 'string' ? value.trim() : '';
 
-    const withSessionApiKey = (token: string | undefined): typeof settings => {
+    const withRemoteSecrets = (params: { cloudApiKey?: string; runtimeSessionApiKey?: string }): typeof settings => {
       const secrets = { ...(settings.secrets ?? {}) } as Record<string, unknown>;
-      if (token) {
-        secrets.sessionApiKey = token;
-      } else {
-        delete secrets.sessionApiKey;
-      }
+      if (params.cloudApiKey) secrets.cloudApiKey = params.cloudApiKey;
+      else delete secrets.cloudApiKey;
+      if (params.runtimeSessionApiKey) secrets.runtimeSessionApiKey = params.runtimeSessionApiKey;
+      else delete secrets.runtimeSessionApiKey;
       return { ...settings, secrets: secrets as typeof settings.secrets };
     };
 
     if (typeof settings.serverUrl === 'string' && settings.serverUrl.trim()) {
-      const keyInfo = getServerSessionApiKeySecretKey(settings.serverUrl);
-      if (keyInfo.ok) {
-        const legacyToken = trimOrEmpty(settings.secrets?.sessionApiKey);
+      const rawServerUrl = settings.serverUrl.trim();
+      const isCloud = isOpenHandsCloudServerUrl(rawServerUrl);
 
-        let stored: string | undefined;
+      const cloudKeyInfo = isCloud ? getServerCloudApiKeySecretKey(rawServerUrl) : null;
+      const runtimeKeyInfo = getServerRuntimeSessionApiKeySecretKey(rawServerUrl);
+
+      let cloudApiKey: string | undefined;
+      if (cloudKeyInfo?.ok) {
         try {
-          stored = await context.secrets.get(keyInfo.secretKey);
+          cloudApiKey = trimOrEmpty(await context.secrets.get(cloudKeyInfo.secretKey)) || undefined;
         } catch {
-          stored = undefined;
-        }
-        const perServerToken = trimOrEmpty(stored);
-
-        if (perServerToken) {
-          settings = withSessionApiKey(perServerToken);
-        } else if (!legacyToken) {
-          // No per-server token and no legacy token: do not send a session key at all.
-          settings = withSessionApiKey(undefined);
-        } else {
-          // Legacy token exists, but do not auto-send it to an arbitrary server. Offer one-time migration.
-          const serverHash = keyInfo.secretKey.split('.server.')[1] ?? keyInfo.secretKey;
-          const promptKey = `openhands.sessionApiKey.migrationPrompted.${serverHash}`;
-          const alreadyPrompted = context.globalState.get<boolean>(promptKey) === true;
-
-          if (alreadyPrompted) {
-            settings = withSessionApiKey(undefined);
-          } else {
-            // Mark prompted before awaiting UI to avoid duplicate prompts from rapid config changes.
-            await context.globalState.update(promptKey, true);
-
-            const serverLabel = (() => {
-              try {
-                const url = new URL(keyInfo.normalizedServerUrl);
-                return url.hostname + (url.port ? `:${url.port}` : '');
-              } catch {
-                return keyInfo.normalizedServerUrl;
-              }
-            })();
-
-            const action = await vscode.window.showWarningMessage(
-              `OpenHands: A legacy ${getRemoteAuthKeyLabelForServerUrl(settings.serverUrl)} is set. Use it for ${serverLabel}?`,
-              { modal: true },
-              'Use key for this server',
-              'Not now',
-            );
-
-            if (action === 'Use key for this server') {
-              try {
-                await context.secrets.store(keyInfo.secretKey, legacyToken);
-                secrets.set(keyInfo.secretKey, legacyToken);
-                settings = withSessionApiKey(legacyToken);
-              } catch (err) {
-                outputChannel?.appendLine(`[auth] Failed to migrate session API key for ${keyInfo.normalizedServerUrl}: ${renderError(err)}`);
-                settings = withSessionApiKey(undefined);
-              }
-            } else {
-              settings = withSessionApiKey(undefined);
-            }
-          }
+          cloudApiKey = undefined;
         }
       }
+
+      let runtimeSessionApiKey: string | undefined;
+      if (runtimeKeyInfo.ok) {
+        try {
+          runtimeSessionApiKey = trimOrEmpty(await context.secrets.get(runtimeKeyInfo.secretKey)) || undefined;
+        } catch {
+          runtimeSessionApiKey = undefined;
+        }
+      }
+
+      settings = withRemoteSecrets({ cloudApiKey, runtimeSessionApiKey });
     }
 
     const cfg = vscode.workspace.getConfiguration();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,6 +84,7 @@ let verboseEventLogging = false;
 let localAgentContext: AgentContext | undefined;
 let activeEditorFilePath: string | undefined;
 let lastRemoteAuthPromptAtMs = 0;
+let lastRemoteServerUrl: string | undefined;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -484,6 +485,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     if (typeof settings.serverUrl === 'string' && settings.serverUrl.trim()) {
       const rawServerUrl = settings.serverUrl.trim();
+      lastRemoteServerUrl = rawServerUrl;
       const isCloud = isOpenHandsCloudServerUrl(rawServerUrl);
 
       const cloudKeyInfo = isCloud ? getServerCloudApiKeySecretKey(rawServerUrl) : null;
@@ -687,14 +689,27 @@ export function activate(context: vscode.ExtensionContext) {
           if (now - lastRemoteAuthPromptAtMs < 60_000) return;
           lastRemoteAuthPromptAtMs = now;
 
+          const serverUrl = lastRemoteServerUrl;
+          const isCloudServer = typeof serverUrl === 'string' && serverUrl.trim().length > 0
+            ? isOpenHandsCloudServerUrl(serverUrl)
+            : false;
+
           const action = await vscode.window.showWarningMessage(
-            'OpenHands: Authentication failed connecting to the selected server. Login now?',
-            'Login',
+            isCloudServer
+              ? 'OpenHands: Authentication failed connecting to OpenHands Cloud. Login now?'
+              : 'OpenHands: Authentication failed connecting to the selected server. Set Runtime Session API Key now?',
+            isCloudServer ? 'Login' : 'Set Key',
             'Dismiss',
           );
-          if (action !== 'Login') return;
+          if (!action || action === 'Dismiss') return;
 
-          await vscode.commands.executeCommand('openhands.cloudLogin');
+          if (isCloudServer && action === 'Login') {
+            await vscode.commands.executeCommand('openhands.cloudLogin');
+            return;
+          }
+          if (!isCloudServer && action === 'Set Key') {
+            await vscode.commands.executeCommand('openhands.setRuntimeSessionApiKey');
+          }
         })();
       });
 

--- a/src/extension/cloudLoginCommand.ts
+++ b/src/extension/cloudLoginCommand.ts
@@ -3,9 +3,8 @@ import { SettingsManager } from '../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import { startDeviceAuthorization, pollDeviceToken, type HttpClientLike } from '../auth/deviceFlow';
 import {
-  getServerSessionApiKeySecretKey,
-  LEGACY_SESSION_API_KEY_SECRET_KEY,
-} from '../auth/serverSessionApiKeys';
+  getServerCloudApiKeySecretKey,
+} from '../auth/serverCloudApiKeys';
 
 type Output = Pick<vscode.OutputChannel, 'appendLine'>;
 
@@ -16,10 +15,6 @@ function renderServerLabel(serverUrl: string): string {
   } catch {
     return serverUrl;
   }
-}
-
-function trimOrEmpty(value: string | undefined): string {
-  return typeof value === 'string' ? value.trim() : '';
 }
 
 export function registerCloudLoginCommand(options: {
@@ -45,7 +40,7 @@ export function registerCloudLoginCommand(options: {
       return;
     }
 
-    const keyInfo = getServerSessionApiKeySecretKey(currentServerUrl);
+    const keyInfo = getServerCloudApiKeySecretKey(currentServerUrl);
     if (!keyInfo.ok) {
       void vscode.window.showErrorMessage(`OpenHands: Invalid server URL: ${keyInfo.error}`);
       return;
@@ -135,22 +130,7 @@ export function registerCloudLoginCommand(options: {
 
     await context.secrets.store(keyInfo.secretKey, trimmedToken);
 
-    let legacyRaw: string | undefined;
-    try {
-      legacyRaw = await context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
-    } catch {
-      legacyRaw = undefined;
-    }
-    const legacyValue = trimOrEmpty(legacyRaw);
-    const canUpdateLegacy = !legacyValue || legacyValue === trimmedToken;
-    if (canUpdateLegacy) {
-      await context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmedToken);
-    }
-
     output?.appendLine(`[auth] Stored cloud API key for ${keyInfo.normalizedServerUrl}.`);
-    if (!canUpdateLegacy && legacyValue) {
-      output?.appendLine('[auth] Legacy openhands.sessionApiKey was not overwritten (different value already set).');
-    }
 
     options.onLoginCompleted?.({ normalizedServerUrl: keyInfo.normalizedServerUrl });
 

--- a/src/extension/cloudLogoutCommand.ts
+++ b/src/extension/cloudLogoutCommand.ts
@@ -2,9 +2,8 @@ import * as vscode from 'vscode';
 import { SettingsManager } from '../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import {
-  getServerSessionApiKeySecretKey,
-  LEGACY_SESSION_API_KEY_SECRET_KEY,
-} from '../auth/serverSessionApiKeys';
+  getServerCloudApiKeySecretKey,
+} from '../auth/serverCloudApiKeys';
 
 type Output = Pick<vscode.OutputChannel, 'appendLine'>;
 
@@ -15,10 +14,6 @@ function renderServerLabel(serverUrl: string): string {
   } catch {
     return serverUrl;
   }
-}
-
-function trimOrEmpty(value: string | undefined): string {
-  return typeof value === 'string' ? value.trim() : '';
 }
 
 export function registerCloudLogoutCommand(options: {
@@ -43,7 +38,7 @@ export function registerCloudLogoutCommand(options: {
       return;
     }
 
-    const keyInfo = getServerSessionApiKeySecretKey(currentServerUrl);
+    const keyInfo = getServerCloudApiKeySecretKey(currentServerUrl);
     if (!keyInfo.ok) {
       void vscode.window.showErrorMessage(`OpenHands: Invalid server URL: ${keyInfo.error}`);
       return;
@@ -61,32 +56,9 @@ export function registerCloudLogoutCommand(options: {
 
     const output = options.getOutputChannel();
 
-    let serverTokenRaw: string | undefined;
-    try {
-      serverTokenRaw = await context.secrets.get(keyInfo.secretKey);
-    } catch {
-      serverTokenRaw = undefined;
-    }
-    const serverToken = trimOrEmpty(serverTokenRaw);
-
     await context.secrets.delete(keyInfo.secretKey);
 
-    let legacyRaw: string | undefined;
-    try {
-      legacyRaw = await context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
-    } catch {
-      legacyRaw = undefined;
-    }
-    const legacyValue = trimOrEmpty(legacyRaw);
-    const shouldClearLegacy = !legacyValue || (!!serverToken && legacyValue === serverToken);
-    if (shouldClearLegacy) {
-      await context.secrets.delete(LEGACY_SESSION_API_KEY_SECRET_KEY);
-    }
-
-    output?.appendLine(`[auth] Cleared session API key for ${keyInfo.normalizedServerUrl}.`);
-    if (!shouldClearLegacy && legacyValue) {
-      output?.appendLine('[auth] Legacy openhands.sessionApiKey was not cleared (different value already set).');
-    }
+    output?.appendLine(`[auth] Cleared cloud API key for ${keyInfo.normalizedServerUrl}.`);
 
     void vscode.window.showInformationMessage(`OpenHands: Logged out of ${serverLabel}.`);
   });

--- a/src/extension/secretCommands.ts
+++ b/src/extension/secretCommands.ts
@@ -2,8 +2,9 @@ import * as vscode from 'vscode';
 import { SettingsManager, type OpenHandsSettings } from '../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import type { ConversationInstance, SecretRegistry } from '@openhands/agent-sdk-ts';
-import { getServerSessionApiKeySecretKey, LEGACY_SESSION_API_KEY_SECRET_KEY } from '../auth/serverSessionApiKeys';
-import { getRemoteAuthKeyLabelForServerUrl, isOpenHandsCloudServerUrl } from '../shared/cloudServers';
+import { getServerCloudApiKeySecretKey } from '../auth/serverCloudApiKeys';
+import { getServerRuntimeSessionApiKeySecretKey } from '../auth/serverRuntimeSessionApiKeys';
+import { isOpenHandsCloudServerUrl } from '../shared/cloudServers';
 
 type SecretKey = keyof OpenHandsSettings['secrets'];
 
@@ -17,16 +18,31 @@ async function syncSecretStatusIndicators(params: { context: vscode.ExtensionCon
     return typeof value === 'string' && value.trim().length > 0;
   };
 
-  let settingsSecrets: OpenHandsSettings['secrets'] | undefined;
+  let settings: OpenHandsSettings | undefined;
   try {
     const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(params.context));
-    settingsSecrets = (await settingsMgr.get())?.secrets;
+    settings = await settingsMgr.get();
   } catch {
     // Best-effort: do not surface errors for a purely UX indicator.
-    settingsSecrets = undefined;
+    settings = undefined;
   }
 
   const getIsSetFromSettingsSecrets = (value: unknown): boolean => typeof value === 'string' && value.trim().length > 0;
+
+  const serverUrl = typeof settings?.serverUrl === 'string' ? settings.serverUrl.trim() : '';
+  const isCloud = Boolean(serverUrl) && isOpenHandsCloudServerUrl(serverUrl);
+  const isCloudApiKeySet = await (async (): Promise<boolean> => {
+    if (!serverUrl || !isCloud) return false;
+    const keyInfo = getServerCloudApiKeySecretKey(serverUrl);
+    if (!keyInfo.ok) return false;
+    return await getIsSetFromSecretStorage(keyInfo.secretKey);
+  })();
+  const isRuntimeSessionApiKeySet = await (async (): Promise<boolean> => {
+    if (!serverUrl) return false;
+    const keyInfo = getServerRuntimeSessionApiKeySecretKey(serverUrl);
+    if (!keyInfo.ok) return false;
+    return await getIsSetFromSecretStorage(keyInfo.secretKey);
+  })();
 
   const indicators: Array<{ key: string; isSet: boolean }> = [
     { key: 'openhands.secrets.openaiApiKey', isSet: await getIsSetFromSecretStorage('OPENAI_API_KEY') },
@@ -35,12 +51,13 @@ async function syncSecretStatusIndicators(params: { context: vscode.ExtensionCon
     { key: 'openhands.secrets.litellmApiKey', isSet: await getIsSetFromSecretStorage('LITELLM_API_KEY') },
     { key: 'openhands.secrets.geminiLlmApiKey', isSet: await getIsSetFromSecretStorage('GEMINI_API_KEY') },
 
-    { key: 'openhands.secrets.sessionApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.sessionApiKey) },
-    { key: 'openhands.secrets.githubToken', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.githubToken) },
-    { key: 'openhands.hal.ttsApiKey', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.halTtsApiKey) },
-    { key: 'openhands.secrets.customSecret1', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret1) },
-    { key: 'openhands.secrets.customSecret2', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret2) },
-    { key: 'openhands.secrets.customSecret3', isSet: getIsSetFromSettingsSecrets(settingsSecrets?.customSecret3) },
+    { key: 'openhands.secrets.cloudApiKey', isSet: isCloudApiKeySet },
+    { key: 'openhands.secrets.runtimeSessionApiKey', isSet: isRuntimeSessionApiKeySet },
+    { key: 'openhands.secrets.githubToken', isSet: getIsSetFromSettingsSecrets(settings?.secrets?.githubToken) },
+    { key: 'openhands.hal.ttsApiKey', isSet: getIsSetFromSettingsSecrets(settings?.secrets?.halTtsApiKey) },
+    { key: 'openhands.secrets.customSecret1', isSet: getIsSetFromSettingsSecrets(settings?.secrets?.customSecret1) },
+    { key: 'openhands.secrets.customSecret2', isSet: getIsSetFromSettingsSecrets(settings?.secrets?.customSecret2) },
+    { key: 'openhands.secrets.customSecret3', isSet: getIsSetFromSettingsSecrets(settings?.secrets?.customSecret3) },
   ];
 
   for (const indicator of indicators) {
@@ -272,35 +289,46 @@ export function registerSecretCommands(params: {
     errorPrefix: 'Failed to save Gemini API key',
   });
 
-  const setSessionApiKey = vscode.commands.registerCommand('openhands.setSessionApiKey', async () => {
-    const trimOrEmpty = (value: unknown): string => typeof value === 'string' ? value.trim() : '';
-    let errorPrefix = 'Failed to save Remote API Key';
+  const updateConversationSettingsBestEffort = async (patch: Partial<OpenHandsSettings['secrets']>): Promise<void> => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(params.context));
+      const updated = await settingsMgr.get();
+      params.getConversation()?.setSettings({ ...updated, secrets: { ...updated.secrets, ...patch } });
+    } catch {
+      // Best-effort only.
+    }
+  };
 
+  const setCloudApiKey = vscode.commands.registerCommand('openhands.setCloudApiKey', async () => {
     try {
       const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(params.context));
       const existing = await settingsMgr.get();
       const serverUrl = typeof existing.serverUrl === 'string' ? existing.serverUrl.trim() : '';
-      const authKeyLabel = getRemoteAuthKeyLabelForServerUrl(serverUrl);
-      const isCloud = Boolean(serverUrl) && isOpenHandsCloudServerUrl(serverUrl);
+      if (!serverUrl) {
+        void vscode.window.showErrorMessage('OpenHands: Select a remote server before setting a Cloud API Key.');
+        return;
+      }
+      if (!isOpenHandsCloudServerUrl(serverUrl)) {
+        void vscode.window.showErrorMessage('OpenHands: Cloud API Key is only used for OpenHands Cloud/SaaS servers.');
+        return;
+      }
 
-      const title = authKeyLabel;
-      const prompt = isCloud
-        ? 'Enter your OpenHands Cloud API key. It will be stored securely in VS Code SecretStorage.'
-        : 'Enter your Session API key for the remote agent-server. It will be stored securely in VS Code SecretStorage.';
-      const successMessage = `${authKeyLabel} saved securely.`;
-      const clearedMessage = `${authKeyLabel} cleared.`;
-      errorPrefix = `Failed to save ${authKeyLabel}`;
+      const keyInfo = getServerCloudApiKeySecretKey(serverUrl);
+      if (!keyInfo.ok) {
+        void vscode.window.showErrorMessage(`OpenHands: Invalid server URL: ${keyInfo.error}`);
+        return;
+      }
 
-      const keyInfo = serverUrl ? getServerSessionApiKeySecretKey(serverUrl) : null;
-      const storageKey = keyInfo?.ok ? keyInfo.secretKey : LEGACY_SESSION_API_KEY_SECRET_KEY;
+      const title = 'Cloud API Key';
+      const prompt = 'Enter your OpenHands Cloud API key. It will be stored securely in VS Code SecretStorage.';
 
       let currentValue: string | undefined;
       try {
-        currentValue = await params.context.secrets.get(storageKey);
+        currentValue = await params.context.secrets.get(keyInfo.secretKey);
       } catch {
         currentValue = undefined;
       }
-      const isCurrentlySet = trimOrEmpty(currentValue).length > 0;
+      const isCurrentlySet = typeof currentValue === 'string' && currentValue.trim().length > 0;
 
       if (isCurrentlySet) {
         const action = await vscode.window.showQuickPick(
@@ -308,31 +336,20 @@ export function registerSecretCommands(params: {
             { label: 'Update', value: 'update', description: 'Enter a new value (stored securely)' },
             { label: 'Clear', value: 'clear', description: 'Remove the stored value' },
           ],
-          {
-            title,
-            placeHolder: 'Choose an action',
-            canPickMany: false,
-          }
+          { title, placeHolder: 'Choose an action', canPickMany: false }
         );
         if (!action) return;
-
         if (action.value === 'clear') {
           const confirmed = await vscode.window.showWarningMessage(
-            `Clear ${title}${keyInfo?.ok ? ` for ${keyInfo.normalizedServerUrl}` : ''}?`,
+            `Clear ${title} for ${keyInfo.normalizedServerUrl}?`,
             { modal: true },
             'Clear'
           );
           if (confirmed !== 'Clear') return;
-
-          await params.context.secrets.delete(storageKey);
-          params.secrets.set(storageKey, undefined);
-          vscode.window.showInformationMessage(clearedMessage);
-
-          const updated = await settingsMgr.get();
-          const next = keyInfo?.ok
-            ? { ...updated, secrets: { ...updated.secrets, sessionApiKey: undefined } }
-            : updated;
-          params.getConversation()?.setSettings(next);
+          await params.context.secrets.delete(keyInfo.secretKey);
+          params.secrets.set(keyInfo.secretKey, undefined);
+          await updateConversationSettingsBestEffort({ cloudApiKey: undefined });
+          void vscode.window.showInformationMessage('Cloud API Key cleared.');
           await syncSecretStatusIndicatorsBestEffort();
           return;
         }
@@ -342,45 +359,93 @@ export function registerSecretCommands(params: {
         title,
         password: true,
         prompt,
-        placeHolder: isCloud ? 'paste token...' : 'sk-...',
+        placeHolder: 'paste token...',
       });
-
       if (value === undefined) return;
       const trimmed = value.trim();
       if (!trimmed) return;
 
-      if (keyInfo?.ok) {
-        await params.context.secrets.store(storageKey, trimmed);
-        params.secrets.set(storageKey, trimmed);
-
-        let legacyRaw: string | undefined;
-        try {
-          legacyRaw = await params.context.secrets.get(LEGACY_SESSION_API_KEY_SECRET_KEY);
-        } catch {
-          legacyRaw = undefined;
-        }
-        const legacyValue = trimOrEmpty(legacyRaw);
-        const canUpdateLegacy = !legacyValue || legacyValue === trimmed;
-        if (canUpdateLegacy) {
-          await params.context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
-          params.secrets.set(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
-        }
-      } else {
-        await params.context.secrets.store(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
-        params.secrets.set(LEGACY_SESSION_API_KEY_SECRET_KEY, trimmed);
-      }
-
-      vscode.window.showInformationMessage(successMessage);
-
-      const updated = await settingsMgr.get();
-      const next = keyInfo?.ok
-        ? { ...updated, secrets: { ...updated.secrets, sessionApiKey: trimmed } }
-        : updated;
-      params.getConversation()?.setSettings(next);
+      await params.context.secrets.store(keyInfo.secretKey, trimmed);
+      params.secrets.set(keyInfo.secretKey, trimmed);
+      await updateConversationSettingsBestEffort({ cloudApiKey: trimmed });
+      void vscode.window.showInformationMessage('Cloud API Key saved securely.');
       await syncSecretStatusIndicatorsBestEffort();
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      vscode.window.showErrorMessage(`${errorPrefix}: ${message}`);
+      void vscode.window.showErrorMessage(`Failed to save Cloud API Key: ${message}`);
+    }
+  });
+
+  const setRuntimeSessionApiKey = vscode.commands.registerCommand('openhands.setRuntimeSessionApiKey', async () => {
+    try {
+      const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(params.context));
+      const existing = await settingsMgr.get();
+      const serverUrl = typeof existing.serverUrl === 'string' ? existing.serverUrl.trim() : '';
+      if (!serverUrl) {
+        void vscode.window.showErrorMessage('OpenHands: Select a remote server before setting a Runtime Session API Key.');
+        return;
+      }
+
+      const keyInfo = getServerRuntimeSessionApiKeySecretKey(serverUrl);
+      if (!keyInfo.ok) {
+        void vscode.window.showErrorMessage(`OpenHands: Invalid server URL: ${keyInfo.error}`);
+        return;
+      }
+
+      const title = 'Runtime Session API Key';
+      const prompt = 'Enter the runtime session API key (`session_api_key`) for the remote agent-server. It will be stored securely in VS Code SecretStorage.';
+
+      let currentValue: string | undefined;
+      try {
+        currentValue = await params.context.secrets.get(keyInfo.secretKey);
+      } catch {
+        currentValue = undefined;
+      }
+      const isCurrentlySet = typeof currentValue === 'string' && currentValue.trim().length > 0;
+
+      if (isCurrentlySet) {
+        const action = await vscode.window.showQuickPick(
+          [
+            { label: 'Update', value: 'update', description: 'Enter a new value (stored securely)' },
+            { label: 'Clear', value: 'clear', description: 'Remove the stored value' },
+          ],
+          { title, placeHolder: 'Choose an action', canPickMany: false }
+        );
+        if (!action) return;
+        if (action.value === 'clear') {
+          const confirmed = await vscode.window.showWarningMessage(
+            `Clear ${title} for ${keyInfo.normalizedServerUrl}?`,
+            { modal: true },
+            'Clear'
+          );
+          if (confirmed !== 'Clear') return;
+          await params.context.secrets.delete(keyInfo.secretKey);
+          params.secrets.set(keyInfo.secretKey, undefined);
+          await updateConversationSettingsBestEffort({ runtimeSessionApiKey: undefined });
+          void vscode.window.showInformationMessage('Runtime Session API Key cleared.');
+          await syncSecretStatusIndicatorsBestEffort();
+          return;
+        }
+      }
+
+      const value = await vscode.window.showInputBox({
+        title,
+        password: true,
+        prompt,
+        placeHolder: 'sk-...',
+      });
+      if (value === undefined) return;
+      const trimmed = value.trim();
+      if (!trimmed) return;
+
+      await params.context.secrets.store(keyInfo.secretKey, trimmed);
+      params.secrets.set(keyInfo.secretKey, trimmed);
+      await updateConversationSettingsBestEffort({ runtimeSessionApiKey: trimmed });
+      void vscode.window.showInformationMessage('Runtime Session API Key saved securely.');
+      await syncSecretStatusIndicatorsBestEffort();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      void vscode.window.showErrorMessage(`Failed to save Runtime Session API Key: ${message}`);
     }
   });
 
@@ -440,7 +505,8 @@ export function registerSecretCommands(params: {
     setOpenRouterApiKey,
     setLiteLlmApiKey,
     setGeminiLlmApiKey,
-    setSessionApiKey,
+    setCloudApiKey,
+    setRuntimeSessionApiKey,
     setGithubToken,
     setHalTtsApiKey,
     setCustomSecret1,

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -31,7 +31,8 @@ export type OpenHandsSettings = ServerSettings & {
   hal: HalSettings;
   servers: SavedServer[];
   secrets: {
-    sessionApiKey?: string;
+    cloudApiKey?: string;
+    runtimeSessionApiKey?: string;
     llmApiKey?: string;
     awsAccessKeyId?: string;
     awsSecretAccessKey?: string;
@@ -357,7 +358,6 @@ export class SettingsManager {
       cache: this.adapter.get<boolean>('openhands.hal.cache', DEFAULTS.hal.cache) ?? DEFAULTS.hal.cache,
     };
     const secrets = {
-      sessionApiKey: await this.adapter.getSecret('openhands.sessionApiKey'),
       llmApiKey: await this.adapter.getSecret('openhands.llmApiKey'),
       awsAccessKeyId: await this.adapter.getSecret('openhands.awsAccessKeyId'),
       awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
@@ -430,9 +430,6 @@ export class SettingsManager {
     }
 
     if (partial.secrets) {
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'sessionApiKey')) {
-        ops.push(this.adapter.storeSecret('openhands.sessionApiKey', partial.secrets.sessionApiKey));
-      }
       if (Object.prototype.hasOwnProperty.call(partial.secrets, 'llmApiKey')) {
         ops.push(this.adapter.storeSecret('openhands.llmApiKey', partial.secrets.llmApiKey));
       }

--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -31,6 +31,12 @@ export type OpenHandsSettings = ServerSettings & {
   hal: HalSettings;
   servers: SavedServer[];
   secrets: {
+    /**
+     * Remote-mode credentials are injected by the extension host at runtime.
+     *
+     * These values are intentionally not persisted via `SettingsManager.update()` because they
+     * live in per-server VS Code SecretStorage slots.
+     */
     cloudApiKey?: string;
     runtimeSessionApiKey?: string;
     llmApiKey?: string;

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -203,7 +203,7 @@ describe('SettingsManager', () => {
         volume: 0.25,
         cache: false,
       },
-      secrets: { sessionApiKey: 'sess', llmApiKey: 'key' }
+      secrets: { llmApiKey: 'key' }
     });
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://example:1234');
@@ -228,7 +228,6 @@ describe('SettingsManager', () => {
     expect(s.hal.modelId).toBe('eleven_turbo_v2');
     expect(s.hal.volume).toBe(0.25);
     expect(s.hal.cache).toBe(false);
-    expect(s.secrets.sessionApiKey).toBe('sess');
     expect(s.secrets.llmApiKey).toBe('key');
     // HAL voice_confirm does not have a separate Gemini secret setting; it relies on profile/provider/global keys.
   });

--- a/src/shared/cloudServers.ts
+++ b/src/shared/cloudServers.ts
@@ -15,6 +15,5 @@ export function isOpenHandsCloudServerUrl(raw: string): boolean {
 }
 
 export function getRemoteAuthKeyLabelForServerUrl(raw: string): string {
-  return isOpenHandsCloudServerUrl(raw) ? 'Cloud API Key' : 'Session API Key';
+  return isOpenHandsCloudServerUrl(raw) ? 'Cloud API Key' : 'Runtime Session API Key';
 }
-

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -28,7 +28,8 @@ const ensureRequiredLocalToolIds = (toolIds: LocalToolId[]): LocalToolId[] => {
 
 type RemoteToolListDeps = {
   serverUrl: string;
-  sessionApiKey?: string;
+  cloudApiKey?: string;
+  runtimeSessionApiKey?: string;
 };
 
 const getRemoteToolListDeps = (conversation: unknown): RemoteToolListDeps | null => {
@@ -37,10 +38,15 @@ const getRemoteToolListDeps = (conversation: unknown): RemoteToolListDeps | null
   const serverUrl = candidate.serverUrl;
   if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) return null;
 
-  const rawSessionKey =
-    (candidate.settings as { secrets?: { sessionApiKey?: unknown } } | undefined)?.secrets?.sessionApiKey;
-  const sessionApiKey = typeof rawSessionKey === 'string' && rawSessionKey.trim().length > 0 ? rawSessionKey : undefined;
-  return { serverUrl: serverUrl.trim(), sessionApiKey };
+  const rawSecrets =
+    (candidate.settings as { secrets?: { runtimeSessionApiKey?: unknown; cloudApiKey?: unknown } } | undefined)?.secrets;
+
+  const rawCloudKey = rawSecrets?.cloudApiKey;
+  const cloudApiKey = typeof rawCloudKey === 'string' && rawCloudKey.trim().length > 0 ? rawCloudKey.trim() : undefined;
+
+  const rawRuntimeKey = rawSecrets?.runtimeSessionApiKey;
+  const runtimeSessionApiKey = typeof rawRuntimeKey === 'string' && rawRuntimeKey.trim().length > 0 ? rawRuntimeKey.trim() : undefined;
+  return { serverUrl: serverUrl.trim(), cloudApiKey, runtimeSessionApiKey };
 };
 
 async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[] | null> {
@@ -48,12 +54,10 @@ async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[
   if (!normalized.ok) return null;
   const url = `${normalized.url}/api/tools/`;
   const headers: Record<string, string> = {};
-  if (params.sessionApiKey) {
-    if (isOpenHandsCloudServerUrl(normalized.url)) {
-      headers['Authorization'] = `Bearer ${params.sessionApiKey}`;
-    } else {
-      headers['X-Session-API-Key'] = params.sessionApiKey;
-    }
+  if (isOpenHandsCloudServerUrl(normalized.url)) {
+    if (params.cloudApiKey) headers['Authorization'] = `Bearer ${params.cloudApiKey}`;
+  } else if (params.runtimeSessionApiKey) {
+    headers['X-Session-API-Key'] = params.runtimeSessionApiKey;
   }
 
   const fetchFn = globalThis.fetch;

--- a/tests/e2e/AGENT_SERVER_QUICKSTART.md
+++ b/tests/e2e/AGENT_SERVER_QUICKSTART.md
@@ -16,11 +16,11 @@ Option A: agent-sdk local (recommended for developers)
 
 Option B: remote server
 - If you have a remote agent-server URL, set openhands.serverUrl accordingly.
-- If it requires a session API key, set it via `OpenHands: Set Session API Key`.
+- If it requires a session API key, set it via `OpenHands: Set Runtime Session API Key`.
 
-Session API Key (optional)
-- HTTP: the extension adds `X-Session-API-Key` when `openhands.secrets.sessionApiKey` is set
-- WebSocket: the extension appends `?session_api_key=...` to the WS URL when `openhands.secrets.sessionApiKey` is set
+Runtime Session API Key (optional)
+- HTTP: the extension adds `X-Session-API-Key` when `openhands.secrets.runtimeSessionApiKey` is set
+- WebSocket: the extension appends `?session_api_key=...` to the WS URL when `openhands.secrets.runtimeSessionApiKey` is set
 
 Notes
 - The extension sends a Start Conversation payload containing LLM and tool configuration for PoC. Ensure your server accepts that.


### PR DESCRIPTION
Separates OpenHands Cloud/SaaS auth (Bearer cloud API key) from runtime agent-server auth (X-Session-API-Key runtime session key).

Changes:
- VS Code SecretStorage: per-server cloudApiKey + runtimeSessionApiKey (no legacy sessionApiKey / no compat)
- Commands/UI: OpenHands: Set Cloud API Key + OpenHands: Set Runtime Session API Key
- SDK/extension: correct header usage (cloud=Bearer, runtime=X-Session-API-Key + WS ?session_api_key=)
- Docs updated to match terminology

Validation:
- npm test
- npm run typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distinct credentials: Cloud API Key for OpenHands Cloud and Runtime Session API Key for remote agent servers.
  * Per-server secret storage to prevent cross-server token clobbering and enable separate cloud/runtime tokens.

* **Commands**
  * "Set Remote API Key" renamed to "Set Cloud API Key".
  * Added "Set Runtime Session API Key" command.

* **Configuration**
  * Cloud servers use Bearer Authorization; remote/runtime servers use X-Session-API-Key (and WS query param) for runtime keys.

* **Docs**
  * Updated guidance, labels, and examples to reflect the two-key model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->