### PR TITLE
Audit: harden debug JSON redaction (oh-tab-7c0)

### DIFF
--- a/src/extension/__tests__/debugJsonOutputChannel.test.ts
+++ b/src/extension/__tests__/debugJsonOutputChannel.test.ts
@@ -47,6 +47,6 @@ describe('createDebugJsonOutputChannel', () => {
 
     expect(payload.responses_reasoning_item.encrypted_content).toBe(encrypted);
     const printed = mocks.appendLines.join('\n');
-    expect(printed).toContain('"encrypted_content": "abcd…wxyz"');
+    expect(printed).toContain('"encrypted_content": "abcd...wxyz"');
   });
 });

--- a/src/extension/debugJsonOutputChannel.ts
+++ b/src/extension/debugJsonOutputChannel.ts
@@ -1,12 +1,7 @@
 import * as vscode from 'vscode';
 import { maskSecretsInText } from '../shared/maskSecrets';
+import { safeStringify } from '../shared/safeStringify';
 import type { SecretRegistry } from '@openhands/agent-sdk-ts';
-
-function truncateEncryptedContentForDisplay(value: string): string {
-  const trimmed = value.trim();
-  if (trimmed.length <= 12) return value;
-  return `${trimmed.slice(0, 4)}…${trimmed.slice(-4)}`;
-}
 
 export interface DebugJsonOutputChannel {
   /** Log JSON data with a category badge and pretty formatting */
@@ -83,13 +78,14 @@ export function createDebugJsonOutputChannel(
 
   const formatJsonPretty = (data: unknown): string => {
     try {
-      const jsonString = JSON.stringify(data, (key: string, value: unknown) => {
-        if (key === 'encrypted_content' && typeof value === 'string') {
-          return truncateEncryptedContentForDisplay(value);
-        }
-        return value;
-      }, 2);
-      return maskSecrets(jsonString);
+      const safeJson = safeStringify(data);
+      if (safeJson.startsWith('<unserializable')) return safeJson;
+      try {
+        const parsed = JSON.parse(safeJson) as unknown;
+        return maskSecrets(JSON.stringify(parsed, null, 2));
+      } catch {
+        return maskSecrets(safeJson);
+      }
     } catch (e) {
       return `<failed to stringify: ${String(e)}>`;
     }


### PR DESCRIPTION
## Summary
- use shared safeStringify for debug JSON output (heuristic redaction + truncation)
- keep pretty formatting while preserving redactions
- update test expectations

## Testing
- npx vitest run src/extension/__tests__/debugJsonOutputChannel.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/914">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
