### PR TITLE
Add TerminalTool background integration test (oh-tab-adx9)

### DIFF
--- a/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk-ts/src/tools/__tests__/TerminalTool.session.test.ts
@@ -230,6 +230,58 @@ describe('TerminalTool session behavior', () => {
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
   });
 
+  it('runs a foreground command while a background job is still running', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    const tool = new TerminalTool();
+    let backgroundPid: number | null = null;
+
+    try {
+      let started = await tool.execute(
+        tool.validate({ command: 'sleep 2 & echo $!', timeout: 0.2 }),
+        { workspace },
+      );
+      for (let i = 0; i < 5 && started.exit_code === -1; i++) {
+        started = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.2 }), { workspace });
+      }
+
+      expect(started.exit_code).toBe(0);
+      expect((started.stderr ?? '').trim()).toBe('');
+      const pidText = (started.stdout ?? '').trim();
+      expect(pidText).toMatch(/^\d+$/);
+      backgroundPid = Number.parseInt(pidText, 10);
+      expect(Number.isFinite(backgroundPid)).toBe(true);
+
+      const second = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
+      expect(second.exit_code).toBe(0);
+      expect((second.stdout ?? '').trim()).toBe('second');
+      expect((second.stderr ?? '').trim()).toBe('');
+
+      const running = await tool.execute(
+        tool.validate({ command: `ps -p ${backgroundPid} -o pid=`, timeout: 0.2 }),
+        { workspace },
+      );
+      expect(running.exit_code).toBe(0);
+      expect((running.stdout ?? '').trim()).toBe(String(backgroundPid));
+
+      await new Promise((resolve) => setTimeout(resolve, 2100));
+      const finished = await tool.execute(
+        tool.validate({ command: `ps -p ${backgroundPid} -o pid=`, timeout: 0.2 }),
+        { workspace },
+      );
+      expect((finished.stdout ?? '').trim()).toBe('');
+      expect(finished.exit_code).not.toBe(0);
+    } finally {
+      if (backgroundPid && Number.isFinite(backgroundPid)) {
+        await tool.execute(
+          tool.validate({ command: `kill ${backgroundPid} 2>/dev/null || true`, timeout: 0.2 }),
+          { workspace },
+        );
+      }
+      await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
+    }
+  });
+
   it('returns the final exit code when a timed-out command completes later', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);


### PR DESCRIPTION
## Summary
- Add an integration-style TerminalTool session test covering background + foreground sequencing.
- Assert stdout/stderr/exit_code payloads and verify the background PID exits cleanly.

## Testing
- npm test -w @openhands/agent-sdk-ts -- --run src/tools/__tests__/TerminalTool.session.test.ts

### Bead
oh-tab-adx9: Agent-SDK: TerminalTool integration test for background + foreground sequencing
Status: open
Priority: P2
Type: task
Created: 2026-01-27 17:33
Updated: 2026-01-27 17:33

Description:
Add an integration test for TerminalTool that exercises the oh-tab-okh behavior with a real shell session:
- Start a background command that runs briefly (e.g., `sleep 1 &`), and ensure the tool reports it as started/complete (exit metadata parsed).
- While it is still running, issue a second foreground command (e.g., `echo second`) and verify it returns promptly with correct stdout.
- Ensure the background command finishes cleanly and does not leave a hanging process.
- Verify the tool output payloads (stdout/stderr/exit_code) are correct since they are sent to the LLM.

Note: this is an integration-style test that uses a real shell (not the event injector). It should be isolated and clean up resources.

Acceptance Criteria:
- Background command can start and return “started/completed” without blocking a subsequent command.
- Foreground command executed while background running returns correct stdout.
- Background process completes and no lingering processes remain.
- Asserts tool output shape/content (stdout/stderr/exit_code) for both commands.

Labels: [agent-sdk integration terminal tests]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/938">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for concurrent foreground and background process execution, validating process lifecycle behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
OpenHands roasted review (PurpleCat): CI green; CodeRabbit SUCCESS; Gemini/Devin OK; optional suggestion to increase background wait time for extra robustness. Approved via Agent Mail on 2026-01-27.
