### PR TITLE
Audit runtime: mask error outputs (oh-tab-9w3)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1070,7 +1070,8 @@ export class Agent extends EventEmitter {
 
       return `${message} (${contextParts.join(', ')})`;
     })();
-    return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail } as Event;
+    const maskedDetail = this.secretMasker.maskText(detail);
+    return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail: maskedDetail } as Event;
   }
 
   private ensureSystemPrompt() {
@@ -1123,7 +1124,8 @@ export class Agent extends EventEmitter {
   }
 
   private async emitToolError(toolCall: ToolCall, error: string): Promise<void> {
-    const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, error);
+    const maskedError = this.secretMasker.maskText(error);
+    const { agentErrorEvent, toolMessageEvent } = createToolCallErrorEvents(toolCall, maskedError);
     await this.pushEventWithHooks(agentErrorEvent);
     await this.pushEventWithHooks(toolMessageEvent);
   }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts
@@ -69,6 +69,16 @@ describe('textSanitizers', () => {
     expect(text.length).toBeLessThan(250);
   });
 
+  it('sanitizeMessageForDebug redacts non-tool text content', () => {
+    const message: Message = {
+      role: 'user',
+      content: [{ type: 'text', text: 'Authorization: Bearer SECRET', cache_prompt: false }],
+    };
+    const sanitized = sanitizeMessageForDebug(message);
+    const text = sanitized.content[0].type === 'text' ? sanitized.content[0].text : '';
+    expect(text).toBe('Authorization: Bearer ***');
+  });
+
   it('sanitizeChatRequestForDebug strips system prompt, lists tool names, and includes parameters when provided', () => {
     const request: ChatCompletionRequest = {
       systemPrompt: 'REAL_SYSTEM',

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -118,13 +118,12 @@ const sanitizeToolCallsForDebug = (toolCalls: ToolCall[] | undefined): ToolCall[
 
 export const sanitizeMessageForDebug = (message: Message): Message => {
   const safeToolCalls = sanitizeToolCallsForDebug(message.tool_calls);
-  const safeContent = message.role === 'tool'
-    ? message.content.map((item) => (
-      item.type === 'text'
-        ? { ...item, text: truncateToolMessageForDebug(redactStringHeuristics(item.text)) }
-        : item
-    ))
-    : message.content;
+  const safeContent = message.content.map((item) => {
+    if (item.type !== 'text') return item;
+    const redacted = redactStringHeuristics(item.text);
+    const text = message.role === 'tool' ? truncateToolMessageForDebug(redacted) : redacted;
+    return { ...item, text };
+  });
 
   const out: Message = { ...message, content: safeContent };
   if (safeToolCalls) out.tool_calls = safeToolCalls;

--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -121,7 +121,7 @@ export const sanitizeMessageForDebug = (message: Message): Message => {
   const safeContent = message.role === 'tool'
     ? message.content.map((item) => (
       item.type === 'text'
-        ? { ...item, text: truncateToolMessageForDebug(item.text) }
+        ? { ...item, text: truncateToolMessageForDebug(redactStringHeuristics(item.text)) }
         : item
     ))
     : message.content;


### PR DESCRIPTION
## Summary
- mask secrets in tool error events to avoid leaking raw values to AgentError/tool messages
- mask conversation error details before emitting ConversationErrorEvent
- redact tool message text in debug sanitization path

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.tool-errors.test.ts

### Bead
Audit: packages/agent-sdk-ts/src/sdk/runtime/* - agent runtime module
Security audit for runtime module. Key files: secretMasker.ts (secret redaction), textSanitizers.ts (output sanitization), Agent.ts (56KB - main orchestration). Security: verify all output paths use sanitization. Tech debt: Agent.ts is 56KB single file.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/902">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Masked sensitive content in error details and tool-related error messages to prevent exposure in error events.
  * Applied broader message sanitization so text content is redacted consistently before any truncation for debug output.

* **Tests**
  * Added a test verifying redaction of non-tool text content in debug sanitization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
