### PR TITLE
Deduplicate optimistic user messages (oh-tab-sxx)

### DIFF
--- a/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
+++ b/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
@@ -64,6 +64,40 @@ describe('App - optimistic user MessageEvent rendering', () => {
     expect(screen.queryByTestId('queued-messages-badge')).toBeNull();
   });
 
+  it('skips an optimistic user message if the persisted event already arrived', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    });
+
+    postToWindow({ type: 'status', status: 'online', mode: 'remote' });
+
+    const persisted: MessageEvent = {
+      kind: 'MessageEvent',
+      id: 'server:test',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: persisted });
+
+    const optimistic: MessageEvent = {
+      kind: 'MessageEvent',
+      id: 'optimistic:test',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: optimistic });
+
+    expect(screen.getAllByText('hello')).toHaveLength(1);
+  });
+
   it('deduplicates an optimistic user message when the persisted event adds <environment information> extended content', async () => {
     render(<App />);
 

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -59,6 +59,8 @@ const isOptimisticUserMessageEvent = (event: Event): boolean => (
 const isEnvironmentInfoBlock = (text: string): boolean =>
   text.trimStart().toLowerCase().startsWith('<environment information>');
 
+const OPTIMISTIC_DEDUPE_WINDOW_MS = 2000;
+
 const fingerprintMessageEvent = (event: MessageEvent): string => {
   const role = event.llm_message?.role ?? '';
   const content = Array.isArray(event.llm_message?.content) ? event.llm_message.content : [];
@@ -94,6 +96,7 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
   } = options;
 
   const streamingStateRef = useRef(initialLlmStreamingState);
+  const recentUserMessageFingerprintsRef = useRef<Map<string, number>>(new Map());
 
   const handleConversationStateUpdate = useCallback((event: Event) => {
     if (!isConversationStateUpdateEvent(event)) return false;
@@ -237,8 +240,23 @@ export function useConversationEvents(options: UseConversationEventsOptions) {
   const handleRenderableEvent = useCallback((event: Event) => {
     if (!isRenderableEvent(event)) return;
 
-    if (isMessageEvent(event) && event.source === 'user' && !isOptimisticUserMessageEvent(event)) {
-      setQueuedMessagesCount((prev) => Math.max(0, prev - 1));
+    if (isMessageEvent(event) && event.source === 'user') {
+      const fingerprint = fingerprintMessageEvent(event);
+      const now = Date.now();
+      const recent = recentUserMessageFingerprintsRef.current;
+      for (const [key, timestamp] of recent.entries()) {
+        if (now - timestamp > OPTIMISTIC_DEDUPE_WINDOW_MS) {
+          recent.delete(key);
+        }
+      }
+      if (isOptimisticUserMessageEvent(event)) {
+        if (recent.has(fingerprint)) {
+          return;
+        }
+      } else {
+        recent.set(fingerprint, now);
+        setQueuedMessagesCount((prev) => Math.max(0, prev - 1));
+      }
     }
 
     setEvents((ev) => {


### PR DESCRIPTION
## Summary
- skip late optimistic user events when a matching persisted event already arrived
- keep existing optimistic dedupe for normal ordering
- add regression test

## Testing
- npx vitest run src/webview-src/__tests__/App.optimisticUserMessage.test.tsx

## E2E
- Not added: race depends on server/webview message ordering; covered with a focused unit test instead.

### Review
OpenHands roasted review (PurpleCat): asked about 2s optimistic dedupe window possibly suppressing identical user messages; rationale provided that it only suppresses optimistic echoes and persisted messages still render. Approved via Agent Mail on 2026-01-27.
