### PR TITLE
[oh-tab-zhwi.7.1] Extract shared LLM HTTP retry helper

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/anthropic.ts
@@ -1,18 +1,8 @@
-import { setTimeout as delay } from 'node:timers/promises';
 import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions, type ToolCallAccumulator } from './types';
 import { getAnthropicThinkingBudget } from './providerQuirks';
+import { NonRetryableHttpStatusError, requestWithRetry } from './httpRetry';
 
 const decoder = new TextDecoder();
-
-class NonRetryableHttpStatusError extends Error {
-  readonly status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = 'NonRetryableHttpStatusError';
-    this.status = status;
-  }
-}
 
 // Anthropic content block types
 type AnthropicThinkingBlock = {
@@ -387,51 +377,20 @@ export class AnthropicClient implements LLMClient {
   }
 
   private async fetchWithRetry(request: ChatCompletionRequest): Promise<Response> {
-    let attempt = 0;
-    let delayMs = this.retry.baseDelayMs;
-    let lastError: Error | undefined;
-
-    while (attempt <= this.retry.maxRetries) {
-      try {
-        const controller = new AbortController();
-        const effectiveSeconds = (typeof this.config.timeoutSeconds === 'number' && this.config.timeoutSeconds > 0)
-          ? this.config.timeoutSeconds
-          : (DEFAULT_TIMEOUT_MS / 1000);
-        const timeout = setTimeout(() => controller.abort(), effectiveSeconds * 1000);
-        const response = await fetch(this.requestUrl(), {
-          method: 'POST',
-          headers: this.requestHeaders(),
-          body: JSON.stringify(this.requestBody(request)),
-          signal: controller.signal,
-        });
-        clearTimeout(timeout);
-
-        if (!response.ok) {
-          if (this.retry.retryOn(response.status) && attempt < this.retry.maxRetries) {
-            await delay(delayMs);
-            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-            attempt += 1;
-            continue;
-          }
-
-          const message = await response.text();
-          throw new NonRetryableHttpStatusError(response.status, `Anthropic request failed (${response.status}): ${message}`);
-        }
-
-        return response;
-      } catch (error) {
-        if (error instanceof NonRetryableHttpStatusError) {
-          throw error;
-        }
-        lastError = error as Error;
-        if (attempt >= this.retry.maxRetries) break;
-        await delay(delayMs);
-        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-        attempt += 1;
-      }
-    }
-
-    throw lastError ?? new Error('Anthropic request failed after retries');
+    return requestWithRetry<Response>({
+      retry: this.retry,
+      timeoutSeconds: this.config.timeoutSeconds,
+      defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+      request: (signal) => fetch(this.requestUrl(), {
+        method: 'POST',
+        headers: this.requestHeaders(),
+        body: JSON.stringify(this.requestBody(request)),
+        signal,
+      }),
+      parseResponse: (response) => Promise.resolve(response),
+      buildStatusError: (status, detail) => new NonRetryableHttpStatusError(status, `Anthropic request failed (${status}): ${detail}`),
+      finalErrorMessage: 'Anthropic request failed after retries',
+    });
   }
 
   private requestUrl(): string {

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions } from './types';
 import type { Content, Message, ToolCall } from '../types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
+import { NonRetryableHttpStatusError, requestWithRetry } from './httpRetry';
 
 /**
  * Gemini Client
@@ -20,18 +21,6 @@ import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
  */
 
 const decoder = new TextDecoder();
-
-const delay = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
-
-class NonRetryableHttpStatusError extends Error {
-  readonly status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = 'NonRetryableHttpStatusError';
-    this.status = status;
-  }
-}
 
 type GeminiRole = 'user' | 'model';
 
