### PR TITLE
Audit: skip symlinked skills (oh-tab-j7d)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -590,6 +590,25 @@ Knowledge content`);
       expect(repoSkills.has('claude')).toBe(false);
     });
 
+    it('skips symlinked skill files and directories', () => {
+      const externalFile = join(tempDir, 'external-skill.md');
+      writeFileSync(externalFile, 'External skill');
+      symlinkSync(externalFile, join(skillDir, 'symlink-skill.md'));
+
+      const externalDir = join(tempDir, 'external-skill-dir');
+      mkdirSync(externalDir, { recursive: true });
+      writeFileSync(join(externalDir, 'SKILL.md'), 'External agent skill');
+      symlinkSync(externalDir, join(skillDir, 'linked-skill'));
+
+      writeFileSync(join(skillDir, 'real-skill.md'), 'Real skill');
+
+      const { repoSkills, agentSkills } = loadSkillsFromDir(skillDir);
+
+      expect(repoSkills.has('real-skill')).toBe(true);
+      expect(repoSkills.has('symlink-skill')).toBe(false);
+      expect(agentSkills.has('linked-skill')).toBe(false);
+    });
+
     it('truncates oversized third-party files', () => {
       const repoRoot = join(tempDir, 'repo');
       const head = 'HEAD\n';

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -461,7 +461,8 @@ export function loadSkillsFromDir(skillDir: string): {
       const entries = readdirSync(dir);
       for (const entry of entries) {
         const fullPath = join(dir, entry);
-        const stat = statSync(fullPath);
+        const stat = lstatSync(fullPath);
+        if (stat.isSymbolicLink()) continue;
         if (stat.isDirectory()) {
           if (excludedDirs.has(fullPath)) continue;
           collectMarkdownFiles(fullPath);
@@ -571,7 +572,9 @@ function findSkillMd(skillDir: string): string | null {
   const entries = readdirSync(skillDir);
   for (const entry of entries) {
     const fullPath = join(skillDir, entry);
-    if (statSync(fullPath).isFile() && entry.toLowerCase() === 'skill.md') {
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isFile() && entry.toLowerCase() === 'skill.md') {
       return fullPath;
     }
   }
@@ -583,7 +586,8 @@ function findSkillMdDirectories(skillsDir: string): string[] {
   if (!existsSync(skillsDir) || !statSync(skillsDir).isDirectory()) return results;
   for (const entry of readdirSync(skillsDir)) {
     const fullPath = join(skillsDir, entry);
-    if (!statSync(fullPath).isDirectory()) continue;
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
     const skillMd = findSkillMd(fullPath);
     if (skillMd) results.push(skillMd);
   }


### PR DESCRIPTION
## Summary
- ignore symlinked skill files/directories when scanning skills
- add coverage for symlinked skills

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/915">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
