### PR TITLE
[oh-tab-zhwi.5.1] Decouple shared settings message types

### DIFF
--- a/src/settings/SettingsManager.ts
+++ b/src/settings/SettingsManager.ts
@@ -1,54 +1,13 @@
-import type { SettingsAdapter, LLMSettings, ServerSettings, AgentSettings, ConversationSettings, ConfirmationSettings } from './SettingsAdapter';
+import type { SettingsAdapter } from './SettingsAdapter';
 import type { HalMode } from '../shared/halTypes';
+import type { HalSettings, OpenHandsSettings, SavedServer } from '../shared/settingsTypes';
 import { DEFAULT_HAL_LLM_PROFILE_ID } from '../shared/halDefaults';
 import { normalizeServerUrl } from '../shared/serverUrls';
 import { normalizeNonEmptyString } from '../shared/stringUtils';
+import type { AgentSettings, ConfirmationSettings, ConversationSettings, LLMSettings } from '@openhands/agent-sdk-ts';
 import { detectProviderFromBaseUrl, ensureDefaultProfiles, listProfiles, loadProfile } from '@openhands/agent-sdk-ts';
 
-export interface SavedServer {
-  url: string;
-  label?: string;
-}
-
-export type HalSettings = {
-  enabled: boolean;
-  mode: HalMode;
-  llmProfileId: string;
-  userName: string;
-  voiceAId?: string;
-  voiceUserId?: string;
-  modelId?: string;
-  volume: number;
-  cache: boolean;
-};
-
-export type OpenHandsSettings = ServerSettings & {
-  llm: LLMSettings;
-  oracle?: { profileId?: string | null };
-  agent: AgentSettings;
-  conversation: ConversationSettings;
-  confirmation: ConfirmationSettings;
-  hal: HalSettings;
-  servers: SavedServer[];
-  secrets: {
-    /**
-     * Remote-mode credentials are injected by the extension host at runtime.
-     *
-     * These values are intentionally not persisted via `SettingsManager.update()` because they
-     * live in per-server VS Code SecretStorage slots.
-     */
-    cloudApiKey?: string;
-    runtimeSessionApiKey?: string;
-    llmApiKey?: string;
-    awsAccessKeyId?: string;
-    awsSecretAccessKey?: string;
-    githubToken?: string;
-    halTtsApiKey?: string;
-    customSecret1?: string;
-    customSecret2?: string;
-    customSecret3?: string;
-  };
-};
+export type { HalSettings, OpenHandsSettings, SavedServer } from '../shared/settingsTypes';
 
 const DEFAULTS: OpenHandsSettings = {
   serverUrl: '',

--- a/src/shared/settingsTypes.ts
+++ b/src/shared/settingsTypes.ts
@@ -1,0 +1,55 @@
+import type {
+  AgentSettings,
+  ConfirmationSettings,
+  ConversationSettings,
+  LLMSettings,
+  ServerSettings,
+} from '@openhands/agent-sdk-ts';
+import type { HalMode } from './halTypes';
+
+export interface SavedServer {
+  url: string;
+  label?: string;
+}
+
+export type HalSettings = {
+  enabled: boolean;
+  mode: HalMode;
+  llmProfileId: string;
+  userName: string;
+  voiceAId?: string;
+  voiceUserId?: string;
+  modelId?: string;
+  volume: number;
+  cache: boolean;
+};
+
+export type OpenHandsSettingsSecrets = {
+  /**
+   * Remote-mode credentials are injected by the extension host at runtime.
+   *
+   * These values are intentionally not persisted via `SettingsManager.update()`
+   * because they live in per-server VS Code SecretStorage slots.
+   */
+  cloudApiKey?: string;
+  runtimeSessionApiKey?: string;
+  llmApiKey?: string;
+  awsAccessKeyId?: string;
+  awsSecretAccessKey?: string;
+  githubToken?: string;
+  halTtsApiKey?: string;
+  customSecret1?: string;
+  customSecret2?: string;
+  customSecret3?: string;
+};
+
+export type OpenHandsSettings = ServerSettings & {
+  llm: LLMSettings;
+  oracle?: { profileId?: string | null };
+  agent: AgentSettings;
+  conversation: ConversationSettings;
+  confirmation: ConfirmationSettings;
+  hal: HalSettings;
+  servers: SavedServer[];
+  secrets: OpenHandsSettingsSecrets;
+};

--- a/src/shared/webviewMessages.ts
+++ b/src/shared/webviewMessages.ts
@@ -1,6 +1,6 @@
 import type { BashEvent, Event } from '@openhands/agent-sdk-ts';
 import type { LLMConfiguration } from '@openhands/agent-sdk-ts';
-import type { OpenHandsSettings, SavedServer } from '../settings/SettingsManager';
+import type { HalSettings, SavedServer } from './settingsTypes';
 
 /** Default auto-dismiss delay for transient status messages (in milliseconds). */
 export const STATUS_MESSAGE_DISMISS_DELAY_MS = 5000;
@@ -48,7 +48,7 @@ export type HostToWebviewMessage =
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: true; profileId: string }
   | { type: 'llmProfileApiKeySetResponse'; requestId: string; ok: false; profileId: string; error: string }
   | { type: 'serverListUpdated'; servers: SavedServer[]; serverUrl: string }
