### PR TITLE
Audit settings: dedupe secret storage keys (oh-tab-us7)

### DIFF
--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -82,6 +82,17 @@ const HAL_CONFIG_UPDATES: Array<[keyof HalSettings, string]> = [
   ['cache', 'openhands.hal.cache'],
 ];
 
+const SECRET_STORAGE_KEYS: Array<{ key: keyof OpenHandsSettings['secrets']; storageKey: string }> = [
+  { key: 'llmApiKey', storageKey: 'openhands.llmApiKey' },
+  { key: 'awsAccessKeyId', storageKey: 'openhands.awsAccessKeyId' },
+  { key: 'awsSecretAccessKey', storageKey: 'openhands.awsSecretAccessKey' },
+  { key: 'githubToken', storageKey: 'openhands.githubToken' },
+  { key: 'halTtsApiKey', storageKey: 'openhands.hal.ttsApiKey' },
+  { key: 'customSecret1', storageKey: 'openhands.customSecret1' },
+  { key: 'customSecret2', storageKey: 'openhands.customSecret2' },
+  { key: 'customSecret3', storageKey: 'openhands.customSecret3' },
+];
+
 const isSafeProfileId = (value: string): boolean => {
   if (!value.trim()) return false;
   if (value !== value.trim()) return false;
@@ -363,17 +374,10 @@ export class SettingsManager {
       ),
       cache: this.adapter.get<boolean>('openhands.hal.cache', DEFAULTS.hal.cache) ?? DEFAULTS.hal.cache,
     };
-    const secrets = {
-      llmApiKey: await this.adapter.getSecret('openhands.llmApiKey'),
-      awsAccessKeyId: await this.adapter.getSecret('openhands.awsAccessKeyId'),
-      awsSecretAccessKey: await this.adapter.getSecret('openhands.awsSecretAccessKey'),
-      githubToken: await this.adapter.getSecret('openhands.githubToken'),
-      halTtsApiKey: await this.adapter.getSecret('openhands.hal.ttsApiKey'),
-
-      customSecret1: await this.adapter.getSecret('openhands.customSecret1'),
-      customSecret2: await this.adapter.getSecret('openhands.customSecret2'),
-      customSecret3: await this.adapter.getSecret('openhands.customSecret3'),
-    };
+    const secrets = {} as OpenHandsSettings['secrets'];
+    for (const entry of SECRET_STORAGE_KEYS) {
+      secrets[entry.key] = await this.adapter.getSecret(entry.storageKey);
+    }
     return { serverUrl, servers, llm, oracle, agent, conversation, confirmation, hal, secrets };
   }
 
@@ -436,30 +440,10 @@ export class SettingsManager {
     }
 
     if (partial.secrets) {
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'llmApiKey')) {
-        ops.push(this.adapter.storeSecret('openhands.llmApiKey', partial.secrets.llmApiKey));
-      }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsAccessKeyId')) {
-        ops.push(this.adapter.storeSecret('openhands.awsAccessKeyId', partial.secrets.awsAccessKeyId));
-      }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'awsSecretAccessKey')) {
-        ops.push(this.adapter.storeSecret('openhands.awsSecretAccessKey', partial.secrets.awsSecretAccessKey));
-      }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'githubToken')) {
-        ops.push(this.adapter.storeSecret('openhands.githubToken', partial.secrets.githubToken));
-      }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'halTtsApiKey')) {
-        ops.push(this.adapter.storeSecret('openhands.hal.ttsApiKey', partial.secrets.halTtsApiKey));
-      }
-
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret1')) {
-        ops.push(this.adapter.storeSecret('openhands.customSecret1', partial.secrets.customSecret1));
-      }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret2')) {
-        ops.push(this.adapter.storeSecret('openhands.customSecret2', partial.secrets.customSecret2));
-      }
-      if (Object.prototype.hasOwnProperty.call(partial.secrets, 'customSecret3')) {
-        ops.push(this.adapter.storeSecret('openhands.customSecret3', partial.secrets.customSecret3));
+      for (const entry of SECRET_STORAGE_KEYS) {
+        if (Object.prototype.hasOwnProperty.call(partial.secrets, entry.key)) {
+          ops.push(this.adapter.storeSecret(entry.storageKey, partial.secrets[entry.key]));
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- centralize secret storage keys in SettingsManager to reduce repetitive get/update logic
- behavior unchanged; no change to cloud/runtime secrets handling

## Testing
- not run (lint-staged: eslint --max-warnings=0)

### Bead
Audit: src/settings/* - settings management module
Security and design audit for src/settings/ module (SettingsManager.ts, SettingsAdapter.ts, VscodeSettingsAdapter.ts).

**Security Review:**
- Secrets read from VS Code SecretStorage via adapter pattern (good abstraction)
- cloudApiKey/runtimeSessionApiKey not persisted via update() - correct per-server handling
- No logging of secret values in SettingsManager
- isSafeProfileId() validates profile IDs against path traversal

**Tech Debt / Design Issues:**
- get() method is ~100 lines of repetitive property reads - could use schema-driven approach
- update() has ~50 lines of repetitive hasOwnProperty checks
- HAL_CONFIG_UPDATES array duplicates config keys that appear elsewhere
- Warning accumulation pattern (drainServerNormalizationWarnings) is unusual
- DEFAULTS hardcodes 'Engel' as default userName (line 61)

**Files:** SettingsManager.ts, SettingsAdapter.ts, VscodeSettingsAdapter.ts

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/906">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat (Agent Mail, 2026-01-24): Approved; no blockers.
