### PR TITLE
Break src/webview/host circular imports (oh-tab-zhwi.4.1)

### DIFF
--- a/src/webview/host/createWebviewMessageHandler.ts
+++ b/src/webview/host/createWebviewMessageHandler.ts
@@ -1,10 +1,9 @@
 import * as vscode from 'vscode';
-import type { SecretRegistry } from '@openhands/agent-sdk-ts';
 import { SettingsManager } from '../../settings/SettingsManager';
 import { VscodeSettingsAdapter } from '../../settings/VscodeSettingsAdapter';
 import { resolveConfiguredLlmLabel } from '../../shared/llmProfiles';
 
-import type { HostToWebviewMessage, WebviewE2EInfo, WebviewToHostMessage } from '../../shared/webviewMessages';
+import type { WebviewE2EInfo, WebviewToHostMessage } from '../../shared/webviewMessages';
 // Environment info is provided via AgentContext.userMessageSuffix (extension host).
 
 import { listSkillFiles } from './skills';
@@ -21,83 +20,8 @@ import { handleSend } from './handlers/send';
 import { handleLlmProfileApiKeySetRequest, handleLlmProfileApiKeyStatusRequest, handleLlmProfileDeleteRequest, handleLlmProfileLoadRequest, handleLlmProfileSaveRequest, handleLlmProfilesListRequest, handleSetLlmProfileId, listAvailableLlmProfiles } from './handlers/llmProfiles';
 import { computeWelcomeSecretStatus } from '../../shared/welcomeSecretStatus';
 import { createElevenlabsTtsGateFactory, handleHalTtsRequest, handleHalVoiceConfirmRequest } from './handlers/hal';
