### PR TITLE
[oh-tab-a1g] Docs: WS header auth (no URL secrets)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -93,7 +93,7 @@ A VS Code extension that provides a sidebar chat view to interact with OpenHands
   - POST `/api/conversations/{id}/run` - resume
   - POST `/api/conversations/{id}/events/respond_to_confirmation` - approve/reject
   - GET `/api/conversations/{id}/events/` - list events
-- Auth: X-Session-API-Key header (HTTP), `?session_api_key` query param (WebSocket)
+- Auth: `X-Session-API-Key` header (HTTP + non-browser WS handshake). Browser clients may still require legacy WS query-param auth (`?session_api_key=...`) due to header constraints; avoid secrets in URLs when possible.
 
 ### Message Format
 ```json

--- a/docs/agent_server_test_matrix.md
+++ b/docs/agent_server_test_matrix.md
@@ -16,6 +16,7 @@ This document captures the minimal setup and a test matrix for running the OpenH
   - WS: `ws(s)://{serverUrl}/sockets/events/{conversationId}?resend_all=true`
     - Auth: WS handshake headers for non-browser clients (`X-Session-API-Key` / `Authorization: Bearer ...`).
     - Legacy (browser-only): `?session_api_key=...` query param.
+    - Note: the “no URL secrets” WS contract lands once upstream `OpenHands/software-agent-sdk#1786` is deployed and downstream `enyst/OpenHands-Tab#873` is merged.
 - Python agent-sdk examples:
   - `~/repos/agent-sdk/examples/02_remote_agent_server/01_convo_with_local_agent_server.py`
   - Server command used there: `python -m openhands.agent_server --host 127.0.0.1 --port 8001`

--- a/docs/agent_server_test_matrix.md
+++ b/docs/agent_server_test_matrix.md
@@ -13,7 +13,9 @@ This document captures the minimal setup and a test matrix for running the OpenH
 
 - TS RemoteConversation endpoints: `packages/agent-sdk-ts/src/sdk/conversation/RemoteConversation.ts`
   - HTTP: `POST {serverUrl}/api/conversations`
-  - WS: `ws(s)://{serverUrl}/sockets/events/{conversationId}?session_api_key=...&resend_all=true`
+  - WS: `ws(s)://{serverUrl}/sockets/events/{conversationId}?resend_all=true`
+    - Auth: WS handshake headers for non-browser clients (`X-Session-API-Key` / `Authorization: Bearer ...`).
+    - Legacy (browser-only): `?session_api_key=...` query param.
 - Python agent-sdk examples:
   - `~/repos/agent-sdk/examples/02_remote_agent_server/01_convo_with_local_agent_server.py`
   - Server command used there: `python -m openhands.agent_server --host 127.0.0.1 --port 8001`

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -23,7 +23,14 @@ The key takeaway: **cloud device-flow returns a user API key / access token for 
 - **Origin:** Sandbox/runtime creation (generated per sandbox/runtime)
 - **Used to authenticate to:** the **nested runtime / agent-server** HTTP APIs and its WebSocket/event stream
 - **Transport (HTTP):** `X-Session-API-Key: <session_api_key>`
-- **Transport (WS):** currently frequently appears as a **query param** `?session_api_key=…` for browser WS constraints (this is the `oh-tab-h3g` security concern)
+- **Transport (WS):** prefer **headers** (no secrets in URLs).
+  - Non-browser clients: use `X-Session-API-Key` or `Authorization: Bearer ...` during the WS handshake.
+  - Browser clients: legacy `?session_api_key=...` query param (can’t set custom headers).
+  - See `oh-tab-h3g`.
+
+**Related work (Jan 22, 2026)**
+- Upstream unblock: OpenHands/software-agent-sdk#1786 + OpenHands/docs#270
+- Downstream change (draft): enyst/OpenHands-Tab#873 (removes `session_api_key` from WS URLs; merge blocked until upstream is merged/deployed)
 
 ---
 