@@ -387,54 +376,21 @@ export class GeminiClient implements LLMClient {
   }
 
   private async fetchWithRetry(request: ChatCompletionRequest): Promise<Response> {
-    let attempt = 0;
-    let delayMs = this.retry.baseDelayMs;
-    let lastError: Error | undefined;
-
-    while (attempt <= this.retry.maxRetries) {
-      try {
-        const controller = new AbortController();
-        const effectiveSeconds = (typeof this.config.timeoutSeconds === 'number' && this.config.timeoutSeconds > 0)
-          ? this.config.timeoutSeconds
-          : (DEFAULT_TIMEOUT_MS / 1000);
-        const timeout = setTimeout(() => controller.abort(), effectiveSeconds * 1000);
-        let response: Response;
-        try {
-          response = await fetch(this.requestUrl(), {
-            method: 'POST',
-            headers: this.requestHeaders(),
-            body: JSON.stringify(toRequestBody(this.config, request)),
-            signal: controller.signal,
-          });
-        } finally {
-          clearTimeout(timeout);
-        }
-
-        if (!response.ok) {
-          const shouldRetry = this.retry.retryOn(response.status) && attempt < this.retry.maxRetries;
-          if (shouldRetry) {
-            await delay(delayMs);
-            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-            attempt += 1;
-            continue;
-          }
-          const detail = await response.text().catch(() => '');
-          throw new NonRetryableHttpStatusError(response.status, `LLM request failed (HTTP ${response.status}): ${detail.slice(0, 500)}`);
-        }
-
-        return response;
-      } catch (err) {
-        if (err instanceof NonRetryableHttpStatusError) {
-          throw err;
-        }
-        lastError = err instanceof Error ? err : new Error(String(err));
-        if (attempt >= this.retry.maxRetries) break;
-        await delay(delayMs);
-        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-        attempt += 1;
-      }
-    }
-
-    throw lastError ?? new Error('LLM request failed');
+    return requestWithRetry<Response>({
+      retry: this.retry,
+      timeoutSeconds: this.config.timeoutSeconds,
+      defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+      request: (signal) => fetch(this.requestUrl(), {
+        method: 'POST',
+        headers: this.requestHeaders(),
+        body: JSON.stringify(toRequestBody(this.config, request)),
+        signal,
+      }),
+      parseResponse: (response) => Promise.resolve(response),
+      readErrorBody: async (response) => response.text().catch(() => ''),
+      buildStatusError: (status, detail) =>
+        new NonRetryableHttpStatusError(status, `LLM request failed (HTTP ${status}): ${detail.slice(0, 500)}`),
+      finalErrorMessage: 'LLM request failed',
+    });
   }
 }

--- a/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/gemini.ts
@@ -387,7 +387,6 @@ export class GeminiClient implements LLMClient {
         signal,
       }),
       parseResponse: (response) => Promise.resolve(response),
-      readErrorBody: async (response) => response.text().catch(() => ''),
       buildStatusError: (status, detail) =>
         new NonRetryableHttpStatusError(status, `LLM request failed (HTTP ${status}): ${detail.slice(0, 500)}`),
       finalErrorMessage: 'LLM request failed',

