### PR TITLE
Cloud remote: V1 bootstrap to nested runtime

### DIFF
--- a/docs/cloud_oauth_device_flow.md
+++ b/docs/cloud_oauth_device_flow.md
@@ -17,8 +17,10 @@ Important:
 
 - Remote mode uses two distinct fields:
   - `settings.secrets.cloudApiKey` for **SaaS/app-server** calls (Bearer).
-  - `settings.secrets.runtimeSessionApiKey` for **nested agent-server** calls (X-Session-API-Key / WS query param).
-- Tokens are stored in VS Code SecretStorage as per-server entries (see `src/auth/serverCloudApiKeys.ts` and `src/auth/serverRuntimeSessionApiKeys.ts`).
+  - `settings.secrets.runtimeSessionApiKey` for **agent-server** calls (X-Session-API-Key / WS query param).
+    - For **direct/non-cloud** agent-server connections, this may come from per-server SecretStorage.
+    - For OpenHands Cloud, this is obtained via SaaS V1 bootstrap and is kept in-memory only.
+- Tokens are stored in VS Code SecretStorage as per-server entries (see `src/auth/serverCloudApiKeys.ts` and `src/auth/serverRuntimeSessionApiKeys.ts`). For OpenHands Cloud, only the `cloudApiKey` is persisted; the runtime `session_api_key` is ephemeral.
 
 ## Clarification: two different keys (very important)
 
@@ -115,11 +117,11 @@ Problem:
 
 Recommendation:
 - Store the **cloud API key** per canonical SaaS server URL in VS Code SecretStorage.
-- Store the latest **runtime `session_api_key`** per SaaS server URL as well (useful for reconnect/debug; it is still runtime-scoped and expected to change across sandboxes/conversations).
+- Do **not** persist the runtime `session_api_key` for cloud servers. It is obtained from the SaaS V1 bootstrap (`/api/v1/app-conversations*`) and is **kept in-memory only** for the lifetime of the running conversation (it is sandbox/runtime-scoped and expected to change).
 
 Suggested secret keys:
 - `openhands.cloudApiKey.server.<hash>` (server-specific cloud token)
-- `openhands.runtimeSessionApiKey.server.<hash>` (server-specific runtime session key)
+- `openhands.runtimeSessionApiKey.server.<hash>` (server-specific runtime session key for **direct/non-cloud** agent-server connections)
 
 Where `<hash>` is a stable hash of the normalized server URL (e.g. SHA-256 hex of `normalizeServerUrl(url).url`).
 

--- a/docs/e2e_testing.md
+++ b/docs/e2e_testing.md
@@ -121,7 +121,7 @@ The suite `tests/e2e/deviceFlowAuth.test.ts` validates the device-flow login loo
 - Run all E2E: `npm run e2e`
 - The suite sets `E2E_CLOUD_LOGIN=1` so the extension uses test-friendly UX (no browser open, no post-login prompts).
 - Covered scenarios include:
-  - Happy path login stores a per-server session key
+  - Happy path login stores a per-server `cloudApiKey` (SaaS user token)
   - Logout clears stored credentials
   - Error paths: `access_denied`, `expired_token`
   - Polling backoff: `slow_down` then success
@@ -133,7 +133,7 @@ To validate against the real cloud server (`https://app.all-hands.dev`):
 1) Set server URL to `https://app.all-hands.dev` (via “OpenHands: Configure”)
 2) Run “OpenHands: Login to Remote Server (Device Flow)” and complete the browser flow
 3) Verify remote usage works (e.g., “OpenHands: Start New Conversation” succeeds and the chat goes online)
-4) Restart VS Code and verify the token persists (remote usage still works without re-login)
+4) Restart VS Code and verify the cloud token persists (remote usage still works without re-login)
 5) Run “OpenHands: Logout of Remote Server” and verify remote usage fails (401/403) until you re-login
 
 ## CI Integration

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -19,9 +19,10 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
   - Used only for OpenHands Cloud/SaaS servers (e.g. `https://app.all-hands.dev`).
   - HTTP header: `Authorization: Bearer <cloudApiKey>`
 - `openhands.runtimeSessionApiKey.server.<hash>` (VS Code SecretStorage; per-server)
