### PR TITLE
Fix message hover group leakage (oh-tab-b2k)

### DIFF
--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -165,7 +165,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
       bgOpacity={bgOpacity}
       index={index}
       dataTestId="message-event"
-      className={`${isUser ? '!bg-neutral-700' : ''} group`}
+      className={`${isUser ? '!bg-neutral-700' : ''} group/message`}
       alignRight={isUser}
     >
       {canCopyText && (
@@ -173,7 +173,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
           type="button"
           onClick={handleCopyText}
           aria-label="Copy message text"
-          className="absolute bottom-2 right-2 opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1.5 shadow-sm"
+          className="absolute bottom-2 right-2 opacity-0 pointer-events-none group-hover/message:opacity-100 group-hover/message:pointer-events-auto transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1.5 shadow-sm"
         >
           <span className="codicon codicon-copy text-xs" />
         </button>


### PR DESCRIPTION
## Summary
- Scope the message container hover group to avoid leaking `group-hover` styles into nested Selected files buttons.
- Update the copy button hover classes to target the scoped message group.

## Testing
- lintstaged (eslint)

### Bead
oh-tab-b2k: Webview: group-hover on message container leaks to Selected files icons
Status: open
Priority: P2
Type: bug
Created: 2026-01-27 17:21
Updated: 2026-01-27 17:21

Description:
After PR #935, MessageEventBlock adds `group` to the outer EventContainer to show the copy button on hover. This causes nested context file buttons (which also use `group`) to have their `group-hover` styles triggered when hovering anywhere on the message container, because Tailwind `group-hover` matches any ancestor with the `group` class. Result: go-to-file icons in the Selected files list highlight even when not hovering the specific button.

Reference: https://github.com/enyst/OpenHands-Tab/pull/935#discussion_r2732608232

Suggested fix: use named groups (e.g. `group/message` + `group-hover/message` for the copy button) or otherwise scope hover state so nested file buttons keep their own hover behavior.

Acceptance Criteria:
- Copy button still appears only when hovering the message container.
- Selected files go-to-file icon opacity changes only when hovering the specific file button (not the whole message).
- No regressions to other hover behaviors in MessageEventBlock.

Labels: [bug tailwind ui webview]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/936">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved copy button hover interactions on message event blocks for better visibility and responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
OpenHands roasted review (PurpleCat): confirmed named group fix and hover scoping; CI green; no issues. Approved via Agent Mail on 2026-01-27.
