### PR TITLE
[oh-tab-h3g] Security: drop session_api_key from RemoteConversation WS URL

### DIFF
--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -70,6 +70,7 @@ class MockWS {
 vi.mock('ws', () => ({ default: MockWS }));
 
 const getEventWS = () => wsInstances.find((ws) => ws.url.includes('/sockets/events')) ?? wsInstances[0];
+const getEventWSHeaders = () => (getEventWS()?.options?.headers ?? {}) as Record<string, unknown>;
 
 const baseSettings = {
   llm: { model: 'test-model' },
@@ -1139,7 +1140,7 @@ describe('RemoteConversation', () => {
     expect(ws.url).toContain('resend_all=true');
   });
 
-  it('does not include session_api_key in ws URL and uses ws headers for auth', async () => {
+  it('does not include session_api_key in WebSocket URL query params', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toContain('/events/search');
       return {
@@ -1164,11 +1165,15 @@ describe('RemoteConversation', () => {
 
     const ws = getEventWS();
     expect(ws.url).toContain('resend_all=true');
-    expect(ws.url).not.toContain('session_api_key');
-    expect(ws.options?.headers?.['X-Session-API-Key']).toBe('session-key');
+    expect(ws.url).not.toContain('session_api_key=');
+    expect(ws.url).not.toContain('session-key');
+
+    const headers = getEventWSHeaders();
+    expect(headers['X-Session-API-Key']).toBe('session-key');
+    expect(headers['Content-Type']).toBeUndefined();
   });
 
-  it('falls back to legacy session_api_key ws query auth on 403 handshake response', async () => {
+  it('does not retry WebSocket with session_api_key query auth after a 403 handshake response', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toContain('/events/search');
       return {
@@ -1189,21 +1194,19 @@ describe('RemoteConversation', () => {
       },
     });
 
+    const errors: unknown[] = [];
+    conversation.on('error', (error) => errors.push(error));
+
     await conversation.restoreConversation('abc');
 
-    const firstWs = getEventWS();
-    expect(firstWs.url).toContain('resend_all=true');
-    expect(firstWs.url).not.toContain('session_api_key');
-    expect(firstWs.options?.headers?.['X-Session-API-Key']).toBe('session-key');
+    const ws = getEventWS();
+    ws.error(new Error('Unexpected server response: 403'));
 
-    firstWs.error(new Error('Unexpected server response: 403'));
-
-    const eventSockets = wsInstances.filter((ws) => ws.url.includes('/sockets/events'));
-    expect(eventSockets).toHaveLength(2);
-    const fallbackWs = eventSockets[1];
-    expect(fallbackWs.url).toContain('resend_all=true');
-    expect(fallbackWs.url).toContain('session_api_key=session-key');
-    expect(fallbackWs.options?.headers?.['X-Session-API-Key']).toBe('session-key');
+    const eventSockets = wsInstances.filter((socket) => socket.url.includes('/sockets/events'));
+    expect(eventSockets).toHaveLength(1);
+    expect(eventSockets[0]?.url).not.toContain('session_api_key=');
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toContain('403');
   });
 
   it('does not attempt WebSocket connect when history fetch fails', async () => {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -144,7 +144,6 @@ export class RemoteConversation extends EventEmitter {
   private static readonly historyPageLimit = 100;
   private static readonly wsHandshakeTimeoutMs = 10_000;
   private static readonly httpTimeoutMs = 15_000;
-  private useLegacyWsSessionKeyQueryAuth = false;
 
   readonly state: RemoteState;
   private workspaceClient?: RemoteWorkspace;
@@ -292,10 +291,6 @@ export class RemoteConversation extends EventEmitter {
     const oldApiKey = getWorkspaceAuthKey(this.serverUrl, this.settings);
     const newApiKey = getWorkspaceAuthKey(this.serverUrl, settings);
     this.settings = settings;
-    if (oldApiKey !== newApiKey) {
-      // Re-probe header auth after key rotations; fall back to legacy query auth only if needed.
-      this.useLegacyWsSessionKeyQueryAuth = false;
-    }
     if (this.workspaceClient && oldApiKey !== newApiKey) {
       this.workspaceClient = undefined;
     }
@@ -304,7 +299,6 @@ export class RemoteConversation extends EventEmitter {
   setServerUrl(url: string) {
     this.serverUrl = normalizeRemoteServerUrl(url);
     this.workspaceClient = undefined;
-    this.useLegacyWsSessionKeyQueryAuth = false;
   }
 
   async startNewConversation(): Promise<string | undefined> {
@@ -764,26 +758,6 @@ export class RemoteConversation extends EventEmitter {
     return headers;
   }
 
-  private getRuntimeSessionApiKey(): string {
-    const runtimeSessionApiKey = this.settings?.secrets?.runtimeSessionApiKey;
-    return typeof runtimeSessionApiKey === 'string' ? runtimeSessionApiKey.trim() : '';
-  }
-
-  private canUseLegacyWsSessionKeyQueryAuth(): boolean {
-    return !isOpenHandsCloudServerUrl(this.serverUrl) && Boolean(this.getRuntimeSessionApiKey());
-  }
-
-  private shouldRetryWithLegacyWsSessionKeyQueryAuth(err: unknown, usedLegacyWsSessionKeyQueryAuth: boolean): boolean {
-    if (usedLegacyWsSessionKeyQueryAuth) return false;
-    if (!this.canUseLegacyWsSessionKeyQueryAuth()) return false;
-    const message = err instanceof Error
-      ? err.message
-      : typeof err === 'string'
-        ? err
-        : '';
-    return /unexpected server response:\s*(401|403)/i.test(message);
-  }
-
   private clearReconnect() {
     if (this.reconnectTimer) { clearTimeout(this.reconnectTimer); this.reconnectTimer = undefined; }
   }
@@ -842,11 +816,7 @@ export class RemoteConversation extends EventEmitter {
   private connect() {
     if (!this.conversationId) return;
     const base = this.getApiBaseUrl();
-    const usedLegacyWsSessionKeyQueryAuth = this.useLegacyWsSessionKeyQueryAuth;
     const params = new URLSearchParams();
-    if (usedLegacyWsSessionKeyQueryAuth) {
-      params.set('session_api_key', this.getRuntimeSessionApiKey());
-    }
     params.set('resend_all', 'true');
     const qs = params.toString();
     const wsUrl = `${base.replace(/^http/, 'ws')}/sockets/events/${this.conversationId}?${qs}`;
@@ -889,19 +859,6 @@ export class RemoteConversation extends EventEmitter {
     });
     ws.on('error', (err: Error) => {
       if (this.ws !== ws) return;
-      if (this.shouldRetryWithLegacyWsSessionKeyQueryAuth(err, usedLegacyWsSessionKeyQueryAuth)) {
-        this.clearWsHandshakeTimer();
-        this.useLegacyWsSessionKeyQueryAuth = true;
-        ws.removeAllListeners();
-        this.ws = undefined;
-        try {
-          ws.close();
-        } catch (closeErr) {
-          void closeErr;
-        }
-        this.connect();
-        return;
-      }
       this.clearWsHandshakeTimer();
       this.emit('error', err);
       this.setStatus('offline');

--- a/tests/e2e/AGENT_SERVER_QUICKSTART.md
+++ b/tests/e2e/AGENT_SERVER_QUICKSTART.md
@@ -20,7 +20,7 @@ Option B: remote server
 
 Runtime Session API Key (optional)
 - HTTP: the extension adds `X-Session-API-Key` when `openhands.secrets.runtimeSessionApiKey` is set
-- WebSocket: the extension appends `?session_api_key=...` to the WS URL when `openhands.secrets.runtimeSessionApiKey` is set
+- WebSocket: the extension authenticates via headers only (no `session_api_key` in the WS URL). Your agent-server must accept WS auth via `X-Session-API-Key` (or `Authorization: Bearer ...`) headers.
 
 Notes
 - The extension sends a Start Conversation payload containing LLM and tool configuration for PoC. Ensure your server accepts that.


### PR DESCRIPTION
Fixes oh-tab-h3g.

- Removes `session_api_key` from the RemoteConversation WebSocket URL query string (prevents URL secret leakage).
- Removes the legacy 401/403 retry path that reintroduced `session_api_key` into the WS URL.
- Adds unit test coverage asserting the WS URL contains no `session_api_key` or key material.

Notes
- Runtime-key agent servers must support WS auth via headers (for example `X-Session-API-Key` or `Authorization: Bearer ...`).
- This change intentionally keeps session secrets out of WS URLs; there is no query-string fallback.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/873" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * WebSocket authentication now uses headers exclusively; legacy URL query parameter fallback and retry behavior removed.

* **Tests**
  * Tests updated to assert header-based WS auth, to ensure no session key appears in WS URLs, and to capture error emission on failed handshakes.

* **Documentation**
  * Quickstart/WS docs updated to reflect header-only authentication (X-Session-API-Key or Bearer).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->