-  - Used for agent-server endpoints (local python server or nested cloud runtime agent-server).
+  - Used for **direct/non-cloud** agent-server endpoints (e.g. a local python agent-server or self-hosted agent-server).
   - HTTP header: `X-Session-API-Key: <runtimeSessionApiKey>`
   - WebSocket query param: `?session_api_key=<runtimeSessionApiKey>`
+  - Note (OpenHands Cloud): the nested runtime `session_api_key` is obtained via SaaS V1 bootstrap (`/api/v1/app-conversations*`) and is **not persisted**; it is injected into in-memory `settings.secrets.runtimeSessionApiKey` only for the lifetime of the running conversation.
 
 ## 2) Conversation lifecycle & persistence
 

--- a/src/__tests__/cloudRemoteBootstrap.test.ts
+++ b/src/__tests__/cloudRemoteBootstrap.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { bootstrapCloudRemoteConversation } from '../cloud/cloudRemoteBootstrap';
+
+describe('bootstrapCloudRemoteConversation', () => {
+  it('uses Bearer-only SaaS auth and returns nested runtime connection info', async () => {
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([
+          { status: 'WORKING' },
+          { status: 'READY', app_conversation_id: 'ac-123' },
+        ]),
+        text: () => Promise.resolve(''),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([
+          {
+            conversation_url: 'https://runtime.example.com/api/conversations/conv-456',
+            session_api_key: 'runtime-key-xyz',
+          },
+        ]),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+
+    const result = await bootstrapCloudRemoteConversation({
+      saasServerUrl: 'https://app.all-hands.dev',
+      cloudApiKey: 'cloud-key-abc',
+      fetchFn: fetchSpy as unknown as typeof fetch,
+      timeoutMs: 10_000,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy.mock.calls[0]?.[0]).toBe('https://app.all-hands.dev/api/v1/app-conversations/stream-start');
+    expect(fetchSpy.mock.calls[0]?.[1]).toEqual(expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer cloud-key-abc',
+      }),
+    }));
+    expect((fetchSpy.mock.calls[0]?.[1] as any)?.headers?.['X-Session-API-Key']).toBeUndefined();
+
+    expect(fetchSpy.mock.calls[1]?.[0]).toContain('/api/v1/app-conversations?ids=');
+    expect(fetchSpy.mock.calls[1]?.[1]).toEqual(expect.objectContaining({
+      method: 'GET',
+      headers: expect.objectContaining({
+        Authorization: 'Bearer cloud-key-abc',
+      }),
+    }));
+
+    expect(result).toEqual(expect.objectContaining({
+      saasServerUrl: 'https://app.all-hands.dev',
+      appConversationId: 'ac-123',
+      conversationUrl: 'https://runtime.example.com/api/conversations/conv-456',
+      nestedServerUrl: 'https://runtime.example.com',
+      conversationId: 'conv-456',
+      runtimeSessionApiKey: 'runtime-key-xyz',
+    }));
+  });
+
+  it('errors clearly when V1 endpoints are missing', async () => {
+    const fetchSpy = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(''),
+    } as unknown as Response);
+
+    await expect(bootstrapCloudRemoteConversation({
+      saasServerUrl: 'https://app.all-hands.dev',
+      cloudApiKey: 'cloud-key-abc',
+      fetchFn: fetchSpy as unknown as typeof fetch,
+      timeoutMs: 10_000,
+    })).rejects.toThrow(/does not support V1/i);
+  });
+});
+

