### PR TITLE
Audit auth: extract per-server secret helper (oh-tab-4ar)

### DIFF
--- a/src/auth/serverCloudApiKeys.ts
+++ b/src/auth/serverCloudApiKeys.ts
@@ -1,20 +1,9 @@
-import { createHash } from 'crypto';
-import { normalizeServerUrl } from '../shared/serverUrls';
+import { getPerServerSecretKey, type PerServerSecretKeyResult } from './serverSecretKeys';
 
 export const CLOUD_API_KEY_SECRET_KEY = 'openhands.cloudApiKey';
 
-export type ServerCloudApiKeySecretKeyResult =
-  | { ok: true; normalizedServerUrl: string; secretKey: string }
-  | { ok: false; error: string };
+export type ServerCloudApiKeySecretKeyResult = PerServerSecretKeyResult;
 
 export function getServerCloudApiKeySecretKey(serverUrl: string): ServerCloudApiKeySecretKeyResult {
-  const normalized = normalizeServerUrl(serverUrl);
-  if (!normalized.ok) return { ok: false, error: normalized.error };
-
-  const hash = createHash('sha256').update(normalized.url).digest('hex');
-  return {
-    ok: true,
-    normalizedServerUrl: normalized.url,
-    secretKey: `${CLOUD_API_KEY_SECRET_KEY}.server.${hash}`,
-  };
+  return getPerServerSecretKey(serverUrl, CLOUD_API_KEY_SECRET_KEY);
 }

--- a/src/auth/serverRuntimeSessionApiKeys.ts
+++ b/src/auth/serverRuntimeSessionApiKeys.ts
@@ -1,21 +1,9 @@
-import { createHash } from 'crypto';
-import { normalizeServerUrl } from '../shared/serverUrls';
+import { getPerServerSecretKey, type PerServerSecretKeyResult } from './serverSecretKeys';
 
 export const RUNTIME_SESSION_API_KEY_SECRET_KEY = 'openhands.runtimeSessionApiKey';
 
-export type ServerRuntimeSessionApiKeySecretKeyResult =
-  | { ok: true; normalizedServerUrl: string; secretKey: string }
-  | { ok: false; error: string };
+export type ServerRuntimeSessionApiKeySecretKeyResult = PerServerSecretKeyResult;
 
 export function getServerRuntimeSessionApiKeySecretKey(serverUrl: string): ServerRuntimeSessionApiKeySecretKeyResult {
-  const normalized = normalizeServerUrl(serverUrl);
-  if (!normalized.ok) return { ok: false, error: normalized.error };
-
-  const hash = createHash('sha256').update(normalized.url).digest('hex');
-  return {
-    ok: true,
-    normalizedServerUrl: normalized.url,
-    secretKey: `${RUNTIME_SESSION_API_KEY_SECRET_KEY}.server.${hash}`,
-  };
+  return getPerServerSecretKey(serverUrl, RUNTIME_SESSION_API_KEY_SECRET_KEY);
 }
-

--- a/src/auth/serverSecretKeys.ts
+++ b/src/auth/serverSecretKeys.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'crypto';
+import { normalizeServerUrl } from '../shared/serverUrls';
+
+export type PerServerSecretKeyResult =
+  | { ok: true; normalizedServerUrl: string; secretKey: string }
+  | { ok: false; error: string };
+
+export function getPerServerSecretKey(serverUrl: string, prefix: string): PerServerSecretKeyResult {
+  const normalized = normalizeServerUrl(serverUrl);
+  if (!normalized.ok) return { ok: false, error: normalized.error };
+
+  const hash = createHash('sha256').update(normalized.url).digest('hex');
+  return {
+    ok: true,
+    normalizedServerUrl: normalized.url,
+    secretKey: `${prefix}.server.${hash}`,
+  };
+}


### PR DESCRIPTION
## Summary
- extract shared per-server secret key helper to remove duplication
- keep existing public APIs for cloud/runtime secret key helpers

## Testing
- not run (lint-staged: eslint --max-warnings=0)

### Bead
Audit: src/auth/* - auth module security & design

Security and design audit for src/auth/ module (deviceFlow.ts, httpClient.ts, tokenStorage.ts, serverCloudApiKeys.ts, serverRuntimeSessionApiKeys.ts, url.ts).

**Security Review:**
- deviceFlow.ts: OAuth device flow impl looks solid; handles error cases well; no token logging
- httpClient.ts: Network error handling OK; no credential leakage in errors
- tokenStorage.ts: Thin wrapper over SecretStorage - minimal attack surface
- serverCloudApiKeys.ts / serverRuntimeSessionApiKeys.ts: SHA-256 hash for per-server keys is good

**Tech Debt / Design Issues:**
- DRY violation: serverCloudApiKeys.ts and serverRuntimeSessionApiKeys.ts are nearly identical (~95% same code). Extract shared getPerServerSecretKey(serverUrl, prefix) helper.
- deviceFlow.ts: Clock injection is good for testing but DEFAULT_CLOCK uses setTimeout which could be simplified.
- No rate limiting on device flow polling beyond server-specified interval.

**Files:** deviceFlow.ts, httpClient.ts, tokenStorage.ts, serverCloudApiKeys.ts, serverRuntimeSessionApiKeys.ts, url.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/903">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified internal secret key generation logic to reduce code duplication and improve maintainability across authentication modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat (Agent Mail, 2026-01-24): Approved; no blockers.
