### PR TITLE
Add message copy button (oh-tab-zlu)

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -37,6 +37,20 @@ describe('Agent-SDK event rendering', () => {
     expect(await screen.findByText('OpenHands says')).toBeInTheDocument();
   });
 
+  it('shows a copy button for user messages with text', async () => {
+    render(<App />);
+    const ev: AgentMessageEvent = {
+      kind: 'MessageEvent',
+      source: 'user',
+      llm_message: {
+        role: 'user',
+        content: [{ type: 'text', text: 'Copy me' }],
+      },
+    } as any;
+    postToWindow({ type: 'event', event: ev });
+    expect(await screen.findByLabelText('Copy message text')).toBeInTheDocument();
+  });
+
   it('does not show Extended Thinking on assistant tool-call messages', async () => {
     render(<App />);
     const ev: AgentMessageEvent = {

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -128,8 +128,8 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
     } catch {
       // Fall back to execCommand copy.
     }
+    const textarea = document.createElement('textarea');
     try {
-      const textarea = document.createElement('textarea');
       textarea.value = payload;
       textarea.style.position = 'fixed';
       textarea.style.opacity = '0';
@@ -137,9 +137,10 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
       textarea.focus();
       textarea.select();
       document.execCommand('copy');
-      document.body.removeChild(textarea);
     } catch {
       // Ignore clipboard failures.
+    } finally {
+      textarea.remove();
     }
   };
   const handleCopyText = () => {

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -115,6 +115,36 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
 
   const { main: textContent, attachments } = parseAttachmentBlocks(withoutContext);
   const imageContent = message.content.filter((c) => c.type === 'image');
+  const canCopyText = (isUser || isAgent) && textContent.trim().length > 0;
+
+  const copyMessageText = async () => {
+    if (!canCopyText) return;
+    const payload = textContent;
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(payload);
+        return;
+      }
+    } catch {
+      // Fall back to execCommand copy.
+    }
+    try {
+      const textarea = document.createElement('textarea');
+      textarea.value = payload;
+      textarea.style.position = 'fixed';
+      textarea.style.opacity = '0';
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textarea);
+    } catch {
+      // Ignore clipboard failures.
+    }
+  };
+  const handleCopyText = () => {
+    void copyMessageText();
+  };
 
   const accentColor = isUser ? USER_ACCENT_COLOR : isAgent ? AGENT_ACCENT_COLOR : DEFAULT_ACCENT_COLOR;
   const icon = isUser ? 'account' : isAgent ? 'hubot' : 'info';
@@ -134,9 +164,19 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
       bgOpacity={bgOpacity}
       index={index}
       dataTestId="message-event"
-      className={isUser ? '!bg-neutral-700' : ''}
+      className={`${isUser ? '!bg-neutral-700' : ''} group`}
       alignRight={isUser}
     >
+      {canCopyText && (
+        <button
+          type="button"
+          onClick={handleCopyText}
+          aria-label="Copy message text"
+          className="absolute bottom-2 right-2 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1.5 shadow-sm"
+        >
+          <span className="codicon codicon-copy text-xs" />
+        </button>
+      )}
       <div className={`flex items-start gap-3 ${isUser ? 'flex-row-reverse' : ''}`}>
         {!isUser && (
           <div


### PR DESCRIPTION
## Summary
- add hover copy-to-clipboard button for user/assistant message text
- add rendering test

## Testing
- npx vitest run src/webview-src/__tests__/event.rendering.test.tsx

## E2E
- Not added: UI-only affordance covered by unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard functionality for message text. Users can now copy message content via a copy button that appears on hover for user messages.

* **Tests**
  * Added test coverage for the copy button functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
OpenHands roasted review (PurpleCat): flagged clipboard fallback DOM leak; fixed by removing textarea in `finally` (commit 6e93789). Approved via Agent Mail on 2026-01-27.