--- a/src/cloud/cloudRemoteBootstrap.ts
+++ b/src/cloud/cloudRemoteBootstrap.ts
@@ -1,0 +1,183 @@
+import { normalizeServerUrl } from '../shared/serverUrls';
+
+export type CloudBootstrapResult = {
+  saasServerUrl: string;
+  appConversationId: string;
+  conversationUrl: string;
+  nestedServerUrl: string;
+  conversationId: string;
+  runtimeSessionApiKey: string;
+};
+
+type AppConversationStartTask = {
+  status?: unknown;
+  detail?: unknown;
+  app_conversation_id?: unknown;
+};
+
+type AppConversation = {
+  conversation_url?: unknown;
+  session_api_key?: unknown;
+};
+
+function parseNestedConversationUrl(conversationUrl: string): { nestedServerUrl: string; conversationId: string } | null {
+  let url: URL;
+  try {
+    url = new URL(conversationUrl);
+  } catch {
+    return null;
+  }
+
+  const pathname = url.pathname.replace(/\/$/, '');
+  const parts = pathname.split('/').filter(Boolean);
+  const conversationsIndex = parts.lastIndexOf('conversations');
+  if (conversationsIndex <= 0) return null;
+  if (parts[conversationsIndex - 1] !== 'api') return null;
+  const id = parts[conversationsIndex + 1];
+  if (!id) return null;
+
+  const baseParts = parts.slice(0, conversationsIndex - 1); // drop `/api/conversations/<id>`
+  const basePath = baseParts.length ? `/${baseParts.join('/')}` : '';
+  const nested = `${url.origin}${basePath}`;
+  return { nestedServerUrl: nested, conversationId: id };
+}
+
+function buildAuthHeaders(cloudApiKey: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${cloudApiKey}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+async function fetchJsonWithTimeout(fetchFn: typeof fetch, url: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchFn(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function bootstrapCloudRemoteConversation(params: {
+  saasServerUrl: string;
+  cloudApiKey: string;
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}): Promise<CloudBootstrapResult> {
+  const normalized = normalizeServerUrl(params.saasServerUrl);
+  if (!normalized.ok) {
+    throw new Error(`Cloud bootstrap failed: invalid serverUrl (${normalized.error})`);
+  }
+
+  const cloudApiKey = params.cloudApiKey.trim();
+  if (!cloudApiKey) {
+    throw new Error('Cloud bootstrap failed: missing Cloud API Key');
+  }
+
+  const fetchFn = params.fetchFn ?? globalThis.fetch;
+  if (typeof fetchFn !== 'function') {
+    throw new Error('Cloud bootstrap failed: global fetch unavailable');
+  }
+
+  const timeoutMs = typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs)
+    ? Math.max(1000, Math.trunc(params.timeoutMs))
+    : 120_000;
+
+  const saasServerUrl = normalized.url.replace(/\/$/, '');
+  const startUrl = `${saasServerUrl}/api/v1/app-conversations/stream-start`;
+  const startRes = await fetchJsonWithTimeout(fetchFn, startUrl, {
+    method: 'POST',
+    headers: buildAuthHeaders(cloudApiKey),
+    body: JSON.stringify({}),
+  }, timeoutMs);
+
+  if (!startRes.ok) {
+    const detail = await startRes.text().catch(() => '');
+    const status = startRes.status;
+    if (status === 401 || status === 403) {
+      throw new Error(`Cloud bootstrap failed (HTTP ${status}): invalid or expired Cloud API Key.`);
+    }
+    if (status === 404) {
+      throw new Error(`Cloud bootstrap failed (HTTP 404): server does not support V1 app-conversations.`);
+    }
+    throw new Error(`Cloud bootstrap failed (HTTP ${status})${detail ? `: ${detail}` : ''}`);
+  }
+
+  const tasks: unknown = await startRes.json().catch(() => null);
+  if (!Array.isArray(tasks)) {
+    throw new Error('Cloud bootstrap failed: invalid stream-start response (expected JSON array)');
+  }
+
+  const taskList = tasks as AppConversationStartTask[];
+  let readyTask: AppConversationStartTask | undefined;
+  for (let i = taskList.length - 1; i >= 0; i -= 1) {
+    const task = taskList[i];
+    if (task?.status !== 'READY') continue;
+    if (typeof task.app_conversation_id !== 'string') continue;
+    if (!task.app_conversation_id.trim()) continue;
+    readyTask = task;
+    break;
+  }
+
+  const appConversationId = typeof readyTask?.app_conversation_id === 'string' ? readyTask.app_conversation_id.trim() : '';
+  if (!appConversationId) {
+    let errorTask: AppConversationStartTask | undefined;
+    for (let i = taskList.length - 1; i >= 0; i -= 1) {
+      const task = taskList[i];
+      if (task?.status === 'ERROR') {
+        errorTask = task;
+        break;
+      }
+    }
+    const errorDetail = typeof errorTask?.detail === 'string' ? errorTask.detail : '';
+    throw new Error(`Cloud bootstrap failed: app conversation never reached READY${errorDetail ? ` (${errorDetail})` : ''}`);
+  }
+
+  const getUrl = `${saasServerUrl}/api/v1/app-conversations?ids=${encodeURIComponent(appConversationId)}`;
+  const getRes = await fetchJsonWithTimeout(fetchFn, getUrl, {
+    method: 'GET',
+    headers: buildAuthHeaders(cloudApiKey),
+  }, timeoutMs);
+
+  if (!getRes.ok) {
+    const detail = await getRes.text().catch(() => '');
+    const status = getRes.status;
+    if (status === 401 || status === 403) {
+      throw new Error(`Cloud bootstrap failed (HTTP ${status}): invalid or expired Cloud API Key.`);
+    }
+    throw new Error(`Cloud bootstrap failed fetching app conversation (HTTP ${status})${detail ? `: ${detail}` : ''}`);
+  }
+
+  const conversations: unknown = await getRes.json().catch(() => null);
+  if (!Array.isArray(conversations)) {
+    throw new Error('Cloud bootstrap failed: invalid app-conversations response (expected JSON array)');
+  }
+
+  const info = conversations.find((c): c is AppConversation => Boolean(c && typeof c === 'object'));
+  const conversationUrl =
+    typeof info?.conversation_url === 'string' && info.conversation_url.trim().length > 0 ? info.conversation_url.trim() : '';
+  const runtimeSessionApiKey =
+    typeof info?.session_api_key === 'string' && info.session_api_key.trim().length > 0 ? info.session_api_key.trim() : '';
+
+  if (!conversationUrl) {
+    throw new Error('Cloud bootstrap failed: response missing conversation_url');
+  }
+  if (!runtimeSessionApiKey) {
+    throw new Error('Cloud bootstrap failed: response missing session_api_key');
+  }
+
+  const parsed = parseNestedConversationUrl(conversationUrl);
+  if (!parsed) {
+    throw new Error(`Cloud bootstrap failed: could not parse conversation_url (${conversationUrl})`);
+  }
+
+  return {
+    saasServerUrl,
+    appConversationId,
+    conversationUrl,
+    nestedServerUrl: parsed.nestedServerUrl,
+    conversationId: parsed.conversationId,
+    runtimeSessionApiKey,
+  };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,6 +36,7 @@ import { getServerRuntimeSessionApiKeySecretKey } from './auth/serverRuntimeSess
 import { isOpenHandsCloudServerUrl } from './shared/cloudServers';
 import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
 import { registerCloudLogoutCommand } from './extension/cloudLogoutCommand';
+import { bootstrapCloudRemoteConversation, type CloudBootstrapResult } from './cloud/cloudRemoteBootstrap';
 import {
   createOutputLogger,
   normalizeOutputVerbosity,
@@ -85,6 +86,7 @@ let localAgentContext: AgentContext | undefined;
 let activeEditorFilePath: string | undefined;
 let lastRemoteAuthPromptAtMs = 0;
 let lastRemoteServerUrl: string | undefined;
+let cloudRemoteBootstrap: CloudBootstrapResult | null = null;
 const receivedTerminalEvents: { type?: string; timestamp: number }[] = []; // Track terminal events for testing
 const MAX_TERMINAL_EVENTS = 1000; // Ring buffer size limit to prevent memory growth
 const MAX_EVENT_BACKLOG = 2000;
@@ -563,6 +565,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     const desiredMode: 'local' | 'remote' = settings.serverUrl ? 'remote' : 'local';
     const savedIdKey = desiredMode === 'local' ? 'openhands.conversationId.local' : 'openhands.conversationId.remote';
+    const rawServerUrl = typeof settings.serverUrl === 'string' ? settings.serverUrl.trim() : '';
+    const isCloudRemote = desiredMode === 'remote' && rawServerUrl ? isOpenHandsCloudServerUrl(rawServerUrl) : false;
     if (options?.modeSwitched) {
       // Switching modes should always start a fresh conversation, never restore prior state.
       resetConversationEventBacklog(undefined);
@@ -573,6 +577,13 @@ export function activate(context: vscode.ExtensionContext) {
     let savedId = (options?.uiJustCreated || options?.modeSwitched)
       ? undefined
       : context.workspaceState.get<string>(savedIdKey);
+
+    if (isCloudRemote) {
+      // Cloud remote conversations are bootstrapped through SaaS V1 and require an ephemeral runtime session key.
+      // Do not attempt to restore persisted conversation ids for this mode.
+      savedId = undefined;
+      await context.workspaceState.update(savedIdKey, undefined);
+    }
 
     if (savedId) {
       const looksLocal = savedId.startsWith('local-');
@@ -587,6 +598,7 @@ export function activate(context: vscode.ExtensionContext) {
         conversation?.disconnect();
       } catch {}
       fileEditNoteTracker.reset();
+      cloudRemoteBootstrap = null;
 
       const persistenceDir =
         desiredMode === 'local'
@@ -619,8 +631,36 @@ export function activate(context: vscode.ExtensionContext) {
         syncActiveEditorSystemMessageSuffix(vscode.window.activeTextEditor);
       }
 
+      let effectiveServerUrl = settings.serverUrl ?? undefined;
+      let bootstrapConversationId: string | undefined;
+      if (desiredMode === 'remote' && isCloudRemote) {
+        const cloudApiKey = settings.secrets?.cloudApiKey ?? '';
+        if (!cloudApiKey) {
+          const action = await vscode.window.showWarningMessage(
+            'OpenHands Cloud: Login required to start a cloud runtime.',
+            'Login',
+            'Dismiss',
+          );
+          if (action === 'Login') {
+            await vscode.commands.executeCommand('openhands.cloudLogin');
+          }
+          throw new Error('OpenHands Cloud: missing Cloud API Key.');
+        }
+
+        const bootstrap = await vscode.window.withProgress(
+          { location: vscode.ProgressLocation.Notification, title: 'OpenHands Cloud: starting runtime…' },
+          async () => bootstrapCloudRemoteConversation({ saasServerUrl: rawServerUrl, cloudApiKey }),
+        );
+        cloudRemoteBootstrap = bootstrap;
+        bootstrapConversationId = bootstrap.conversationId;
+        effectiveServerUrl = bootstrap.nestedServerUrl;
+        // Inject the runtime key into the in-memory settings only (do not persist to SecretStorage).
+        settings = withRemoteSecrets({ cloudApiKey, runtimeSessionApiKey: bootstrap.runtimeSessionApiKey });
+        savedId = bootstrapConversationId;
+      }
+
       const conversationOptions = {
-        serverUrl: settings.serverUrl ?? undefined,
+        serverUrl: effectiveServerUrl,
         settings,
         workspaceRoot,
         tools: settings.serverUrl ? undefined : resolveLocalTools(),
@@ -628,6 +668,7 @@ export function activate(context: vscode.ExtensionContext) {
         persistenceDir,
         agentContext,
         pastedImagesBaseDir,
+        conversationId: bootstrapConversationId,
       };
 
       // Populate user environment info suffix for local mode (after agentContext is created & system message synced)
@@ -724,6 +765,17 @@ export function activate(context: vscode.ExtensionContext) {
         }
       }
     } else if (conversation) {
+      if (isCloudRemote && cloudRemoteBootstrap?.saasServerUrl) {
+        // Keep runtime session key in-memory only; refresh settings from SecretStorage won't include it.
+        const normalizedBootstrapSaas = cloudRemoteBootstrap.saasServerUrl;
+        const normalizedCurrent = typeof settings.serverUrl === 'string' ? settings.serverUrl.trim().replace(/\/$/, '') : '';
+        if (normalizedCurrent && normalizedCurrent === normalizedBootstrapSaas) {
+          settings = withRemoteSecrets({
+            cloudApiKey: settings.secrets?.cloudApiKey ?? undefined,
+            runtimeSessionApiKey: cloudRemoteBootstrap.runtimeSessionApiKey,
+          });
+        }
+      }
       conversation.setSettings(settings);
     } else {
       outputChannel?.appendLine('[warn] Conversation unavailable during settings refresh');


### PR DESCRIPTION
### Bead

(full bead contents)


oh-tab-voc.8: Cloud remote: 2-stage connect via V1 app-conversations (bootstrap nested runtime)
Status: in_progress
Priority: P1
Type: task
Assignee: BlackCat
Created: 2026-01-22 03:58
Updated: 2026-01-22 06:22

Description:
Implement the **cloud 2-stage remote connection** architecture for OpenHands Cloud / SaaS servers.

Problem
- Today, oh-tab treats `settings.serverUrl` as an **agent-server** base URL and `settings.secrets.sessionApiKey` as a single “remote key”, and `RemoteConversation` directly calls `POST {serverUrl}/api/conversations`.
- For OpenHands Cloud/SaaS (e.g. `https://app.all-hands.dev`), that model is wrong: the device-flow token is a **Cloud API Key / SaaS user token**, but the actual runtime operations must be done against a **nested agent-server** inside a sandbox using a separate **runtime `session_api_key`**.

Required architecture (2-stage)
1) User performs interactive cloud login (device flow) in the extension host → store **Cloud API Key** (SaaS user token).
2) Client calls SaaS **V1 app-server** endpoints using `Authorization: Bearer <cloud_api_key>` to obtain:
   - `conversation_url` (nested agent-server conversation URL)
   - `session_api_key` (runtime/sandbox credential)
3) Client connects to the nested agent-server and uses **runtime** auth:
   - HTTP: `X-Session-API-Key: <runtime_session_api_key>`
   - WS (current upstream requirement): `?session_api_key=<runtime_session_api_key>`

Why this bead exists
- PR #862 clarified terminology/UI and stopped using the cloud token as `X-Session-API-Key` for SaaS calls, but oh-tab still lacks the actual “bootstrap → connect nested runtime” flow.

Key codebase references (oh-tab)
- Conversation factory chooses remote when `serverUrl` is set: `packages/agent-sdk-ts/src/sdk/conversation/index.ts:35`.
- RemoteConversation starts a conversation via legacy `POST /api/conversations`: `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts:386`.
- WS connect currently uses `?session_api_key=` (still tracked by `oh-tab-h3g`).

Upstream app-server V1 references (odie checkout; source of truth)
- V1 router prefix `/api/v1`: `~/repos/odie/openhands/app_server/v1_router.py:13`.
- App conversation routes prefix `/app-conversations`: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_router.py:77`.
- Start (non-stream): `POST /api/v1/app-conversations`: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_router.py:200`.
- Start (stream): `POST /api/v1/app-conversations/stream-start`: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_router.py:242`.
- Request model: `AppConversationStartRequest`: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_models.py:94`.
- Streaming implementation yields `AppConversationStartTask` JSON objects: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_router.py:624`.
- Batch-get app conversations: `GET /api/v1/app-conversations?ids=<uuid>`: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_router.py:187`.
- `AppConversation` includes `conversation_url` + `session_api_key`: `~/repos/odie/openhands/app_server/app_conversation/app_conversation_models.py:68`.
- Those fields are populated from sandbox.exposed_urls + sandbox.session_api_key: `~/repos/odie/openhands/app_server/app_conversation/live_status_app_conversation_service.py:431` (see `conversation_url += '/api/conversations/{id}'` at `...:455` and `session_api_key = sandbox.session_api_key` at `...:456`).
### Scope note (near-term): 3 remote targets
We currently only care about three remote scenarios, and it is OK to implement them as separate named paths for clarity:
- `remote-local`: localhost python agent-server (no auth)
- `cloud remote`: SaaS + nested runtime agent-server (2-stage; two credentials)
- `remote-runtime-direct` (optional): direct agent-server using runtime `session_api_key` only (OK to hardcode host for testing)


Design:
## Proposed implementation (oh-tab)

### 1) Add an async “remote connect” factory
Add an async factory that encapsulates cloud bootstrap + nested runtime connection.

Shape (one of):
- `connectRemoteConversation(...)` exported from `packages/agent-sdk-ts/src/sdk/conversation/` (preferred), or
- `RemoteConversation.connect(...)` as a `static` method.

Key requirement: this must be **async**, because cloud bootstrap requires one or more SaaS HTTP calls.

### 2) Cloud bootstrap should be V1-first and explicit
For cloud/SaaS server URLs (per `isOpenHandsCloudServerUrl(...)`), do:

A) Start or ensure the app conversation exists
- Prefer: `POST {saas}/api/v1/app-conversations/stream-start`
  - Auth: `Authorization: Bearer <cloud_api_key>`
  - Body: `AppConversationStartRequest` (likely minimal `{}` is acceptable; confirm for oh-tab’s needs).
  - Parse the streamed JSON array until a task returns `status=READY` and has `app_conversation_id`.

B) Fetch runtime connection info
- Call: `GET {saas}/api/v1/app-conversations?ids=<app_conversation_id>`
- Extract:
  - `conversation_url` (e.g. `<agent_server_url>/api/conversations/<uuid>`)
  - `session_api_key` (runtime key)

C) Connect to nested agent-server
- Derive nested server base URL from `conversation_url` (strip `/api/conversations/<id>`).
- Derive `conversationId` from `conversation_url`.
- Instantiate `RemoteConversation` targeting the nested runtime:
  - `serverUrl = <agent_server_url>`
  - `conversationId = <uuid>`
  - runtime key should be used for `X-Session-API-Key` (and WS query param for now).

### 3) Credential handling rules
- Cloud API Key:
  - retrieved from VS Code SecretStorage (extension host) and passed into SDK as input
  - used only as `Authorization: Bearer ...` for SaaS/app-server calls
  - never used as `X-Session-API-Key`
  - never put into WS query params
- Runtime `session_api_key`:
  - obtained from SaaS V1 response (`AppConversation.session_api_key`)
  - used only to talk to nested agent-server
  - should be treated as ephemeral runtime state; do **not** persist in SecretStorage as a user secret

### 4) Where to wire this
- Current synchronous factory `Conversation(options)` cannot do this by itself.
- Preferred wiring:
  - keep `Conversation(options)` as-is for local + non-cloud direct remote
  - add new host-side code path that calls `await connectRemoteConversation(...)` when server is cloud

### 5) Fallback policy
- Do not use legacy V0 `/api/conversations` on the SaaS host by default.
- If V1 endpoints are unavailable (404), either:
  - hard-fail with a clear error (“server does not support V1 cloud remote bootstrap”), or
  - explicitly gated fallback to legacy V0 (documented as legacy only).

### 6) Tests
Add Vitest coverage for:
- cloud bootstrap calls use Bearer-only to SaaS
- runtime key is used for nested agent-server calls (headers + WS query param)
- correct parsing of `conversation_url` → base URL + id
- error mapping: 401/403 (cloud key invalid), 404 (v1 missing), malformed payload
## Scope note (near-term): supported remote targets
We currently only need to support **three** practical remote scenarios, and it is acceptable to implement them as **separate, explicit code paths/classes** for readability (no need to over-generalize yet):

1) **remote-local**: `localhost` running the python agent-server (typically **no auth**).
2) **cloud remote (SaaS + nested runtime)**: full 2-stage auth:
   - Cloud login yields **Cloud API Key / SaaS user token**.
   - Use SaaS **V1** (`/api/v1/app-conversations*`) with `Authorization: Bearer <cloud_api_key>` to obtain `conversation_url` + runtime `session_api_key`.
   - Connect directly to the nested agent-server using runtime auth (`X-Session-API-Key: <runtime_session_api_key>` and WS `?session_api_key=` for now).
