### PR TITLE
[oh-tab-zhwi.6.2] Deduplicate runtime summarizer helpers

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/fileDiffSummarizer.ts
@@ -4,6 +4,13 @@ import { promisify } from 'node:util';
 import type { ChatCompletionRequest, LLMClient } from '../llm';
 import { getGeminiClient } from './geminiClient';
 import type { SecretRegistry } from './SecretRegistry';
+import {
+  clipTextMiddle,
+  collectStreamedText,
+  maskSecrets,
+  resolveNonNegativeIntOption,
+  truncateSummary,
+} from './summarizerCommon';
 
 const execFileAsync = promisify(execFile);
 
@@ -24,42 +31,11 @@ const DEFAULT_MAX_PROMPT_CHARS = 4_000;
 const DEFAULT_MAX_SUMMARY_CHARS = 5_000;
 const CLIP_MARKER = '<diff clipped>';
 
-const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {
-  if (value === undefined) return defaultValue;
-  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
-  return Math.max(0, Math.trunc(value));
-};
-
-const clipTextMiddle = (text: string, maxChars: number): string => {
-  if (maxChars <= 0) return '';
-  if (text.length <= maxChars) return text;
-  const markerBudget = CLIP_MARKER.length + 2;
-  if (maxChars < markerBudget) return text.slice(0, maxChars);
-  const available = maxChars - markerBudget;
-  const headLen = Math.ceil(available / 2);
-  const tailLen = Math.floor(available / 2);
-  const head = text.slice(0, headLen);
-  const tail = tailLen === 0 ? '' : text.slice(-tailLen);
-  return `${head}\n${CLIP_MARKER}\n${tail}`;
-};
-
 const getLineCount = (text: string): number => {
   if (!text) return 0;
   return text.split('\n').length;
 };
 
-const maskSecrets = (text: string, secrets: SecretRegistry): string => {
-  let masked = text;
-  const values = secrets
-    .getRegisteredValues()
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-    .sort((a, b) => b.length - a.length);
-  for (const value of values) {
-    masked = masked.replaceAll(value, '***');
-  }
-  return masked;
-};
 
 const computeChangedRegion = (oldContent: string, newContent: string) => {
   const oldLines = oldContent.split('\n');
@@ -158,7 +134,7 @@ export async function summarizeFileChangesWithGeminiFlash(
     newChangedText || '(empty)',
   ].join('\n');
 
-  const safePrompt = clipTextMiddle(maskSecrets(rawPrompt, options.secrets), maxPromptChars);
+  const safePrompt = clipTextMiddle(maskSecrets(rawPrompt, options.secrets), maxPromptChars, CLIP_MARKER);
   const request: ChatCompletionRequest = {
     systemPrompt: 'You summarize diffs for an IDE UI.',
     messages: [{ role: 'user', content: [{ type: 'text', text: safePrompt }] }],
@@ -170,14 +146,9 @@ export async function summarizeFileChangesWithGeminiFlash(
       usageId: 'file-diff-summarizer',
       profileId: 'gemini-flash-summarizer',
     }));
-  let text = '';
-  for await (const chunk of client.streamChat(request)) {
-    if (chunk.type === 'text') text += chunk.text;
-  }
+  const text = await collectStreamedText(client, request);
 
   const summary = maskSecrets(text, options.secrets).trim();
   if (!summary) return undefined;
-  if (summary.length <= maxSummaryChars) return summary;
-  if (maxSummaryChars === 1) return '…';
-  return summary.slice(0, maxSummaryChars - 1) + '…';
+  return truncateSummary(summary, maxSummaryChars);
 }

--- a/packages/agent-sdk-ts/src/sdk/runtime/gitChangeSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/gitChangeSummarizer.ts
@@ -4,6 +4,13 @@ import { promisify } from 'node:util';
 import type { ChatCompletionRequest, LLMClient } from '../llm';
 import { getGeminiClient } from './geminiClient';
 import type { SecretRegistry } from './SecretRegistry';
+import {
+  clipTextMiddle,
+  collectStreamedText,
+  maskSecrets,
+  resolveNonNegativeIntOption,
+  truncateSummary,
+} from './summarizerCommon';
 
 const execFileAsync = promisify(execFile);
 