@@ -175,8 +182,8 @@ Note: this file explicitly labels itself “LEGACY V0 CODE” and warns not to e
 **Repo:** `~/repos/agent-sdk` (python agent-server)
 
 (Previously inspected in our audit follow-up work)
-- Agent-server WS currently requires `session_api_key` query param when session auth is enabled.
-- BlackCastle validated locally that **headers-only WS fails** when `SESSION_API_KEY` is set.
+- As of upstream agent-server `main` (Jan 2026), WS auth requires the `session_api_key` query param when session auth is enabled.
+- Upstream unblock OpenHands/software-agent-sdk#1786 adds WS auth via headers (`X-Session-API-Key` / `Authorization: Bearer ...`) while keeping the query-param path for browser clients.
 
 ---
 
@@ -198,13 +205,14 @@ Note: this file explicitly labels itself “LEGACY V0 CODE” and warns not to e
   - `X-Session-API-Key: <runtimeSessionApiKey>`
 
 - `connect()` constructs WS URL:
-  - `${base.replace(/^http/, 'ws')}/sockets/events/${conversationId}?session_api_key=<runtimeSessionApiKey>&resend_all=true` (non-cloud only)
+  - Legacy (before enyst/OpenHands-Tab#873): `${base.replace(/^http/, 'ws')}/sockets/events/${conversationId}?session_api_key=<runtimeSessionApiKey>&resend_all=true` (non-cloud only)
+  - Target direction (enyst/OpenHands-Tab#873): `${base.replace(/^http/, 'ws')}/sockets/events/${conversationId}?resend_all=true` with WS auth via headers only
 
 This is the exact “secret-in-URL” issue from bead `oh-tab-h3g`.
 
 Clarification:
 - The cloud/SaaS device-flow token should be sent as `Authorization: Bearer <cloud_api_key>` to SaaS endpoints.
-- The runtime/sandbox `session_api_key` should be sent as `X-Session-API-Key: <runtime_session_api_key>` to the nested agent-server (and currently as `?session_api_key=...` for WS).
+- The runtime/sandbox `session_api_key` should be sent as `X-Session-API-Key: <runtime_session_api_key>` to the nested agent-server (and, for legacy browser clients, sometimes as `?session_api_key=...` for WS).
 
 ### 5.3 Why the cloud token vs runtime token confusion matters
 There are multiple server surfaces:
@@ -241,7 +249,7 @@ A V1-aligned client flow generally looks like:
 
 4) **For WS auth (`oh-tab-h3g`)**
    - ideal: server supports WS header auth or a short-lived ticket
-   - current reality: server requires `?session_api_key=…` query param
+   - current reality (as of upstream agent-server `main` in Jan 2026): WS auth requires `?session_api_key=…` when session auth is enabled; OpenHands/software-agent-sdk#1786 adds header auth
 
 ### 6.2 Concretely: where to get `agent_server_url` and runtime `session_api_key`
 From V1 app-server code:
@@ -312,8 +320,8 @@ The goal is to validate which token works against which surface without flooding
 - `GET <agent_server_url>/api/conversations/<id>` with `X-Session-API-Key: <runtime_session_api_key>`
 
 4) WS handshake sanity (one attempt)
-- Connect to the agent-server events WS using `?session_api_key=<runtime_session_api_key>`.
-- Try headers-only once to confirm whether the server supports it.
+- Prefer WS header auth (no secrets in URLs): `X-Session-API-Key: <runtime_session_api_key>` (or `Authorization: Bearer ...`).
+- If the server/client cannot do header auth (legacy browser path), the query param `?session_api_key=...` may still be required.
 
 Never print tokens; avoid retries/loops.
 
@@ -322,7 +330,7 @@ Never print tokens; avoid retries/loops.
 ## 8) Open questions to resolve before changing `oh-tab-h3g`
 
 - Does the deployed cloud agent-server accept WS header auth today?