3) **remote-runtime-direct (optional)**: a directly reachable agent-server that uses only the runtime `session_api_key` (useful for testing/experiments). It is OK to hardcode a known host while we validate this path.

Design preference: prioritize **clarity** and **correct naming** over DRY helpers. Keep it easy to add more remote types later.


Notes:

## Local dev context (enyst machine)
- On this machine, OpenHands-CLI has already been used to authenticate against Cloud.
- Reference CLI implementation lives at `~/repos/OpenHands-CLI`.
- This can be used for local testing/validation (e.g., optional “import token from CLI” flow), but production oh-tab auth should continue to store per-server tokens in VS Code SecretStorage.


Acceptance Criteria:
- With `serverUrl=https://app.all-hands.dev` and a valid Cloud API Key:
  - oh-tab uses **V1** endpoints on SaaS (`/api/v1/app-conversations/stream-start` + `GET /api/v1/app-conversations?ids=...`) to obtain `conversation_url` and runtime `session_api_key`.
  - oh-tab connects to the nested agent-server at `conversation_url` and authenticates using runtime `session_api_key`.
  - no request sends the cloud token as `X-Session-API-Key`.
- With a non-cloud agent-server URL:
  - remote mode continues to work (no regressions).
- Runtime `session_api_key` is not persisted to SecretStorage.