-
-export type WebviewHost = {
-  postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
-};
-
-export type CreateWebviewMessageHandlerDeps = {
-  context: vscode.ExtensionContext;
-  host: WebviewHost;
-  secretRegistry?: SecretRegistry;
-  getQueuedUserEditNotes: () => string[];
-  clearQueuedUserEditNotes: () => void;
-
-  getConversation: () => import('@openhands/agent-sdk-ts').ConversationInstance | undefined;
-  getConversationMode: () => 'local' | 'remote';
-  getConversationStoreRoot: () => string | undefined;
-  resolveConversationStoreRoot: () => Promise<string>;
-
-  /**
-   * Optional override for the LLM profile store root directory. Defaults to `~/.openhands/llm-profiles`.
-   * Intended for tests only (no workspace overrides).
-   */
-  getLlmProfilesStoreRoot?: () => string | undefined;
-
-  setWebviewReadyState: (conversationId?: string, lastSeenSeq?: number) => void;
-  setWebviewE2EReady?: (ready: boolean) => void;
-  setWebviewE2EInfo?: (info: WebviewE2EInfo | null) => void;
-  setLastKnownLlmLabel: (label: string | null) => void;
-  getLastKnownLlmLabel: () => string | null;
-
-  flushConversationEventBacklog: (args: {
-    postMessage: WebviewHost['postMessage'];
-    clientConversationId?: string;
-    clientLastSeenSeq?: number;
-  }) => void;
-
-  onRenderedEventsResponse: (
-    requestId: string,
-    info: {
-      count: number;
-      eventTypes: string[];
-      events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
-    }
-  ) => void;
-  onUiStateResponse: (
-    requestId: string,
-    info: {
-      input: string;
-      showContextPicker: boolean;
-      showSkillsPopover: boolean;
-      showHistory: boolean;
-      workspaceFilesCount: number;
-      selectedContextFiles: string[];
-      skillsCount: number;
-      attachmentsCount: number;
-      hasWelcomeProviderKey: boolean;
-      hasWelcomeGeminiKey: boolean;
-      showWelcomeProviderKeyMessage: boolean;
-      showWelcomeGeminiKeyMessage: boolean;
-    }
-  ) => void;
-  onHalStateResponse: (
-    requestId: string,
-    info: {
-      enabled: boolean;
-      mode: string;
-      phase: string;
-      eye: string;
-      stepIndex: number | null;
-      decision: string | null;
-      lastError: string | null;
-    }
-  ) => void;
-
-  isDevBridgeEnabled: () => boolean;
-  getOutputChannel: () => vscode.OutputChannel | undefined;
-  fileLog: (line: string) => void;
-};
+import type { CreateWebviewMessageHandlerDeps } from './webviewMessageHandler.types';
+export type { CreateWebviewMessageHandlerDeps, WebviewHost } from './webviewMessageHandler.types';
 
 export function createWebviewMessageHandler(deps: CreateWebviewMessageHandlerDeps) {
   const { context, host } = deps;

--- a/src/webview/host/handlers/attachments.ts
+++ b/src/webview/host/handlers/attachments.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import { resolvePreferredWorkspaceFolderUri } from '../../../shared/workspaceRoot';
 import { toAttachmentLabel } from '../attachments';
-import type { WebviewHost } from '../createWebviewMessageHandler';
+import type { WebviewHost } from '../webviewMessageHandler.types';
 
 export async function handleSelectAttachments(args: {
   context: vscode.ExtensionContext;
@@ -75,4 +75,3 @@ export async function handleOpenAttachment(message: Extract<WebviewToHostMessage
     void vscode.window.showErrorMessage(`Failed to open attachment: ${reason}`);
   }
 }
-

--- a/src/webview/host/handlers/devBridge.ts
+++ b/src/webview/host/handlers/devBridge.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
-import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps } from '../webviewMessageHandler.types';
 
 export function handleWebviewConsole(args: {
   deps: CreateWebviewMessageHandlerDeps;
@@ -47,4 +47,3 @@ export function handleWebviewWebSocket(args: {
   args.outputChannel?.appendLine(parts.join(' '));
   args.deps.fileLog(parts.join(' '));
 }
-

--- a/src/webview/host/handlers/hal.ts
+++ b/src/webview/host/handlers/hal.ts
@@ -10,7 +10,7 @@ import { getHalDialogueLinesForMode } from '../../../shared/halScript';
 import { maskSecretsInText } from '../../../shared/maskSecrets';
 import type { SettingsManager } from '../../../settings/SettingsManager';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
-import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../webviewMessageHandler.types';
 import * as llmProfilesStore from '../llmProfilesStore';
 import { createStoredSecretHelpers, getProviderApiKeyName } from './secretHelpers';
 

--- a/src/webview/host/handlers/history.ts
+++ b/src/webview/host/handlers/history.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
-import type { WebviewHost, CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../webviewMessageHandler.types';
 import { getConversationHistoryList, persistConversationTitle } from '../conversationHistory';
 import { summarizeWithLocalLlm } from '../../../extension/summarizeWithLocalLlm';
 import type { OpenHandsSettings } from '../../../settings/SettingsManager';

--- a/src/webview/host/handlers/llmProfiles.ts
+++ b/src/webview/host/handlers/llmProfiles.ts
@@ -4,7 +4,7 @@ import { assertValidProfileId, detectProviderFromBaseUrl, LLMProfileValidationEr
 import type { SettingsManager } from '../../../settings/SettingsManager';
 import { resolveConfiguredLlmLabel } from '../../../shared/llmProfiles';
 import { STATUS_MESSAGE_DISMISS_DELAY_MS, type WebviewToHostMessage } from '../../../shared/webviewMessages';
-import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../webviewMessageHandler.types';
 import * as llmProfilesStore from '../llmProfilesStore';
 import { createStoredSecretHelpers, getProviderApiKeyName, isLlmProvider } from './secretHelpers';
 

--- a/src/webview/host/handlers/send.ts
+++ b/src/webview/host/handlers/send.ts
@@ -7,8 +7,7 @@ import type { MessageEvent } from '@openhands/agent-sdk-ts';
 import { OPENHANDS_IMAGE_URL_PREFIX, getGlobalStorageBaseDir, getPastedImagePath, parseBase64DataImageUrl, rewriteDataImageMarkdown, rewriteOpenHandsImageUrls } from '../../../shared/pastedImages';
 import { MAX_PASTED_IMAGE_BYTES, MAX_PASTED_IMAGES } from '../../../shared/pasteLimits';
 import { buildAttachmentBlocks, safeParseUri } from '../attachments';
-import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
-import type { WebviewHost } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../webviewMessageHandler.types';
 
 async function persistPastedImage(baseDir: string, imageId: string, bytes: Uint8Array): Promise<void> {
   const filePath = getPastedImagePath(baseDir, imageId);

--- a/src/webview/host/handlers/servers.ts
+++ b/src/webview/host/handlers/servers.ts
@@ -1,5 +1,5 @@
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
-import type { WebviewHost } from '../createWebviewMessageHandler';
+import type { WebviewHost } from '../webviewMessageHandler.types';
 import { normalizeServerUrl } from '../../../shared/serverUrls';
 
 type SettingsManagerLike = {
@@ -115,4 +115,3 @@ export async function handleSwitchToLocal(args: {
     serverUrl: '',
   });
 }
-

--- a/src/webview/host/handlers/stateResponses.ts
+++ b/src/webview/host/handlers/stateResponses.ts
@@ -1,5 +1,5 @@
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
-import type { CreateWebviewMessageHandlerDeps } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps } from '../webviewMessageHandler.types';
 
 export function handleRenderedEventsResponse(args: {
   deps: CreateWebviewMessageHandlerDeps;
@@ -46,4 +46,3 @@ export function handleHalStateResponse(args: {
     lastError: args.message.lastError,
   });
 }
-

--- a/src/webview/host/handlers/tools.ts
+++ b/src/webview/host/handlers/tools.ts
@@ -4,7 +4,7 @@ import { getDefaultLocalToolIds, listLocalToolDescriptors, normalizeLocalToolIds
 import { isOpenHandsCloudServerUrl } from '../../../shared/cloudServers';
 import { normalizeServerUrl } from '../../../shared/serverUrls';
 import { isOpenHandsSettingsSecrets } from '../../../settings/SettingsManager';
-import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../createWebviewMessageHandler';
+import type { CreateWebviewMessageHandlerDeps, WebviewHost } from '../webviewMessageHandler.types';
 
 type LocalConversationToolControls = {
   mode: 'local';

--- a/src/webview/host/webviewMessageHandler.types.ts
+++ b/src/webview/host/webviewMessageHandler.types.ts
@@ -1,0 +1,80 @@
+import type * as vscode from 'vscode';
+import type { ConversationInstance, SecretRegistry } from '@openhands/agent-sdk-ts';
+import type { HostToWebviewMessage, WebviewE2EInfo } from '../../shared/webviewMessages';
+
+export type WebviewHost = {
+  postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
+};
+
+export type CreateWebviewMessageHandlerDeps = {
+  context: vscode.ExtensionContext;
+  host: WebviewHost;
+  secretRegistry?: SecretRegistry;
+  getQueuedUserEditNotes: () => string[];
+  clearQueuedUserEditNotes: () => void;
+
+  getConversation: () => ConversationInstance | undefined;
+  getConversationMode: () => 'local' | 'remote';
+  getConversationStoreRoot: () => string | undefined;
+  resolveConversationStoreRoot: () => Promise<string>;
+
+  /**
+   * Optional override for the LLM profile store root directory. Defaults to `~/.openhands/llm-profiles`.
+   * Intended for tests only (no workspace overrides).
+   */
+  getLlmProfilesStoreRoot?: () => string | undefined;
+
+  setWebviewReadyState: (conversationId?: string, lastSeenSeq?: number) => void;
+  setWebviewE2EReady?: (ready: boolean) => void;
+  setWebviewE2EInfo?: (info: WebviewE2EInfo | null) => void;
+  setLastKnownLlmLabel: (label: string | null) => void;
+  getLastKnownLlmLabel: () => string | null;
+
+  flushConversationEventBacklog: (args: {
+    postMessage: WebviewHost['postMessage'];
+    clientConversationId?: string;
+    clientLastSeenSeq?: number;
+  }) => void;
+
+  onRenderedEventsResponse: (
+    requestId: string,
+    info: {
+      count: number;
+      eventTypes: string[];
+      events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
+    }
+  ) => void;
+  onUiStateResponse: (
+    requestId: string,
+    info: {
+      input: string;
+      showContextPicker: boolean;
+      showSkillsPopover: boolean;
+      showHistory: boolean;
+      workspaceFilesCount: number;
+      selectedContextFiles: string[];
+      skillsCount: number;
+      attachmentsCount: number;
+      hasWelcomeProviderKey: boolean;
+      hasWelcomeGeminiKey: boolean;
+      showWelcomeProviderKeyMessage: boolean;
+      showWelcomeGeminiKeyMessage: boolean;
+    }
+  ) => void;
+  onHalStateResponse: (
+    requestId: string,
+    info: {
+      enabled: boolean;
+      mode: string;
+      phase: string;
+      eye: string;
+      stepIndex: number | null;
+      decision: string | null;
+      lastError: string | null;
+    }
+  ) => void;
+
+  isDevBridgeEnabled: () => boolean;
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  fileLog: (line: string) => void;
+};


### PR DESCRIPTION
## Summary
- break `src/webview/host` import cycles by moving `CreateWebviewMessageHandlerDeps` and `WebviewHost` types into a dedicated module: `src/webview/host/webviewMessageHandler.types.ts`
- update all handler modules to import shared types from the new module instead of importing from `createWebviewMessageHandler.ts`
- keep backward compatibility by re-exporting the moved types from `createWebviewMessageHandler.ts`

## Validation
- `npx vitest run src/webview/host/__tests__/createWebviewMessageHandler.serversPersist.test.ts src/webview/host/__tests__/createWebviewMessageHandler.send.environmentInfo.test.ts src/webview/host/__tests__/createWebviewMessageHandler.halVoiceConfirm.profile.test.ts src/webview/host/__tests__/createWebviewMessageHandler.openWorkspaceDiff.test.ts`
- `npm run lint`
- `npm run typecheck`
- `npx madge --extensions ts,tsx --circular --json --ts-config tsconfig.json --exclude '^\.\./packages/agent-sdk-ts/dist' src`

### Bead
- id: `oh-tab-zhwi.4.1`
- title: `Fix: eliminate circular dependencies in src/webview/host message handlers`
- description: `Madge reports cycles centered on src/webview/host/createWebviewMessageHandler.ts and handlers/*. Refactor handler registration/composition to remove import cycles without changing behavior.`
- acceptance criteria:
  - `madge circular report for src has 0 cycles under src/webview/host.`
  - `Existing webview host tests pass.`
  - `Architecture notes document the new dependency direction.`
- status: `in_progress`
- priority: `1`
- issue_type: `task`
- assignee: `RedCastle`
- labels: `architecture`, `cycle`, `refactor`, `webview`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal type definitions for the webview message handler into a dedicated module, consolidating type imports across multiple handler files. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->