### PR TITLE
Audit RemoteWorkspace: dedupe runtime API calls (oh-tab-1ob)

### DIFF
--- a/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk-ts/src/workspace/RemoteWorkspace.ts
@@ -372,34 +372,22 @@ export class RemoteWorkspace implements BaseWorkspace {
   }
 
   async pause(): Promise<void> {
-    if (!this.runtimeApiUrl || !this.runtimeId) {
-      throw new Error('RemoteWorkspace.pause requires runtimeApiUrl + runtimeId');
-    }
-
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (this.runtimeApiKey) headers['X-API-Key'] = this.runtimeApiKey;
-
-    const res = await this.fetchWithTimeout(`${this.runtimeApiUrl}/pause`, {
-      method: 'POST',
-      headers,
-      body: JSON.stringify({ runtime_id: this.runtimeId }),
-    }, 30_000);
-
-    if (!res.ok) {
-      const detail = await res.text().catch(() => '');
-      throw new Error(`RemoteWorkspace.pause failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
-    }
+    await this.callRuntimeApi('pause');
   }
 
   async resume(): Promise<void> {
+    await this.callRuntimeApi('resume');
+  }
+
+  private async callRuntimeApi(action: 'pause' | 'resume'): Promise<void> {
     if (!this.runtimeApiUrl || !this.runtimeId) {
-      throw new Error('RemoteWorkspace.resume requires runtimeApiUrl + runtimeId');
+      throw new Error(`RemoteWorkspace.${action} requires runtimeApiUrl + runtimeId`);
     }
 
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (this.runtimeApiKey) headers['X-API-Key'] = this.runtimeApiKey;
 
-    const res = await this.fetchWithTimeout(`${this.runtimeApiUrl}/resume`, {
+    const res = await this.fetchWithTimeout(`${this.runtimeApiUrl}/${action}`, {
       method: 'POST',
       headers,
       body: JSON.stringify({ runtime_id: this.runtimeId }),
@@ -407,7 +395,7 @@ export class RemoteWorkspace implements BaseWorkspace {
 
     if (!res.ok) {
       const detail = await res.text().catch(() => '');
-      throw new Error(`RemoteWorkspace.resume failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
+      throw new Error(`RemoteWorkspace.${action} failed (HTTP ${res.status})${detail ? `: ${detail}` : ''}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- factor shared runtime API call logic for pause/resume in RemoteWorkspace
- keep behavior unchanged while reducing duplication

## Testing
- not run (lint-staged: npm run lint -w @openhands/agent-sdk-ts)

### Bead
Audit: RemoteWorkspace.ts - remote file operations
Security audit for RemoteWorkspace.ts (475 lines). Auth headers look correct (Bearer for cloud, X-Session-API-Key for runtime). Tech debt: large class, file upload/download could be factored out.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/907">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat (Agent Mail, 2026-01-24): Approved; minor suggestion to name the 30_000 timeout constant.
