### PR TITLE
Trim README + link missing docs in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,12 @@ OpenHands-Tab/
 - E2E tests: `npm run e2e` (Mocha + @vscode/test-electron)
 - Place tests in `__tests__/` directories alongside source
 
+## Git Hooks
+
+This repo uses Husky + lint-staged to run ESLint on staged `*.ts`/`*.tsx` files before commit (installed automatically by `npm install` via the `prepare` script).
+
+- Run manually: `npm exec -- lint-staged`
+
 ## Commits
 
 Short imperative sentences. Reference issues with `(#123)`.
@@ -306,6 +312,8 @@ Pitfalls to avoid
 - [docs/PRD.md](docs/PRD.md) - Product requirements
 - [docs/agent-sdk-architecture.md](docs/agent-sdk-architecture.md) - SDK architecture
 - [docs/vscode_local_setup.md](docs/vscode_local_setup.md) - Local development setup
+- [docs/vscode_remote_setup.md](docs/vscode_remote_setup.md) - Headless/remote setup
+- [docs/settings_prd.md](docs/settings_prd.md) - Settings and configuration PRD
 - [packages/agent-sdk-ts/AGENTS.md](packages/agent-sdk-ts/AGENTS.md) - SDK-specific guidelines
 
 

--- a/README.md
+++ b/README.md
@@ -30,41 +30,18 @@ Alternatively, for humans in development mode:
   - Run [OpenHands-CLI](https://github.com/OpenHands/OpenHands-CLI), or another agent of your choice, including itself
   - Tell it to clone, build, install, or ask it questions about this repo if you'd like. It can tell stories.
 
-### Development (recommended)
-
-1. Run [OpenHands-CLI](https://github.com/OpenHands/OpenHands-CLI) in the extension directory
-2. Tell it to build, install, and run VSCode in dev/debug on `cwd`
-3. Have fun!
-
-### Development (old style)
+### Development
 
 1. Open the project in VS Code
 2. Press F5 to launch Extension Development Host
-3. Click the OpenHands icon in the Activity Bar (or run "OpenHands: Open") to reveal the chat sidebar view
-
-### Git Hooks
-
-This repo uses Husky + lint-staged to run ESLint on staged `*.ts`/`*.tsx` files before commit (installed automatically by `npm install` via the `prepare` script).
-
-- Run manually: `npm exec -- lint-staged`
-
-### Useful commands
-
-- **OpenHands: Explain Selection** - Explain selected code in the editor (context menu)
-- (maybe, outdated) **OpenHands: Configure** - Set up server URL, API keys
+3. Click the OpenHands icon in the Activity Bar to reveal the chat sidebar view
 
 ### Configuration
 
 - You can use LLM Profiles View or regular VS Code Settings to set LLM Providers API key(s)
 - Set Gemini API key (used for summarizations, highly **recommended**)
-- Set ElevenLabs API key (optional feature)
 - Set GitHub token
 - Leave server URL blank for local mode, or set it to connect to an [agent-server](https://github.com/OpenHands/software-agent-sdk)
-
-**Using Gemini**: Gemini can be used in three ways:
-- **As the main agent LLM**: set `openhands.llm.profileId` to a Gemini profile id (e.g., `gemini-flash`) and configure your API key via **OpenHands: Set Gemini API Key**
-- **As utility for summarization**: highly recommended, just set the key and it will be used for the built-in Gemini profiles
-- **For HAL voice confirmation** (optional): HAL uses its own Gemini profile specified by `openhands.hal.llmProfileId` (default: `gemini-flash-hal`) for audio understanding in voice_confirm mode
 
 ## Documentation
 
@@ -72,12 +49,9 @@ This repo uses Husky + lint-staged to run ESLint on staged `*.ts`/`*.tsx` files 
 |----------|-------------|
 | [AGENTS.md](AGENTS.md) | Quick reference for AI agents |
 | [docs/PRD.md](docs/PRD.md) | Product requirements and architecture |
-| [docs/settings_prd.md](docs/settings_prd.md) | Product requirements and architecture |
 | [docs/agent-sdk-architecture.md](docs/agent-sdk-architecture.md) | SDK architecture details |
-| [docs/context-token-breakdown.md](docs/context-token-breakdown.md) | Why context tokens can be high in local mode |
 | [docs/vscode_local_setup.md](docs/vscode_local_setup.md) | Local development setup |
 | [docs/vscode_remote_setup.md](docs/vscode_remote_setup.md) | Headless/remote setup |
-| [packages/agent-sdk-ts/AGENTS.md](packages/agent-sdk-ts/AGENTS.md) | SDK development guide |
 
 ## Architecture
 
@@ -86,12 +60,7 @@ This is an npm workspace with two packages:
 1. **Root package** - VS Code extension (`src/`)
 2. **@openhands/agent-sdk-ts** - TypeScript SDK (`packages/agent-sdk-ts/`)
 
-The SDK provides:
-- `Conversation` API for local/remote agent execution
-- LLM clients (Anthropic, OpenAI-compatible, Gemini)
-- Tools (Terminal, FileEditor, TaskTracker, Browser, Glob, Grep, BrowserUse, PlanningFileEditor, Delegate, Finish)
-- `Workspace` factory for connecting to remote servers
-- Protocol types and event handling
+The SDK provides the `Conversation` API, LLM clients, tools, and protocol types.
 
 ## Commands
 
@@ -99,13 +68,7 @@ The SDK provides:
 npm run build           # Build SDK + extension + webview
 npm run compile         # Compile TypeScript + Tailwind + webview (faster)
 npm test                # Run all tests
-npm run test:watch      # Run tests in watch mode
 npm run lint            # Lint all code
-npm run lint:fix        # Auto-fix lint issues
-npm run typecheck       # Type check all code
-npm run watch           # Development watch mode
-npm run e2e             # E2E tests
-npm run e2e:agent-server  # E2E tests against remote agent-server
 npm run package         # Package extension as VSIX
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Alternatively, for humans in development mode:
 - Set GitHub token
 - Leave server URL blank for local mode, or set it to connect to an [agent-server](https://github.com/OpenHands/software-agent-sdk)
 
+**Using Gemini**: Gemini can be used in three ways:
+- **As the main agent LLM**: set `openhands.llm.profileId` to a Gemini profile id (e.g., `gemini-flash`) and configure your API key via **OpenHands: Set Gemini API Key**
+- **As utility for summarization**: highly recommended, just set the key and it will be used for the built-in Gemini profiles
+- **For HAL voice confirmation** (optional): HAL uses its own Gemini profile specified by `openhands.hal.llmProfileId` (default: `gemini-flash-hal`) for audio understanding in voice_confirm mode
+
 ## Documentation
 
 | Document | Description |

--- a/README.md
+++ b/README.md
@@ -30,7 +30,13 @@ Alternatively, for humans in development mode:
   - Run [OpenHands-CLI](https://github.com/OpenHands/OpenHands-CLI), or another agent of your choice, including itself
   - Tell it to clone, build, install, or ask it questions about this repo if you'd like. It can tell stories.
 
-### Development
+### Development (recommended)
+
+1. Run [OpenHands-CLI](https://github.com/OpenHands/OpenHands-CLI) in the extension directory
+2. Tell it to build, install, and run VSCode in dev/debug on `cwd`
+3. Have fun!
+
+### Development (old style)
 
 1. Open the project in VS Code
 2. Press F5 to launch Extension Development Host

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,6 +13,9 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **settings.test.ts**: Tests settings and configuration commands
 - **history.test.ts**: Tests conversation history and restore functionality
 - **messaging.test.ts**: Tests message events and rendering
+- **uiFlows.test.ts**: Tests UI flows via command-driven harness (non-UI automation)
+- **uiFlowsUi.test.ts**: UI-driven smoke test using CDP (gated by `E2E_UI=1`). The context picker
+  selection is skipped if no workspace file options appear within the timeout (see bead `oh-tab-puxi`).
 - **serverSelection.test.ts**: Tests server selection and local/remote mode switching
 - **llmSwitching.test.ts**: Tests switching LLM provider/model/api mode (local, mock server)
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels
@@ -30,6 +33,8 @@ These run inside VS Code and execute the actual tests:
 - **suite/settings.ts**: Tests extension commands and diagnostics structure
 - **suite/history.ts**: Tests conversation state and event backlog
 - **suite/messaging.ts**: Tests message event rendering and multi-part content
+- **suite/uiFlows.ts**: Exercises UI flows via host-side commands
+- **suite/uiFlowsUi.ts**: Exercises UI flows via CDP-based UI automation
 - **suite/serverSelection.ts**: Tests mode switching and diagnostics state
 - **suite/llmSwitching.ts**: Exercises local LLM switching against a mock server
 - **suite/confirmation.ts**: Tests actions with different security risk levels

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -20,7 +20,6 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **llmSwitching.test.ts**: Tests switching LLM provider/model/api mode (local, mock server)
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels
 - **errorHandling.test.ts**: Tests error events and error state handling
-- **uiFlowsUi.test.ts**: UI-driven smoke test using Playwright CDP (gated by `E2E_UI=1`)
 - **agentServerRemote.test.ts**: (Optional) Starts a local python agent-server and tests remote mode end-to-end (gated by `E2E_AGENT_SERVER=1`)
 - **agentServerRemoteAuth.test.ts**: (Optional) Starts a local python agent-server with `SESSION_API_KEY` enabled and tests runtime-key auth end-to-end (gated by `E2E_AGENT_SERVER=1`)
 - **agentServerRemoteCloudBootstrap.test.ts**: (Optional) Starts a local python agent-server + local mock SaaS server and tests cloud bootstrap wiring end-to-end (gated by `E2E_AGENT_SERVER=1`)
@@ -39,7 +38,6 @@ These run inside VS Code and execute the actual tests:
 - **suite/llmSwitching.ts**: Exercises local LLM switching against a mock server
 - **suite/confirmation.ts**: Tests actions with different security risk levels
 - **suite/errorHandling.ts**: Tests error events and recovery
-- **suite/uiFlowsUi.ts**: Clicks/hover UI flows in the webview using Playwright
 
 ### Helper Files
 - **testHelpers.ts**: Utility functions including VS Code download with retry

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -74,7 +74,9 @@ export async function run(): Promise<void> {
 
     await webview.waitForSelector('[data-testid="header-totals-row"]', { timeoutMs: 45000, visible: true });
 
-    // Context picker: open, select README.md, close.
+    // Context picker: open, select a file if options appear, close.
+    // Note: in CI the workspace file list can be empty; we skip selection when no options
+    // appear within the timeout (tracked in bead oh-tab-puxi).
     await webview.click('[data-testid="open-context-picker"]');
     await webview.waitForSelector('[data-testid="context-picker"]', { timeoutMs: 15000, visible: true });
 


### PR DESCRIPTION
## Summary
- Add Git Hooks note to AGENTS.md
- Link docs/settings_prd.md and docs/vscode_remote_setup.md in AGENTS.md
- Trim README.md to remove agent-redundant sections and extra command/doc listings

## Rationale
Reduce README duplication by moving agent-centric details into AGENTS.md, while ensuring missing docs are still discoverable by agents.

## Testing
- Not run (doc-only changes)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/945">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated and simplified development setup and commands
  * Added Git Hooks guidance for staged-file linting
  * Expanded reference library with remote setup and configuration guides

* **Tests**
  * Added new end-to-end UI flow tests
  * Improved UI test reliability with conditional picker behavior for CI environments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->