### PR TITLE
Add OpenHandsSettings guards for secrets

### DIFF
--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -93,6 +93,42 @@ const SECRET_STORAGE_KEYS: Array<{ key: keyof OpenHandsSettings['secrets']; stor
   { key: 'customSecret3', storageKey: 'openhands.customSecret3' },
 ];
 
+const OPENHANDS_SECRET_KEYS: Array<keyof OpenHandsSettings['secrets']> = [
+  'cloudApiKey',
+  'runtimeSessionApiKey',
+  'llmApiKey',
+  'awsAccessKeyId',
+  'awsSecretAccessKey',
+  'githubToken',
+  'halTtsApiKey',
+  'customSecret1',
+  'customSecret2',
+  'customSecret3',
+];
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+export const isOpenHandsSettingsSecrets = (value: unknown): value is OpenHandsSettings['secrets'] => {
+  if (!isRecord(value)) return false;
+  for (const key of OPENHANDS_SECRET_KEYS) {
+    const entry = value[key];
+    if (entry !== undefined && typeof entry !== 'string') return false;
+  }
+  return true;
+};
+
+export const isOpenHandsSettings = (value: unknown): value is OpenHandsSettings => {
+  if (!isRecord(value)) return false;
+  if (!isRecord(value.llm)) return false;
+  if (!isRecord(value.agent)) return false;
+  if (!isRecord(value.conversation)) return false;
+  if (!isRecord(value.confirmation)) return false;
+  if (!isRecord(value.hal)) return false;
+  if (!Array.isArray(value.servers)) return false;
+  return isOpenHandsSettingsSecrets(value.secrets);
+};
+
 const isSafeProfileId = (value: string): boolean => {
   if (!value.trim()) return false;
   if (value !== value.trim()) return false;

--- a/src/settings/__tests__/SettingsManager.test.ts
+++ b/src/settings/__tests__/SettingsManager.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { saveProfile } from '@openhands/agent-sdk-ts';
-import { SettingsManager } from '../SettingsManager';
+import { SettingsManager, isOpenHandsSettings, isOpenHandsSettingsSecrets } from '../SettingsManager';
 import type { SettingsAdapter } from '../SettingsAdapter';
 
 class MemoryAdapter implements SettingsAdapter {
@@ -388,5 +388,27 @@ describe('SettingsManager', () => {
 
     const s = await mgr.get();
     expect(s.serverUrl).toBe('http://global:5000');
+  });
+
+  it('validates settings secrets with a type guard', () => {
+    expect(isOpenHandsSettingsSecrets({ llmApiKey: 'sk-test', customSecret1: 'custom' })).toBe(true);
+    expect(isOpenHandsSettingsSecrets({ llmApiKey: 123 } as unknown)).toBe(false);
+    expect(isOpenHandsSettingsSecrets(null)).toBe(false);
+  });
+
+  it('validates OpenHandsSettings shape with a type guard', async () => {
+    const s = await mgr.get();
+    expect(isOpenHandsSettings(s)).toBe(true);
+
+    const invalid = {
+      llm: {},
+      agent: {},
+      conversation: {},
+      confirmation: {},
+      hal: {},
+      servers: [],
+      secrets: { llmApiKey: 123 },
+    };
+    expect(isOpenHandsSettings(invalid)).toBe(false);
   });
 });

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -3,6 +3,7 @@ import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds, resolveLocalTools, type LocalToolId } from '../../../shared/localTools';
 import { isOpenHandsCloudServerUrl } from '../../../shared/cloudServers';
 import { normalizeServerUrl } from '../../../shared/serverUrls';
+import { isOpenHandsSettingsSecrets } from '../../../settings/SettingsManager';
 import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
 
 type LocalConversationToolControls = {
@@ -18,6 +19,12 @@ export const isLocalConversationToolControls = (value: unknown): value is LocalC
     && typeof candidate.getToolNames === 'function'
     && typeof candidate.setTools === 'function';
 };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeSecret = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 
 const ensureRequiredLocalToolIds = (toolIds: LocalToolId[]): LocalToolId[] => {
   // `finish` is always enabled by the runtime agent (for safe termination).
@@ -38,14 +45,13 @@ const getRemoteToolListDeps = (conversation: unknown): RemoteToolListDeps | null
   const serverUrl = candidate.serverUrl;
   if (typeof serverUrl !== 'string' || serverUrl.trim().length === 0) return null;
 
-  const rawSecrets =
-    (candidate.settings as { secrets?: { runtimeSessionApiKey?: unknown; cloudApiKey?: unknown } } | undefined)?.secrets;
+  const rawSettings = isRecord(candidate.settings) ? candidate.settings : undefined;
+  const rawSecrets = rawSettings?.secrets;
+  const secrets = isOpenHandsSettingsSecrets(rawSecrets) ? rawSecrets : undefined;
 
-  const rawCloudKey = rawSecrets?.cloudApiKey;
-  const cloudApiKey = typeof rawCloudKey === 'string' && rawCloudKey.trim().length > 0 ? rawCloudKey.trim() : undefined;
+  const cloudApiKey = normalizeSecret(secrets?.cloudApiKey);
 
-  const rawRuntimeKey = rawSecrets?.runtimeSessionApiKey;
-  const runtimeSessionApiKey = typeof rawRuntimeKey === 'string' && rawRuntimeKey.trim().length > 0 ? rawRuntimeKey.trim() : undefined;
+  const runtimeSessionApiKey = normalizeSecret(secrets?.runtimeSessionApiKey);
   return { serverUrl: serverUrl.trim(), cloudApiKey, runtimeSessionApiKey };
 };
 


### PR DESCRIPTION
## Summary
- add OpenHandsSettings type guards (including secrets)
- use secrets guard when reading conversation settings for tool list
- add guard coverage in SettingsManager tests

## Testing
- npx vitest run src/settings/__tests__/SettingsManager.test.ts

### Bead
oh-tab-922: Tech debt: add type guards for OpenHandsSettings secrets
Status: open
Priority: P3
Type: task
Created: 2026-01-24 12:56
Updated: 2026-01-24 12:56

Description:
Add runtime type guards for OpenHandsSettings (especially secrets) to validate shape before use and reduce unsafe casts. Aim for lightweight guards used at boundaries (e.g., settings load).

Acceptance Criteria:
Type guard(s) exist for OpenHandsSettings (including secrets) and are used where settings are deserialized; tests updated/added as needed.

Labels: [settings tech-debt]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/928">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

### Review
- PinkCat approved on 2026-01-24; no changes requested.
