### PR TITLE
Audit: redact observation output (oh-tab-ohl)

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -315,6 +315,27 @@ describe('Agent-SDK event rendering', () => {
     expect(await screen.findByText(/Directory listing output from bash execution/)).toBeInTheDocument();
   });
 
+  it('redacts secrets in ObservationEvent raw output', async () => {
+    render(<App />);
+    const ev = {
+      kind: 'ObservationEvent',
+      source: 'environment' as const,
+      observation: {
+        output: 'Authorization: Bearer sk-abcdef1234567890',
+        token: 'ghp_0123456789abcdef0123456789abcdef',
+      },
+      tool_name: 'terminal',
+      tool_call_id: 'call_obs_secret',
+      action_id: 'action_obs_secret'
+    } as any;
+    postToWindow({ type: 'event', event: ev });
+    const toggle = await screen.findByRole('button', { name: /Show environment result/i });
+    fireEvent.click(toggle);
+    expect(await screen.findByText(/\[REDACTED\]/)).toBeInTheDocument();
+    expect(screen.queryByText(/sk-abcdef1234567890/)).toBeNull();
+    expect(screen.queryByText(/ghp_0123456789abcdef/)).toBeNull();
+  });
+
   it('renders UserRejectObservation', async () => {
     render(<App />);
     const ev = {

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -17,6 +17,31 @@ import { Tooltip } from '../Tooltip';
  * Renders environment result - shows observation with summary and expandable raw data.
  */
 export function ObservationEventBlock({ event, index }: { event: ObservationEvent; index?: number }) {
+  const redactObservationText = (text: string): string => {
+    const REDACTED = '[REDACTED]';
+    let t = text;
+
+    // Authorization / Bearer patterns
+    t = t.replace(/(Authorization\s*:\s*Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+    t = t.replace(/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+
+    // Common token prefixes
+    t = t.replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gi, REDACTED);
+    t = t.replace(/\bgh[pousr]_[A-Za-z0-9]{12,}\b/gi, REDACTED);
+    t = t.replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gi, REDACTED);
+
+    // AWS access key ids (AKIA..., ASIA...)
+    t = t.replace(/\b(AKIA|ASIA)[0-9A-Z]{16}\b/g, REDACTED);
+
+    // Common key=value or key: value patterns
+    const keyPattern =
+      /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret|aws[_-]?access[_-]?key[_-]?id|aws[_-]?secret[_-]?access[_-]?key)/gi;
+    t = t.replace(new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'), (_m, key) => `${key}: ${REDACTED}`);
+    t = t.replace(new RegExp(`([?&])(${keyPattern.source})=([^&\\s]+)`, 'gi'), (_m, sep, key) => `${sep}${key}=${REDACTED}`);
+
+    return t;
+  };
+
   const [isExpanded, setIsExpanded] = useState(false);
   const isFinishTool = event.tool_name === 'finish';
   const maybeMessage = isFinishTool ? event.observation['message'] : undefined;
@@ -76,7 +101,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
   })();
   const hasSummary = observationSummary !== null;
   const shouldShowRaw = isFileEditObservation ? false : !hasSummary || isExpanded;
-  const observationString = shouldShowRaw ? JSON.stringify(event.observation, null, 2) : '';
+  const observationString = shouldShowRaw ? redactObservationText(JSON.stringify(event.observation, null, 2)) : '';
   const isTruncated = shouldShowRaw && observationString.length > 2000;
   const showHeaderToggle = hasSummary && event.tool_name !== 'terminal' && !isFileEditObservation;
   const showFooterToggle = !hasSummary && isTruncated;


### PR DESCRIPTION
## Summary
- redact common secret patterns in raw observation JSON output
- add coverage for redacted observation output

## Testing
- npx vitest run src/webview-src/__tests__/event.rendering.test.tsx
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/916">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
