### PR TITLE
Audit webview host: improve secret lookup fallback (oh-tab-v1e)

### DIFF
--- a/src/webview/host/handlers/secretHelpers.ts
+++ b/src/webview/host/handlers/secretHelpers.ts
@@ -37,7 +37,10 @@ export const createStoredSecretHelpers = (args: {
     try {
       let resolved = args.secretRegistry ? await args.secretRegistry.get(trimmedKey) : undefined;
       if (!resolved) {
-        resolved = process.env[trimmedKey] ?? (await args.context.secrets.get(trimmedKey));
+        resolved = await args.context.secrets.get(trimmedKey);
+        if (!resolved) {
+          resolved = process.env[trimmedKey];
+        }
       }
       const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
       return trimmedValue || undefined;

--- a/src/webview/host/handlers/secretHelpers.ts
+++ b/src/webview/host/handlers/secretHelpers.ts
@@ -35,9 +35,10 @@ export const createStoredSecretHelpers = (args: {
     const trimmedKey = key.trim();
     if (!trimmedKey) return undefined;
     try {
-      const resolved = args.secretRegistry
-        ? await args.secretRegistry.get(trimmedKey)
-        : (process.env[trimmedKey] ?? (await args.context.secrets.get(trimmedKey)));
+      let resolved = args.secretRegistry ? await args.secretRegistry.get(trimmedKey) : undefined;
+      if (!resolved) {
+        resolved = process.env[trimmedKey] ?? (await args.context.secrets.get(trimmedKey));
+      }
       const trimmedValue = typeof resolved === 'string' ? resolved.trim() : '';
       return trimmedValue || undefined;
     } catch {
@@ -51,4 +52,3 @@ export const createStoredSecretHelpers = (args: {
 
   return { getStoredSecret, hasStoredSecret };
 };
-


### PR DESCRIPTION
## Summary
- ensure webview host secret helper falls back to VS Code SecretStorage/env when registry misses
- avoids false negatives for provider-key presence without exposing values

## Testing
- not run (lint-staged: eslint --max-warnings=0)

### Bead
Audit: src/webview/host/* - webview host handlers
Security audit for webview host handlers. Key concern: webview/host boundary - ensure secrets never cross to webview. Files: secretHelpers.ts, llmProfiles.ts (15KB), tools.ts, send.ts. Tech debt: llmProfiles.ts is large and could be split.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/909">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal secret retrieval logic to use an explicit fallback chain for better maintainability and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
- Note: SecretStorage precedence fix verified.
