### PR TITLE
Tech debt: consolidate redaction heuristics

### DIFF
--- a/src/shared/redaction.ts
+++ b/src/shared/redaction.ts
@@ -1,0 +1,38 @@
+export const REDACTED = '[REDACTED]';
+
+const KEY_PATTERN =
+  /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret|aws[_-]?access[_-]?key[_-]?id|aws[_-]?secret[_-]?access[_-]?key)/i;
+
+const TOKEN_PATTERNS: RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{12,}\b/gi,
+  /\bgh[pousr]_[A-Za-z0-9]{12,}\b/gi,
+  /\bgithub_pat_[A-Za-z0-9_]{12,}\b/gi,
+  // AWS access key ids (AKIA..., ASIA...)
+  /\b(AKIA|ASIA)[0-9A-Z]{16}\b/g,
+];
+
+export function redactStringHeuristics(text: string): string {
+  let t = text;
+
+  // Authorization / Bearer patterns
+  t = t.replace(/(Authorization\s*:\s*Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+  t = t.replace(/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
+  // URL-embedded credentials (userinfo)
+  t = t.replace(/((?:https?|wss?):\/\/)([^/\s@]+)@/gi, `$1${REDACTED}@`);
+
+  TOKEN_PATTERNS.forEach((pattern) => {
+    t = t.replace(pattern, REDACTED);
+  });
+
+  // Common key=value or key: value patterns
+  t = t.replace(
+    new RegExp(`(${KEY_PATTERN.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'),
+    (_m, key) => `${key}: ${REDACTED}`
+  );
+  t = t.replace(
+    new RegExp(`([?&])(${KEY_PATTERN.source})=([^&\\s]+)`, 'gi'),
+    (_m, sep, key) => `${sep}${key}=${REDACTED}`
+  );
+
+  return t;
+}

--- a/src/shared/safeStringify.ts
+++ b/src/shared/safeStringify.ts
@@ -1,4 +1,4 @@
-const REDACTED = '[REDACTED]';
+import { REDACTED, redactStringHeuristics } from './redaction';
 
 // Keys containing encrypted/signature data from LLM APIs that should be truncated for display
 // These are opaque blobs that must be round-tripped exactly but are meaningless to display in full
@@ -32,32 +32,6 @@ function shouldRedactKey(key: string): boolean {
     k === 'auth' ||
     k.includes('authorization')
   );
-}
-
-function redactStringHeuristics(text: string): string {
-  let t = text;
-
-  // Authorization / Bearer patterns
-  t = t.replace(/(Authorization\s*:\s*Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
-  t = t.replace(/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
-  // URL-embedded credentials (userinfo)
-  t = t.replace(/((?:https?|wss?):\/\/)([^/\s@]+)@/gi, `$1${REDACTED}@`);
-
-  // Common token prefixes
-  t = t.replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gi, REDACTED);
-  t = t.replace(/\bgh[pousr]_[A-Za-z0-9]{12,}\b/gi, REDACTED);
-  t = t.replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gi, REDACTED);
-
-  // AWS access key ids (AKIA..., ASIA...)
-  t = t.replace(/\b(AKIA|ASIA)[0-9A-Z]{16}\b/g, REDACTED);
-
-  // Common key=value or key: value patterns
-  const keyPattern =
-    /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret|aws[_-]?access[_-]?key[_-]?id|aws[_-]?secret[_-]?access[_-]?key)/gi;
-  t = t.replace(new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'), (_m, key) => `${key}: ${REDACTED}`);
-  t = t.replace(new RegExp(`([?&])(${keyPattern.source})=([^&\\s]+)`, 'gi'), (_m, sep, key) => `${sep}${key}=${REDACTED}`);
-
-  return t;
 }
 
 /* eslint-disable @typescript-eslint/no-unsafe-return */

--- a/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ObservationEventBlock.tsx
@@ -12,36 +12,12 @@ import {
   withAlpha,
 } from './shared';
 import { Tooltip } from '../Tooltip';
+import { redactStringHeuristics } from '../../../shared/redaction';
 
 /**
  * Renders environment result - shows observation with summary and expandable raw data.
  */
 export function ObservationEventBlock({ event, index }: { event: ObservationEvent; index?: number }) {
-  const redactObservationText = (text: string): string => {
-    const REDACTED = '[REDACTED]';
-    let t = text;
-
-    // Authorization / Bearer patterns
-    t = t.replace(/(Authorization\s*:\s*Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
-    t = t.replace(/(Bearer\s+)[^\s]+/gi, `$1${REDACTED}`);
-
-    // Common token prefixes
-    t = t.replace(/\bsk-[A-Za-z0-9_-]{12,}\b/gi, REDACTED);
-    t = t.replace(/\bgh[pousr]_[A-Za-z0-9]{12,}\b/gi, REDACTED);
-    t = t.replace(/\bgithub_pat_[A-Za-z0-9_]{12,}\b/gi, REDACTED);
-
-    // AWS access key ids (AKIA..., ASIA...)
-    t = t.replace(/\b(AKIA|ASIA)[0-9A-Z]{16}\b/g, REDACTED);
-
-    // Common key=value or key: value patterns
-    const keyPattern =
-      /(api[_-]?key|access[_-]?token|refresh[_-]?token|session[_-]?api[_-]?key|password|secret|client[_-]?secret|aws[_-]?access[_-]?key[_-]?id|aws[_-]?secret[_-]?access[_-]?key)/gi;
-    t = t.replace(new RegExp(`(${keyPattern.source})\\s*[:=]\\s*"?([^"\\s&]+)"?`, 'gi'), (_m, key) => `${key}: ${REDACTED}`);
-    t = t.replace(new RegExp(`([?&])(${keyPattern.source})=([^&\\s]+)`, 'gi'), (_m, sep, key) => `${sep}${key}=${REDACTED}`);
-
-    return t;
-  };
-
   const [isExpanded, setIsExpanded] = useState(false);
   const isFinishTool = event.tool_name === 'finish';
   const maybeMessage = isFinishTool ? event.observation['message'] : undefined;
@@ -101,7 +77,7 @@ export function ObservationEventBlock({ event, index }: { event: ObservationEven
   })();
   const hasSummary = observationSummary !== null;
   const shouldShowRaw = isFileEditObservation ? false : !hasSummary || isExpanded;
-  const observationString = shouldShowRaw ? redactObservationText(JSON.stringify(event.observation, null, 2)) : '';
+  const observationString = shouldShowRaw ? redactStringHeuristics(JSON.stringify(event.observation, null, 2)) : '';
   const isTruncated = shouldShowRaw && observationString.length > 2000;
   const showHeaderToggle = hasSummary && event.tool_name !== 'terminal' && !isFileEditObservation;
   const showFooterToggle = !hasSummary && isTruncated;


### PR DESCRIPTION
## Summary
- extract shared redaction heuristics into `src/shared/redaction.ts`
- reuse shared heuristics in `safeStringify` and ObservationEventBlock

## Testing
- npx vitest run src/shared/__tests__/safeStringify.test.ts
- npx vitest run src/webview-src/__tests__/event.rendering.test.tsx -t "redacts secrets in ObservationEvent raw output"

### Bead

oh-tab-919: Tech debt: extract shared secret redaction patterns
Status: open
Priority: P3
Type: task
Created: 2026-01-24 12:44
Updated: 2026-01-24 12:44

Description:
Consolidate shared secret redaction patterns/constants used across the codebase (e.g., safeStringify heuristics, webview observation redaction) into a common helper to keep behavior consistent.

Acceptance Criteria:
Shared redaction helper exists and is used by both safeStringify and webview ObservationEventBlock; behavior matches existing patterns; tests updated/added if needed.

Labels: [redaction tech-debt]


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/926">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sensitive data redaction across the entire application for improved security. Improved masking now consistently handles authorization headers, URL-embedded credentials, API tokens, and sensitive key-value patterns throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
### Review
- PinkCat approved via Agent Mail on 2026-01-24.