-  | { type: 'halSettings'; hal: OpenHandsSettings['hal'] }
+  | { type: 'halSettings'; hal: HalSettings }
   | {
     type: 'historyList';
     conversations: Array<{

--- a/src/shared/welcomeSecretStatus.ts
+++ b/src/shared/welcomeSecretStatus.ts
@@ -1,6 +1,6 @@
 import type * as vscode from 'vscode';
 import { listProfiles } from '@openhands/agent-sdk-ts';
-import type { OpenHandsSettings } from '../settings/SettingsManager';
+import type { OpenHandsSettings } from './settingsTypes';
 
 const PROVIDER_STORAGE_KEYS = [
   'OPENAI_API_KEY',
@@ -60,4 +60,3 @@ export async function computeWelcomeSecretStatus(args: {
   const hasProviderKey = hasGeminiKey || hasGenericKey || hasAnyProviderStorageKey || hasAnyProfileKey;
   return { hasProviderKey, hasGeminiKey };
 }
-


### PR DESCRIPTION
## Summary
- add `src/shared/settingsTypes.ts` as a boundary-safe shared type module for transport-facing settings/server shapes
- migrate `src/shared/webviewMessages.ts` and `src/shared/welcomeSecretStatus.ts` to import from the new shared types module instead of `src/settings/SettingsManager.ts`
- keep `SettingsManager` as a compatibility export surface by re-exporting `OpenHandsSettings`, `SavedServer`, and `HalSettings`

## Validation
- `npx vitest run src/settings/__tests__/SettingsManager.test.ts src/webview-src/__tests__/event.handlers.test.tsx`
- `npm run typecheck`
- `npm run lint`

### Bead
ID: `oh-tab-zhwi.5.1`
Title: Decouple shared message types from SettingsManager types
Description: Move transport-facing settings/server type aliases used by shared/webview messaging into a neutral shared type module, and update shared/webviewMessages.ts + shared/welcomeSecretStatus.ts to import from that boundary-safe location instead of SettingsManager.ts.
Acceptance criteria:
- src/shared no longer imports from src/settings/SettingsManager.ts.
- Host/webview message type contracts remain unchanged for callers.
- Typecheck and existing host/webview tests remain green.
### Review
- Reviewer `PinkStone` provided explicit **APPROVED** gate decision in Agent Mail thread `oh-tab-zhwi.5.1` (message `5033`).
- Reviewer local validation: targeted settings/webview tests, `npm run typecheck`, and `npm run lint`.
- GitHub checks were all green (`build`, `test`, `agent-server-e2e`, `e2e`, `e2e-ui`).
- Addressed process hygiene: resolved the remaining non-blocking Gemini review thread (type-consistency suggestion) without widening scope.