Labels: [agent-sdk-ts auth cloud conversation remote teleport v1]

Depends on (4):
  → oh-tab-voc.1: Investigate CLI device auth and design oh-tab implementation [P1]
  → oh-tab-voc.3: Implement OAuth 2.0 Device Flow for oh-tab [P1]
  → oh-tab-voc.9: SecretStorage: separate cloudApiKey vs runtimeSessionApiKey (no legacy)
 [P1]
  → oh-tab-voc.7: Session API Key: scope to server + avoid cross-server leak [P2]

Blocks (1):
  ← oh-tab-2az: E2E: remote servers (cloud bootstrap + runtime key) [P1]


### Summary
- Adds a host-side cloud bootstrap path that uses SaaS V1 app-conversations to derive the nested runtime agent-server URL + conversation id + runtime `session_api_key`.
- Connects to the nested agent-server using runtime auth only, and keeps the runtime key in-memory (no SecretStorage persistence).

### Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenHands Cloud remote conversations with automatic SaaS bootstrap initialization
  * Improved credential handling: Cloud API keys persist while runtime session keys remain ephemeral in-memory
  * Added progress indicator during cloud bootstrap and enhanced login flow for missing credentials

* **Documentation**
  * Updated documentation clarifying cloud vs. non-cloud authentication and credential persistence

* **Tests**
  * Added comprehensive unit tests for cloud bootstrap functionality

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->