### PR TITLE
Audit: mask secrets in terminal log output

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -31,6 +31,7 @@ const defaultMockSettings = {
 };
 
 let mockSettings = structuredClone(defaultMockSettings);
+let registeredSecretValues: string[] = [];
 
 const startDeviceAuthorizationMock = vi.fn();
 const pollDeviceTokenMock = vi.fn();
@@ -55,6 +56,10 @@ vi.mock('../settings/VscodeSettingsAdapter', () => ({
     return this;
   }),
 }));
+
+afterEach(() => {
+  registeredSecretValues = [];
+});
 
 let lastConversation: any = null;
 vi.mock('@openhands/agent-sdk-ts', () => {
@@ -85,7 +90,7 @@ vi.mock('@openhands/agent-sdk-ts', () => {
 
     set = vi.fn();
 
-    getRegisteredValues = vi.fn(() => []);
+    getRegisteredValues = vi.fn(() => registeredSecretValues);
   }
 
   const Conversation = vi.fn((options: any) => {
@@ -1394,6 +1399,42 @@ describe('Settings and modes', () => {
     expect(joined).toContain('$ mixed_output\r\n');
     expect(joined).toContain('stdout line\r\n');
     expect(joined).toContain('stderr line\r\n');
+  });
+
+  it('masks secrets in terminal output before writing to the log', async () => {
+    registeredSecretValues = ['supersecret'];
+    mockSettings.serverUrl = undefined as any;
+    extension = await import('../extension');
+    await extension.activate(mockContext);
+    await resolveChatView(mockContext);
+
+    const { writes } = mockOpenHandsTerminalLog();
+
+    const conv = (await import('@openhands/agent-sdk-ts')).__getLastConversation?.();
+
+    conv?.emit('terminal', {
+      id: 'bash-secret-1',
+      type: 'BashCommand',
+      timestamp: '2025-01-01T00:00:00.000Z',
+      command_id: 'tc-secret-1',
+      order: 0,
+      command: 'echo supersecret',
+    });
+    conv?.emit('terminal', {
+      id: 'bash-secret-2',
+      type: 'BashOutput',
+      timestamp: '2025-01-01T00:00:01.000Z',
+      command_id: 'tc-secret-1',
+      order: 1,
+      exit_code: 0,
+      stdout: 'token=supersecret\n',
+      stderr: null,
+    });
+
+    const joined = writes.join('');
+    expect(joined).toContain('$ echo [REDACTED]\r\n');
+    expect(joined).toContain('token=[REDACTED]\r\n');
+    expect(joined).not.toContain('supersecret');
   });
 
   it('coalesces CR-only progress output in the OpenHands terminal log', async () => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,6 +173,24 @@ function renderError(err: unknown): string {
   return maskSecretsInText(rendered, secretRegistry);
 }
 
+function maskTerminalEventForDisplay(event: BashEvent): BashEvent {
+  if (!secretRegistry) return event;
+
+  if (isBashCommand(event)) {
+    const command = maskSecretsInText(event.command, secretRegistry);
+    return command === event.command ? event : { ...event, command };
+  }
+
+  if (isBashOutput(event)) {
+    const stdout = typeof event.stdout === 'string' ? maskSecretsInText(event.stdout, secretRegistry) : event.stdout;
+    const stderr = typeof event.stderr === 'string' ? maskSecretsInText(event.stderr, secretRegistry) : event.stderr;
+    if (stdout === event.stdout && stderr === event.stderr) return event;
+    return { ...event, stdout, stderr };
+  }
+
+  return event;
+}
+
 function resolveActiveEditorFilePath(editor: vscode.TextEditor | undefined): string | undefined {
   return getFileBackedFsPath(editor?.document?.uri);
 }
@@ -421,10 +439,11 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   const handleTerminalEvent = (event: BashEvent) => {
+    const displayEvent = maskTerminalEventForDisplay(event);
     pushWithLimit(receivedTerminalEvents, { type: event.type, timestamp: Date.now() }, MAX_TERMINAL_EVENTS);
 
     if (chatView && chatWebviewReady && chatView.visible) {
-      void chatView.webview.postMessage({ type: 'terminalEvent', event } satisfies HostToWebviewMessage);
+      void chatView.webview.postMessage({ type: 'terminalEvent', event: displayEvent } satisfies HostToWebviewMessage);
     }
 
     if (conversationMode !== 'local') {
@@ -447,27 +466,27 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     try {
-      if (isBashCommand(event)) {
+      if (isBashCommand(displayEvent)) {
         // Add a spacer only if previous output didn't end with a newline
         terminalLogPty.ensureNewline?.();
-        terminalLogPty.writeLine(`$ ${event.command}`);
-        if (event.command_id) printedExitFor.delete(event.command_id);
-      } else if (isBashOutput(event)) {
-        if (event.stdout) terminalLogPty.write(event.stdout);
-        if (event.stderr) terminalLogPty.write(event.stderr);
+        terminalLogPty.writeLine(`$ ${displayEvent.command}`);
+        if (displayEvent.command_id) printedExitFor.delete(displayEvent.command_id);
+      } else if (isBashOutput(displayEvent)) {
+        if (displayEvent.stdout) terminalLogPty.write(displayEvent.stdout);
+        if (displayEvent.stderr) terminalLogPty.write(displayEvent.stderr);
         // Defensive: if exit_code is provided on output but no BashExit arrives, synthesize a footer once
-        const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
-        const code = 'exit_code' in event ? (event as { exit_code?: number }).exit_code : undefined;
+        const cid = 'command_id' in displayEvent ? (displayEvent as { command_id?: string }).command_id : undefined;
+        const code = 'exit_code' in displayEvent ? (displayEvent as { exit_code?: number }).exit_code : undefined;
         if (cid && typeof code === 'number' && !printedExitFor.has(cid)) {
           terminalLogPty.ensureNewline?.();
           terminalLogPty.writeLine(`[Process exited with code ${code}]`);
           markPrintedExitFor(cid);
         }
-      } else if (isBashExit(event)) {
-        const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
+      } else if (isBashExit(displayEvent)) {
+        const cid = 'command_id' in displayEvent ? (displayEvent as { command_id?: string }).command_id : undefined;
         if (!cid || !printedExitFor.has(cid)) {
           terminalLogPty.ensureNewline?.();
-          terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
+          terminalLogPty.writeLine(`[Process exited with code ${displayEvent.exit_code}]`);
         }
         if (cid) {
           markPrintedExitFor(cid);


### PR DESCRIPTION
## Summary
- mask Bash command/output text with SecretRegistry before writing terminal log
- redact terminal event payloads sent to the webview
- add extension test coverage for terminal secret masking

## Testing
- npx vitest run src/__tests__/extension.test.ts -t "masks secrets in terminal output"

### Bead

oh-tab-pn5: Audit: src/sidebar/* and src/terminal/* - VS Code UI integration
Status: open
Priority: P3
Type: task
Created: 2026-01-24 10:01
Updated: 2026-01-24 10:01

Description:
Security audit for VS Code UI integration. Files: OpenHandsChatViewProvider.ts (60 lines - minimal), OpenHandsTerminalLogPseudoterminal.ts (311 lines - terminal output display). Security: terminal output may contain secrets - ensure masking applied. Lower priority.

Labels: [audit security tech-debt]


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/924">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
### Review
- PinkCat approved via Agent Mail on 2026-01-24.
