### PR TITLE
[oh-tab-7dg3] Move tools-sync side effect out of state updater

### DIFF
--- a/src/webview-src/__tests__/App.toolsPicker.test.tsx
+++ b/src/webview-src/__tests__/App.toolsPicker.test.tsx
@@ -59,10 +59,17 @@ describe('Tools picker', () => {
       expect(screen.getByRole('button', { name: 'Tools' })).toHaveTextContent('3');
     });
 
-    expect(mockApi.postMessage).toHaveBeenCalledWith({
+    const setEnabledToolsCalls = mockApi.postMessage.mock.calls
+      .map(([message]) => message)
+      .filter((message): message is { type: string; toolIds?: string[] } => (
+        typeof message === 'object'
+        && message !== null
+        && (message as { type?: unknown }).type === 'setEnabledTools'
+      ));
+    expect(setEnabledToolsCalls).toEqual([{
       type: 'setEnabledTools',
       toolIds: ['file_editor', 'task_tracker', 'finish'],
-    });
+    }]);
     expect(screen.getByLabelText('Terminal')).toHaveAttribute('aria-selected', 'false');
   });
 
@@ -149,5 +156,46 @@ describe('Tools picker', () => {
     const bashRow = await screen.findByLabelText('execute_bash');
     expect(bashRow).toBeDisabled();
     expect(bashRow).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('does not emit setEnabledTools when host updates tool selection', async () => {
+    render(<App />);
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: { type: 'status', status: 'online', mode: 'local' }
+      }));
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'toolsList',
+          tools: [
+            { id: 'terminal', label: 'Terminal' },
+            { id: 'file_editor', label: 'File Editor' },
+            { id: 'finish', label: 'Finish' },
+          ],
+          enabledToolIds: ['terminal', 'file_editor', 'finish'],
+        }
+      }));
+    });
+
+    mockApi.postMessage.mockClear();
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'toolsList',
+          tools: [
+            { id: 'terminal', label: 'Terminal' },
+            { id: 'file_editor', label: 'File Editor' },
+            { id: 'finish', label: 'Finish' },
+          ],
+          enabledToolIds: ['terminal', 'finish'],
+        }
+      }));
+    });
+
+    expect(mockApi.postMessage).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'setEnabledTools' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Tools' })).toHaveTextContent('2');
+    });
   });
 });

