### PR TITLE
Document UI E2E context picker skip

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,6 +13,9 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **settings.test.ts**: Tests settings and configuration commands
 - **history.test.ts**: Tests conversation history and restore functionality
 - **messaging.test.ts**: Tests message events and rendering
+- **uiFlows.test.ts**: Tests UI flows via command-driven harness (non-UI automation)
+- **uiFlowsUi.test.ts**: UI-driven smoke test using CDP (gated by `E2E_UI=1`). The context picker
+  selection is skipped if no workspace file options appear within the timeout (see bead `oh-tab-puxi`).
 - **serverSelection.test.ts**: Tests server selection and local/remote mode switching
 - **llmSwitching.test.ts**: Tests switching LLM provider/model/api mode (local, mock server)
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels
@@ -30,6 +33,8 @@ These run inside VS Code and execute the actual tests:
 - **suite/settings.ts**: Tests extension commands and diagnostics structure
 - **suite/history.ts**: Tests conversation state and event backlog
 - **suite/messaging.ts**: Tests message event rendering and multi-part content
+- **suite/uiFlows.ts**: Exercises UI flows via host-side commands
+- **suite/uiFlowsUi.ts**: Exercises UI flows via CDP-based UI automation
 - **suite/serverSelection.ts**: Tests mode switching and diagnostics state
 - **suite/llmSwitching.ts**: Exercises local LLM switching against a mock server
 - **suite/confirmation.ts**: Tests actions with different security risk levels

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,7 +20,6 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **llmSwitching.test.ts**: Tests switching LLM provider/model/api mode (local, mock server)
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels
 - **errorHandling.test.ts**: Tests error events and error state handling
-- **uiFlowsUi.test.ts**: UI-driven smoke test using Playwright CDP (gated by `E2E_UI=1`)
 - **agentServerRemote.test.ts**: (Optional) Starts a local python agent-server and tests remote mode end-to-end (gated by `E2E_AGENT_SERVER=1`)
 - **agentServerRemoteAuth.test.ts**: (Optional) Starts a local python agent-server with `SESSION_API_KEY` enabled and tests runtime-key auth end-to-end (gated by `E2E_AGENT_SERVER=1`)
 - **agentServerRemoteCloudBootstrap.test.ts**: (Optional) Starts a local python agent-server + local mock SaaS server and tests cloud bootstrap wiring end-to-end (gated by `E2E_AGENT_SERVER=1`)
@@ -39,7 +38,6 @@ These run inside VS Code and execute the actual tests:
 - **suite/llmSwitching.ts**: Exercises local LLM switching against a mock server
 - **suite/confirmation.ts**: Tests actions with different security risk levels
 - **suite/errorHandling.ts**: Tests error events and recovery
-- **suite/uiFlowsUi.ts**: Clicks/hover UI flows in the webview using Playwright
 
 ### Helper Files
 - **testHelpers.ts**: Utility functions including VS Code download with retry

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -74,7 +74,9 @@ export async function run(): Promise<void> {
 
     await webview.waitForSelector('[data-testid="header-totals-row"]', { timeoutMs: 45000, visible: true });
 
-    // Context picker: open, select README.md, close.
+    // Context picker: open, select a file if options appear, close.
+    // Note: in CI the workspace file list can be empty; we skip selection when no options
+    // appear within the timeout (tracked in bead oh-tab-puxi).
     await webview.click('[data-testid="open-context-picker"]');
     await webview.waitForSelector('[data-testid="context-picker"]', { timeoutMs: 15000, visible: true });
 


### PR DESCRIPTION
## Summary
- document UI E2E context picker skip behavior in test comment and E2E README
- reference follow-up investigation bead for empty options in CI

## Testing
- not run (docs-only)

### Bead
oh-tab-c03s: Document UI E2E context picker skip behavior
Status: open
Priority: P2
Type: task
Created: 2026-01-29 17:45
Updated: 2026-01-29 17:45

Description:
Add explicit docstring/comment in UI E2E flow and note in tests/e2e/README that context selection may be skipped when no options appear in CI. Reference investigate bead oh-tab-puxi.

Labels: [docs]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/943">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage with new UI workflow automation for both host-driven and CDP-based flows.
  * Improved test resilience by making context selection conditional to handle empty-workspace CI scenarios.
* **Documentation**
  * Updated test docs to reflect new gating and coverage distinctions for UI-driven and host-side command flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->