@@ -49,46 +56,6 @@ const DEFAULT_MAX_OVERALL_CHARS = 1_200;
 const DEFAULT_MAX_FILE_SUMMARY_CHARS = 400;
 const DEFAULT_MAX_FILES = 15;
 const CLIP_MARKER = '<diff clipped>';
-
-const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {
-  if (value === undefined) return defaultValue;
-  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
-  return Math.max(0, Math.trunc(value));
-};
-
-const clipTextMiddle = (text: string, maxChars: number): string => {
-  if (maxChars <= 0) return '';
-  if (text.length <= maxChars) return text;
-  const markerBudget = CLIP_MARKER.length + 2;
-  if (maxChars < markerBudget) return text.slice(0, maxChars);
-  const available = maxChars - markerBudget;
-  const headLen = Math.ceil(available / 2);
-  const tailLen = Math.floor(available / 2);
-  const head = text.slice(0, headLen);
-  const tail = tailLen === 0 ? '' : text.slice(-tailLen);
-  return `${head}\n${CLIP_MARKER}\n${tail}`;
-};
-
-const maskSecrets = (text: string, secrets: SecretRegistry): string => {
-  let masked = text;
-  const values = secrets
-    .getRegisteredValues()
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-    .sort((a, b) => b.length - a.length);
-  for (const value of values) {
-    masked = masked.replaceAll(value, '***');
-  }
-  return masked;
-};
-
-const truncateSummary = (text: string, maxChars: number): string => {
-  if (maxChars <= 0) return '';
-  const trimmed = text.trim();
-  if (trimmed.length <= maxChars) return trimmed;
-  if (maxChars === 1) return '…';
-  return trimmed.slice(0, maxChars - 1) + '…';
-};
 
 const defaultExecFileText = async (command: string, args: string[], cwd?: string): Promise<string> => {
   const { stdout } = await execFileAsync(command, args, {
@@ -198,7 +165,7 @@ export async function summarizeGitChangesWithGeminiFlash(
   const patchText = patch.trimEnd();
   if (!nameStatusText && !patchText) return undefined;
 
-  const clippedPatch = clipTextMiddle(patchText, maxDiffChars);
+  const clippedPatch = clipTextMiddle(patchText, maxDiffChars, CLIP_MARKER);
   const rawPrompt = [
     'Summarize a multi-commit git change set for an IDE UI.',
     '',
@@ -219,7 +186,7 @@ export async function summarizeGitChangesWithGeminiFlash(
     clippedPatch || '(empty)',
   ].join('\n');
 
-  const safePrompt = clipTextMiddle(maskSecrets(rawPrompt, options.secrets), maxPromptChars);
+  const safePrompt = clipTextMiddle(maskSecrets(rawPrompt, options.secrets), maxPromptChars, CLIP_MARKER);
   const request: ChatCompletionRequest = {
     systemPrompt: 'You summarize git diffs for an IDE UI.',
     messages: [{ role: 'user', content: [{ type: 'text', text: safePrompt }] }],
@@ -231,10 +198,7 @@ export async function summarizeGitChangesWithGeminiFlash(
       usageId: 'git-change-summarizer',
       profileId: 'gemini-flash-summarizer',
     }));
-  let text = '';
-  for await (const chunk of client.streamChat(request)) {
-    if (chunk.type === 'text') text += chunk.text;
-  }
+  const text = await collectStreamedText(client, request);
 
   const redacted = maskSecrets(text, options.secrets).trim();
   if (!redacted) return undefined;

--- a/packages/agent-sdk-ts/src/sdk/runtime/summarizerCommon.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/summarizerCommon.ts
@@ -1,0 +1,51 @@
+import type { ChatCompletionRequest, LLMClient } from '../llm';
+import type { SecretRegistry } from './SecretRegistry';
+
+export const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {
+  if (value === undefined) return defaultValue;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
+  return Math.max(0, Math.trunc(value));
+};
+
+export const clipTextMiddle = (text: string, maxChars: number, clipMarker: string): string => {
+  if (maxChars <= 0) return '';
+  if (text.length <= maxChars) return text;
+  const markerBudget = clipMarker.length + 2;
+  if (maxChars < markerBudget) return text.slice(0, maxChars);
+  const available = maxChars - markerBudget;
+  const headLen = Math.ceil(available / 2);
+  const tailLen = Math.floor(available / 2);
+  const head = text.slice(0, headLen);
+  const tail = tailLen === 0 ? '' : text.slice(-tailLen);
+  return `${head}\n${clipMarker}\n${tail}`;
+};
+
+export const maskSecrets = (text: string, secrets: SecretRegistry): string => {
+  let masked = text;
+  const values = secrets
+    .getRegisteredValues()
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+    .sort((a, b) => b.length - a.length);
+  for (const value of values) {
+    masked = masked.replaceAll(value, '***');
+  }
+  return masked;
+};
+
+export const truncateSummary = (text: string, maxChars: number): string => {
+  if (maxChars <= 0) return '';
+  if (text.length <= maxChars) return text;
+  if (maxChars === 1) return '…';
+  return text.slice(0, maxChars - 1) + '…';
+};
+
+export const collectStreamedText = async (client: LLMClient, request: ChatCompletionRequest): Promise<string> => {
+  let text = '';
+  for await (const chunk of client.streamChat(request)) {
+    if (chunk.type === 'text') {
+      text += chunk.text;
+    }
+  }
+  return text;
+};

--- a/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/terminalObservationSummarizer.ts
@@ -1,6 +1,13 @@
 import type { ChatCompletionRequest, LLMClient } from '../llm';
 import { getGeminiClient } from './geminiClient';
 import type { SecretRegistry } from './SecretRegistry';
+import {
+  clipTextMiddle,
+  collectStreamedText,
+  maskSecrets,
+  resolveNonNegativeIntOption,
+  truncateSummary,
+} from './summarizerCommon';
 
 export interface TerminalObservationInput {
   command: string;
@@ -25,50 +32,12 @@ const DEFAULT_MAX_PROMPT_CHARS = 6_000;
 const DEFAULT_MAX_SUMMARY_CHARS = 5_000;
 const CLIP_MARKER = '<output clipped>';
 
-const resolveNonNegativeIntOption = (value: unknown, defaultValue: number): number => {
-  if (value === undefined) return defaultValue;
-  if (typeof value !== 'number' || !Number.isFinite(value)) return defaultValue;
-  return Math.max(0, Math.trunc(value));
-};
-
-const clipTextMiddle = (text: string, maxChars: number): string => {
-  if (maxChars <= 0) return '';
-  if (text.length <= maxChars) return text;
-  const markerBudget = CLIP_MARKER.length + 2;
-  if (maxChars < markerBudget) return text.slice(0, maxChars);
-  const available = maxChars - markerBudget;
-  const headLen = Math.ceil(available / 2);
-  const tailLen = Math.floor(available / 2);
-  const head = text.slice(0, headLen);
-  const tail = tailLen === 0 ? '' : text.slice(-tailLen);
-  return `${head}\n${CLIP_MARKER}\n${tail}`;
-};
-
-const maskSecrets = (text: string, secrets: SecretRegistry): string => {
-  let masked = text;
-  const values = secrets
-    .getRegisteredValues()
-    .map((value) => value.trim())
-    .filter((value) => value.length > 0)
-    .sort((a, b) => b.length - a.length);
-  for (const value of values) {
-    masked = masked.replaceAll(value, '***');
-  }
-  return masked;
-};
-
 const summarizeExitCodeFallback = (exitCode: TerminalObservationInput['exit_code']): string => {
   const normalized =
     typeof exitCode === 'number' ? exitCode.toString() : typeof exitCode === 'string' && exitCode.trim() ? exitCode.trim() : 'unknown';
   return normalized === '0' ? 'Done.' : `Done (exit code ${normalized}).`;
 };
 
-const truncateSummary = (text: string, maxChars: number): string => {
-  if (maxChars <= 0) return '';
-  if (text.length <= maxChars) return text;
-  if (maxChars === 1) return '…';
-  return text.slice(0, maxChars - 1) + '…';
-};
 
 export async function summarizeTerminalObservationWithGeminiFlash(
   input: TerminalObservationInput,
@@ -83,7 +52,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
   const stderr = typeof input.stderr === 'string' ? input.stderr.trimEnd() : '';
   const output = stdout && stderr ? `${stdout}\n${stderr}` : stdout || stderr;
 
-  const redactedOutput = clipTextMiddle(maskSecrets(output, options.secrets), maxOutputChars);
+  const redactedOutput = clipTextMiddle(maskSecrets(output, options.secrets), maxOutputChars, CLIP_MARKER);
   const prompt = [
     'Write a concise (1–3 sentence) summary of a terminal command execution performed by an autonomous coding agent.',
     '- Focus on the action taken and key outcome.',
@@ -98,7 +67,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
     redactedOutput || '(empty)',
   ].join('\n');
 
-  const safePrompt = clipTextMiddle(maskSecrets(prompt, options.secrets), maxPromptChars);
+  const safePrompt = clipTextMiddle(maskSecrets(prompt, options.secrets), maxPromptChars, CLIP_MARKER);
   const request: ChatCompletionRequest = {
     systemPrompt: 'You summarize terminal tool results for an IDE UI.',
     messages: [{ role: 'user', content: [{ type: 'text', text: safePrompt }] }],
@@ -111,10 +80,7 @@ export async function summarizeTerminalObservationWithGeminiFlash(
         usageId: 'terminal-observation-summarizer',
         profileId: 'gemini-flash-summarizer',
       }));
-    let text = '';
-    for await (const chunk of client.streamChat(request)) {
-      if (chunk.type === 'text') text += chunk.text;
-    }
+    const text = await collectStreamedText(client, request);
     const summary = maskSecrets(text, options.secrets).trim();
     if (!summary) return fallback;
     return truncateSummary(summary, maxSummaryChars);


### PR DESCRIPTION
## Summary
- add shared runtime summarizer utilities in `packages/agent-sdk-ts/src/sdk/runtime/summarizerCommon.ts`
- deduplicate option parsing, middle clipping, secret masking, truncation, and streamed-text collection across:
  - `terminalObservationSummarizer.ts`
  - `fileDiffSummarizer.ts`
  - `gitChangeSummarizer.ts`
- preserve existing fallback/summary behavior while reducing repeated prompt+parse plumbing

## Validation
- npx vitest run src/sdk/runtime/__tests__/terminalObservationSummarizer.test.ts src/sdk/runtime/__tests__/fileDiffSummarizer.test.ts src/sdk/runtime/__tests__/gitChangeSummarizer.test.ts (in packages/agent-sdk-ts)
- npm run lint -w @openhands/agent-sdk-ts
- npm test -w @openhands/agent-sdk-ts
- npm run typecheck
- npm run lint:duplication

### Bead
```text

oh-tab-zhwi.6.2: Fix: deduplicate summarizer prompt/parse pipelines in sdk/runtime
Status: in_progress
Priority: P2
Type: task
Created: 2026-02-05 22:35
Updated: 2026-02-06 00:32

Description:
Production duplication scan shows overlap between terminalObservationSummarizer.ts, gitChangeSummarizer.ts, and fileDiffSummarizer.ts. Introduce shared utilities for prompt construction, fenced-JSON extraction, and fallback handling.

Notes:
Started implementation on branch codex/oh-tab-zhwi.6.2-summarizer-dedupe

Acceptance Criteria:
- Duplicate code in summarizer modules is reduced.\n- Runtime summarizer tests remain green.\n- Behavior for malformed/partial model output stays stable.

Labels: [agent-sdk-ts architecture duplication refactor runtime]

Depends on (1):
  → oh-tab-zhwi.6: Audit: SDK runtime architecture (packages/agent-sdk-ts/src/sdk/runtime/*) [P1]

```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/955" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
### Review
- Reviewer `PinkStone` provided explicit **APPROVED** gate decision in Agent Mail thread `oh-tab-zhwi.6.2` (message `5032`).
- Reviewer local validation: `npm run lint -w @openhands/agent-sdk-ts`, targeted runtime summarizer tests, and `npm test -w @openhands/agent-sdk-ts`.
- GitHub checks were all green (`build`, `test`, `agent-server-e2e`, `e2e`, `e2e-ui`).
- Addressed process hygiene: resolved the remaining non-blocking Gemini review thread (performance suggestion) without scope expansion for this bead.
