### PR TITLE
Audit extension: refactor ring buffer helpers (oh-tab-4as)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,16 +110,28 @@ const MAX_PRINTED_EXIT_FOR = MAX_TERMINAL_EVENTS;
 
 const printedExitFor = new Map<string, true>();
 
+const pushWithLimit = <T>(buffer: T[], value: T, maxSize: number): void => {
+  buffer.push(value);
+  if (buffer.length > maxSize) {
+    buffer.splice(0, buffer.length - maxSize);
+  }
+};
+
+const setMapWithLimit = <K, V>(map: Map<K, V>, key: K, value: V, maxSize: number): void => {
+  if (map.has(key)) {
+    map.delete(key);
+  }
+  map.set(key, value);
+  while (map.size > maxSize) {
+    const oldest = map.keys().next().value;
+    if (oldest === undefined) return;
+    map.delete(oldest);
+  }
+};
+
 function markPrintedExitFor(commandId: string): void {
   // LRU-ish: bump recency on re-add
-  if (printedExitFor.has(commandId)) {
-    printedExitFor.delete(commandId);
-  }
-  printedExitFor.set(commandId, true);
-
-  if (printedExitFor.size <= MAX_PRINTED_EXIT_FOR) return;
-  const oldest = printedExitFor.keys().next().value;
-  if (oldest) printedExitFor.delete(oldest);
+  setMapWithLimit(printedExitFor, commandId, true, MAX_PRINTED_EXIT_FOR);
 }
 
 function resetConversationEventBacklog(conversationId: string | undefined) {
@@ -409,10 +421,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   const handleTerminalEvent = (event: BashEvent) => {
-    receivedTerminalEvents.push({ type: event.type, timestamp: Date.now() });
-    if (receivedTerminalEvents.length > MAX_TERMINAL_EVENTS) {
-      receivedTerminalEvents.shift();
-    }
+    pushWithLimit(receivedTerminalEvents, { type: event.type, timestamp: Date.now() }, MAX_TERMINAL_EVENTS);
 
     if (chatView && chatWebviewReady && chatView.visible) {
       void chatView.webview.postMessage({ type: 'terminalEvent', event } satisfies HostToWebviewMessage);


### PR DESCRIPTION
## Summary
- factor ring-buffer helpers for terminal event tracking and printed-exit tracking
- keep behavior identical while reducing repetition

## Testing
- not run (lint-staged: eslint --max-warnings=0)

### Bead
Audit: src/extension.ts - main extension entry point
Security and design audit for src/extension.ts (1029 lines).

**Security Review:**
- SecretRegistry properly wraps context.secrets for masking
- Secrets passed through maskSecretsInText for output channels
- cloudApiKey/runtimeSessionApiKey read from SecretStorage correctly
- No obvious token logging issues

**Tech Debt / Design Issues:**
- File is 1029 lines - God Object anti-pattern. Too many responsibilities in one file.
- Many module-level mutable variables (chatView, conversation, terminal, etc.) - global state smell
- ensureConversationAndConnection() is ~200 lines - should be broken up
- Ring buffer implementations (printedExitFor, receivedTerminalEvents) repeated - could extract utility
- Magic numbers scattered (MAX_TERMINAL_EVENTS=1000, MAX_EVENT_BACKLOG=2000, etc.) - should be config

**Recommendations:**
- Split into: activation.ts, convers- Split into: activation.ts, convers- Split into: activation.ts, convers- Split into: activation.Manager class
- Split into: activatioonfig file

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/905">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat (Agent Mail, 2026-01-24): Approved; minor suggestion to comment oldest guard.
