### PR TITLE
Allow background terminal commands (oh-tab-okh)

### DIFF
--- a/packages/agent-sdk-ts/src/tools/TerminalTool.ts
+++ b/packages/agent-sdk-ts/src/tools/TerminalTool.ts
@@ -214,6 +214,7 @@ class TerminalSession {
       const parsed = Number.parseInt(raw, 10);
       if (Number.isFinite(parsed)) {
         cmd.exitCode = parsed;
+        cmd.done = true;
       }
     }
 

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -214,11 +214,14 @@ describe('TerminalTool session behavior', () => {
     created.push(dir);
     const tool = new TerminalTool();
 
-    const started = await tool.execute(
-      tool.validate({ command: 'sleep 0.4 > /dev/null 2>&1 &', timeout: 0.05 }),
+    let completed = await tool.execute(
+      tool.validate({ command: 'sleep 0.4 > /dev/null 2>&1 &', timeout: 0.2 }),
       { workspace },
     );
-    expect(started.exit_code).toBe(0);
+    for (let i = 0; i < 5 && completed.exit_code === -1; i++) {
+      completed = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.2 }), { workspace });
+    }
+    expect(completed.exit_code).toBe(0);
 
     const next = await tool.execute(tool.validate({ command: 'echo ok', timeout: 0.2 }), { workspace });
     expect(next.exit_code).toBe(0);

--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -209,6 +209,24 @@ describe('TerminalTool session behavior', () => {
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
   });
 
+  it('allows a new command after a background command returns immediately', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+
+    const started = await tool.execute(
+      tool.validate({ command: 'sleep 0.4 > /dev/null 2>&1 &', timeout: 0.05 }),
+      { workspace },
+    );
+    expect(started.exit_code).toBe(0);
+
+    const next = await tool.execute(tool.validate({ command: 'echo ok', timeout: 0.2 }), { workspace });
+    expect(next.exit_code).toBe(0);
+    expect((next.stdout ?? '').trim()).toBe('ok');
+
+    await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+  });
+
   it('returns the final exit code when a timed-out command completes later', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);


### PR DESCRIPTION
## Summary
- mark terminal command complete when metadata exit is parsed (handles background commands)
- add session test covering background command follow-up

## Testing
- npx vitest run packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/930">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved terminal tool command completion handling to properly recognize when commands finish executing, ensuring better support for sequential and background command operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
OpenHands roasted review (PurpleCat): CodeRabbit flagged a flaky test; fixed with polling + timeout in background-command test (commit de4e3e3) and documented via PR comment. Approved via Agent Mail on 2026-01-27.
