### PR TITLE
Remove LLM settings usageId

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -167,7 +167,7 @@ Reconnection:
 const conversation = Conversation({
   serverUrl: 'http://localhost:3000',
   settings: {
-    llm: { model: 'claude-sonnet-4-20250514', usageId: 'remote' },
+    llm: { model: 'claude-sonnet-4-20250514' },
     secrets: {
       runtimeSessionApiKey: 'sk_session_xxx',
       llmApiKey: process.env.ANTHROPIC_API_KEY,
@@ -1483,7 +1483,6 @@ const conversation: ConversationInstance = Conversation({
   settings: {
     llm: {
       model: 'claude-sonnet-4-20250514',
-      usageId: 'default-llm',
       temperature: 0.7,
     },
     conversation: {
@@ -1601,7 +1600,6 @@ const conversation = Conversation({
   settings: {
     llm: {
       model: 'claude-sonnet-4-20250514',
-      usageId: 'local-server',
     },
     secrets: {
       llmApiKey: process.env.ANTHROPIC_API_KEY,

--- a/docs/llm_profiles.md
+++ b/docs/llm_profiles.md
@@ -90,6 +90,16 @@ Current selection heuristic (best-effort):
   - Local mode: applies to the **next** LLM request (no interruption of in-flight streaming).
   - Remote mode: applies when you start a **new conversation** (the agent-server does not currently support mid-conversation LLM switching).
 
+### Usage IDs vs Profile IDs
+
+- **`usageId` identifies the component that is spending tokens**, not the profile.
+  - Example usage buckets: `agent` (main assistant), `tool-summarizer`, `file-diff-summarizer`, etc.
+- **`profileId` selects the LLM configuration** (provider/model/base URL/generation params).
+- In OpenHands-Tab, the **main agent usageId is fixed to `agent`**:
+  - Switching profiles does **not** change the usageId.
+  - This keeps the main agent’s totals stable across profile changes (one bucket for the agent).
+- Usage IDs are **not user-configurable in settings**; component-specific usage IDs are set in code.
+
 ### Consistency requirement (critical)
 
 These three must always match (no “snap back to session default”):

--- a/packages/agent-sdk-ts/AGENTS.md
+++ b/packages/agent-sdk-ts/AGENTS.md
@@ -299,7 +299,6 @@ const conversation: ConversationInstance = Conversation({
   settings: {
     llm: {
       model: 'claude-sonnet-4-20250514',
-      usageId: 'default-llm',
       temperature: 0.7,
     },
     conversation: {

--- a/packages/agent-sdk-ts/src/sdk/__tests__/llmSettingsHelpers.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/llmSettingsHelpers.test.ts
@@ -10,7 +10,6 @@ describe('clearRawLlmFieldsWhenProfileSelected', () => {
       baseUrl: 'http://example.test',
       openaiApiMode: 'chat_completions',
       maxInputTokens: 123,
-      usageId: 'u1',
     } as any;
 
     expect(clearRawLlmFieldsWhenProfileSelected(input)).toEqual(input);
@@ -34,7 +33,6 @@ describe('clearRawLlmFieldsWhenProfileSelected', () => {
       reasoningSummary: 'detailed',
       inputCostPerToken: 0.1,
       outputCostPerToken: 0.2,
-      usageId: 'u1',
     } as any;
 
     expect(clearRawLlmFieldsWhenProfileSelected(input)).toEqual({
@@ -57,4 +55,3 @@ describe('clearRawLlmFieldsWhenProfileSelected', () => {
     });
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/__tests__/remoteConversation.test.ts
@@ -315,7 +315,7 @@ describe('RemoteConversation', () => {
         serverUrl: 'http://localhost:3000',
         settings: {
           ...baseSettings,
-          llm: { profileId: 'p1', usageId: 'default-llm' },
+          llm: { profileId: 'p1' },
         } as any,
         profileStoreOptions: { rootDir: dir },
       });

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -360,44 +360,9 @@ export class LocalConversation extends EventEmitter {
 
     const llm = this.settings.llm ?? {};
     const profileId = toOptionalNonEmptyString(llm.profileId);
-    const model = toOptionalNonEmptyString(llm.model);
     const config: PersistedLlmConfig = {};
-    if (profileId) {
-      config.profileId = profileId;
-    } else {
-      if (llm.provider) config.provider = llm.provider;
-      if (model) config.model = model;
-    }
-
-    if (!profileId) {
-      if (llm.openaiApiMode) config.openaiApiMode = llm.openaiApiMode;
-
-      const baseUrl = toOptionalNonEmptyString(llm.baseUrl);
-      if (baseUrl) config.baseUrl = baseUrl;
-      const apiVersion = toOptionalNonEmptyString(llm.apiVersion);
-      if (apiVersion) config.apiVersion = apiVersion;
-
-      if (typeof llm.timeout === 'number' && Number.isFinite(llm.timeout)) config.timeoutSeconds = llm.timeout;
-      if (typeof llm.temperature === 'number' && Number.isFinite(llm.temperature)) config.temperature = llm.temperature;
-      if (typeof llm.topP === 'number' && Number.isFinite(llm.topP)) config.topP = llm.topP;
-      if (typeof llm.topK === 'number' && Number.isFinite(llm.topK)) config.topK = llm.topK;
-      if (typeof llm.maxInputTokens === 'number' && Number.isFinite(llm.maxInputTokens)) {
-        config.maxInputTokens = llm.maxInputTokens;
-      }
-      if (typeof llm.maxOutputTokens === 'number' && Number.isFinite(llm.maxOutputTokens)) {
-        config.maxOutputTokens = llm.maxOutputTokens;
-      }
-
-      if (llm.reasoningEffort) config.reasoningEffort = llm.reasoningEffort;
-      if (llm.reasoningSummary) config.reasoningSummary = llm.reasoningSummary;
-
-      if (typeof llm.inputCostPerToken === 'number' && Number.isFinite(llm.inputCostPerToken)) {
-        config.inputCostPerToken = llm.inputCostPerToken;
-      }
-      if (typeof llm.outputCostPerToken === 'number' && Number.isFinite(llm.outputCostPerToken)) {
-        config.outputCostPerToken = llm.outputCostPerToken;
-      }
-    }
+    if (!profileId) return;
+    config.profileId = profileId;
 
     if (!Object.keys(config).length) return;
     this.persistence.writeLlmConfig(config);
@@ -407,33 +372,13 @@ export class LocalConversation extends EventEmitter {
     if (!store.readLlmConfig) return;
     const persisted = store.readLlmConfig();
     if (!persisted) return;
-    if (!persisted.profileId && !persisted.model) return;
+    if (!persisted.profileId) return;
 
     const existing = this.settings.llm ?? {};
-    const merged: OpenHandsSettings['llm'] = persisted.profileId
-      ? clearRawLlmFieldsWhenProfileSelected({
-        ...existing,
-        profileId: persisted.profileId,
-      })
-      : {
-        ...existing,
-        profileId: undefined,
-        provider: persisted.provider ?? undefined,
-        model: persisted.model ?? undefined,
-        openaiApiMode: persisted.openaiApiMode ?? undefined,
-        baseUrl: persisted.baseUrl ?? undefined,
-        apiVersion: persisted.apiVersion ?? undefined,
-        timeout: persisted.timeoutSeconds ?? undefined,
-        temperature: persisted.temperature ?? undefined,
-        topP: persisted.topP ?? undefined,
-        topK: persisted.topK ?? undefined,
-        maxInputTokens: persisted.maxInputTokens ?? undefined,
-        maxOutputTokens: persisted.maxOutputTokens ?? undefined,
-        reasoningEffort: persisted.reasoningEffort ?? undefined,
-        reasoningSummary: persisted.reasoningSummary ?? undefined,
-        inputCostPerToken: persisted.inputCostPerToken ?? undefined,
-        outputCostPerToken: persisted.outputCostPerToken ?? undefined,
-      };
+    const merged: OpenHandsSettings['llm'] = clearRawLlmFieldsWhenProfileSelected({
+      ...existing,
+      profileId: persisted.profileId,
+    });
 
     this.settings = { ...this.settings, llm: merged };
     this.agent.setSettings(this.settings);

--- a/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk-ts/src/sdk/conversation/LocalConversation.ts
@@ -369,9 +369,6 @@ export class LocalConversation extends EventEmitter {
       if (model) config.model = model;
     }
 
-    const usageId = toOptionalNonEmptyString(llm.usageId);
-    if (usageId) config.usageId = usageId;
-
     if (!profileId) {
       if (llm.openaiApiMode) config.openaiApiMode = llm.openaiApiMode;
 
@@ -417,14 +414,12 @@ export class LocalConversation extends EventEmitter {
       ? clearRawLlmFieldsWhenProfileSelected({
         ...existing,
         profileId: persisted.profileId,
-        usageId: persisted.usageId ?? undefined,
       })
       : {
         ...existing,
         profileId: undefined,
         provider: persisted.provider ?? undefined,
         model: persisted.model ?? undefined,
-        usageId: persisted.usageId ?? undefined,
         openaiApiMode: persisted.openaiApiMode ?? undefined,
         baseUrl: persisted.baseUrl ?? undefined,
         apiVersion: persisted.apiVersion ?? undefined,

--- a/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/persistence.ts
@@ -10,7 +10,6 @@ export type PersistedLlmConfig = {
   profileId?: string;
   provider?: LLMProvider;
   model?: string;
-  usageId?: string;
   openaiApiMode?: OpenAIChatApi;
   baseUrl?: string;
   apiVersion?: string;
@@ -72,8 +71,6 @@ export const parsePersistedLlmConfig = (value: unknown): PersistedLlmConfig | un
   if (provider) config.provider = provider;
   const model = toOptionalNonEmptyString(value.model);
   if (model) config.model = model;
-  const usageId = toOptionalNonEmptyString(value.usageId);
-  if (usageId) config.usageId = usageId;
   const openaiApiMode = toOptionalOpenAiApiMode(value.openaiApiMode);
   if (openaiApiMode) config.openaiApiMode = openaiApiMode;
   const baseUrl = toOptionalNonEmptyString(value.baseUrl);

--- a/packages/agent-sdk-ts/src/sdk/types/settings.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/settings.ts
@@ -1,7 +1,6 @@
 import type { LLMProvider, OpenAIChatApi, ReasoningSummary } from '../llm/types';
 
 export type LLMSettings = {
-  usageId?: string | null;
   /**
    * Optional LLM profile identifier (filename stem under the profile store).
    * When set, the effective provider/model/baseUrl/etc are resolved from the profile store.

--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -9,7 +9,6 @@ import * as os from 'os';
 const defaultMockSettings = {
   serverUrl: 'http://localhost:3000',
   llm: {
-    usageId: 'default-llm',
     model: 'claude-3-5-sonnet-20241022',
     baseUrl: undefined,
   },


### PR DESCRIPTION
## Summary
- remove LLM settings usageId and persistence support
- update tests and example docs to drop usageId usage
- document usageId vs profileId behavior in llm profiles doc

## Testing
- lint-staged (eslint, sdk lint)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/946">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated examples and added guidance clarifying the difference between profile IDs and usage IDs and how profile switching appears in the UI.

* **Bug Fixes**
  * Removed the `usageId` field from LLM configuration and persisted settings; systems now rely on `profileId` for LLM selection and runtime switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->