### PR TITLE
Audit: normalize security risk handling (oh-tab-sq5)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/security/__tests__/analyzer.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/__tests__/analyzer.test.ts
@@ -43,6 +43,12 @@ describe('LLMSecurityAnalyzer', () => {
       const action = createActionEvent('MEDIUM');
       expect(analyzer.securityRisk(action)).toBe('MEDIUM');
     });
+
+    it('treats invalid risk levels as HIGH', () => {
+      const analyzer = new LLMSecurityAnalyzer();
+      const action = createActionEvent('CRITICAL' as SecurityRisk);
+      expect(analyzer.securityRisk(action)).toBe('HIGH');
+    });
   });
 
   describe('analyzeEvent', () => {

--- a/packages/agent-sdk-ts/src/sdk/security/__tests__/confirmationPolicy.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/__tests__/confirmationPolicy.test.ts
@@ -5,6 +5,7 @@ import {
   ConfirmRisky,
   createConfirmationPolicyFromSettings,
 } from '../confirmationPolicy';
+import type { SecurityRisk } from '../../types';
 
 describe('AlwaysConfirm', () => {
   it('always returns true regardless of risk level', () => {
@@ -83,6 +84,11 @@ describe('ConfirmRisky', () => {
       const policy = new ConfirmRisky({ confirmUnknown: true });
       expect(policy.shouldConfirm('UNKNOWN')).toBe(true);
     });
+  });
+
+  it('treats invalid risk values as HIGH', () => {
+    const policy = new ConfirmRisky({ threshold: 'MEDIUM', confirmUnknown: false });
+    expect(policy.shouldConfirm('CRITICAL' as unknown as SecurityRisk)).toBe(true);
   });
 
   it('has kind ConfirmRisky', () => {

--- a/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/analyzer.ts
@@ -1,5 +1,6 @@
 import type { ActionEvent, Event, SecurityRisk } from '../types';
 import { isActionEvent } from '../types';
+import { normalizeSecurityRisk } from './riskUtils';
 
 export interface SecurityAnalyzer {
   kind: string;
@@ -12,7 +13,7 @@ export class LLMSecurityAnalyzer implements SecurityAnalyzer {
   readonly kind = 'LLMSecurityAnalyzer' as const;
 
   securityRisk(action: ActionEvent): SecurityRisk {
-    return action.security_risk ?? 'UNKNOWN';
+    return normalizeSecurityRisk(action.security_risk);
   }
 
   analyzeEvent(event: Event): SecurityRisk | null {

--- a/packages/agent-sdk-ts/src/sdk/security/confirmationPolicy.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/confirmationPolicy.ts
@@ -1,5 +1,6 @@
 import type { ConfirmationSettings } from '../types/settings';
 import type { SecurityRisk } from '../types';
+import { normalizeSecurityRisk } from './riskUtils';
 
 const SECURITY_RISK_ORDER: Array<Exclude<SecurityRisk, 'UNKNOWN'>> = ['LOW', 'MEDIUM', 'HIGH'];
 
@@ -39,8 +40,9 @@ export class ConfirmRisky implements ConfirmationPolicy {
   }
 
   shouldConfirm(risk: SecurityRisk = 'UNKNOWN'): boolean {
-    if (risk === 'UNKNOWN') return this.confirmUnknown;
-    return SECURITY_RISK_ORDER.indexOf(risk) >= SECURITY_RISK_ORDER.indexOf(this.threshold);
+    const normalizedRisk = normalizeSecurityRisk(risk);
+    if (normalizedRisk === 'UNKNOWN') return this.confirmUnknown;
+    return SECURITY_RISK_ORDER.indexOf(normalizedRisk) >= SECURITY_RISK_ORDER.indexOf(this.threshold);
   }
 }
 
@@ -54,4 +56,3 @@ export const createConfirmationPolicyFromSettings = (settings?: ConfirmationSett
   }
   return new NeverConfirm();
 };
-

--- a/packages/agent-sdk-ts/src/sdk/security/riskUtils.ts
+++ b/packages/agent-sdk-ts/src/sdk/security/riskUtils.ts
@@ -1,0 +1,8 @@
+import type { SecurityRisk } from '../types';
+
+const VALID_SECURITY_RISKS: SecurityRisk[] = ['UNKNOWN', 'LOW', 'MEDIUM', 'HIGH'];
+
+export function normalizeSecurityRisk(risk?: SecurityRisk): SecurityRisk {
+  if (!risk) return 'UNKNOWN';
+  return VALID_SECURITY_RISKS.includes(risk) ? risk : 'HIGH';
+}


### PR DESCRIPTION
## Summary
- normalize invalid security_risk values to HIGH (fail closed)
- reuse normalization in analyzer + confirmation policy
- add tests for invalid risk handling

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/security/__tests__/confirmationPolicy.test.ts packages/agent-sdk-ts/src/sdk/security/__tests__/analyzer.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/912">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
