### PR TITLE
Align ThinkActionSummary with schema (oh-tab-3rg)

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -329,6 +329,24 @@ describe('Agent-SDK event rendering', () => {
     expect(await screen.findByText(/We should compare the two approaches/)).toBeInTheDocument();
   });
 
+  it('does not render think ActionEvent content without action.thought', async () => {
+    render(<App />);
+    const ev = {
+      kind: 'ActionEvent',
+      source: 'agent' as const,
+      thought: [],
+      action: { message: 'Legacy thought text' },
+      tool_name: 'think',
+      tool_call_id: 'call_action_think_legacy',
+      tool_call: { id: 'call_action_think_legacy', type: 'function' as const, function: { name: 'think', arguments: '{}' } },
+      llm_response_id: 'resp_action_think_legacy'
+    } as any;
+    postToWindow({ type: 'event', event: ev });
+    await waitFor(() => {
+      expect(screen.queryByText(/Legacy thought text/)).toBeNull();
+    });
+  });
+
   it('renders ObservationEvent', async () => {
     render(<App />);
     const ev = {

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -421,7 +421,7 @@ export function TerminalActionSummary({ action }: { action: JsonRecord | null })
 
 export function ThinkActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
   if (!action) return null;
-  const thought = getString(action.thought) ?? getString(action.message);
+  const thought = getString(action.thought);
   if (!thought) return null;
   return (
     <div className="text-sm leading-relaxed space-y-1">


### PR DESCRIPTION
## Summary
- Remove the `action.message` fallback from ThinkActionSummary to match the ThinkTool schema.
- Add a rendering test that ensures think content only appears when `action.thought` is present.

## Testing
- npm test -- --run src/webview-src/__tests__/event.rendering.test.tsx

### Bead
oh-tab-3rg: Webview: ThinkActionSummary should use action.thought only
Status: open
Priority: P2
Type: chore
Created: 2026-01-27 17:25
Updated: 2026-01-27 17:25

Description:
Gemini review on PR #934 noted that ThinkTool schema uses `thought`, so falling back to `action.message` is unnecessary and potentially confusing. In `src/webview-src/components/eventBlocks/shared.tsx`, ThinkActionSummary currently uses:

`const thought = getString(action.thought) ?? getString(action.message);`

Recommendation: drop the `action.message` fallback and use only `action.thought` (or otherwise align with the ThinkTool schema).

Reference: https://github.com/enyst/OpenHands-Tab/pull/934#discussion_r2732591117

Acceptance Criteria:
- ThinkActionSummary renders only when `action.thought` is present.
- No fallback to `action.message` remains (schema-aligned).
- Existing think action rendering tests still pass (update tests if needed).

Labels: [cleanup think ui webview]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/937">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering logic for think ActionEvent content to only display when explicitly provided, preventing unintended fallback behavior.

* **Tests**
  * Added test case to verify think ActionEvent content is not rendered when not explicitly provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
OpenHands roasted review (PurpleCat): CI green; CodeRabbit SUCCESS; Gemini/Devin OK; optional test robustness note only. Approved via Agent Mail on 2026-01-27.
