### PR TITLE
Render think action content (oh-tab-knm)

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -299,6 +299,22 @@ describe('Agent-SDK event rendering', () => {
     expect((await screen.findAllByText(/terminal/)).length).toBeGreaterThan(0);
   });
 
+  it('renders think ActionEvent content', async () => {
+    render(<App />);
+    const ev = {
+      kind: 'ActionEvent',
+      source: 'agent' as const,
+      thought: [],
+      action: { thought: 'We should compare the two approaches before deciding.' },
+      tool_name: 'think',
+      tool_call_id: 'call_action_think',
+      tool_call: { id: 'call_action_think', type: 'function' as const, function: { name: 'think', arguments: '{}' } },
+      llm_response_id: 'resp_action_think'
+    } as any;
+    postToWindow({ type: 'event', event: ev });
+    expect(await screen.findByText(/We should compare the two approaches/)).toBeInTheDocument();
+  });
+
   it('renders ObservationEvent', async () => {
     render(<App />);
     const ev = {

--- a/src/webview-src/components/eventBlocks/ActionEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/ActionEventBlock.tsx
@@ -10,6 +10,7 @@ import {
   GlobActionSummary,
   GrepActionSummary,
   TerminalActionSummary,
+  ThinkActionSummary,
   withAlpha,
 } from './shared';
 
@@ -27,6 +28,8 @@ export function ActionEventBlock({ event, index }: { event: ActionEvent; index?:
         return <FileEditorActionSummary action={event.action} />;
       case 'terminal':
         return <TerminalActionSummary action={event.action} />;
+      case 'think':
+        return <ThinkActionSummary action={event.action} />;
       case 'glob':
         return <GlobActionSummary action={event.action} />;
       case 'grep':
@@ -97,4 +100,3 @@ export function ActionEventBlock({ event, index }: { event: ActionEvent; index?:
     </EventContainer>
   );
 }
-

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -419,6 +419,20 @@ export function TerminalActionSummary({ action }: { action: JsonRecord | null })
   );
 }
 
+export function ThinkActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+  if (!action) return null;
+  const thought = getString(action.thought) ?? getString(action.message);
+  if (!thought) return null;
+  return (
+    <div className="text-sm leading-relaxed space-y-1">
+      <p>The agent logged a thought.</p>
+      <pre className="font-mono text-xs text-stone-400 bg-black/20 rounded-lg p-3 border border-white/[0.04] whitespace-pre-wrap break-words">
+        {thought}
+      </pre>
+    </div>
+  );
+}
+
 export function TerminalObservationSummary({
   observation,
   isExpanded,


### PR DESCRIPTION
## Summary
- add a think action summary to render think tool text cleanly
- wire ActionEventBlock to show it
- add rendering test

## Testing
- npx vitest run src/webview-src/__tests__/event.rendering.test.tsx

## E2E
- Not added: UI rendering-only change covered by unit test.

### Review
OpenHands roasted review (PurpleCat): noted fallback to `action.message` likely won’t hit but harmless. Approved via Agent Mail on 2026-01-27.
