### PR TITLE
Fix image paste duplicate messages (oh-tab-fdz)

### DIFF
--- a/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
+++ b/src/webview-src/__tests__/App.optimisticUserMessage.test.tsx
@@ -144,4 +144,39 @@ describe('App - optimistic user MessageEvent rendering', () => {
 
     expect(screen.getAllByText('hello')).toHaveLength(1);
   });
+
+  it('deduplicates an optimistic user message when the persisted event adds <EXTRA_INFO> extended content', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'webviewReady' });
+    });
+
+    postToWindow({ type: 'status', status: 'online', mode: 'local' });
+
+    const optimistic: MessageEvent = {
+      kind: 'MessageEvent',
+      id: 'optimistic:test',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'hello' }],
+      },
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: optimistic });
+
+    const persisted: MessageEvent = {
+      ...optimistic,
+      id: 'server:test',
+      extended_content: [
+        {
+          type: 'text',
+          text: '<EXTRA_INFO>\nInjected skill content\n</EXTRA_INFO>',
+        },
+      ],
+    } as MessageEvent;
+    postToWindow({ type: 'event', event: persisted });
+
+    expect(screen.getAllByText('hello')).toHaveLength(1);
+  });
 });

--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -61,11 +61,17 @@ const isEnvironmentInfoBlock = (text: string): boolean =>
 
 const OPTIMISTIC_DEDUPE_WINDOW_MS = 2000;
 
+const isExtraInfoBlock = (text: string): boolean =>
+  text.trimStart().toLowerCase().startsWith('<extra_info>');
+
 const fingerprintMessageEvent = (event: MessageEvent): string => {
   const role = event.llm_message?.role ?? '';
   const content = Array.isArray(event.llm_message?.content) ? event.llm_message.content : [];
   const extended = Array.isArray(event.extended_content)
-    ? event.extended_content.filter((c) => !(c?.type === 'text' && typeof c.text === 'string' && isEnvironmentInfoBlock(c.text)))
+    ? event.extended_content.filter((c) => {
+      if (!(c?.type === 'text' && typeof c.text === 'string')) return true;
+      return !isEnvironmentInfoBlock(c.text) && !isExtraInfoBlock(c.text);
+    })
     : [];
   try {
     return JSON.stringify({ role, content, extended });


### PR DESCRIPTION
## Summary
- ignore <EXTRA_INFO> blocks when fingerprinting user messages for optimistic dedupe
- add regression test for optimistic vs persisted with extra info

## Testing
- npx vitest run src/webview-src/__tests__/App.optimisticUserMessage.test.tsx

## E2E
- Not added: issue is a webview dedupe edge case; covered with unit test.

### Review
OpenHands roasted review (PurpleCat): asked whether ignoring `<EXTRA_INFO>` could cause incorrect dedupe; clarified it is deterministic per message and only suppresses optimistic echoes. Approved via Agent Mail on 2026-01-27.
