### PR TITLE
Audit LLM: share OpenAI headers (oh-tab-4xv)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -2,6 +2,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions, type ToolCallAccumulator } from './types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 import { supportsThinkingBlocks } from './providerQuirks';
+import { buildOpenAiHeaders } from './openaiHeaders';
 
 const decoder = new TextDecoder();
 
@@ -14,11 +15,6 @@ class NonRetryableHttpStatusError extends Error {
     this.status = status;
   }
 }
-
-const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
-  ...(base ?? {}),
-  ...(overrides ?? {}),
-});
 
 type OpenAIThinkingContentBlock = {
   type: 'thinking';
@@ -438,16 +434,10 @@ export class OpenAICompatibleClient implements LLMClient {
   }
 
   private requestHeaders(): Record<string, string> {
-    const baseHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${this.apiKey}`,
-    };
-
-    if (this.config.provider === 'openrouter') {
-      baseHeaders['HTTP-Referer'] = 'https://openhands.io';
-      baseHeaders['X-Title'] = 'OpenHands';
-    }
-
-    return mergeHeaders(baseHeaders, this.config.headers);
+    return buildOpenAiHeaders({
+      apiKey: this.apiKey,
+      provider: this.config.provider,
+      headers: this.config.headers,
+    });
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -2,6 +2,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import type { Message, ResponsesReasoningItem, ToolCall } from '../types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 import { DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions } from './types';
+import { buildOpenAiHeaders } from './openaiHeaders';
 
 class NonRetryableHttpStatusError extends Error {
   readonly status: number;
@@ -12,11 +13,6 @@ class NonRetryableHttpStatusError extends Error {
     this.status = status;
   }
 }
-
-const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
-  ...(base ?? {}),
-  ...(overrides ?? {}),
-});
 
 const defaultBaseUrls: Record<string, string> = {
   openai: DEFAULT_PROVIDER_BASE_URLS.openai,
@@ -429,16 +425,10 @@ export class OpenAIResponsesClient implements LLMClient {
   }
 
   private requestHeaders(): Record<string, string> {
-    const baseHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${this.apiKey}`,
-    };
-
-    if (this.config.provider === 'openrouter') {
-      baseHeaders['HTTP-Referer'] = 'https://openhands.io';
-      baseHeaders['X-Title'] = 'OpenHands';
-    }
-
-    return mergeHeaders(baseHeaders, this.config.headers);
+    return buildOpenAiHeaders({
+      apiKey: this.apiKey,
+      provider: this.config.provider,
+      headers: this.config.headers,
+    });
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/llm/openaiHeaders.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openaiHeaders.ts
@@ -1,0 +1,22 @@
+export const mergeHeaders = (base?: Record<string, string>, overrides?: Record<string, string>): Record<string, string> => ({
+  ...(base ?? {}),
+  ...(overrides ?? {}),
+});
+
+export const buildOpenAiHeaders = (params: {
+  apiKey: string;
+  provider?: string;
+  headers?: Record<string, string>;
+}): Record<string, string> => {
+  const baseHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${params.apiKey}`,
+  };
+
+  if (params.provider === 'openrouter') {
+    baseHeaders['HTTP-Referer'] = 'https://openhands.io';
+    baseHeaders['X-Title'] = 'OpenHands';
+  }
+
+  return mergeHeaders(baseHeaders, params.headers);
+};


### PR DESCRIPTION
## Summary
- extract shared OpenAI header builder for compatible + responses clients
- keep provider-specific headers unchanged

## Testing
- not run (lint-staged: npm run lint -w @openhands/agent-sdk-ts)

### Bead
Audit: packages/agent-sdk-ts/src/sdk/llm/* - LLM client module
Security audit for LLM module (3925 lines total). API keys passed via headers (x-api-key, Authorization Bearer). No obvious logging of keys. Tech debt: multiple provider implementations with similar patterns could share more code.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/908">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat (Agent Mail, 2026-01-24): Approved; minor note about mergeHeaders export.
