### PR TITLE
Audit: harden cloud bootstrap errors (oh-tab-zpm)

### DIFF
--- a/src/__tests__/cloudRemoteBootstrap.test.ts
+++ b/src/__tests__/cloudRemoteBootstrap.test.ts
@@ -243,6 +243,44 @@ describe('bootstrapCloudRemoteConversation', () => {
     })).rejects.toThrow(/could not parse conversation_url/i);
   });
 
+  it('redacts query params from conversation_url in parse errors', async () => {
+    const fetchSpy = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([
+          { status: 'READY', app_conversation_id: 'ac-123' },
+        ]),
+        text: () => Promise.resolve(''),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([
+          {
+            conversation_url: 'https://runtime.example.com/invalid/path?session_api_key=runtime-key-xyz&token=abc',
+            session_api_key: 'runtime-key-xyz',
+          },
+        ]),
+        text: () => Promise.resolve(''),
+      } as unknown as Response);
+
+    let error: Error | undefined;
+    try {
+      await bootstrapCloudRemoteConversation({
+        saasServerUrl: 'https://app.all-hands.dev',
+        cloudApiKey: 'cloud-key-abc',
+        fetchFn: fetchSpy as unknown as typeof fetch,
+        timeoutMs: 10_000,
+      });
+    } catch (err) {
+      error = err as Error;
+    }
+
+    expect(error?.message).toMatch(/could not parse conversation_url/i);
+    expect(error?.message).not.toMatch(/session_api_key|runtime-key-xyz|token=abc/i);
+  });
+
   it('errors when GET app-conversations returns 401', async () => {
     const fetchSpy = vi.fn()
       .mockResolvedValueOnce({
@@ -267,4 +305,3 @@ describe('bootstrapCloudRemoteConversation', () => {
     })).rejects.toThrow(/invalid or expired Cloud API Key/i);
   });
 });
-

--- a/src/cloud/cloudRemoteBootstrap.ts
+++ b/src/cloud/cloudRemoteBootstrap.ts
@@ -20,6 +20,8 @@ type AppConversation = {
   session_api_key?: unknown;
 };
 
+const MAX_ERROR_DETAIL_CHARS = 300;
+
 function parseNestedConversationUrl(conversationUrl: string): { nestedServerUrl: string; conversationId: string } | null {
   let url: URL;
   try {
@@ -40,6 +42,28 @@ function parseNestedConversationUrl(conversationUrl: string): { nestedServerUrl:
   const basePath = baseParts.length ? `/${baseParts.join('/')}` : '';
   const nested = `${url.origin}${basePath}`;
   return { nestedServerUrl: nested, conversationId: id };
+}
+
+function sanitizeErrorDetail(detail: string): string {
+  if (!detail) return '';
+  const trimmed = detail.trim();
+  if (!trimmed) return '';
+  const singleLine = trimmed.replace(/\s+/g, ' ');
+  if (singleLine.length <= MAX_ERROR_DETAIL_CHARS) return singleLine;
+  return `${singleLine.slice(0, MAX_ERROR_DETAIL_CHARS)}…`;
+}
+
+function formatUrlForError(value: string): string {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    url.search = '';
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return value;
+  }
 }
 
 function buildAuthHeaders(cloudApiKey: string): Record<string, string> {
@@ -93,7 +117,7 @@ export async function bootstrapCloudRemoteConversation(params: {
   }, timeoutMs);
 
   if (!startRes.ok) {
-    const detail = await startRes.text().catch(() => '');
+    const detail = sanitizeErrorDetail(await startRes.text().catch(() => ''));
     const status = startRes.status;
     if (status === 401 || status === 403) {
       throw new Error(`Cloud bootstrap failed (HTTP ${status}): invalid or expired Cloud API Key.`);
@@ -130,7 +154,8 @@ export async function bootstrapCloudRemoteConversation(params: {
         break;
       }
     }
-    const errorDetail = typeof errorTask?.detail === 'string' ? errorTask.detail : '';
+    const rawErrorDetail = typeof errorTask?.detail === 'string' ? errorTask.detail : '';
+    const errorDetail = sanitizeErrorDetail(rawErrorDetail);
     throw new Error(`Cloud bootstrap failed: app conversation never reached READY${errorDetail ? ` (${errorDetail})` : ''}`);
   }
 
@@ -141,7 +166,7 @@ export async function bootstrapCloudRemoteConversation(params: {
   }, timeoutMs);
 
   if (!getRes.ok) {
-    const detail = await getRes.text().catch(() => '');
+    const detail = sanitizeErrorDetail(await getRes.text().catch(() => ''));
     const status = getRes.status;
     if (status === 401 || status === 403) {
       throw new Error(`Cloud bootstrap failed (HTTP ${status}): invalid or expired Cloud API Key.`);
@@ -169,7 +194,7 @@ export async function bootstrapCloudRemoteConversation(params: {
 
   const parsed = parseNestedConversationUrl(conversationUrl);
   if (!parsed) {
-    throw new Error(`Cloud bootstrap failed: could not parse conversation_url (${conversationUrl})`);
+    throw new Error(`Cloud bootstrap failed: could not parse conversation_url (${formatUrlForError(conversationUrl)})`);
   }
 
   return {


### PR DESCRIPTION
## Summary
- sanitize server error details to single-line capped output
- remove query/hash/userinfo from conversation_url in parse errors
- add coverage for query redaction in parse failures

## Testing
- npx vitest run src/__tests__/cloudRemoteBootstrap.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/911">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
