### PR TITLE
Tech debt: remove sessionApiKey from redaction list

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/textSanitizers.ts
@@ -28,7 +28,7 @@ const SENSITIVE_KEYS = new Set([
   'awsAccessKeyId', 'awsSecretAccessKey',
   'cloudApiKey', 'cloud_api_key',
   'runtimeSessionApiKey', 'runtime_session_api_key',
-  'sessionApiKey', 'session_api_key', 'x_api_key', 'x-api-key',
+  'session_api_key', 'x_api_key', 'x-api-key',
 ]);
 
 const shouldRedactKey = (key: string): boolean => {


### PR DESCRIPTION
## Summary
- remove stale `sessionApiKey` entry from SDK text sanitizer sensitive keys list

## Testing
- npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/textSanitizers.test.ts

### Bead

oh-tab-921: Tech debt: remove stale sessionApiKey from SENSITIVE_KEYS
Status: open
Priority: P3
Type: task
Created: 2026-01-24 12:52
Updated: 2026-01-24 12:52

Description:
Remove the stale camelCase sessionApiKey entry from SENSITIVE_KEYS in text sanitization. Keep current redaction behavior via heuristics or remaining keys.

Acceptance Criteria:
sessionApiKey removed from SENSITIVE_KEYS; redaction behavior unchanged for sensitive keys.

Labels: [redaction tech-debt]


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/927">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
### Review
- PinkCat approved via Agent Mail on 2026-01-24.
