### PR TITLE
Audit: harden diagnostics redaction (oh-tab-h3v)

### DIFF
--- a/src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
+++ b/src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
@@ -32,4 +32,13 @@ describe('sanitizeDiagnosticsText', () => {
     expect(preview).not.toContain(secret);
     expect(preview).not.toContain('…(truncated)');
   });
+
+  it('redacts common token patterns even without registered secrets', () => {
+    const text = 'Authorization: Bearer sk-abcdef1234567890';
+
+    const preview = sanitizeDiagnosticsText(text, { maxChars: 4000 });
+
+    expect(preview).toContain('[REDACTED]');
+    expect(preview).not.toContain('sk-abcdef1234567890');
+  });
 });

--- a/src/dev/registerDiagnosticsCommands.ts
+++ b/src/dev/registerDiagnosticsCommands.ts
@@ -4,6 +4,7 @@ import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
 import { DEFAULT_HAL_STATE } from '../shared/halDefaults';
 import { resolveConfiguredLlmLabel } from '../shared/llmProfiles';
 import { maskSecretsInText } from '../shared/maskSecrets';
+import { safeStringify } from '../shared/safeStringify';
 import type { HostToWebviewMessage } from '../shared/webviewMessages';
 import type { ConversationEventBacklog, BufferedConversationEvent } from '../conversation/eventBacklog';
 import type { HalStateSnapshot } from '../shared/halTypes';
@@ -124,7 +125,17 @@ const truncatePreview = (text: string, maxChars: number): string => {
 };
 
 export function sanitizeDiagnosticsText(text: string, params: { secretRegistry?: SecretRegistry; maxChars: number }): string {
-  const masked = maskSecretsInText(text, params.secretRegistry);
+  let redacted = text;
+  try {
+    const safe = safeStringify(text);
+    if (!safe.startsWith('<unserializable')) {
+      const parsed = JSON.parse(safe) as unknown;
+      if (typeof parsed === 'string') redacted = parsed;
+    }
+  } catch {
+    // Best-effort only; fall back to original text.
+  }
+  const masked = maskSecretsInText(redacted, params.secretRegistry);
   return masked.length > params.maxChars ? truncatePreview(masked, params.maxChars) : masked;
 }
 
@@ -355,7 +366,7 @@ export function registerDiagnosticsCommands(deps: RegisterDiagnosticsCommandsDep
     const observationText = (() => {
       if (typeof observation === 'string') return observation;
       try {
-        return JSON.stringify(observation);
+        return safeStringify(observation);
       } catch {
         return String(observation);
       }


### PR DESCRIPTION
## Summary
- apply heuristic redaction to diagnostics text (not just registered secrets)
- use safeStringify for observation diagnostics
- add coverage for heuristic redaction

## Testing
- npx vitest run src/dev/__tests__/registerDiagnosticsCommands.redaction.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/918">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added verification that sensitive token patterns (e.g., authorization tokens) are properly redacted in diagnostic output

* **Chores**
  * Enhanced diagnostic text serialization for more reliable and robust token redaction handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat approved on 2026-01-24 via Agent Mail.
