### PR TITLE
Add code-block copy button (oh-tab-aj2)

### DIFF
--- a/src/webview-src/__tests__/event.rendering.test.tsx
+++ b/src/webview-src/__tests__/event.rendering.test.tsx
@@ -105,6 +105,7 @@ describe('Agent-SDK event rendering', () => {
 
     const fenced = await screen.findByText(/console\.log/);
     expect(fenced.closest('pre')).not.toBeNull();
+    expect(await screen.findByLabelText('Copy code block')).toBeInTheDocument();
 
     const link = await screen.findByRole('button', { name: 'docs' });
     fireEvent.click(link);

--- a/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
+++ b/src/webview-src/components/eventBlocks/MessageEventBlock.tsx
@@ -1,5 +1,6 @@
 import type { MessageEvent as AgentMessageEvent } from '@openhands/agent-sdk-ts';
 import { isTextContent } from '@openhands/agent-sdk-ts';
+import { useState } from 'react';
 import {
   AGENT_ACCENT_COLOR,
   DEFAULT_ACCENT_COLOR,
@@ -21,6 +22,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
   const isUser = message.role === 'user';
   const isAgent = message.role === 'assistant';
   const hasToolCalls = Array.isArray(message.tool_calls) && message.tool_calls.length > 0;
+  const [hideMessageCopy, setHideMessageCopy] = useState(false);
 
   function truncateEnvironmentInformationForDisplay(text: string): string {
     const lines = text.split(/\r?\n/);
@@ -144,6 +146,7 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
     }
   };
   const handleCopyText = () => {
+    setHideMessageCopy(true);
     void copyMessageText();
   };
 
@@ -167,13 +170,16 @@ export function MessageEventBlock({ event, index }: { event: AgentMessageEvent; 
       dataTestId="message-event"
       className={`${isUser ? '!bg-neutral-700' : ''} group/message`}
       alignRight={isUser}
+      onMouseLeave={() => setHideMessageCopy(false)}
     >
       {canCopyText && (
         <button
           type="button"
           onClick={handleCopyText}
           aria-label="Copy message text"
-          className="absolute bottom-2 right-2 opacity-0 pointer-events-none group-hover/message:opacity-100 group-hover/message:pointer-events-auto transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1.5 shadow-sm"
+          className={`absolute top-2 right-2 opacity-0 pointer-events-none transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1.5 shadow-sm ${
+            hideMessageCopy ? '' : 'group-hover/message:opacity-100 group-hover/message:pointer-events-auto'
+          }`}
         >
           <span className="codicon codicon-copy text-xs" />
         </button>

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -55,7 +55,9 @@ const formatSizeDelta = (previous?: number, next?: number): string | undefined =
 const collectTextFromNode = (node: ReactNode): string => {
   if (typeof node === 'string' || typeof node === 'number') return String(node);
   if (Array.isArray(node)) return node.map(collectTextFromNode).join('');
-  if (React.isValidElement(node)) return collectTextFromNode(node.props.children as ReactNode);
+  if (React.isValidElement<{ children?: ReactNode }>(node)) {
+    return collectTextFromNode(node.props.children);
+  }
   return '';
 };
 

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import React, { type ReactNode, useMemo, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
@@ -51,6 +51,73 @@ const formatSizeDelta = (previous?: number, next?: number): string | undefined =
   const sign = delta > 0 ? '+' : '';
   return 'File size changed by ' + sign + delta.toLocaleString() + ' ' + unit + '.';
 };
+
+const collectTextFromNode = (node: ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectTextFromNode).join('');
+  if (React.isValidElement(node)) return collectTextFromNode(node.props.children as ReactNode);
+  return '';
+};
+
+const copyTextToClipboard = async (payload: string) => {
+  if (!payload) return;
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(payload);
+      return;
+    }
+  } catch {
+    // Fall back to execCommand copy.
+  }
+  const textarea = document.createElement('textarea');
+  try {
+    textarea.value = payload;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    document.execCommand('copy');
+  } catch {
+    // Ignore clipboard failures.
+  } finally {
+    textarea.remove();
+  }
+};
+
+function CodeBlock({ children }: { children: ReactNode }) {
+  const [hideCopy, setHideCopy] = useState(false);
+  const codeText = useMemo(() => {
+    const raw = collectTextFromNode(children);
+    return raw.replace(/\n$/, '');
+  }, [children]);
+  const shouldShowCopy = codeText.trim().length > 0;
+  const handleCopy = () => {
+    setHideCopy(true);
+    void copyTextToClipboard(codeText);
+  };
+
+  return (
+    <pre
+      className="mt-2 first:mt-0 font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 pr-10 leading-relaxed text-xs overflow-auto whitespace-pre [&_code]:bg-transparent [&_code]:border-0 [&_code]:px-0 [&_code]:py-0 [&_code]:rounded-none relative group/codeblock"
+      onMouseLeave={() => setHideCopy(false)}
+    >
+      {shouldShowCopy && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy code block"
+          className={`absolute top-2 right-2 opacity-0 pointer-events-none transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1 shadow-sm ${
+            hideCopy ? '' : 'group-hover/codeblock:opacity-100 group-hover/codeblock:pointer-events-auto'
+          }`}
+        >
+          <span className="codicon codicon-copy text-[11px]" />
+        </button>
+      )}
+      {children}
+    </pre>
+  );
+}
 
 const postMessage = (message: WebviewToHostMessage) => {
   const api = getVscodeApi();
@@ -203,11 +270,7 @@ export function MarkdownMessage({ text }: { text: string }) {
         h1: ({ children }) => <h1 className="text-lg font-semibold mt-3 first:mt-0">{children}</h1>,
         h2: ({ children }) => <h2 className="text-base font-semibold mt-3 first:mt-0">{children}</h2>,
         h3: ({ children }) => <h3 className="text-sm font-semibold mt-3 first:mt-0">{children}</h3>,
-        pre: ({ children }) => (
-          <pre className="mt-2 first:mt-0 font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 leading-relaxed text-xs overflow-auto whitespace-pre [&_code]:bg-transparent [&_code]:border-0 [&_code]:px-0 [&_code]:py-0 [&_code]:rounded-none">
-            {children}
-          </pre>
-        ),
+        pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
         code: ({ className, children }) => (
           <code
             className={[
@@ -720,6 +783,7 @@ export function EventContainer({
   index = 0,
   dataTestId,
   alignRight = false,
+  onMouseLeave,
 }: {
   children: React.ReactNode;
   accentColor: string;
@@ -728,6 +792,7 @@ export function EventContainer({
   index?: number;
   dataTestId?: string;
   alignRight?: boolean;
+  onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
 }) {
   const animationDelay = `${index * 40}ms`;
   const bgOpacityPercent = Math.round(bgOpacity * 100);
@@ -752,6 +817,7 @@ export function EventContainer({
         ${alignRight ? 'ml-auto max-w-[85%]' : ''}
         ${className}
       `}
+      onMouseLeave={onMouseLeave}
       style={{
         [alignRight ? 'borderRightColor' : 'borderLeftColor']: accentColor,
         background: `linear-gradient(${alignRight ? '225deg' : '135deg'}, color-mix(in srgb, ${accentColor} ${bgOpacityPercent}%, transparent) 0%, color-mix(in srgb, ${accentColor} ${Math.round(bgOpacity * 50)}%, transparent) 100%)`,


### PR DESCRIPTION
## Summary
- Add per-code-block copy buttons that appear on hover and copy just that block's text.
- Move message-level copy button to the message top-right and hide copy buttons immediately after click.
- Scope hover groups to avoid leaking hover styles into nested elements.

## Testing
- npx vitest run src/webview-src/__tests__/event.rendering.test.tsx

### Bead
oh-tab-aj2: Webview: copy button for code blocks (hover-only, top-right)
Status: open
Priority: P2
Type: feature
Created: 2026-01-27 17:22
Updated: 2026-01-27 17:22

Description:
Add a copy-to-clipboard button for individual code blocks in assistant/user messages. When a Markdown code block (triple backticks) is rendered, hovering the code block should show a small copy icon in the top-right of that code block only. Clicking copies just that code block's text. This should be independent from the existing message-level copy button (oh-tab-zlu).

Also align hover UX for both copy buttons:
- Message-level copy button (from oh-tab-zlu) should appear as a small icon in the top-right corner of the message container on hover (not bottom-right).
- Code-block copy button appears top-right of the code block on hover.
- Both should hide when the mouse leaves the respective hover area, and also hide immediately after clicking copy (but can re-appear on re-hover).

Notes:
- Scope hover so code-block copy does not affect other UI (e.g., avoid Tailwind group-hover leaking to nested elements).
- Prefer existing codicon for copy.
- Clipboard: use navigator.clipboard.writeText with fallback if needed.

Acceptance Criteria:
- Hovering a code block shows a small copy icon at the code block's top-right; clicking copies only that block's code text.
- Hovering the message container shows the message-level copy icon at the message top-right; it copies the message text (not code block only).
- Both icons hide on mouse leave and hide immediately after click, but re-appear on re-hover.
- No hover style leakage to other nested elements (e.g., Selected files icons).

Labels: [clipboard copy ui webview]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/939">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copy-to-clipboard functionality for code blocks with improved UI handling.
  * Enhanced clipboard support with fallback mechanism for broader browser compatibility.

* **Tests**
  * Added verification for code block copy control visibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
OpenHands roasted review (PurpleCat): CI green; CodeRabbit SUCCESS; Gemini/Devin OK; optional refactor to dedupe clipboard helper. Approved via Agent Mail on 2026-01-27.
