### PR TITLE
Audit: tighten bash event guards (oh-tab-jte)

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/types/__tests__/typeGuards.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/__tests__/typeGuards.test.ts
@@ -338,6 +338,30 @@ describe('Bash event guards', () => {
       expect(isBashEvent({ type: 'BashCommand' })).toBe(false);
       expect(isBashEvent({ type: 'BashCommand', command_id: 'id' })).toBe(false);
     });
+
+    it('rejects invalid output payload field types', () => {
+      expect(isBashEvent({
+        id: '2',
+        type: 'BashOutput',
+        timestamp: '2024-01-01T00:00:00Z',
+        command_id: 'cmd1',
+        order: 1,
+        exit_code: '0',
+        stdout: 'output',
+        stderr: null,
+      })).toBe(false);
+
+      expect(isBashEvent({
+        id: '2',
+        type: 'BashOutput',
+        timestamp: '2024-01-01T00:00:00Z',
+        command_id: 'cmd1',
+        order: 1,
+        exit_code: 0,
+        stdout: 123,
+        stderr: null,
+      })).toBe(false);
+    });
   });
 
   describe('Bash event kind guards', () => {

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -284,7 +284,11 @@ export const isBashEvent = (candidate: unknown): candidate is BashEvent => {
     case 'BashCommand':
       return typeof e.command === 'string';
     case 'BashOutput':
-      return 'exit_code' in e && 'stdout' in e && 'stderr' in e;
+      return (
+        ('exit_code' in e && (e.exit_code === null || typeof e.exit_code === 'number'))
+        && ('stdout' in e && (e.stdout === null || typeof e.stdout === 'string'))
+        && ('stderr' in e && (e.stderr === null || typeof e.stderr === 'string'))
+      );
     case 'BashExit':
       return typeof e.exit_code === 'number';
     default:


### PR DESCRIPTION
## Summary
- require BashOutput fields to be string/null and exit_code to be number/null
- add coverage for invalid bash output payloads

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/types/__tests__/typeGuards.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/923">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
### Review
- PinkCat approved via Agent Mail on 2026-01-24.
