### PR TITLE
[oh-tab-zhwi.3.3] Extract HAL voice-confirm hook

### DIFF
--- a/src/webview-src/components/app/halFlow/useHalVoiceConfirm.ts
+++ b/src/webview-src/components/app/halFlow/useHalVoiceConfirm.ts
@@ -20,6 +20,17 @@ interface UseHalVoiceConfirmArgs {
   halVoiceConfirmFallbackKey: string | null;
 }
 
+const stopStreamTracks = (stream: MediaStream | null) => {
+  if (!stream) return;
+  for (const track of stream.getTracks()) {
+    try {
+      track.stop();
+    } catch {
+      // ignore
+    }
+  }
+};
+
 export function useHalVoiceConfirm({
   halPhaseRef,
   halSettingsRef,
@@ -59,15 +70,7 @@ export function useHalVoiceConfirm({
     halVoiceRecorderRef.current = null;
     halVoiceChunksRef.current = [];
     const stream = halVoiceStreamRef.current;
-    if (stream) {
-      for (const track of stream.getTracks()) {
-        try {
-          track.stop();
-        } catch {
-          // ignore
-        }
-      }
-    }
+    stopStreamTracks(stream);
     halVoiceStreamRef.current = null;
     halVoiceConfirmRequestIdRef.current = null;
   }, []);
@@ -116,13 +119,7 @@ export function useHalVoiceConfirm({
       }
 
       if (halPhaseRef.current !== 'listening' || getHalConversationKey() !== conversationKey || halActiveKeyRef.current !== sessionKey) {
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {
-            // ignore
-          }
-        }
+        stopStreamTracks(stream);
         return;
       }
 
@@ -139,13 +136,7 @@ export function useHalVoiceConfirm({
         recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {
-            // ignore
-          }
-        }
+        stopStreamTracks(stream);
         disableVoiceConfirmForConversation(`Microphone recording is not supported: ${reason}`);
         return;
       }
@@ -167,15 +158,7 @@ export function useHalVoiceConfirm({
           halVoiceRecorderRef.current = null;
           const activeStream = halVoiceStreamRef.current;
           halVoiceStreamRef.current = null;
-          if (activeStream) {
-            for (const track of activeStream.getTracks()) {
-              try {
-                track.stop();
-              } catch {
-                // ignore
-              }
-            }
-          }
+          stopStreamTracks(activeStream);
 
           if (shouldDiscard) return;
           if (chunks.length === 0) {
@@ -217,13 +200,7 @@ export function useHalVoiceConfirm({
         recorder.start();
       } catch (err) {
         const reason = err instanceof Error ? err.message : String(err);
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {
-            // ignore
-          }
-        }
+        stopStreamTracks(stream);
         disableVoiceConfirmForConversation(`Failed to start recording: ${reason}`);
       }
     })();
@@ -277,14 +254,15 @@ export function useHalVoiceConfirm({
   }, [cleanupHalVoiceConfirm, getHalConversationKey, resetHalUiState, setHalVoiceConfirmFallbackKey, showStatusMessage]);
 
   const handleHalVoiceConfirmResponse = useCallback((payload: unknown, onDecision: (decision: HalDecision) => void) => {
+    if (typeof payload !== 'object' || payload === null) return;
+    const parsedPayload = payload as Record<string, unknown>;
+
     const currentRequestId = halVoiceConfirmRequestIdRef.current;
-    const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
-    if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) return;
+    if (!currentRequestId || typeof parsedPayload.requestId !== 'string' || parsedPayload.requestId !== currentRequestId) return;
     halVoiceConfirmRequestIdRef.current = null;
 
-    const ok = (payload as { ok?: unknown } | undefined)?.ok;
-    if (ok === true) {
-      const decisionRaw = (payload as { decision?: unknown } | undefined)?.decision;
+    if (parsedPayload.ok === true) {
+      const decisionRaw = parsedPayload.decision;
       if (!isHalDecision(decisionRaw)) {
         disableVoiceConfirmForConversation('Gemini returned an invalid decision. Using buttons instead.');
         return;
@@ -294,7 +272,7 @@ export function useHalVoiceConfirm({
       return;
     }
 
-    const error = (payload as { error?: unknown } | undefined)?.error;
+    const error = parsedPayload.error;
     const message = typeof error === 'string' && error.trim() ? error.trim() : 'Gemini classification failed';
     disableVoiceConfirmForConversation(message);
   }, [disableVoiceConfirmForConversation]);

--- a/src/webview-src/components/app/halFlow/useHalVoiceConfirm.ts
+++ b/src/webview-src/components/app/halFlow/useHalVoiceConfirm.ts
@@ -1,0 +1,310 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { isHalDecision, type HalDecision, type HalEye, type HalPhase } from '../../../../shared/halTypes';
+import type { WebviewToHostMessage } from '../../../../shared/webviewMessages';
+import type { ShowStatusMessage } from '../useStatusMessages';
+import { blobToBase64 } from './blobToBase64';
+import type { HalSettingsSnapshot, HalUiState } from './types';
+
+interface UseHalVoiceConfirmArgs {
+  halPhaseRef: React.MutableRefObject<HalPhase>;
+  halSettingsRef: React.MutableRefObject<HalSettingsSnapshot>;
+  halActiveKeyRef: React.MutableRefObject<string | null>;
+  getHalConversationKey: () => string;
+  postMessage: (msg: WebviewToHostMessage) => void;
+  showStatusMessage: ShowStatusMessage;
+  resetHalUiState: (overrides?: Partial<HalUiState>) => void;
+  setHalPhase: React.Dispatch<React.SetStateAction<HalPhase>>;
+  setHalEye: React.Dispatch<React.SetStateAction<HalEye>>;
+  setHalLastError: React.Dispatch<React.SetStateAction<string | null>>;
+  setHalVoiceConfirmFallbackKey: React.Dispatch<React.SetStateAction<string | null>>;
+  halVoiceConfirmFallbackKey: string | null;
+}
+
+export function useHalVoiceConfirm({
+  halPhaseRef,
+  halSettingsRef,
+  halActiveKeyRef,
+  getHalConversationKey,
+  postMessage,
+  showStatusMessage,
+  resetHalUiState,
+  setHalPhase,
+  setHalEye,
+  setHalLastError,
+  setHalVoiceConfirmFallbackKey,
+  halVoiceConfirmFallbackKey,
+}: UseHalVoiceConfirmArgs) {
+  const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
+  const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
+  const halVoiceConfirmSeqRef = useRef(0);
+  const halVoiceDiscardNextStopRef = useRef(false);
+  const halVoiceStreamRef = useRef<MediaStream | null>(null);
+  const halVoiceRecorderRef = useRef<MediaRecorder | null>(null);
+  const halVoiceChunksRef = useRef<Blob[]>([]);
+
+  useEffect(() => {
+    halVoiceConfirmFallbackKeyRef.current = halVoiceConfirmFallbackKey;
+  }, [halVoiceConfirmFallbackKey]);
+
+  const cleanupHalVoiceConfirm = useCallback(() => {
+    const recorder = halVoiceRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      try {
+        halVoiceDiscardNextStopRef.current = true;
+        recorder.stop();
+      } catch {
+        // ignore
+      }
+    }
+    halVoiceRecorderRef.current = null;
+    halVoiceChunksRef.current = [];
+    const stream = halVoiceStreamRef.current;
+    if (stream) {
+      for (const track of stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          // ignore
+        }
+      }
+    }
+    halVoiceStreamRef.current = null;
+    halVoiceConfirmRequestIdRef.current = null;
+  }, []);
+
+  const disableVoiceConfirmForConversation = useCallback((message: string) => {
+    const key = getHalConversationKey();
+    setHalVoiceConfirmFallbackKey(key);
+    halVoiceConfirmFallbackKeyRef.current = key;
+    cleanupHalVoiceConfirm();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', lastError: message });
+    showStatusMessage('warn', message);
+  }, [cleanupHalVoiceConfirm, getHalConversationKey, resetHalUiState, setHalVoiceConfirmFallbackKey, showStatusMessage]);
+
+  const handleStartVoiceConfirm = useCallback(() => {
+    void (async () => {
+      if (halPhaseRef.current !== 'awaiting_user') return;
+      if (halSettingsRef.current.mode !== 'voice_confirm') return;
+      if (halVoiceConfirmFallbackKeyRef.current === getHalConversationKey()) return;
+      if (
+        typeof navigator === 'undefined' ||
+        typeof navigator.mediaDevices?.getUserMedia !== 'function' ||
+        typeof MediaRecorder === 'undefined'
+      ) {
+        disableVoiceConfirmForConversation('Microphone is unavailable in this environment. Using buttons instead.');
+        return;
+      }
+
+      const conversationKey = getHalConversationKey();
+      const sessionKey = halActiveKeyRef.current;
+
+      cleanupHalVoiceConfirm();
+      halVoiceDiscardNextStopRef.current = false;
+      halVoiceChunksRef.current = [];
+      setHalLastError(null);
+      halPhaseRef.current = 'listening';
+      setHalPhase('listening');
+      setHalEye('pulsating');
+
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        disableVoiceConfirmForConversation(`Microphone permission denied or unavailable: ${reason}`);
+        return;
+      }
+
+      if (halPhaseRef.current !== 'listening' || getHalConversationKey() !== conversationKey || halActiveKeyRef.current !== sessionKey) {
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {
+            // ignore
+          }
+        }
+        return;
+      }
+
+      const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus'];
+      const mimeType = candidates.find((type) => {
+        try {
+          return MediaRecorder.isTypeSupported(type);
+        } catch {
+          return false;
+        }
+      });
+      let recorder: MediaRecorder;
+      try {
+        recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {
+            // ignore
+          }
+        }
+        disableVoiceConfirmForConversation(`Microphone recording is not supported: ${reason}`);
+        return;
+      }
+
+      halVoiceStreamRef.current = stream;
+      halVoiceRecorderRef.current = recorder;
+      recorder.ondataavailable = (event) => {
+        if (event.data && event.data.size > 0) {
+          halVoiceChunksRef.current.push(event.data);
+        }
+      };
+      recorder.onstop = () => {
+        void (async () => {
+          const shouldDiscard = halVoiceDiscardNextStopRef.current;
+          halVoiceDiscardNextStopRef.current = false;
+
+          const chunks = halVoiceChunksRef.current;
+          halVoiceChunksRef.current = [];
+          halVoiceRecorderRef.current = null;
+          const activeStream = halVoiceStreamRef.current;
+          halVoiceStreamRef.current = null;
+          if (activeStream) {
+            for (const track of activeStream.getTracks()) {
+              try {
+                track.stop();
+              } catch {
+                // ignore
+              }
+            }
+          }
+
+          if (shouldDiscard) return;
+          if (chunks.length === 0) {
+            disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+            return;
+          }
+
+          try {
+            const blob = new Blob(chunks, { type: recorder.mimeType || mimeType || 'audio/webm' });
+            if (blob.size === 0) {
+              disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+              return;
+            }
+            const audioBase64 = await blobToBase64(blob);
+            if (!audioBase64) {
+              disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
+              return;
+            }
+            const requestId = `halVoiceConfirm:${Date.now().toString(36)}:${(halVoiceConfirmSeqRef.current++).toString(36)}`;
+            halVoiceConfirmRequestIdRef.current = requestId;
+            setHalLastError(null);
+            halPhaseRef.current = 'classifying';
+            setHalPhase('classifying');
+            setHalEye('pulsating');
+            postMessage({
+              type: 'halVoiceConfirmRequest',
+              requestId,
+              mimeType: blob.type || 'audio/webm',
+              audioBase64,
+            });
+          } catch (err) {
+            const reason = err instanceof Error ? err.message : String(err);
+            disableVoiceConfirmForConversation(`Failed to process recorded audio: ${reason}`);
+          }
+        })();
+      };
+
+      try {
+        recorder.start();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        for (const track of stream.getTracks()) {
+          try {
+            track.stop();
+          } catch {
+            // ignore
+          }
+        }
+        disableVoiceConfirmForConversation(`Failed to start recording: ${reason}`);
+      }
+    })();
+  }, [
+    cleanupHalVoiceConfirm,
+    disableVoiceConfirmForConversation,
+    getHalConversationKey,
+    halActiveKeyRef,
+    halPhaseRef,
+    halSettingsRef,
+    postMessage,
+    setHalEye,
+    setHalLastError,
+    setHalPhase,
+  ]);
+
+  const handleStopVoiceConfirm = useCallback(() => {
+    if (halPhaseRef.current !== 'listening') return;
+    const recorder = halVoiceRecorderRef.current;
+    if (!recorder || recorder.state === 'inactive') return;
+    try {
+      recorder.stop();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      disableVoiceConfirmForConversation(`Failed to stop recording: ${reason}`);
+    }
+  }, [disableVoiceConfirmForConversation, halPhaseRef]);
+
+  const handleCancelVoiceConfirm = useCallback(() => {
+    if (halPhaseRef.current !== 'listening') return;
+    halVoiceDiscardNextStopRef.current = true;
+    const recorder = halVoiceRecorderRef.current;
+    if (recorder && recorder.state !== 'inactive') {
+      try {
+        recorder.stop();
+      } catch {
+        // ignore
+      }
+    }
+    cleanupHalVoiceConfirm();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating' });
+  }, [cleanupHalVoiceConfirm, halPhaseRef, resetHalUiState]);
+
+  const handleUseButtonsInstead = useCallback(() => {
+    const key = getHalConversationKey();
+    setHalVoiceConfirmFallbackKey(key);
+    halVoiceConfirmFallbackKeyRef.current = key;
+    cleanupHalVoiceConfirm();
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating' });
+    showStatusMessage('info', 'Switched to button decision for this conversation.');
+  }, [cleanupHalVoiceConfirm, getHalConversationKey, resetHalUiState, setHalVoiceConfirmFallbackKey, showStatusMessage]);
+
+  const handleHalVoiceConfirmResponse = useCallback((payload: unknown, onDecision: (decision: HalDecision) => void) => {
+    const currentRequestId = halVoiceConfirmRequestIdRef.current;
+    const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
+    if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) return;
+    halVoiceConfirmRequestIdRef.current = null;
+
+    const ok = (payload as { ok?: unknown } | undefined)?.ok;
+    if (ok === true) {
+      const decisionRaw = (payload as { decision?: unknown } | undefined)?.decision;
+      if (!isHalDecision(decisionRaw)) {
+        disableVoiceConfirmForConversation('Gemini returned an invalid decision. Using buttons instead.');
+        return;
+      }
+
+      onDecision(decisionRaw);
+      return;
+    }
+
+    const error = (payload as { error?: unknown } | undefined)?.error;
+    const message = typeof error === 'string' && error.trim() ? error.trim() : 'Gemini classification failed';
+    disableVoiceConfirmForConversation(message);
+  }, [disableVoiceConfirmForConversation]);
+
+  return {
+    cleanupHalVoiceConfirm,
+    handleStartVoiceConfirm,
+    handleStopVoiceConfirm,
+    handleCancelVoiceConfirm,
+    handleUseButtonsInstead,
+    handleHalVoiceConfirmResponse,
+  };
+}

