### PR TITLE
fix: avoid consuming response body twice in E2E test

### DIFF
--- a/tests/e2e/agentServerRemoteCloudBootstrap.test.ts
+++ b/tests/e2e/agentServerRemoteCloudBootstrap.test.ts
@@ -200,11 +200,16 @@ async function startMockSaasServer(params: {
         max_iterations: 1,
       }),
     });
-    const json = await res.json().catch(() => ({})) as { id?: string; conversation_id?: string; uuid?: string };
+    const text = await res.text().catch(() => '');
+    let json: { id?: string; conversation_id?: string; uuid?: string } = {};
+    try {
+      json = JSON.parse(text) as typeof json;
+    } catch {
+      // Not valid JSON, will use text in error message below
+    }
     const id = (json.id || json.conversation_id || json.uuid || '').trim();
     if (!id) {
-      const detail = await res.text().catch(() => '');
-      throw new Error(`Mock SaaS failed to create conversation on agent-server (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
+      throw new Error(`Mock SaaS failed to create conversation on agent-server (HTTP ${res.status})${text ? `: ${text}` : ''}`);
     }
     return id;
   };


### PR DESCRIPTION
## Summary

Fixes a bug in `tests/e2e/agentServerRemoteCloudBootstrap.test.ts` where the HTTP response body was being consumed twice.

## Problem

In the `createConversationOnAgentServer` function, the code was:
1. Calling `res.json()` to parse the response body
2. If the JSON didn't contain a valid ID, calling `res.text()` to get more details for the error message

However, HTTP response bodies can only be consumed once. After `res.json()` consumes the body, `res.text()` will always return an empty string.

## Solution

Read the body as text first, then parse as JSON. This ensures the original response text is available for error messages if parsing fails or the ID is missing.

```typescript
// Before (buggy)
const json = await res.json().catch(() => ({}));
const id = (json.id || json.conversation_id || json.uuid || '').trim();
if (!id) {
  const detail = await res.text().catch(() => '');  // Always empty!
  throw new Error(`...${detail ? `: ${detail}` : ''}`);
}

// After (fixed)
const text = await res.text().catch(() => '');
let json = {};
try {
  json = JSON.parse(text);
} catch {
  // Not valid JSON, will use text in error message below
}
const id = (json.id || json.conversation_id || json.uuid || '').trim();
if (!id) {
  throw new Error(`...${text ? `: ${text}` : ''}`);  // Has the actual response!
}
```

## Testing

- TypeScript compilation passes (`npx tsc --noEmit -p tsconfig.e2e.json`)

## Related

This was flagged by an AI reviewer on PR #870.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a7e7ce578e104319971a5aae8a3cad2a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test reliability for cloud bootstrap functionality with improved response handling and error messaging capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/872">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
