### PR TITLE
Docs: clarify cloud vs runtime auth UX

### DIFF
--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -34,7 +34,7 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
 - The **runtime session API key** is fetched per-conversation from SaaS `/api/v1/app-conversations*` and kept **in-memory only** (not persisted).
 - Auth headers:
   - SaaS/app-server: `Authorization: Bearer <cloudApiKey>`
-  - Nested runtime: `X-Session-API-Key: <runtime_session_api_key>` (or `Authorization: Bearer ...` when supported)
+  - Nested runtime: `X-Session-API-Key: <runtimeSessionApiKey>` (or `Authorization: Bearer ...` when supported)
 
 **Direct/self-hosted agent-servers (non-cloud):**
 - Use **OpenHands: Set Runtime Session API Key** to store a per-server runtime key.

--- a/docs/settings_prd.md
+++ b/docs/settings_prd.md
@@ -27,6 +27,26 @@ Purpose: document the *actual* settings used by the OpenHands-Tab VS Code extens
     - Downstream change (draft): enyst/OpenHands-Tab#873 removes `session_api_key` from WS URLs; merge is blocked until upstream OpenHands/software-agent-sdk#1786 is merged/deployed.
   - Note (OpenHands Cloud): the nested runtime `session_api_key` is obtained via SaaS V1 bootstrap (`/api/v1/app-conversations*`) and is **not persisted**; it is injected into in-memory `settings.secrets.runtimeSessionApiKey` only for the lifetime of the running conversation.
 
+### Cloud vs runtime auth UX (user view)
+**Cloud/SaaS servers (e.g. `app.all-hands.dev`):**
+- Use **OpenHands: Login to Remote Server (Device Flow)** to obtain and store a **cloud API key**.
+- Storage: `openhands.cloudApiKey.server.<hash>` in VS Code SecretStorage.
+- The **runtime session API key** is fetched per-conversation from SaaS `/api/v1/app-conversations*` and kept **in-memory only** (not persisted).
+- Auth headers:
+  - SaaS/app-server: `Authorization: Bearer <cloudApiKey>`
+  - Nested runtime: `X-Session-API-Key: <runtime_session_api_key>` (or `Authorization: Bearer ...` when supported)
+
+**Direct/self-hosted agent-servers (non-cloud):**
+- Use **OpenHands: Set Runtime Session API Key** to store a per-server runtime key.
+- Storage: `openhands.runtimeSessionApiKey.server.<hash>` in VS Code SecretStorage.
+- Auth header: `X-Session-API-Key: <runtimeSessionApiKey>`
+
+**Troubleshooting quick checks:**
+- 401/403 on **cloud**: re-run device flow login, confirm `serverUrl` is a cloud host, and ensure you are not using a runtime session key as a cloud key.
+- 401/403 on **non-cloud**: set the runtime session API key (must match the server’s `SESSION_API_KEY`), and verify the selected server URL.
+- Keys are **per-server**: switching servers requires separate login/key entry.
+- To clear cloud auth, use **OpenHands: Logout of Remote Server**; to clear runtime auth, run **OpenHands: Set Runtime Session API Key** and choose “Clear”.
+
 ## 2) Conversation lifecycle & persistence
 
 ### Conversation IDs


### PR DESCRIPTION
## Summary
- add a Cloud vs runtime auth UX section to settings PRD
- document storage locations, headers, and troubleshooting for cloud vs self-hosted

## Testing
- Not run (docs-only change)

### Bead
oh-tab-8xc: Docs: clarify cloud + runtime auth UX flow
Status: open
Priority: P4
Type: task
Created: 2026-01-24 13:21
Updated: 2026-01-24 13:21

Description:
Document how cloudApiKey and runtimeSessionApiKey are used in OpenHands-Tab (local vs remote/cloud modes, SecretStorage vs settings secrets), including user-visible UX flows and troubleshooting.

Acceptance Criteria:
Documentation explains cloud vs runtime auth flow, where keys are stored, and common troubleshooting steps. Links or references to relevant settings/commands as needed.

Labels: [auth docs ux]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/929">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive authentication configuration guide covering cloud and self-hosted deployment scenarios, including secret management, HTTP header setup, key retention policies, and troubleshooting procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- PinkCat approved on 2026-01-24; no changes requested.