--- a/src/webview-src/components/app/useHalFlow.ts
+++ b/src/webview-src/components/app/useHalFlow.ts
@@ -2,12 +2,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ActionEvent } from '@openhands/agent-sdk-ts';
 import { getHalDialogueLinesForMode, type HalScriptLine } from '../../../shared/halScript';
 import { DEFAULT_HAL_STATE } from '../../../shared/halDefaults';
-import { isHalDecision, isHalMode, type HalDecision, type HalEye, type HalPhase, type HalStateSnapshot } from '../../../shared/halTypes';
+import { isHalMode, type HalDecision, type HalEye, type HalPhase, type HalStateSnapshot } from '../../../shared/halTypes';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import type { ShowStatusMessage } from './useStatusMessages';
-import { blobToBase64 } from './halFlow/blobToBase64';
 import { DEFAULT_HAL_SETTINGS, DEFAULT_HAL_UI_STATE, type HalSettingsSnapshot, type HalUiState } from './halFlow/types';
 import { useHalBundledAudioEffects } from './halFlow/useHalBundledAudio';
+import { useHalVoiceConfirm } from './halFlow/useHalVoiceConfirm';
 
 export type { HalSettingsSnapshot };
 
@@ -44,13 +44,6 @@ export function useHalFlow(deps: {
   const halAudioUrlRef = useRef<string | null>(null);
   const halAudioPlayTokenRef = useRef(0);
   const halTtsRequestSeqRef = useRef(0);
-  const halVoiceConfirmFallbackKeyRef = useRef<string | null>(null);
-  const halVoiceConfirmRequestIdRef = useRef<string | null>(null);
-  const halVoiceConfirmSeqRef = useRef(0);
-  const halVoiceDiscardNextStopRef = useRef(false);
-  const halVoiceStreamRef = useRef<MediaStream | null>(null);
-  const halVoiceRecorderRef = useRef<MediaRecorder | null>(null);
-  const halVoiceChunksRef = useRef<Blob[]>([]);
   const halActiveKeyRef = useRef<string | null>(null);
   const halEnabledRef = useRef<boolean>(false);
   const halPhaseRef = useRef<HalPhase>('idle');
@@ -74,16 +67,14 @@ export function useHalFlow(deps: {
   }, [halSuppressedKey]);
 
   useEffect(() => {
-    halVoiceConfirmFallbackKeyRef.current = halVoiceConfirmFallbackKey;
-  }, [halVoiceConfirmFallbackKey]);
-
-  useEffect(() => {
     halSettingsRef.current = halSettings;
   }, [halSettings]);
 
   useEffect(() => {
     halStepIndexRef.current = halStepIndex;
   }, [halStepIndex]);
+
+  const getHalConversationKey = useCallback(() => deps.conversationIdRef.current ?? 'unknown', [deps.conversationIdRef]);
 
   const stopHalAudio = useCallback(() => {
     halAudioPlayTokenRef.current += 1;
@@ -102,28 +93,6 @@ export function useHalFlow(deps: {
     }
     halTtsRequestIdRef.current = null;
     halTtsRequestedKeyRef.current = null;
-  }, []);
-
-  const cleanupHalVoiceConfirm = useCallback(() => {
-    const recorder = halVoiceRecorderRef.current;
-    if (recorder && recorder.state !== 'inactive') {
-      try {
-        halVoiceDiscardNextStopRef.current = true;
-        recorder.stop();
-      } catch {}
-    }
-    halVoiceRecorderRef.current = null;
-    halVoiceChunksRef.current = [];
-    const stream = halVoiceStreamRef.current;
-    if (stream) {
-      for (const track of stream.getTracks()) {
-        try {
-          track.stop();
-        } catch {}
-      }
-    }
-    halVoiceStreamRef.current = null;
-    halVoiceConfirmRequestIdRef.current = null;
   }, []);
 
   const clearHalTimer = useCallback(() => {
@@ -148,6 +117,28 @@ export function useHalFlow(deps: {
     setHalLastError(next.lastError);
   }, []);
 
+  const {
+    cleanupHalVoiceConfirm,
+    handleStartVoiceConfirm,
+    handleStopVoiceConfirm,
+    handleCancelVoiceConfirm,
+    handleUseButtonsInstead,
+    handleHalVoiceConfirmResponse: consumeHalVoiceConfirmResponse,
+  } = useHalVoiceConfirm({
+    halPhaseRef,
+    halSettingsRef,
+    halActiveKeyRef,
+    getHalConversationKey,
+    postMessage: deps.postMessage,
+    showStatusMessage: deps.showStatusMessage,
+    resetHalUiState,
+    setHalPhase,
+    setHalEye,
+    setHalLastError,
+    setHalVoiceConfirmFallbackKey,
+    halVoiceConfirmFallbackKey,
+  });
+
   const cleanupHalFlow = useCallback(() => {
     clearHalTimer();
     stopHalAudio();
@@ -162,8 +153,6 @@ export function useHalFlow(deps: {
   useEffect(() => {
     halDialogueRef.current = halDialogueLines;
   }, [halDialogueLines]);
-
-  const getHalConversationKey = useCallback(() => deps.conversationIdRef.current ?? 'unknown', [deps.conversationIdRef]);
 
   const maybeUpdateHalFlow = useCallback(() => {
     if (halTeleportInProgressRef.current) return;
@@ -304,191 +293,6 @@ export function useHalFlow(deps: {
     requestHalTts({ conversationId: convoId, stepIndex: halStepIndex });
   }, [deps.conversationIdRef, halDisabledConversationId, halPhase, halStepIndex, requestHalTts]);
 
-  const disableVoiceConfirmForConversation = useCallback((message: string) => {
-    const key = getHalConversationKey();
-    setHalVoiceConfirmFallbackKey(key);
-    halVoiceConfirmFallbackKeyRef.current = key;
-    cleanupHalVoiceConfirm();
-    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', lastError: message });
-    deps.showStatusMessage('warn', message);
-  }, [cleanupHalVoiceConfirm, deps.showStatusMessage, getHalConversationKey, resetHalUiState]);
-
-  const handleStartVoiceConfirm = useCallback(() => {
-    void (async () => {
-      if (halPhaseRef.current !== 'awaiting_user') return;
-      if (halSettingsRef.current.mode !== 'voice_confirm') return;
-      if (halVoiceConfirmFallbackKeyRef.current === getHalConversationKey()) return;
-      if (
-        typeof navigator === 'undefined' ||
-        typeof navigator.mediaDevices?.getUserMedia !== 'function' ||
-        typeof MediaRecorder === 'undefined'
-      ) {
-        disableVoiceConfirmForConversation('Microphone is unavailable in this environment. Using buttons instead.');
-        return;
-      }
-
-      const conversationKey = getHalConversationKey();
-      const sessionKey = halActiveKeyRef.current;
-
-      cleanupHalVoiceConfirm();
-      halVoiceDiscardNextStopRef.current = false;
-      halVoiceChunksRef.current = [];
-      setHalLastError(null);
-      halPhaseRef.current = 'listening';
-      setHalPhase('listening');
-      setHalEye('pulsating');
-
-      let stream: MediaStream;
-      try {
-        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        disableVoiceConfirmForConversation(`Microphone permission denied or unavailable: ${reason}`);
-        return;
-      }
-
-      if (halPhaseRef.current !== 'listening' || getHalConversationKey() !== conversationKey || halActiveKeyRef.current !== sessionKey) {
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {}
-        }
-        return;
-      }
-
-      const candidates = ['audio/webm;codecs=opus', 'audio/webm', 'audio/ogg;codecs=opus'];
-      const mimeType = candidates.find((t) => {
-        try {
-          return MediaRecorder.isTypeSupported(t);
-        } catch {
-          return false;
-        }
-      });
-      let recorder: MediaRecorder;
-      try {
-        recorder = mimeType ? new MediaRecorder(stream, { mimeType }) : new MediaRecorder(stream);
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {}
-        }
-        disableVoiceConfirmForConversation(`Microphone recording is not supported: ${reason}`);
-        return;
-      }
-
-      halVoiceStreamRef.current = stream;
-      halVoiceRecorderRef.current = recorder;
-      recorder.ondataavailable = (e) => {
-        if (e.data && e.data.size > 0) {
-          halVoiceChunksRef.current.push(e.data);
-        }
-      };
-      recorder.onstop = () => {
-        void (async () => {
-          const shouldDiscard = halVoiceDiscardNextStopRef.current;
-          halVoiceDiscardNextStopRef.current = false;
-
-          const chunks = halVoiceChunksRef.current;
-          halVoiceChunksRef.current = [];
-          halVoiceRecorderRef.current = null;
-          const activeStream = halVoiceStreamRef.current;
-          halVoiceStreamRef.current = null;
-          if (activeStream) {
-            for (const track of activeStream.getTracks()) {
-              try {
-                track.stop();
-              } catch {}
-            }
-          }
-
-          if (shouldDiscard) return;
-          if (chunks.length === 0) {
-            disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
-            return;
-          }
-
-          try {
-            const blob = new Blob(chunks, { type: recorder.mimeType || mimeType || 'audio/webm' });
-            if (blob.size === 0) {
-              disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
-              return;
-            }
-            const audioBase64 = await blobToBase64(blob);
-            if (!audioBase64) {
-              disableVoiceConfirmForConversation('No audio was captured. Using buttons instead.');
-              return;
-            }
-            const requestId = `halVoiceConfirm:${Date.now().toString(36)}:${(halVoiceConfirmSeqRef.current++).toString(36)}`;
-            halVoiceConfirmRequestIdRef.current = requestId;
-            setHalLastError(null);
-            halPhaseRef.current = 'classifying';
-            setHalPhase('classifying');
-            setHalEye('pulsating');
-            deps.postMessage({
-              type: 'halVoiceConfirmRequest',
-              requestId,
-              mimeType: blob.type || 'audio/webm',
-              audioBase64,
-            });
-          } catch (err) {
-            const reason = err instanceof Error ? err.message : String(err);
-            disableVoiceConfirmForConversation(`Failed to process recorded audio: ${reason}`);
-          }
-        })();
-      };
-
-      try {
-        recorder.start();
-      } catch (err) {
-        const reason = err instanceof Error ? err.message : String(err);
-        for (const track of stream.getTracks()) {
-          try {
-            track.stop();
-          } catch {}
-        }
-        disableVoiceConfirmForConversation(`Failed to start recording: ${reason}`);
-        return;
-      }
-    })();
-  }, [cleanupHalVoiceConfirm, deps.postMessage, disableVoiceConfirmForConversation, getHalConversationKey]);
-
-  const handleStopVoiceConfirm = useCallback(() => {
-    if (halPhaseRef.current !== 'listening') return;
-    const recorder = halVoiceRecorderRef.current;
-    if (!recorder) return;
-    if (recorder.state === 'inactive') return;
-    try {
-      recorder.stop();
-    } catch (err) {
-      const reason = err instanceof Error ? err.message : String(err);
-      disableVoiceConfirmForConversation(`Failed to stop recording: ${reason}`);
-    }
-  }, [disableVoiceConfirmForConversation]);
-
-  const handleCancelVoiceConfirm = useCallback(() => {
-    if (halPhaseRef.current !== 'listening') return;
-    halVoiceDiscardNextStopRef.current = true;
-    const recorder = halVoiceRecorderRef.current;
-    if (recorder && recorder.state !== 'inactive') {
-      try {
-        recorder.stop();
-      } catch {}
-    }
-    cleanupHalVoiceConfirm();
-    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating' });
-  }, [cleanupHalVoiceConfirm, resetHalUiState]);
-
-  const handleUseButtonsInstead = useCallback(() => {
-    const key = getHalConversationKey();
-    setHalVoiceConfirmFallbackKey(key);
-    halVoiceConfirmFallbackKeyRef.current = key;
-    cleanupHalVoiceConfirm();
-    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating' });
-    deps.showStatusMessage('info', 'Switched to button decision for this conversation.');
-  }, [cleanupHalVoiceConfirm, deps.showStatusMessage, getHalConversationKey, resetHalUiState]);
-
   const handleHalExit = useCallback((opts?: { sessionKey?: string | null }) => {
     if (halTeleportInProgressRef.current || halPhaseRef.current === 'waiting_remote') {
       deps.postMessage({ type: 'command', command: 'cancelTeleportAction' });
@@ -598,45 +402,26 @@ export function useHalFlow(deps: {
     setHalSuppressedKeySynced,
   ]);
 
-    const applyHalVoiceConfirmDecision = useCallback((decision: HalDecision, options?: { rejectReason?: string }) => {
-      cleanupHalVoiceConfirm();
-      setHalForceRejectInput(false);
+  const applyHalVoiceConfirmDecision = useCallback((decision: HalDecision, options?: { rejectReason?: string }) => {
+    cleanupHalVoiceConfirm();
+    setHalForceRejectInput(false);
 
-      if (decision === 'teleport_remote') {
-        handleHalTeleport();
-        return;
-      }
+    if (decision === 'teleport_remote') {
+      handleHalTeleport();
+      return;
+    }
 
-      resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', decision });
-      if (decision === 'approve_local') {
-        deps.handleApprove();
-      } else {
-        deps.handleReject(options?.rejectReason);
-      }
-    }, [cleanupHalVoiceConfirm, deps.handleApprove, deps.handleReject, handleHalTeleport, resetHalUiState]);
+    resetHalUiState({ phase: 'awaiting_user', eye: 'pulsating', decision });
+    if (decision === 'approve_local') {
+      deps.handleApprove();
+    } else {
+      deps.handleReject(options?.rejectReason);
+    }
+  }, [cleanupHalVoiceConfirm, deps.handleApprove, deps.handleReject, handleHalTeleport, resetHalUiState]);
 
-    const handleHalVoiceConfirmResponse = useCallback((payload: unknown) => {
-      const currentRequestId = halVoiceConfirmRequestIdRef.current;
-      const requestId = (payload as { requestId?: unknown } | undefined)?.requestId;
-      if (!currentRequestId || typeof requestId !== 'string' || requestId !== currentRequestId) return;
-      halVoiceConfirmRequestIdRef.current = null;
-
-    const ok = (payload as { ok?: unknown } | undefined)?.ok;
-      if (ok === true) {
-        const decisionRaw = (payload as { decision?: unknown } | undefined)?.decision;
-        if (!isHalDecision(decisionRaw)) {
-          disableVoiceConfirmForConversation('Gemini returned an invalid decision. Using buttons instead.');
-          return;
-        }
-
-        applyHalVoiceConfirmDecision(decisionRaw);
-        return;
-      }
-
-    const error = (payload as { error?: unknown } | undefined)?.error;
-    const message = typeof error === 'string' && error.trim() ? error.trim() : 'Gemini classification failed';
-    disableVoiceConfirmForConversation(message);
-    }, [applyHalVoiceConfirmDecision, disableVoiceConfirmForConversation]);
+  const handleHalVoiceConfirmResponse = useCallback((payload: unknown) => {
+    consumeHalVoiceConfirmResponse(payload, applyHalVoiceConfirmDecision);
+  }, [applyHalVoiceConfirmDecision, consumeHalVoiceConfirmResponse]);
 
   const handleHalTeleportUnavailable = useCallback((error: unknown) => {
     if (halPhaseRef.current === 'idle' && halSuppressedKeyRef.current && halSuppressedKeyRef.current === halActiveKeyRef.current) {


### PR DESCRIPTION
## Summary
- Extract HAL voice-confirm capture/classification flow from `useHalFlow.ts` into `halFlow/useHalVoiceConfirm.ts`.
- Keep `useHalFlow` focused on orchestration/state transitions while delegating voice media lifecycle to a dedicated hook.
- Preserve existing voice-confirm fallback, classify, and decision behavior.

## Validation
- `npx eslint src/webview-src/components/app/useHalFlow.ts src/webview-src/components/app/halFlow/useHalVoiceConfirm.ts`
- `npm run typecheck`
- `npx vitest run src/webview-src/__tests__/Hal.voiceConfirm.test.tsx src/webview-src/__tests__/App.confirmation.test.tsx src/webview-src/__tests__/App.advanced.test.tsx`

### Bead
```json
[
  {
    "id": "oh-tab-zhwi.3.3",
    "title": "Refactor useHalFlow into focused state/media/transport hooks",
    "description": "Decompose src/webview-src/components/app/useHalFlow.ts into focused units (state machine/derived HAL state, media capture+playback, host transport handlers) while keeping behavior stable. Current single-hook design couples browser media APIs, transport protocols, and UI transitions in one file.",
    "acceptance_criteria": "- useHalFlow.ts shrinks materially and delegates to focused hooks/modules.\\n- HAL behavior (bundled/tts/voice_confirm + teleport paths) remains unchanged.\\n- Existing HAL/webview tests stay green and new targeted tests cover extracted units.",
    "notes": "Implementing on branch codex/oh-tab-zhwi.3.3-hal-flow-hooks (worktree /Users/enyst/repos/oh-tab-zhwi-3-3); PR #964 opened: https://github.com/enyst/OpenHands-Tab/pull/964",
    "status": "in_progress",
    "priority": 2,
    "issue_type": "task",
    "created_at": "2026-02-05T23:05:38.487602+01:00",
    "updated_at": "2026-02-06T10:15:07.073755+01:00",
    "labels": [
      "architecture",
      "hal",
      "refactor",
      "ui",
      "webview"
    ],
    "dependencies": [
      {
        "id": "oh-tab-zhwi.3",
        "title": "Audit: webview UI architecture (src/webview-src/*)",
        "description": "Analyze React webview UI structure for component size, state ownership, duplication, and boundary clarity. Focus on App.tsx, LlmProfilesView.tsx, eventBlocks, and HAL flows.",
        "acceptance_criteria": "- Component-level findings documented with specific files/functions.\\n- Follow-up fix beads created for each prioritized issue.\\n- Existing bead alignment (e.g., oh-tab-agno) documented.",
        "status": "in_progress",
        "priority": 1,
        "issue_type": "task",
        "created_at": "2026-02-05T22:35:06.065334+01:00",
        "updated_at": "2026-02-05T23:05:38.312936+01:00",
        "labels": [
          "architecture",
          "audit",
          "ui",
          "webview"
        ],
        "dependency_type": "discovered-from"
      },
      {
        "id": "oh-tab-czz",
        "title": "(tech debt) Webview: split useHalFlow.ts into smaller hooks",
        "description": "Problem\n- `src/webview-src/components/app/useHalFlow.ts` is ~1000 LOC and mixes multiple concerns (HAL state/UX decisions, host message wiring, and UI-facing derived state).\n- This increases review cost and makes small HAL changes risky.\n\nGoal\n- Behavior-preserving refactor into smaller hooks/modules that follow TS/React idioms.\n\nProposed approach\n- Split into cohesive units (names illustrative):\n  - `useHalState` (normalized HAL snapshot + reducers)\n  - `useHalHostBridge` (host messaging + request/response)\n  - `useHalUiDecisions` (pure derived logic)\n  - `useHalActions` (handlers/callbacks)\n- Keep `useHalFlow.ts` as a thin orchestrator (or eliminate it if it becomes just composition).\n\nConstraints\n- No UX changes; keep existing tests and stable ids.",
        "acceptance_criteria": "- `useHalFlow.ts` shrinks materially or becomes a thin composition layer.\n- Existing webview tests remain green.\n- No behavioral/UX regressions.",
        "status": "closed",
        "priority": 4,
        "issue_type": "chore",
        "created_at": "2026-01-15T06:16:24.561483+01:00",
        "updated_at": "2026-01-16T00:32:26.462234+01:00",
        "closed_at": "2026-01-16T00:32:26.462234+01:00",
        "labels": [
          "hal",
          "refactor",
          "tech-debt",
          "webview"
        ],
        "dependency_type": "related"
      }
    ]
  }
]
```

### Review
- Designated reviewer `PinkStone` posted explicit gate approval in Agent Mail thread `oh-tab-zhwi.3.3` for latest head `bd69d1e`.
- Reviewer validated in isolated worktree: `eslint` on HAL files, `npm run typecheck`, and HAL-focused tests (`Hal.voiceConfirm`, `App.confirmation`, `App.advanced`).
- Addressed Gemini findings on this PR before approval: payload shape guard for voice-confirm response handling and stream-stop helper deduplication; related threads are resolved in GitHub.
- All required GitHub checks are green.