-  - Local python agent-server does **not** (per BlackCastle’s test).
+  - Upstream agent-server `main` historically required `?session_api_key=...`; OpenHands/software-agent-sdk#1786 adds header auth.
 
 - Does SaaS proxy any of the agent-server WS paths?
   - We did not find `sockets/events` routes in enterprise; the agent-sdk-ts WS path likely targets the agent-server directly.

--- a/docs/cloud-auth-flow.md
+++ b/docs/cloud-auth-flow.md
@@ -28,7 +28,7 @@ The key takeaway: **cloud device-flow returns a user API key / access token for 
   - Browser clients: legacy `?session_api_key=...` query param (can’t set custom headers).
   - See `oh-tab-h3g`.
 
-**Related work (Jan 22, 2026)**
+## Related work (Jan 22, 2026)
 - Upstream unblock: OpenHands/software-agent-sdk#1786 + OpenHands/docs#270
 - Downstream change (draft): enyst/OpenHands-Tab#873 (removes `session_api_key` from WS URLs; merge blocked until upstream is merged/deployed)
 

--- a/docs/cloud_oauth_device_flow.md
+++ b/docs/cloud_oauth_device_flow.md
@@ -17,7 +17,7 @@ Important:
 
 - Remote mode uses two distinct fields:
   - `settings.secrets.cloudApiKey` for **SaaS/app-server** calls (Bearer).
-  - `settings.secrets.runtimeSessionApiKey` for **agent-server** calls (X-Session-API-Key / WS query param).
+  - `settings.secrets.runtimeSessionApiKey` for **agent-server** calls (`X-Session-API-Key` for HTTP + WS handshake headers; legacy WS query-param auth only for browser clients).
     - For **direct/non-cloud** agent-server connections, this may come from per-server SecretStorage.
     - For OpenHands Cloud, this is obtained via SaaS V1 bootstrap and is kept in-memory only.
 - Tokens are stored in VS Code SecretStorage as per-server entries (see `src/auth/serverCloudApiKeys.ts` and `src/auth/serverRuntimeSessionApiKeys.ts`). For OpenHands Cloud, only the `cloudApiKey` is persisted; the runtime `session_api_key` is ephemeral.
@@ -34,7 +34,11 @@ OpenHands Cloud remote mode involves two different secrets:
 2) **Runtime session API key** (`session_api_key`, sandbox/runtime-scoped)
    - Used to authenticate requests to the **nested runtime agent-server** (HTTP + WS).
    - Transport (HTTP): `X-Session-API-Key: <runtime_session_api_key>`.
-   - Transport (WS today): query param `?session_api_key=<runtime_session_api_key>` (see `oh-tab-h3g`).
+   - Transport (WS): prefer header auth (no secrets in URLs).
+     - Non-browser clients: use `X-Session-API-Key` or `Authorization: Bearer ...` during the WS handshake.
+     - Browser clients: legacy `?session_api_key=...` query param.
+     - Upstream unblock: OpenHands/software-agent-sdk#1786 + OpenHands/docs#270
+     - Downstream change (draft): enyst/OpenHands-Tab#873 (merge blocked until upstream is merged/deployed)
 
 The cloud API key is **not** the same as the runtime `session_api_key`.
 
@@ -51,7 +55,7 @@ Goal: after cloud login, use the cloud API key to discover the nested agent-serv
    - Continue to document legacy `/api/conversations*` for compatibility, but avoid depending on it.
 3) Connect to the nested agent-server directly
    - Base URL: derived from `conversation_url`
-   - Auth: `X-Session-API-Key: <runtime_session_api_key>` and (today) WS `?session_api_key=...`
+   - Auth: `X-Session-API-Key: <runtime_session_api_key>` (HTTP + WS handshake headers). Legacy WS query-param auth is only for browser clients.
 
 ## Reference implementation: OpenHands-CLI
 