--- a/packages/agent-sdk-ts/src/sdk/llm/httpRetry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/httpRetry.ts
@@ -1,0 +1,77 @@
+import { setTimeout as delay } from 'node:timers/promises';
+import type { RetryOptions } from './types';
+
+export class NonRetryableHttpStatusError extends Error {
+  readonly status: number;
+
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = 'NonRetryableHttpStatusError';
+    this.status = status;
+  }
+}
+
+export type RequestWithRetryOptions<T> = {
+  retry: RetryOptions;
+  timeoutSeconds?: number | null;
+  defaultTimeoutMs: number;
+  request: (signal: AbortSignal) => Promise<Response>;
+  parseResponse: (response: Response) => Promise<T>;
+  buildStatusError: (status: number, detail: string) => NonRetryableHttpStatusError;
+  finalErrorMessage: string;
+  readErrorBody?: (response: Response) => Promise<string>;
+};
+
+const resolveTimeoutMs = (timeoutSeconds: number | null | undefined, defaultTimeoutMs: number): number =>
+  (typeof timeoutSeconds === 'number' && timeoutSeconds > 0 ? timeoutSeconds * 1000 : defaultTimeoutMs);
+
+export async function requestWithRetry<T>(options: RequestWithRetryOptions<T>): Promise<T> {
+  let attempt = 0;
+  let delayMs = options.retry.baseDelayMs;
+  let lastError: Error | undefined;
+
+  while (attempt <= options.retry.maxRetries) {
+    try {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), resolveTimeoutMs(options.timeoutSeconds, options.defaultTimeoutMs));
+      let response: Response;
+      try {
+        response = await options.request(controller.signal);
+      } finally {
+        clearTimeout(timeout);
+      }
+
+      if (!response.ok) {
+        const shouldRetry = options.retry.retryOn(response.status) && attempt < options.retry.maxRetries;
+        if (shouldRetry) {
+          await delay(delayMs);
+          delayMs = Math.min(options.retry.maxDelayMs, delayMs * 2);
+          attempt += 1;
+          continue;
+        }
+
+        const detail = options.readErrorBody
+          ? await options.readErrorBody(response)
+          : await response.text();
+        throw options.buildStatusError(response.status, detail);
+      }
+
+      return await options.parseResponse(response);
+    } catch (error) {
+      if (error instanceof NonRetryableHttpStatusError) {
+        throw error;
+      }
+
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt >= options.retry.maxRetries) {
+        break;
+      }
+
+      await delay(delayMs);
+      delayMs = Math.min(options.retry.maxDelayMs, delayMs * 2);
+      attempt += 1;
+    }
+  }
+
+  throw lastError ?? new Error(options.finalErrorMessage);
+}

--- a/packages/agent-sdk-ts/src/sdk/llm/httpRetry.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/httpRetry.ts
@@ -52,7 +52,7 @@ export async function requestWithRetry<T>(options: RequestWithRetryOptions<T>): 
 
         const detail = options.readErrorBody
           ? await options.readErrorBody(response)
-          : await response.text();
+          : await response.text().catch(() => `(error reading response body for status: ${response.status})`);
         throw options.buildStatusError(response.status, detail);
       }
 

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-compatible.ts
@@ -1,20 +1,10 @@
-import { setTimeout as delay } from 'node:timers/promises';
 import { reduceTextContent, DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type RetryOptions, type ToolCallAccumulator } from './types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 import { supportsThinkingBlocks } from './providerQuirks';
 import { buildOpenAiHeaders } from './openaiHeaders';
+import { NonRetryableHttpStatusError, requestWithRetry } from './httpRetry';
 
 const decoder = new TextDecoder();
