### PR TITLE
Audit: harden conversation backlog size (oh-tab-zgj)

### DIFF
--- a/src/conversation/__tests__/eventBacklog.test.ts
+++ b/src/conversation/__tests__/eventBacklog.test.ts
@@ -29,6 +29,16 @@ describe('ConversationEventBacklog', () => {
     expect(seqs).toEqual([2, 3, 4]);
   });
 
+  it('defaults maxSize when provided value is invalid', () => {
+    const backlog = new ConversationEventBacklog({ maxSize: 0 });
+    backlog.reset('conv-1');
+    backlog.push(mkMessageEvent('m1'));
+    backlog.push(mkMessageEvent('m2'));
+
+    expect(backlog.getSize()).toBe(2);
+    expect(backlog.getLatestSeq()).toBe(2);
+  });
+
   it('flushes a full replay when client conversation id mismatches', () => {
     const backlog = new ConversationEventBacklog({ maxSize: 5 });
     backlog.reset('conv-1');

--- a/src/conversation/eventBacklog.ts
+++ b/src/conversation/eventBacklog.ts
@@ -20,7 +20,10 @@ export class ConversationEventBacklog {
   private conversationId: string | undefined;
 
   constructor(options?: { maxSize?: number }) {
-    this.maxSize = options?.maxSize ?? 2000;
+    const rawMaxSize = options?.maxSize;
+    this.maxSize = typeof rawMaxSize === 'number' && Number.isFinite(rawMaxSize) && rawMaxSize > 0
+      ? Math.floor(rawMaxSize)
+      : 2000;
   }
 
   reset(conversationId: string | undefined): void {


### PR DESCRIPTION
## Summary
- guard invalid backlog maxSize values to prevent modulo errors
- add coverage for invalid maxSize

## Testing
- npx vitest run src/conversation/__tests__/eventBacklog.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/917">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
