### PR TITLE
Fix remote tools auth header parity

### DIFF
--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -111,7 +111,6 @@ describe('Tools picker host messages', () => {
       method: 'GET',
       headers: expect.objectContaining({
         'X-Session-API-Key': 'test-key-123',
-        Authorization: 'Bearer test-key-123',
       }),
     }));
 
@@ -150,6 +149,30 @@ describe('Tools picker host messages', () => {
       headers: {
         Authorization: 'Bearer cloud-key-abc',
       },
+    }));
+  });
+
+  it('responds to requestTools in remote mode without auth headers when no keys are available', async () => {
+    const fetchSpy = vi.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(['finish']),
+      text: () => Promise.resolve(''),
+    } as unknown as Response));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = {
+      serverUrl: 'http://localhost:3000',
+      settings: { secrets: {} },
+    };
+
+    const { handler } = createRemoteHandler(conversation);
+    await handler({ type: 'requestTools' } as any);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      method: 'GET',
+      headers: {},
     }));
   });
 

--- a/src/__tests__/toolsPicker.host.test.ts
+++ b/src/__tests__/toolsPicker.host.test.ts
@@ -111,6 +111,7 @@ describe('Tools picker host messages', () => {
       method: 'GET',
       headers: expect.objectContaining({
         'X-Session-API-Key': 'test-key-123',
+        Authorization: 'Bearer test-key-123',
       }),
     }));
 
@@ -123,6 +124,33 @@ describe('Tools picker host messages', () => {
       ],
       enabledToolIds: ['execute_bash', 'finish', 'file_edit'],
     });
+  });
+
+  it('responds to requestTools in remote mode using Bearer-only for cloud servers', async () => {
+    const fetchSpy = vi.fn(() => Promise.resolve({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(['finish']),
+      text: () => Promise.resolve(''),
+    } as unknown as Response));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = {
+      serverUrl: 'https://app.all-hands.dev',
+      settings: { secrets: { cloudApiKey: 'cloud-key-abc', runtimeSessionApiKey: 'runtime-key-xyz' } },
+    };
+
+    const { handler } = createRemoteHandler(conversation);
+    await handler({ type: 'requestTools' } as any);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0]?.[0]).toMatch(/\/api\/tools\/$/);
+    expect(fetchSpy.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer cloud-key-abc',
+      },
+    }));
   });
 
   it('applies setEnabledTools by calling conversation.setTools', async () => {

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -57,7 +57,10 @@ async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[
   if (isOpenHandsCloudServerUrl(normalized.url)) {
     if (params.cloudApiKey) headers['Authorization'] = `Bearer ${params.cloudApiKey}`;
   } else if (params.runtimeSessionApiKey) {
+    // Some deployments accept Bearer tokens but not `X-Session-API-Key`.
+    // Send both headers for non-cloud runtimes for maximum compatibility.
     headers['X-Session-API-Key'] = params.runtimeSessionApiKey;
+    headers['Authorization'] = `Bearer ${params.runtimeSessionApiKey}`;
   }
 
   const fetchFn = globalThis.fetch;

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -57,10 +57,7 @@ async function fetchRemoteToolNames(params: RemoteToolListDeps): Promise<string[
   if (isOpenHandsCloudServerUrl(normalized.url)) {
     if (params.cloudApiKey) headers['Authorization'] = `Bearer ${params.cloudApiKey}`;
   } else if (params.runtimeSessionApiKey) {
-    // Some deployments accept Bearer tokens but not `X-Session-API-Key`.
-    // Send both headers for non-cloud runtimes for maximum compatibility.
     headers['X-Session-API-Key'] = params.runtimeSessionApiKey;
-    headers['Authorization'] = `Bearer ${params.runtimeSessionApiKey}`;
   }
 
   const fetchFn = globalThis.fetch;


### PR DESCRIPTION
### Bead

(full bead contents)


oh-tab-auth-headers-parity: Auth: make webview remote tools header logic match RemoteConversation
Status: in_progress
Priority: P2
Type: bug
Assignee: BlackCat
Created: 2026-01-22 03:59
Updated: 2026-01-22 06:11

Description:
Fix auth header parity for the remote tools list fetch.

Context
- After PR #862/#864, remote auth behavior is explicitly split:
  - cloud/SaaS: `Authorization: Bearer <cloudApiKey>` only
  - non-cloud python agent-server runtimes: `X-Session-API-Key: <runtimeSessionApiKey>` only
  - remote-local (no keys): no auth headers

Issue
- Add host-side unit coverage for cloud + no-keys cases so the tools picker can’t regress expected header behavior.

Evidence
- Tools list fetch implementation: `src/webview/host/handlers/tools.ts` (`GET {serverUrl}/api/tools/`).
- Auth header reference behavior: `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts` and `packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts` (cloud Bearer-only; non-cloud X-Session-only).

Design
- Keep header logic inline/explicit (per scope note) and lock behavior with unit tests.

Constraints
- For cloud/SaaS URLs, continue to send **Bearer-only** (do not add `X-Session-API-Key`).

## Scope note: keep header logic explicit
Given the near-term plan to support only a small set of remote targets (localhost/no-auth, cloud bootstrap→nested runtime, and optional direct runtime-key remote), it is acceptable to keep this header logic **inline and explicit** (or lightly shared) rather than forcing a single generalized helper. Prioritize readability and correct naming.


Notes:
PR: https://github.com/enyst/OpenHands-Tab/pull/867

Revised per review: non-cloud python agent-server uses X-Session-API-Key only; remote-local uses no keys; cloud Bearer-only. Added tests. Waiting for OrangeStone approval.

Acceptance Criteria:
- Cloud servers: tool list fetch sends only Authorization: Bearer <cloudApiKey>.
- Non-cloud python agent-server runtimes with SESSION_API_KEY: tool list fetch sends X-Session-API-Key: <runtimeSessionApiKey>.
- Non-cloud remote-local (no key): tool list fetch sends no auth headers.
- Host-side unit tests cover the above.

Labels: [auth compatibility remote tools webview]


### Summary
- Non-cloud tool list fetch uses `X-Session-API-Key` (python agent-server `SESSION_API_KEY` mode).
- Remote-local (no key) sends no auth headers.
- Cloud stays `Authorization: Bearer <cloudApiKey>` only.
- Adds host-side unit coverage.

### Testing
- `npx vitest run src/__tests__/toolsPicker.host.test.ts`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for remote mode tool fetching with bearer token authentication and no-auth scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
