### PR TITLE
Audit: guard local conversation ids (oh-tab-52g)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
@@ -168,6 +168,22 @@ describe('LocalConversation persistence', () => {
     expect(restoredState.values.llm_usage).toEqual(initialState.values.llm_usage);
   });
 
+  it('rejects conversation ids with path separators', () => {
+    const dir = makeTempDir('local-conversation-unsafe-');
+    const workspaceRoot = makeTempDir('local-workspace-');
+    const llm = new MockLLM([{ type: 'finish' }]);
+
+    const restored = new LocalConversation({
+      settings: baseSettings,
+      workspaceRoot,
+      llmClient: llm,
+      persistenceDir: dir,
+    });
+
+    expect(() => restored.restoreConversation('../escape')).toThrow(/Invalid conversation id/i);
+    expect(fs.readdirSync(dir)).toHaveLength(0);
+  });
+
   it('restores persisted LLM config on conversation restore', async () => {
     const dir = makeTempDir('local-conversation-llm-');
     const workspaceRoot = makeTempDir('local-workspace-');

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -33,6 +33,8 @@ const toOptionalNonEmptyString = (value: unknown): string | undefined => {
   return trimmed ? trimmed : undefined;
 };
 
+const hasPathSeparators = (value: string): boolean => /[\\/]/.test(value);
+
 export type ConversationStatus = 'online' | 'offline' | 'connecting';
 
 export interface LocalConversationOptions {
@@ -162,6 +164,12 @@ export class LocalConversation extends EventEmitter {
   }
 
   restoreConversation(id: string) {
+    // Security: guard against path traversal via conversation ids before passing to FileStore.
+    if (hasPathSeparators(id) || id.includes('\0')) {
+      const err = new Error('Invalid conversation id: path separators are not allowed');
+      this.emit('error', err);
+      throw err;
+    }
     // Switch to a new runtime bound to the requested conversation id
     this.conversationId = id;
     this.hasUserMessage = true;


### PR DESCRIPTION
## Summary
- reject conversation ids containing path separators to prevent traversal
- add coverage for invalid ids

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/__tests__/persistence.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/913">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
