### PR TITLE
Simplify extra-info filter (oh-tab-u1g)

### DIFF
--- a/src/webview-src/components/app/useConversationEvents.ts
+++ b/src/webview-src/components/app/useConversationEvents.ts
@@ -69,8 +69,10 @@ const fingerprintMessageEvent = (event: MessageEvent): string => {
   const content = Array.isArray(event.llm_message?.content) ? event.llm_message.content : [];
   const extended = Array.isArray(event.extended_content)
     ? event.extended_content.filter((c) => {
-      if (!(c?.type === 'text' && typeof c.text === 'string')) return true;
-      return !isEnvironmentInfoBlock(c.text) && !isExtraInfoBlock(c.text);
+      if (c?.type === 'text' && typeof c.text === 'string') {
+        return !isEnvironmentInfoBlock(c.text) && !isExtraInfoBlock(c.text);
+      }
+      return true;
     })
     : [];
   try {


### PR DESCRIPTION
## Summary
- Rewrite the extended_content filter to handle the text case first for readability (no behavior change).

## Testing
- npx vitest run src/webview-src/__tests__/App.optimisticUserMessage.test.tsx

### Bead
oh-tab-u1g: Webview: simplify extra-info filter readability
Status: open
Priority: P3
Type: chore
Created: 2026-01-27 17:25
Updated: 2026-01-27 17:25

Description:
Gemini review on PR #933 suggested a readability tweak in `useConversationEvents.ts` for the extended_content filter. Current code uses a negated condition in the `if` guard. Suggest restructuring to handle the primary (text) case first for clarity:

```
if (c?.type === 'text' && typeof c.text === 'string') {
  return !isEnvironmentInfoBlock(c.text) && !isExtraInfoBlock(c.text);
}
return true;
```

Reference: https://github.com/enyst/OpenHands-Tab/pull/933#discussion_r2732578658

Acceptance Criteria:
- Filter logic remains behaviorally identical.
- Readability improves by avoiding negated condition.

Labels: [cleanup readability webview]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/940">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


### Review
OpenHands roasted review (PurpleCat): CI green; CodeRabbit SUCCESS; Gemini/Devin OK; optional comment only. Approved via Agent Mail on 2026-01-27.
