### PR TITLE
Audit shared utils: redact URL credentials (oh-tab-bj9)

### DIFF
--- a/src/shared/__tests__/safeStringify.test.ts
+++ b/src/shared/__tests__/safeStringify.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { safeStringify } from '../safeStringify';
+
+describe('safeStringify', () => {
+  it('redacts auth-like strings in values', () => {
+    const result = safeStringify({ message: 'Authorization: Bearer SECRET' });
+    expect(result).toContain('Authorization: Bearer [REDACTED]');
+  });
+
+  it('redacts URL-embedded credentials', () => {
+    const result = safeStringify({ url: 'https://user:pass@example.com/path' });
+    expect(result).toContain('https://[REDACTED]@example.com/path');
+  });
+
+  it('redacts known secret keys', () => {
+    const result = safeStringify({ apiKey: 'nope', nested: { accessToken: 'nope2' } });
+    expect(result).toContain('"apiKey":"[REDACTED]"');
+    expect(result).toContain('"accessToken":"[REDACTED]"');
+  });
+});

--- a/src/shared/safeStringify.ts
+++ b/src/shared/safeStringify.ts
@@ -40,6 +40,8 @@ function redactStringHeuristics(text: string): string {
   // Authorization / Bearer patterns
   t = t.replace(/(Authorization\s*:\s*Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
   t = t.replace(/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+  // URL-embedded credentials (userinfo)
+  t = t.replace(/((?:https?|wss?):\/\/)([^/\s@]+)@/gi, `$1${REDACTED}@`);
 
   // Common token prefixes
   t = t.replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gi, REDACTED);
@@ -82,4 +84,3 @@ export function safeStringify(value: unknown): string {
   }
 }
 /* eslint-enable @typescript-eslint/no-unsafe-return */
-


### PR DESCRIPTION
## Summary
- redact URL-embedded credentials in `safeStringify`
- add tests for URL credential redaction + key redaction

## Testing
- npx vitest run src/shared/__tests__/safeStringify.test.ts

### Bead
Audit: src/shared/* - shared utilities module
Security audit for shared utilities. Key files: maskSecrets.ts (secret redaction), cloudServers.ts (server URL validation), serverUrls.ts (URL normalization), safeStringify.ts (safe JSON). Review: ensure all URL parsing is safe against injection. Low tech debt - mostly small focused utilities.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/910">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced sensitive data redaction to cover URL-embedded credentials and authentication tokens alongside known secret keys.

* **Tests**
  * Added comprehensive test coverage for sensitive data redaction behavior across various patterns and formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