--- a/src/webview-src/__tests__/App.toolsPicker.test.tsx
+++ b/src/webview-src/__tests__/App.toolsPicker.test.tsx
@@ -61,10 +61,11 @@ describe('Tools picker', () => {
 
     const setEnabledToolsCalls = mockApi.postMessage.mock.calls
       .map(([message]) => message)
-      .filter((message): message is { type: string; toolIds?: string[] } => (
+      .filter((message): message is { type: 'setEnabledTools'; toolIds?: string[] } => (
         typeof message === 'object'
         && message !== null
-        && (message as { type?: unknown }).type === 'setEnabledTools'
+        && 'type' in message
+        && message.type === 'setEnabledTools'
       ));
     expect(setEnabledToolsCalls).toEqual([{
       type: 'setEnabledTools',

--- a/src/webview-src/components/app/useSkillsAndTools.ts
+++ b/src/webview-src/components/app/useSkillsAndTools.ts
@@ -82,15 +82,14 @@ export function useSkillsAndTools({ events, mode, postMessage, showStatusMessage
     if (!pendingSync) {
       return;
     }
+    pendingEnabledToolsSyncRef.current = null;
 
     // Only emit host sync for state transitions initiated by the toggle handler.
     if (!areSameOrderedToolIds(pendingSync, enabledToolIds)) {
-      pendingEnabledToolsSyncRef.current = null;
       return;
     }
 
     postMessage({ type: 'setEnabledTools', toolIds: pendingSync });
-    pendingEnabledToolsSyncRef.current = null;
   }, [enabledToolIds, postMessage]);
 
   const handleToggleTool = useCallback((toolId: string) => {

--- a/src/webview-src/components/app/useSkillsAndTools.ts
+++ b/src/webview-src/components/app/useSkillsAndTools.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { isMessageEvent, type Event } from '@openhands/agent-sdk-ts';
 import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
 import type { ShowStatusMessage } from './useStatusMessages';
@@ -29,6 +29,13 @@ interface UseSkillsAndToolsArgs {
   showStatusMessage: ShowStatusMessage;
 }
 
+function areSameOrderedToolIds(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((id, index) => id === right[index]);
+}
+
 /**
  * Manages skills/tools picker state so App.tsx can focus on wiring.
  */
@@ -38,6 +45,7 @@ export function useSkillsAndTools({ events, mode, postMessage, showStatusMessage
   const [showToolsPopover, setShowToolsPopover] = useState(false);
   const [tools, setTools] = useState<ToolItem[]>([]);
   const [enabledToolIds, setEnabledToolIds] = useState<string[]>([]);
+  const pendingEnabledToolsSyncRef = useRef<string[] | null>(null);
 
   const handleOpenSkills = useCallback(() => {
     setShowToolsPopover(false);
@@ -69,6 +77,22 @@ export function useSkillsAndTools({ events, mode, postMessage, showStatusMessage
     });
   }, [postMessage]);
 
+  useEffect(() => {
+    const pendingSync = pendingEnabledToolsSyncRef.current;
+    if (!pendingSync) {
+      return;
+    }
+
+    // Only emit host sync for state transitions initiated by the toggle handler.
+    if (!areSameOrderedToolIds(pendingSync, enabledToolIds)) {
+      pendingEnabledToolsSyncRef.current = null;
+      return;
+    }
+
+    postMessage({ type: 'setEnabledTools', toolIds: pendingSync });
+    pendingEnabledToolsSyncRef.current = null;
+  }, [enabledToolIds, postMessage]);
+
   const handleToggleTool = useCallback((toolId: string) => {
     if (mode !== 'local') {
       showStatusMessage('info', 'Tools are controlled by the agent-server in remote mode.', { autoDismiss: true, autoDismissDelay: 4000 });
@@ -85,19 +109,22 @@ export function useSkillsAndTools({ events, mode, postMessage, showStatusMessage
       return;
     }
 
+    const knownToolIds = new Set(tools.map((tool) => tool.id));
     setEnabledToolIds((prev) => {
-      const known = new Set(tools.map((tool) => tool.id));
-      if (!known.has(toolId)) return prev;
+      if (!knownToolIds.has(toolId)) return prev;
 
       const nextSet = new Set(prev);
       if (nextSet.has(toolId)) nextSet.delete(toolId);
       else nextSet.add(toolId);
 
       const ordered = tools.map((tool) => tool.id).filter((id) => nextSet.has(id));
-      postMessage({ type: 'setEnabledTools', toolIds: ordered });
+      if (areSameOrderedToolIds(prev, ordered)) {
+        return prev;
+      }
+      pendingEnabledToolsSyncRef.current = ordered;
       return ordered;
     });
-  }, [isToolSelectionLocked, mode, postMessage, showStatusMessage, tools]);
+  }, [isToolSelectionLocked, mode, showStatusMessage, tools]);
 
   return {
     showSkillsPopover,


### PR DESCRIPTION
## Summary
- Remove `setEnabledTools` host messaging from inside the `setEnabledToolIds` updater callback in `useSkillsAndTools`.
- Add a guarded effect-based sync path that emits `setEnabledTools` only for user-initiated toggles and only after committed state updates.
- Preserve host-driven `toolsList` updates without echoing `setEnabledTools` back to the host.
- Add regression coverage to ensure host updates do not trigger `setEnabledTools` and that toggle sync emits exactly one outbound message.

## Validation
- `npx eslint src/webview-src/components/app/useSkillsAndTools.ts src/webview-src/__tests__/App.toolsPicker.test.tsx`
- `npx vitest run src/webview-src/__tests__/App.toolsPicker.test.tsx`

### Bead
```json
[
  {
    "id": "oh-tab-7dg3",
    "title": "Move tools-sync side effect out of state updater in useSkillsAndTools",
    "description": "In src/webview-src/components/app/useSkillsAndTools.ts, postMessage({ type: \"setEnabledTools\", ... }) is executed inside the setEnabledToolIds updater callback. In React Strict Mode this updater can be invoked more than once during development, causing duplicate host messages. Refactor to compute next state purely in updater and emit setEnabledTools from an effect/guarded side-effect path. Keep initial-load semantics explicit (skip-first if needed).",
    "notes": "Implementing in codex/oh-tab-7dg3-tools-sync-side-effect; worktree=/tmp/oh-tab-7dg3; PR #966: https://github.com/enyst/OpenHands-Tab/pull/966",
    "status": "in_progress",
    "priority": 2,
    "issue_type": "task",
    "created_at": "2026-02-07T16:47:28.237336+01:00",
    "updated_at": "2026-02-07T17:07:28.223872+01:00",
    "external_ref": "gh-pr-963#discussion_r2773035196",
    "labels": [
      "architecture",
      "react",
      "strict-mode",
      "webview"
    ]
  }
]
```

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-7dg3`.
- Final gate result: **APPROVED** on head `3a6ac0d` (message id 5111).
- Reviewer validation: targeted eslint + vitest in isolated detached worktree.
- Reviewer confirmed required GitHub checks green and review threads resolved.
