### PR TITLE
Audit: redact HAL voice secrets

### DIFF
--- a/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
+++ b/src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts
@@ -209,4 +209,76 @@ describe('createWebviewMessageHandler (HAL voice_confirm profile)', () => {
       apiKey: 'apiKeyRef-secret',
     }));
   });
+
+  it('redacts Gemini API keys from voice confirm errors', async () => {
+    const cfg = {
+      get: vi.fn((key: string, defaultValue?: unknown) => defaultValue),
+      inspect: vi.fn(() => ({})),
+      update: vi.fn(async () => undefined),
+    };
+
+    (vscode.workspace.getConfiguration as any).mockImplementation(() => cfg);
+
+    const context = {
+      secrets: {
+        get: vi.fn(async () => undefined),
+        store: vi.fn(async () => undefined),
+        delete: vi.fn(async () => undefined),
+      },
+      subscriptions: [],
+    } as unknown as vscode.ExtensionContext;
+
+    const { classifyHalVoiceDecision } = await import('../../../hal/gemini/decisionClassifier');
+    (classifyHalVoiceDecision as any).mockResolvedValueOnce({
+      ok: false,
+      error: 'bad key provider-secret',
+    });
+
+    const secretRegistryGet = vi.fn(async (key: string) => {
+      if (key === 'GEMINI_API_KEY') return 'provider-secret';
+      return undefined;
+    });
+
+    const postMessage = vi.fn(async () => true);
+    const handler = createWebviewMessageHandler({
+      context,
+      host: { postMessage },
+      secretRegistry: {
+        get: secretRegistryGet,
+        getRegisteredValues: () => ['provider-secret'],
+      } as any,
+      getQueuedUserEditNotes: () => [],
+      clearQueuedUserEditNotes: () => {},
+      getConversation: () => undefined,
+      getConversationMode: () => 'local',
+      getConversationStoreRoot: () => undefined,
+      resolveConversationStoreRoot: async () => '/tmp/openhands-conversations',
+      setWebviewReadyState: () => undefined,
+      setLastKnownLlmLabel: () => undefined,
+      getLastKnownLlmLabel: () => null,
+      flushConversationEventBacklog: () => undefined,
+      onRenderedEventsResponse: () => undefined,
+      onUiStateResponse: () => undefined,
+      onHalStateResponse: () => undefined,
+      isDevBridgeEnabled: () => false,
+      getOutputChannel: () => undefined,
+      fileLog: () => undefined,
+    });
+
+    await handler({
+      type: 'halVoiceConfirmRequest',
+      requestId: 'r1',
+      mimeType: 'audio/wav',
+      audioBase64: 'Zm9v',
+    });
+
+    const response = postMessage.mock.calls
+      .map((call) => call[0])
+      .find((payload) => payload?.type === 'halVoiceConfirmResponse');
+
+    expect(response).toBeTruthy();
+    expect(response?.ok).toBe(false);
+    expect(response?.error).toContain('[REDACTED]');
+    expect(response?.error).not.toContain('provider-secret');
+  });
 });

--- a/src/webview/host/__tests__/halTts.redaction.test.ts
+++ b/src/webview/host/__tests__/halTts.redaction.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import { handleHalTtsRequest } from '../handlers/hal';
+
+describe('handleHalTtsRequest', () => {
+  it('redacts the ElevenLabs API key from error messages', async () => {
+    const postMessage = vi.fn(async () => true);
+    const settingsMgr = {
+      get: vi.fn(async () => ({
+        hal: {
+          userName: 'Engel',
+          mode: 'tts_only',
+          voiceAId: 'voice_hal',
+          voiceUserId: 'voice_user',
+          modelId: 'eleven_turbo_v2',
+          volume: 1,
+          cache: true,
+        },
+        secrets: { halTtsApiKey: 'eleven-secret' },
+      })),
+    };
+    const gate = {
+      synthesize: vi.fn(async () => ({
+        ok: false as const,
+        error: 'invalid key eleven-secret',
+        kind: 'auth' as const,
+        disabled: true,
+        shouldNotify: true,
+      })),
+    };
+
+    await handleHalTtsRequest({
+      deps: { secretRegistry: { getRegisteredValues: () => [] } } as any,
+      host: { postMessage },
+      settingsMgr: settingsMgr as any,
+      getElevenlabsTtsGate: () => gate as any,
+      message: { type: 'halTtsRequest', requestId: 'r1', conversationId: 'c1', stepIndex: 0 },
+    });
+
+    const response = postMessage.mock.calls
+      .map((call) => call[0])
+      .find((payload) => payload?.type === 'halTtsResponse');
+
+    expect(response).toBeTruthy();
+    expect(response?.ok).toBe(false);
+    expect(response?.error).toContain('[REDACTED]');
+    expect(response?.error).not.toContain('eleven-secret');
+  });
+});

