### PR TITLE
Audit tools: tighten secret injection (oh-tab-cx4)

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -291,7 +291,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         if (!undo.prevExist) {
           await this.removeCreatedFile(resolved);
         } else {
-          await ws.writeFile(args.path, undo.oldContent ?? '');
+          await ws.writeFile(resolved, undo.oldContent ?? '');
         }
 
         stack.pop();

--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -33,6 +33,14 @@ const TIMEOUT_MESSAGE_TEMPLATE =
 
 type SupportedSignal = 'SIGTERM' | 'SIGINT' | 'SIGTSTP';
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const commandReferencesSecret = (command: string, name: string): boolean => {
+  if (!command || !name) return false;
+  const pattern = new RegExp(`\\b${escapeRegExp(name)}\\b`, 'i');
+  return pattern.test(command);
+};
+
 type RunningTerminalProcess = {
   id: string;
   command: string;
@@ -85,13 +93,12 @@ class TerminalSession {
     const names = secrets.getRegisteredNames();
     if (!names.length) return;
 
-    const lower = trimmed.toLowerCase();
     const updates: Record<string, string> = {};
 
     for (const name of names) {
       const candidate = typeof name === 'string' ? name.trim() : '';
       if (!candidate) continue;
-      if (!lower.includes(candidate.toLowerCase())) continue;
+      if (!commandReferencesSecret(command, candidate)) continue;
       const value = await secrets.get(candidate);
       if (!value) continue;
       updates[candidate] = value;

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -38,6 +38,35 @@ describe('TerminalTool session behavior', () => {
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace, secrets });
   });
 
+  it('avoids injecting secrets when the command does not reference the name', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+    const secrets = new SecretRegistry();
+    const secretName = 'OH_TAB_TEST_SECRET';
+
+    const previous = process.env[secretName];
+    delete process.env[secretName];
+
+    secrets.register(secretName, 'super-secret');
+
+    const result = await tool.execute(
+      tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 0.2 }),
+      { workspace, secrets },
+    );
+
+    expect(result.exit_code).toBe(0);
+    expect(result.stdout ?? '').not.toContain(secretName);
+
+    if (previous === undefined) {
+      delete process.env[secretName];
+    } else {
+      process.env[secretName] = previous;
+    }
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace, secrets });
+  });
+
   it('persists working directory across commands', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -41,30 +41,68 @@ describe('TerminalTool session behavior', () => {
   it('avoids injecting secrets when the command does not reference the name', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
-    const tool = new TerminalTool();
     const secrets = new SecretRegistry();
     const secretName = 'OH_TAB_TEST_SECRET';
 
     const previous = process.env[secretName];
     delete process.env[secretName];
 
-    secrets.register(secretName, 'super-secret');
+    try {
+      const tool = new TerminalTool();
+      secrets.register(secretName, 'super-secret');
 
-    const result = await tool.execute(
-      tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 0.2 }),
-      { workspace, secrets },
-    );
+      const result = await tool.execute(
+        tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 0.2 }),
+        { workspace, secrets },
+      );
 
-    expect(result.exit_code).toBe(0);
-    expect(result.stdout ?? '').not.toContain(secretName);
+      expect(result.exit_code).toBe(0);
+      expect(result.stdout ?? '').not.toContain(secretName);
 
-    if (previous === undefined) {
-      delete process.env[secretName];
-    } else {
-      process.env[secretName] = previous;
+      await tool.execute(tool.validate({ command: '', reset: true }), { workspace, secrets });
+    } finally {
+      if (previous === undefined) {
+        delete process.env[secretName];
+      } else {
+        process.env[secretName] = previous;
+      }
     }
+  });
 
-    await tool.execute(tool.validate({ command: '', reset: true }), { workspace, secrets });
+  it('does not inject secrets for partial name matches', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const secrets = new SecretRegistry();
+    const secretName = 'OH_TAB_TEST_SECRET';
+
+    const previous = process.env[secretName];
+    delete process.env[secretName];
+
+    try {
+      const tool = new TerminalTool();
+      secrets.register(secretName, 'super-secret');
+
+      const trigger = await tool.execute(
+        tool.validate({ command: 'node -e "process.stdout.write(\'OH_TAB_TEST_SECRET_EXTRA\')"', timeout: 0.2 }),
+        { workspace, secrets },
+      );
+      expect(trigger.exit_code).toBe(0);
+
+      const check = await tool.execute(
+        tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 0.2 }),
+        { workspace, secrets },
+      );
+      expect(check.exit_code).toBe(0);
+      expect(check.stdout ?? '').not.toContain(secretName);
+
+      await tool.execute(tool.validate({ command: '', reset: true }), { workspace, secrets });
+    } finally {
+      if (previous === undefined) {
+        delete process.env[secretName];
+      } else {
+        process.env[secretName] = previous;
+      }
+    }
   });
 
   it('persists working directory across commands', async () => {


### PR DESCRIPTION
## Summary
- guard TerminalTool secret injection to only trigger when the command references a secret name token
- align FileEditorTool undo writes with resolved paths for consistency
- add coverage to ensure secrets aren’t injected when the command doesn’t reference the name

## Testing
- npx vitest run packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts

### Bead
Audit: packages/agent-sdk-ts/src/tools/* - agent tools module
Security audit for tools module. CRITICAL: TerminalTool.ts (24KB) - spawns shell commands, injects secrets to env. FileEditorTool.ts (20KB) - file system access. Review: command injection vectors, path traversal, secret leakage in output. Tech debt: large tool files, could extract common patterns.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/901">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undo file operations to write to the correct resolved file path.
  * Improved secret detection to use word-boundary matching instead of substring matching to avoid unintended secret injection.

* **Tests**
  * Added tests verifying secret injection is not triggered by non-referencing commands and by partial name matches.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat (Agent Mail, 2026-01-24): Review complete; ready to merge.