@@ -246,7 +250,7 @@ sequenceDiagram
   Host->>Cloud: OAuth device flow (as above)
   Host->>Cloud: retry POST /api/v1/app-conversations (Authorization: Bearer cloud_api_key)
   Cloud-->>Host: AppConversation { conversation_url, session_api_key, ... }
-  Host->>Agent: connect to conversation_url (X-Session-API-Key: session_api_key, WS ?session_api_key=...)
+  Host->>Agent: connect to conversation_url (X-Session-API-Key: session_api_key; WS auth via headers, no URL secrets)
 ```
 
 ## Threat model (extension-side)

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -23,6 +23,7 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
   - HTTP header: `X-Session-API-Key: <runtimeSessionApiKey>`
   - WebSocket: prefer handshake header auth (no URL secrets): `X-Session-API-Key: <runtimeSessionApiKey>` (or `Authorization: Bearer ...`).
     - Legacy (browser-only): `?session_api_key=<runtimeSessionApiKey>` query param.
+      - This query-param path is deprecated for non-browser clients and is being removed from the extension’s WS URL construction (see `oh-tab-h3g` / PR #873).
     - Downstream change (draft): enyst/OpenHands-Tab#873 removes `session_api_key` from WS URLs; merge is blocked until upstream OpenHands/software-agent-sdk#1786 is merged/deployed.
   - Note (OpenHands Cloud): the nested runtime `session_api_key` is obtained via SaaS V1 bootstrap (`/api/v1/app-conversations*`) and is **not persisted**; it is injected into in-memory `settings.secrets.runtimeSessionApiKey` only for the lifetime of the running conversation.
 

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -21,7 +21,9 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
 - `openhands.runtimeSessionApiKey.server.<hash>` (VS Code SecretStorage; per-server)
   - Used for **direct/non-cloud** agent-server endpoints (e.g. a local python agent-server or self-hosted agent-server).
   - HTTP header: `X-Session-API-Key: <runtimeSessionApiKey>`
-  - WebSocket query param: `?session_api_key=<runtimeSessionApiKey>`
+  - WebSocket: prefer handshake header auth (no URL secrets): `X-Session-API-Key: <runtimeSessionApiKey>` (or `Authorization: Bearer ...`).
+    - Legacy (browser-only): `?session_api_key=<runtimeSessionApiKey>` query param.
+    - Downstream change (draft): enyst/OpenHands-Tab#873 removes `session_api_key` from WS URLs; merge is blocked until upstream OpenHands/software-agent-sdk#1786 is merged/deployed.
   - Note (OpenHands Cloud): the nested runtime `session_api_key` is obtained via SaaS V1 bootstrap (`/api/v1/app-conversations*`) and is **not persisted**; it is injected into in-memory `settings.secrets.runtimeSessionApiKey` only for the lifetime of the running conversation.
 
 ## 2) Conversation lifecycle & persistence


### PR DESCRIPTION
Fixes oh-tab-a1g.

Updates cloud auth / agent-server protocol docs to reflect the security posture: **no secrets in WS URLs**.

- Prefer WS header auth for non-browser clients (`X-Session-API-Key` / `Authorization: Bearer ...`).
- Keep `?session_api_key=...` documented only as a legacy browser constraint.
- Cross-links upstream blockers OpenHands/software-agent-sdk#1786 + OpenHands/docs#270 and downstream PR #873.

Notes
- This is documentation-only; does not change runtime behavior.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/874">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API authentication for HTTP and WebSocket handshakes.
  * Prefer header-based auth (X-Session-API-Key or Authorization Bearer) for non-browser clients.
  * Preserve legacy browser-only WebSocket query-param fallback (?session_api_key=...) where required.
  * Advised avoiding secrets in URLs and updated WebSocket URL construction guidance.
  * Clarified cloud vs runtime/session token usage and updated device-flow and settings guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->