-
-class NonRetryableHttpStatusError extends Error {
-  readonly status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = 'NonRetryableHttpStatusError';
-    this.status = status;
-  }
-}
 
 type OpenAIThinkingContentBlock = {
   type: 'thinking';
@@ -379,51 +369,20 @@ export class OpenAICompatibleClient implements LLMClient {
   }
 
   private async fetchWithRetry(request: ChatCompletionRequest): Promise<Response> {
-    let attempt = 0;
-    let delayMs = this.retry.baseDelayMs;
-    let lastError: Error | undefined;
-
-    while (attempt <= this.retry.maxRetries) {
-      try {
-        const controller = new AbortController();
-        const effectiveSeconds = (typeof this.config.timeoutSeconds === 'number' && this.config.timeoutSeconds > 0)
-          ? this.config.timeoutSeconds
-          : (DEFAULT_TIMEOUT_MS / 1000);
-        const timeout = setTimeout(() => controller.abort(), effectiveSeconds * 1000);
-        const response = await fetch(this.requestUrl(), {
-          method: 'POST',
-          headers: this.requestHeaders(),
-          body: JSON.stringify(toRequestBody(this.config, request)),
-          signal: controller.signal,
-        });
-        clearTimeout(timeout);
-
-        if (!response.ok) {
-          if (this.retry.retryOn(response.status) && attempt < this.retry.maxRetries) {
-            await delay(delayMs);
-            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-            attempt += 1;
-            continue;
-          }
-
-          const message = await response.text();
-          throw new NonRetryableHttpStatusError(response.status, `LLM request failed (${response.status}): ${message}`);
-        }
-
-        return response;
-      } catch (error) {
-        if (error instanceof NonRetryableHttpStatusError) {
-          throw error;
-        }
-        lastError = error as Error;
-        if (attempt >= this.retry.maxRetries) break;
-        await delay(delayMs);
-        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-        attempt += 1;
-      }
-    }
-
-    throw lastError ?? new Error('LLM request failed after retries');
+    return requestWithRetry<Response>({
+      retry: this.retry,
+      timeoutSeconds: this.config.timeoutSeconds,
+      defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+      request: (signal) => fetch(this.requestUrl(), {
+        method: 'POST',
+        headers: this.requestHeaders(),
+        body: JSON.stringify(toRequestBody(this.config, request)),
+        signal,
+      }),
+      parseResponse: (response) => Promise.resolve(response),
+      buildStatusError: (status, detail) => new NonRetryableHttpStatusError(status, `LLM request failed (${status}): ${detail}`),
+      finalErrorMessage: 'LLM request failed after retries',
+    });
   }
 
   private requestUrl(): string {

--- a/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
+++ b/packages/agent-sdk-ts/src/sdk/llm/openai-responses.ts
@@ -1,18 +1,8 @@
-import { setTimeout as delay } from 'node:timers/promises';
 import type { Message, ResponsesReasoningItem, ToolCall } from '../types';
 import { DEFAULT_PROVIDER_BASE_URLS } from './provider';
 import { DEFAULT_RETRY_OPTIONS, DEFAULT_TIMEOUT_MS, type ChatCompletionRequest, type LLMClient, type LLMConfiguration, type LLMStreamChunk, type LLMToolDefinition, type RetryOptions } from './types';
 import { buildOpenAiHeaders } from './openaiHeaders';
-
-class NonRetryableHttpStatusError extends Error {
-  readonly status: number;
-
-  constructor(status: number, message: string) {
-    super(message);
-    this.name = 'NonRetryableHttpStatusError';
-    this.status = status;
-  }
-}
+import { NonRetryableHttpStatusError, requestWithRetry } from './httpRetry';
 
 const defaultBaseUrls: Record<string, string> = {
   openai: DEFAULT_PROVIDER_BASE_URLS.openai,
@@ -367,54 +357,26 @@ export class OpenAIResponsesClient implements LLMClient {
   }
 
   private async fetchWithRetry(request: ChatCompletionRequest): Promise<OpenAIResponsesResponse> {
-    let attempt = 0;
-    let delayMs = this.retry.baseDelayMs;
-    let lastError: Error | undefined;
-
-    while (attempt <= this.retry.maxRetries) {
-      try {
-        const controller = new AbortController();
-        const effectiveSeconds = (typeof this.config.timeoutSeconds === 'number' && this.config.timeoutSeconds > 0)
-          ? this.config.timeoutSeconds
-          : (DEFAULT_TIMEOUT_MS / 1000);
-        const timeout = setTimeout(() => controller.abort(), effectiveSeconds * 1000);
-        const response = await fetch(this.requestUrl(), {
-          method: 'POST',
-          headers: this.requestHeaders(),
-          body: JSON.stringify(toRequestBody(this.config, request)),
-          signal: controller.signal,
-        });
-        clearTimeout(timeout);
-
-        if (!response.ok) {
-          if (this.retry.retryOn(response.status) && attempt < this.retry.maxRetries) {
-            await delay(delayMs);
-            delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-            attempt += 1;
-            continue;
-          }
-          const message = await response.text();
-          throw new NonRetryableHttpStatusError(response.status, `LLM request failed (${response.status}): ${message}`);
-        }
-
+    return requestWithRetry<OpenAIResponsesResponse>({
+      retry: this.retry,
+      timeoutSeconds: this.config.timeoutSeconds,
+      defaultTimeoutMs: DEFAULT_TIMEOUT_MS,
+      request: (signal) => fetch(this.requestUrl(), {
+        method: 'POST',
+        headers: this.requestHeaders(),
+        body: JSON.stringify(toRequestBody(this.config, request)),
+        signal,
+      }),
+      parseResponse: async (response) => {
         const json = await response.json() as unknown;
         if (!isRecord(json)) {
           throw new Error(`Responses API returned non-object payload: ${JSON.stringify(json)}`);
         }
         return json as OpenAIResponsesResponse;
-      } catch (error) {
-        if (error instanceof NonRetryableHttpStatusError) {
-          throw error;
-        }
-        lastError = error as Error;
-        if (attempt >= this.retry.maxRetries) break;
-        await delay(delayMs);
-        delayMs = Math.min(this.retry.maxDelayMs, delayMs * 2);
-        attempt += 1;
-      }
-    }
-
-    throw lastError ?? new Error('LLM request failed after retries');
+      },
+      buildStatusError: (status, detail) => new NonRetryableHttpStatusError(status, `LLM request failed (${status}): ${detail}`),
+      finalErrorMessage: 'LLM request failed after retries',
+    });
   }
 
   private requestUrl(): string {


### PR DESCRIPTION
## Summary
- extract shared HTTP retry/timeout/backoff orchestration into `packages/agent-sdk-ts/src/sdk/llm/httpRetry.ts`
- rewire `openai-compatible.ts`, `openai-responses.ts`, `anthropic.ts`, and `gemini.ts` to use the shared helper while preserving provider-specific status error messages
- keep response parsing/provider quirks local to each client; only transport retry plumbing is shared

## Validation
- npx vitest run src/sdk/llm/__tests__/retryPolicy.test.ts src/sdk/llm/__tests__/thinkingBlocks.test.ts src/sdk/llm/__tests__/errorMapping.test.ts (in packages/agent-sdk-ts)
- npm run lint -w @openhands/agent-sdk-ts
- npm test -w @openhands/agent-sdk-ts
- npm run typecheck
- npm run lint
- npm test

## Duplication
- `npm run lint:duplication` improved from **1.77% (689/38975, 45 clones)** to **1.59% (620/38887, 43 clones)**
- prior top clone between `openai-compatible.ts` and `openai-responses.ts` is removed from the hotspot list

### Bead
```text

oh-tab-zhwi.7.1: Fix: extract shared LLM streaming/response helpers to reduce provider duplication
Status: in_progress
Priority: P2
Type: task
Created: 2026-02-05 22:35
Updated: 2026-02-06 00:15

Description:
Production duplication scan shows repeated logic across openai-compatible.ts, openai-responses.ts, anthropic.ts, gemini.ts. Extract shared helper(s) for common streaming and response normalization behavior while preserving provider-specific quirks.

Notes:
Started implementation on branch codex/oh-tab-zhwi.7.1-llm-provider-helpers

Acceptance Criteria:
- Duplicate blocks in target files are reduced measurably.\n- LLM provider tests remain green (especially streaming/retry/error mapping).\n- Provider-specific branches remain explicit and tested.

Labels: [agent-sdk-ts architecture duplication llm refactor]

Depends on (1):
  → oh-tab-zhwi.7: Audit: SDK LLM provider layer (packages/agent-sdk-ts/src/sdk/llm/*) [P1]

```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/954" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OpenRouter and LiteLLM Proxy as additional LLM providers.

* **Improvements**
  * Enhanced HTTP request reliability with improved error handling and timeout management across LLM clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-zhwi.7.1`.
- Final gate review on latest head (`9637a32`) reported no blocking findings.
- Bot suggestions were addressed in follow-up (`9637a32`): robust error-body fallback in shared helper + removed Gemini-specific redundant override.
- Reviewer revalidated locally (`lint` + targeted LLM tests + package tests) and confirmed GitHub checks all green.
- Explicit gate decision received: **APPROVED**.