--- a/src/webview/host/handlers/hal.ts
+++ b/src/webview/host/handlers/hal.ts
@@ -7,6 +7,7 @@ import { TtsConversationGate } from '../../../hal/elevenlabs/ttsConversationGate
 import { classifyHalVoiceDecision } from '../../../hal/gemini/decisionClassifier';
 import { DEFAULT_HAL_LLM_PROFILE_ID } from '../../../shared/halDefaults';
 import { getHalDialogueLinesForMode } from '../../../shared/halScript';
+import { maskSecretsInText } from '../../../shared/maskSecrets';
 import type { SettingsManager } from '../../../settings/SettingsManager';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
@@ -34,6 +35,23 @@ const llmProfileStoreOptions = (deps: CreateWebviewMessageHandlerDeps): { rootDi
   if (typeof rootDir !== 'string') return {};
   const trimmed = rootDir.trim();
   return trimmed ? { rootDir: trimmed } : {};
+};
+
+const maskHalSecrets = (text: string, extraValues: Array<string | undefined>, registry?: CreateWebviewMessageHandlerDeps['secretRegistry']): string => {
+  if (!text) return text;
+
+  const values = new Set<string>();
+  if (typeof registry?.getRegisteredValues === 'function') {
+    for (const value of registry.getRegisteredValues()) {
+      if (typeof value === 'string' && value.trim()) values.add(value.trim());
+    }
+  }
+  for (const value of extraValues) {
+    if (typeof value === 'string' && value.trim()) values.add(value.trim());
+  }
+
+  if (values.size === 0) return text;
+  return maskSecretsInText(text, { getRegisteredValues: () => Array.from(values) });
 };
 
 export const createElevenlabsTtsGateFactory = (args: {
@@ -100,11 +118,13 @@ export async function handleHalTtsRequest(args: {
     return;
   }
 
+  const maskedError = maskHalSecrets(result.error, [apiKey], args.deps.secretRegistry);
+
   void args.host.postMessage({
     type: 'halTtsResponse',
     requestId: args.message.requestId,
     ok: false,
-    error: result.error,
+    error: maskedError,
     shouldNotify: result.shouldNotify,
     disabled: result.disabled,
   });
@@ -198,5 +218,6 @@ export async function handleHalVoiceConfirmRequest(args: {
     return;
   }
 
-  void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: false, error: result.error });
+  const maskedError = maskHalSecrets(result.error, [halGeminiKey], args.deps.secretRegistry);
+  void args.host.postMessage({ type: 'halVoiceConfirmResponse', requestId: args.message.requestId, ok: false, error: maskedError });
 }


### PR DESCRIPTION
## Summary
- redact HAL voice API keys from TTS/voice-confirm error payloads
- add HAL TTS redaction unit test
- add voice confirm redaction regression test

## Testing
- npx vitest run src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts src/webview/host/__tests__/halTts.redaction.test.ts

### Bead

oh-tab-5g8: Audit: src/hal/* - HAL voice assistant module
Status: open
Priority: P3
Type: task
Created: 2026-01-24 10:00
Updated: 2026-01-24 10:00

Description:
Security audit for HAL module (ElevenLabs TTS, Gemini voice). Files: registerHalCommands.ts (13KB), elevenlabs/* (TTS client), gemini/* (voice). Security: API keys for voice services. Lower priority - non-core feature.

Labels: [audit security tech-debt]


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/925">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sensitive API keys and provider secrets are now redacted from error messages, appearing as [REDACTED] instead of exposing actual values in responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
### Review
- PinkCat approved via Agent Mail on 2026-01-24.
