### PR TITLE
[oh-tab-rrye] Add merge gate for unresolved review threads

### DIFF
--- a/.github/workflows/review-thread-gate.yml
+++ b/.github/workflows/review-thread-gate.yml
@@ -1,0 +1,112 @@
+name: Review Thread Gate
+
+on:
+  pull_request:
+    branches: [ develop ]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: review-thread-gate-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  unresolved-review-threads:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail when unresolved review threads remain (unless waived)
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.info('No pull_request payload available; skipping.');
+              return;
+            }
+
+            const waiverMatch = pr.body?.match(/review-thread-waiver\s*:\s*(.+)/i);
+            const waiverReason = waiverMatch?.[1]?.trim() || null;
+
+            const unresolved = [];
+            let cursor = null;
+            do {
+              const query = `
+                query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $number) {
+                      reviewThreads(first: 100, after: $cursor) {
+                        nodes {
+                          id
+                          isResolved
+                          isOutdated
+                          comments(first: 1) {
+                            nodes {
+                              author { login }
+                              path
+                              line
+                              url
+                            }
+                          }
+                        }
+                        pageInfo {
+                          hasNextPage
+                          endCursor
+                        }
+                      }
+                    }
+                  }
+                }
+              `;
+              const result = await github.graphql(query, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                number: pr.number,
+                cursor,
+              });
+
+              const page = result.repository.pullRequest.reviewThreads;
+              for (const thread of page.nodes) {
+                if (thread.isResolved) continue;
+                const firstComment = thread.comments.nodes[0];
+                unresolved.push({
+                  url: firstComment?.url ?? '(no-url)',
+                  author: firstComment?.author?.login ?? 'unknown',
+                  path: firstComment?.path ?? 'unknown',
+                  line: firstComment?.line ?? '?',
+                  outdated: thread.isOutdated,
+                });
+              }
+
+              cursor = page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null;
+            } while (cursor);
+
+            if (unresolved.length === 0) {
+              core.info('No unresolved review threads found.');
+              return;
+            }
+
+            const summaryLines = unresolved.map(
+              (thread) =>
+                `- ${thread.url} (author: ${thread.author}, file: ${thread.path}:${thread.line}, outdated: ${thread.outdated})`,
+            );
+            await core.summary
+              .addHeading(`Unresolved review threads: ${unresolved.length}`)
+              .addRaw(summaryLines.join('\n'))
+              .write();
+
+            if (waiverReason) {
+              core.warning(
+                `Unresolved review threads remain (${unresolved.length}), but waiver provided: ${waiverReason}`,
+              );
+              return;
+            }
+
+            core.setFailed(
+              `Found ${unresolved.length} unresolved review thread(s). Resolve all threads or add ` +
+              '`review-thread-waiver: <reason>` to the PR body for an intentional waiver.',
+            );

--- a/.github/workflows/review-thread-gate.yml
+++ b/.github/workflows/review-thread-gate.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ develop ]
     types: [opened, synchronize, reopened, ready_for_review, edited]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,9 @@ Reviews (do not merge without review):
 - When merging: edit the PR description to append a `### Review` section summarizing the roasted review(s) from the designated reviewer and any back-and-forth/resolution notes, then merge.
 - If OpenHands feedback is "truly minor" (e.g., wording/typos/formatting only), you can address it without re-requesting review.
 - Merge only when CI is green, review threads are resolved/addressed, and any required branch-protection rules are satisfied.
+- CI guardrail: `Review Thread Gate` fails PRs that still have unresolved review threads.
+  - Intentional exceptions require a PR-body waiver line: `review-thread-waiver: <reason>`.
+  - Waivers must include a concrete reason and, when applicable, a follow-up bead/issue id.
 
 **Reviewer workflow** (the OpenHands roasted review via tmux):
 - Use a clean worktree to avoid clobbering shared branches/uncommitted changes:


### PR DESCRIPTION
## Summary
- Add a dedicated `Review Thread Gate` GitHub workflow that fails pull requests when unresolved review threads remain.
- Add an explicit waiver path via PR body line `review-thread-waiver: <reason>` for intentional exceptions.
- Update `AGENTS.md` merge checklist to require the new gate and document waiver discipline.
- Fix workflow trigger mismatch by removing unused `workflow_dispatch` trigger.

## Validation
- `npm run lint`

### Bead
```json
[
  {
    "id": "oh-tab-rrye",
    "title": "Block merges when review threads remain unresolved",
    "description": "PR #947 was merged with at least one unresolved review thread (discussion_r2771279769) even though code appears fixed. Add a merge-gate check or checklist automation that fails/flags when unresolved threads remain in \"Files changed\" before merge. Include both human and bot review threads; allow explicit waiver note when intentionally ignored.",
    "notes": "Implementing on branch codex/oh-tab-rrye-review-thread-guard; PR #965 opened: https://github.com/enyst/OpenHands-Tab/pull/965",
    "status": "in_progress",
    "priority": 2,
    "issue_type": "chore",
    "created_at": "2026-02-06T09:48:55.581011+01:00",
    "updated_at": "2026-02-07T16:55:37.444936+01:00",
    "external_ref": "gh-pr-947#discussion_r2771279769",
    "labels": [
      "process",
      "review"
    ]
  }
]
```

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-rrye`.
- Final gate result: **APPROVED** on head `5c6fb06` (message id 5100).
- Reviewer validation: diff review for `.github/workflows/review-thread-gate.yml` + `AGENTS.md`, plus `npm run lint` in isolated detached worktree.
- Reviewer confirmed all GitHub checks green and AI review threads resolved before merge.
