### PR TITLE
[oh-tab-zhwi.3.2] Decompose eventBlocks/shared.tsx by concern

### DIFF
--- a/src/webview-src/components/eventBlocks/fileEditorSummary.tsx
+++ b/src/webview-src/components/eventBlocks/fileEditorSummary.tsx
@@ -1,0 +1,224 @@
+import type { ReactElement } from 'react';
+import { Tooltip } from '../Tooltip';
+import { openWorkspaceDiff, openWorkspaceFile } from './openers';
+
+type FileEditorCommand = 'view' | 'create' | 'str_replace' | 'insert';
+type JsonRecord = Record<string, unknown>;
+type LineRange = [number, number];
+
+const isFileEditorCommand = (value: unknown): value is FileEditorCommand =>
+  value === 'view' || value === 'create' || value === 'str_replace' || value === 'insert';
+
+const getString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+const getNumber = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
+
+const isLineRangeTuple = (value: unknown): value is readonly [number, number] =>
+  Array.isArray(value) && value.length === 2;
+
+const parseLineRange = (value: unknown): LineRange | undefined => {
+  if (!isLineRangeTuple(value)) return undefined;
+  const [start, end] = value;
+  if (typeof start !== 'number' || typeof end !== 'number') return undefined;
+  return [start, end];
+};
+
+const getCharCount = (value: unknown): number | undefined => (typeof value === 'string' ? value.length : undefined);
+
+const formatLineRange = (range?: LineRange): string | undefined => {
+  if (!range) return undefined;
+  const [start, end] = range;
+  if (start <= 0) return undefined;
+  if (end === -1) return 'lines ' + start.toLocaleString() + '–end';
+  if (end === start) return 'line ' + start.toLocaleString();
+  return 'lines ' + start.toLocaleString() + '–' + end.toLocaleString();
+};
+
+const formatCharCount = (count?: number): string | undefined => {
+  if (count === undefined) return undefined;
+  const unit = count === 1 ? 'character' : 'characters';
+  return count.toLocaleString() + ' ' + unit;
+};
+
+const formatSizeDelta = (previous?: number, next?: number): string | undefined => {
+  if (previous === undefined || next === undefined) return undefined;
+  const delta = next - previous;
+  if (delta === 0) return 'File size unchanged.';
+  const unit = Math.abs(delta) === 1 ? 'character' : 'characters';
+  const sign = delta > 0 ? '+' : '';
+  return 'File size changed by ' + sign + delta.toLocaleString() + ' ' + unit + '.';
+};
+
+const normalizeDiffContent = (value: unknown): string | undefined => {
+  if (typeof value === 'string') return value;
+  if (value === null) return '';
+  return undefined;
+};
+
+export function InlineFileReference({ path }: { path?: string }) {
+  if (!path) {
+    return <span className="font-mono text-xs text-stone-400">this path</span>;
+  }
+
+  const trimmedPath = path.replace(/[\\/]+$/, '');
+  const normalizedPath = trimmedPath.replaceAll('\\', '/');
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+  const basename = lastSlashIndex >= 0 ? normalizedPath.slice(lastSlashIndex + 1) : normalizedPath;
+  const label = basename || normalizedPath || path;
+
+  return (
+    <Tooltip content={`Open ${path}`} position="top">
+      <button
+        type="button"
+        onClick={() => openWorkspaceFile(path)}
+        className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.06] hover:border-white/[0.1] text-xs font-mono text-brand-300 align-middle max-w-full transition-all duration-150 group"
+        aria-label={`Open ${path}`}
+      >
+        <span className="codicon codicon-file text-brand-400/70" />
+        <span className="truncate max-w-[16rem]">{label}</span>
+        <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
+      </button>
+    </Tooltip>
+  );
+}
+
+function InlineFileDiffReference({ path, oldContent, newContent }: { path?: string; oldContent: unknown; newContent: unknown }) {
+  if (!path) {
+    return <span className="font-mono text-xs text-stone-400">this path</span>;
+  }
+
+  const trimmedPath = path.replace(/[\\/]+$/, '');
+  const normalizedPath = trimmedPath.replaceAll('\\', '/');
+  const lastSlashIndex = normalizedPath.lastIndexOf('/');
+  const basename = lastSlashIndex >= 0 ? normalizedPath.slice(lastSlashIndex + 1) : normalizedPath;
+  const label = basename || normalizedPath || path;
+
+  const oldText = normalizeDiffContent(oldContent);
+  const newText = normalizeDiffContent(newContent);
+  if (oldText === undefined || newText === undefined) {
+    return <InlineFileReference path={path} />;
+  }
+
+  return (
+    <Tooltip content={`View diff for ${path}`} position="top">
+      <button
+        type="button"
+        onClick={() => openWorkspaceDiff(path, oldText, newText, { preferGitHead: true })}
+        className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.06] hover:border-white/[0.1] text-xs font-mono text-brand-300 align-middle max-w-full transition-all duration-150 group"
+        aria-label={`View diff for ${path}`}
+      >
+        <span className="codicon codicon-diff text-brand-400/70" />
+        <span className="truncate max-w-[16rem]">{label}</span>
+        <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
+      </button>
+    </Tooltip>
+  );
+}
+
+/** Renders human-readable summary for file_editor actions */
+export function FileEditorActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
+  if (!action) return null;
+  const command = getString(action.command);
+  if (!isFileEditorCommand(command)) return null;
+  const path = getString(action.path);
+
+  switch (command) {
+    case 'view': {
+      const rangeText = formatLineRange(parseLineRange(action.view_range));
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          <p>The agent wants to read</p>
+          <InlineFileReference path={path} />
+          {rangeText && <p className="text-xs opacity-70">Requested {rangeText}.</p>}
+        </div>
+      );
+    }
+    case 'create': {
+      const planned = formatCharCount(getCharCount(action.file_text));
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          <p>The agent wants to create</p>
+          <InlineFileReference path={path} />
+          {planned && <p className="text-xs opacity-70">They plan to write {planned}.</p>}
+        </div>
+      );
+    }
+    case 'insert': {
+      const planned = formatCharCount(getCharCount(action.new_str));
+      const insertLine = getNumber(action.insert_line);
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          <p>
+            The agent wants to insert text
+            {typeof insertLine === 'number' && (
+              <> at line {insertLine.toLocaleString()}</>
+            )}
+          </p>
+          <InlineFileReference path={path} />
+          {planned && <p className="text-xs opacity-70">They plan to insert {planned}.</p>}
+        </div>
+      );
+    }
+    case 'str_replace': {
+      const planned = formatCharCount(getCharCount(action.new_str));
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          <p>The agent wants to replace text in</p>
+          <InlineFileReference path={path} />
+          {planned && <p className="text-xs opacity-70">They plan to write {planned}.</p>}
+        </div>
+      );
+    }
+    default:
+      return null;
+  }
+}
+
+/** Renders human-readable summary for file_editor observations */
+export function FileEditorObservationSummary({ observation }: { observation: JsonRecord }): ReactElement | null {
+  const path = getString(observation.path);
+  const command = getString(observation.command);
+  const prevExist = observation.prev_exist === true ? true : observation.prev_exist === false ? false : undefined;
+  const rawOld = observation.old_content;
+  const rawNew = observation.new_content;
+  const oldLength = getCharCount(rawOld);
+  const newLength = getCharCount(rawNew);
+  const summary = getString(observation.summary)?.trim();
+
+  if (!isFileEditorCommand(command)) return null;
+
+  switch (command) {
+    case 'view': {
+      const listedDirectory = rawOld === null && typeof rawNew === 'string';
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          <p>Agent {listedDirectory ? 'listed the contents of' : 'read'}</p>
+          <InlineFileReference path={path} />
+        </div>
+      );
+    }
+    case 'create': {
+      const sizeText = formatCharCount(newLength);
+      const verb = prevExist === true ? 'overwrote' : 'created';
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          <p>Agent {verb}</p>
+          <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
+          {sizeText && <p className="text-xs opacity-70">File now contains {sizeText}.</p>}
+        </div>
+      );
+    }
+    case 'insert':
+    case 'str_replace': {
+      const detail = formatSizeDelta(oldLength, newLength);
+      return (
+        <div className="text-sm leading-relaxed space-y-1">
+          {summary ? <p>{summary}</p> : <p>Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}</p>}
+          <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
+          {detail && <p className="text-xs opacity-70">{detail}</p>}
+        </div>
+      );
+    }
+    default:
+      return null;
+  }
+}

--- a/src/webview-src/components/eventBlocks/fileEditorSummary.tsx
+++ b/src/webview-src/components/eventBlocks/fileEditorSummary.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { Tooltip } from '../Tooltip';
 import { openWorkspaceDiff, openWorkspaceFile } from './openers';
+import { getNumber, getString } from './summaryUtils';
 
 type FileEditorCommand = 'view' | 'create' | 'str_replace' | 'insert';
 type JsonRecord = Record<string, unknown>;
@@ -8,9 +9,6 @@ type LineRange = [number, number];
 
 const isFileEditorCommand = (value: unknown): value is FileEditorCommand =>
   value === 'view' || value === 'create' || value === 'str_replace' || value === 'insert';
-
-const getString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
-const getNumber = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
 
 const isLineRangeTuple = (value: unknown): value is readonly [number, number] =>
   Array.isArray(value) && value.length === 2;
@@ -177,7 +175,7 @@ export function FileEditorActionSummary({ action }: { action: JsonRecord | null 
 export function FileEditorObservationSummary({ observation }: { observation: JsonRecord }): ReactElement | null {
   const path = getString(observation.path);
   const command = getString(observation.command);
-  const prevExist = observation.prev_exist === true ? true : observation.prev_exist === false ? false : undefined;
+  const prevExist = typeof observation.prev_exist === 'boolean' ? observation.prev_exist : undefined;
   const rawOld = observation.old_content;
   const rawNew = observation.new_content;
   const oldLength = getCharCount(rawOld);

--- a/src/webview-src/components/eventBlocks/markdown.tsx
+++ b/src/webview-src/components/eventBlocks/markdown.tsx
@@ -1,0 +1,220 @@
+import React, { type ReactNode, useMemo, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
+import { openMarkdownLink } from './openers';
+
+const collectTextFromNode = (node: ReactNode): string => {
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(collectTextFromNode).join('');
+  if (React.isValidElement<{ children?: ReactNode }>(node)) {
+    return collectTextFromNode(node.props.children);
+  }
+  return '';
+};
+
+const copyTextToClipboard = async (payload: string) => {
+  if (!payload) return;
+  try {
+    if (navigator?.clipboard?.writeText) {
+      await navigator.clipboard.writeText(payload);
+      return;
+    }
+  } catch {
+    // Fall back to execCommand copy.
+  }
+  const textarea = document.createElement('textarea');
+  try {
+    textarea.value = payload;
+    textarea.style.position = 'fixed';
+    textarea.style.opacity = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    document.execCommand('copy');
+  } catch {
+    // Ignore clipboard failures.
+  } finally {
+    textarea.remove();
+  }
+};
+
+function CodeBlock({ children }: { children: ReactNode }) {
+  const [hideCopy, setHideCopy] = useState(false);
+  const codeText = useMemo(() => {
+    const raw = collectTextFromNode(children);
+    return raw.replace(/\n$/, '');
+  }, [children]);
+  const shouldShowCopy = codeText.trim().length > 0;
+  const handleCopy = () => {
+    setHideCopy(true);
+    void copyTextToClipboard(codeText);
+  };
+
+  return (
+    <pre
+      className="mt-2 first:mt-0 font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 pr-10 leading-relaxed text-xs overflow-auto whitespace-pre [&_code]:bg-transparent [&_code]:border-0 [&_code]:px-0 [&_code]:py-0 [&_code]:rounded-none relative group/codeblock"
+      onMouseLeave={() => setHideCopy(false)}
+    >
+      {shouldShowCopy && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy code block"
+          className={`absolute top-2 right-2 opacity-0 pointer-events-none transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1 shadow-sm ${
+            hideCopy ? '' : 'group-hover/codeblock:opacity-100 group-hover/codeblock:pointer-events-auto'
+          }`}
+        >
+          <span className="codicon codicon-copy text-[11px]" />
+        </button>
+      )}
+      {children}
+    </pre>
+  );
+}
+
+export const stripEnvironmentInformationBlocks = (text: string): string => {
+  const raw = typeof text === 'string' ? text : '';
+  if (!raw) return raw;
+
+  // Only strip legacy env-info blocks when they appear as a trailing suffix.
+  // Avoid removing user-authored text that happens to include similar tags mid-message.
+  const withoutBlocks = raw.replace(
+    /(?:\r?\n){0,2}<environment information>[\s\S]*?<\/environment information>\s*$/i,
+    '\n\n',
+  );
+
+  // Keep formatting stable after stripping.
+  return withoutBlocks.replace(/\n{3,}/g, '\n\n').trimEnd();
+};
+
+function MarkdownLink({
+  href,
+  children,
+}: {
+  href?: string;
+  children: ReactNode;
+}) {
+  const safeHref = typeof href === 'string' ? href : '';
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        if (!safeHref.trim()) return;
+        openMarkdownLink(safeHref);
+      }}
+      className="text-brand-300 underline decoration-white/20 hover:decoration-white/40 hover:text-brand-200 transition-colors"
+    >
+      {children}
+    </button>
+  );
+}
+
+const ALLOWED_DATA_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp']);
+const MAX_DATA_IMAGE_URL_CHARS = 1_000_000;
+const ALLOWED_WEBVIEW_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
+
+function isAllowedDataImageUrl(url: string): boolean {
+  const trimmed = typeof url === 'string' ? url.trim() : '';
+  if (!trimmed.startsWith('data:')) return false;
+  if (trimmed.length > MAX_DATA_IMAGE_URL_CHARS) return false;
+
+  const match = /^data:([^;,]+)[;,]/.exec(trimmed);
+  const mime = match?.[1]?.toLowerCase();
+  if (!mime) return false;
+  if (!mime.startsWith('image/')) return false;
+  return ALLOWED_DATA_IMAGE_MIME_TYPES.has(mime);
+}
+
+function isAllowedWebviewImageUrl(url: string): boolean {
+  const trimmed = typeof url === 'string' ? url.trim() : '';
+  if (!trimmed) return false;
+  if (trimmed.length > MAX_DATA_IMAGE_URL_CHARS) return false;
+
+  const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.exec(trimmed);
+  if (!schemeMatch) return false;
+
+  const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
+  if (scheme !== 'vscode-webview-resource' && scheme !== 'vscode-resource' && scheme !== 'vscode-webview') {
+    return false;
+  }
+
+  const withoutQuery = trimmed.split(/[?#]/)[0].toLowerCase();
+  return ALLOWED_WEBVIEW_IMAGE_EXTENSIONS.some((ext) => withoutQuery.endsWith(ext));
+}
+
+export function MarkdownMessage({ text }: { text: string }) {
+  const safeUrlTransform = (url: string, key?: string) => {
+    const trimmed = typeof url === 'string' ? url.trim() : '';
+    if (!trimmed) return '';
+    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed; // Windows absolute path
+
+    const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.exec(trimmed);
+    if (!schemeMatch) return trimmed;
+
+    const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
+    if (scheme === 'http' || scheme === 'https' || scheme === 'mailto') return trimmed;
+    if (key === 'src') {
+      if (scheme === 'data' && isAllowedDataImageUrl(trimmed)) return trimmed;
+      if (isAllowedWebviewImageUrl(trimmed)) return trimmed;
+    }
+
+    return '';
+  };
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm, remarkBreaks]}
+      urlTransform={safeUrlTransform}
+      components={{
+        a: ({ href, children }) => <MarkdownLink href={href}>{children}</MarkdownLink>,
+        img: ({ src, alt }) => {
+          const cleanSrc = typeof src === 'string' ? src.trim() : '';
+          const cleanAlt = typeof alt === 'string' ? alt.trim() : '';
+          const label = cleanAlt || cleanSrc || 'image';
+
+          if (!cleanSrc) return <span className="text-stone-400">{label}</span>;
+
+          if (isAllowedDataImageUrl(cleanSrc) || isAllowedWebviewImageUrl(cleanSrc)) {
+            return (
+              <img
+                src={cleanSrc}
+                alt={cleanAlt}
+                className="max-w-full rounded-lg border border-white/[0.06] shadow-event my-2"
+              />
+            );
+          }
+
+          return <MarkdownLink href={src}>{label}</MarkdownLink>;
+        },
+        p: ({ children }) => <p className="mt-2 first:mt-0 leading-relaxed">{children}</p>,
+        ul: ({ children }) => <ul className="mt-2 first:mt-0 list-disc pl-6 space-y-1">{children}</ul>,
+        ol: ({ children }) => <ol className="mt-2 first:mt-0 list-decimal pl-6 space-y-1">{children}</ol>,
+        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+        blockquote: ({ children }) => (
+          <blockquote className="mt-2 first:mt-0 pl-3 border-l-2 border-white/[0.12] text-stone-300 italic">
+            {children}
+          </blockquote>
+        ),
+        hr: () => <hr className="my-3 border-white/[0.08]" />,
+        h1: ({ children }) => <h1 className="text-lg font-semibold mt-3 first:mt-0">{children}</h1>,
+        h2: ({ children }) => <h2 className="text-base font-semibold mt-3 first:mt-0">{children}</h2>,
+        h3: ({ children }) => <h3 className="text-sm font-semibold mt-3 first:mt-0">{children}</h3>,
+        pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
+        code: ({ className, children }) => (
+          <code
+            className={[
+              'px-1.5 py-0.5 rounded-md bg-black/25 border border-white/[0.06] font-mono text-xs text-stone-200',
+              typeof className === 'string' ? className : '',
+            ].filter(Boolean).join(' ')}
+          >
+            {children}
+          </code>
+        ),
+      }}
+    >
+      {text}
+    </ReactMarkdown>
+  );
+}

--- a/src/webview-src/components/eventBlocks/openers.ts
+++ b/src/webview-src/components/eventBlocks/openers.ts
@@ -1,0 +1,25 @@
+import { getVscodeApi } from '../../shared/vscodeApi';
+import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+
+const postMessage = (message: WebviewToHostMessage) => {
+  const api = getVscodeApi();
+  api.postMessage(message);
+};
+
+export const openWorkspaceFile = (path: string) => {
+  postMessage({ type: 'openWorkspaceFile', path });
+};
+
+export const openWorkspaceDiff = (path: string, oldContent: string, newContent: string, options?: { preferGitHead?: boolean }) => {
+  postMessage({
+    type: 'openWorkspaceDiff',
+    path,
+    oldContent,
+    newContent,
+    ...(options?.preferGitHead ? { preferGitHead: true } : {}),
+  });
+};
+
+export const openMarkdownLink = (href: string) => {
+  postMessage({ type: 'openMarkdownLink', href });
+};

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -1,362 +1,17 @@
-import React, { type ReactNode, useMemo, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
-import remarkBreaks from 'remark-breaks';
-import remarkGfm from 'remark-gfm';
-import { getVscodeApi } from '../../shared/vscodeApi';
-import type { WebviewToHostMessage } from '../../../shared/webviewMessages';
+import type { MouseEventHandler, ReactElement, ReactNode } from 'react';
 import { Tooltip } from '../Tooltip';
+import { InlineFileReference } from './fileEditorSummary';
 
-type FileEditorCommand = 'view' | 'create' | 'str_replace' | 'insert';
+export { openMarkdownLink, openWorkspaceDiff, openWorkspaceFile } from './openers';
+export { MarkdownMessage, stripEnvironmentInformationBlocks } from './markdown';
+export { FileEditorActionSummary, FileEditorObservationSummary } from './fileEditorSummary';
+
 type JsonRecord = Record<string, unknown>;
-type LineRange = [number, number];
-
-const isFileEditorCommand = (value: unknown): value is FileEditorCommand =>
-  value === 'view' || value === 'create' || value === 'str_replace' || value === 'insert';
 
 const getString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
 const getNumber = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
 
-const isLineRangeTuple = (value: unknown): value is readonly [number, number] =>
-  Array.isArray(value) && value.length === 2;
-
-const parseLineRange = (value: unknown): LineRange | undefined => {
-  if (!isLineRangeTuple(value)) return undefined;
-  const [start, end] = value;
-  if (typeof start !== 'number' || typeof end !== 'number') return undefined;
-  return [start, end];
-};
-
-const getCharCount = (value: unknown): number | undefined => (typeof value === 'string' ? value.length : undefined);
-
-const formatLineRange = (range?: LineRange): string | undefined => {
-  if (!range) return undefined;
-  const [start, end] = range;
-  if (start <= 0) return undefined;
-  if (end === -1) return 'lines ' + start.toLocaleString() + '–end';
-  if (end === start) return 'line ' + start.toLocaleString();
-  return 'lines ' + start.toLocaleString() + '–' + end.toLocaleString();
-};
-
-const formatCharCount = (count?: number): string | undefined => {
-  if (count === undefined) return undefined;
-  const unit = count === 1 ? 'character' : 'characters';
-  return count.toLocaleString() + ' ' + unit;
-};
-
-const formatSizeDelta = (previous?: number, next?: number): string | undefined => {
-  if (previous === undefined || next === undefined) return undefined;
-  const delta = next - previous;
-  if (delta === 0) return 'File size unchanged.';
-  const unit = Math.abs(delta) === 1 ? 'character' : 'characters';
-  const sign = delta > 0 ? '+' : '';
-  return 'File size changed by ' + sign + delta.toLocaleString() + ' ' + unit + '.';
-};
-
-const collectTextFromNode = (node: ReactNode): string => {
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(collectTextFromNode).join('');
-  if (React.isValidElement<{ children?: ReactNode }>(node)) {
-    return collectTextFromNode(node.props.children);
-  }
-  return '';
-};
-
-const copyTextToClipboard = async (payload: string) => {
-  if (!payload) return;
-  try {
-    if (navigator?.clipboard?.writeText) {
-      await navigator.clipboard.writeText(payload);
-      return;
-    }
-  } catch {
-    // Fall back to execCommand copy.
-  }
-  const textarea = document.createElement('textarea');
-  try {
-    textarea.value = payload;
-    textarea.style.position = 'fixed';
-    textarea.style.opacity = '0';
-    document.body.appendChild(textarea);
-    textarea.focus();
-    textarea.select();
-    document.execCommand('copy');
-  } catch {
-    // Ignore clipboard failures.
-  } finally {
-    textarea.remove();
-  }
-};
-
-function CodeBlock({ children }: { children: ReactNode }) {
-  const [hideCopy, setHideCopy] = useState(false);
-  const codeText = useMemo(() => {
-    const raw = collectTextFromNode(children);
-    return raw.replace(/\n$/, '');
-  }, [children]);
-  const shouldShowCopy = codeText.trim().length > 0;
-  const handleCopy = () => {
-    setHideCopy(true);
-    void copyTextToClipboard(codeText);
-  };
-
-  return (
-    <pre
-      className="mt-2 first:mt-0 font-mono bg-black/20 border border-white/[0.04] rounded-lg p-3 pr-10 leading-relaxed text-xs overflow-auto whitespace-pre [&_code]:bg-transparent [&_code]:border-0 [&_code]:px-0 [&_code]:py-0 [&_code]:rounded-none relative group/codeblock"
-      onMouseLeave={() => setHideCopy(false)}
-    >
-      {shouldShowCopy && (
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label="Copy code block"
-          className={`absolute top-2 right-2 opacity-0 pointer-events-none transition-opacity text-stone-300 hover:text-stone-100 bg-black/30 border border-white/[0.06] rounded-md p-1 shadow-sm ${
-            hideCopy ? '' : 'group-hover/codeblock:opacity-100 group-hover/codeblock:pointer-events-auto'
-          }`}
-        >
-          <span className="codicon codicon-copy text-[11px]" />
-        </button>
-      )}
-      {children}
-    </pre>
-  );
-}
-
-const postMessage = (message: WebviewToHostMessage) => {
-  const api = getVscodeApi();
-  api.postMessage(message);
-};
-
-export const openWorkspaceFile = (path: string) => {
-  postMessage({ type: 'openWorkspaceFile', path });
-};
-
-export const openWorkspaceDiff = (path: string, oldContent: string, newContent: string, options?: { preferGitHead?: boolean }) => {
-  postMessage({
-    type: 'openWorkspaceDiff',
-    path,
-    oldContent,
-    newContent,
-    ...(options?.preferGitHead ? { preferGitHead: true } : {}),
-  });
-};
-
-export const openMarkdownLink = (href: string) => {
-  postMessage({ type: 'openMarkdownLink', href });
-};
-
-export const stripEnvironmentInformationBlocks = (text: string): string => {
-  const raw = typeof text === 'string' ? text : '';
-  if (!raw) return raw;
-
-  // Only strip legacy env-info blocks when they appear as a trailing suffix.
-  // Avoid removing user-authored text that happens to include similar tags mid-message.
-  const withoutBlocks = raw.replace(
-    /(?:\r?\n){0,2}<environment information>[\s\S]*?<\/environment information>\s*$/i,
-    '\n\n',
-  );
-
-  // Keep formatting stable after stripping.
-  return withoutBlocks.replace(/\n{3,}/g, '\n\n').trimEnd();
-};
-
-function MarkdownLink({
-  href,
-  children,
-}: {
-  href?: string;
-  children: ReactNode;
-}) {
-  const safeHref = typeof href === 'string' ? href : '';
-  return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.preventDefault();
-        if (!safeHref.trim()) return;
-        openMarkdownLink(safeHref);
-      }}
-      className="text-brand-300 underline decoration-white/20 hover:decoration-white/40 hover:text-brand-200 transition-colors"
-    >
-      {children}
-    </button>
-  );
-}
-
-const ALLOWED_DATA_IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/gif', 'image/webp']);
-const MAX_DATA_IMAGE_URL_CHARS = 1_000_000;
-const ALLOWED_WEBVIEW_IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp'];
-
-function isAllowedDataImageUrl(url: string): boolean {
-  const trimmed = typeof url === 'string' ? url.trim() : '';
-  if (!trimmed.startsWith('data:')) return false;
-  if (trimmed.length > MAX_DATA_IMAGE_URL_CHARS) return false;
-
-  const match = /^data:([^;,]+)[;,]/.exec(trimmed);
-  const mime = match?.[1]?.toLowerCase();
-  if (!mime) return false;
-  if (!mime.startsWith('image/')) return false;
-  return ALLOWED_DATA_IMAGE_MIME_TYPES.has(mime);
-}
-
-function isAllowedWebviewImageUrl(url: string): boolean {
-  const trimmed = typeof url === 'string' ? url.trim() : '';
-  if (!trimmed) return false;
-  if (trimmed.length > MAX_DATA_IMAGE_URL_CHARS) return false;
-
-  const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.exec(trimmed);
-  if (!schemeMatch) return false;
-
-  const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
-  if (scheme !== 'vscode-webview-resource' && scheme !== 'vscode-resource' && scheme !== 'vscode-webview') {
-    return false;
-  }
-
-  const withoutQuery = trimmed.split(/[?#]/)[0].toLowerCase();
-  return ALLOWED_WEBVIEW_IMAGE_EXTENSIONS.some((ext) => withoutQuery.endsWith(ext));
-}
-
-export function MarkdownMessage({ text }: { text: string }) {
-  const safeUrlTransform = (url: string, key?: string) => {
-    const trimmed = typeof url === 'string' ? url.trim() : '';
-    if (!trimmed) return '';
-    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed; // Windows absolute path
-
-    const schemeMatch = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.exec(trimmed);
-    if (!schemeMatch) return trimmed;
-
-    const scheme = schemeMatch[0].slice(0, -1).toLowerCase();
-    if (scheme === 'http' || scheme === 'https' || scheme === 'mailto') return trimmed;
-    if (key === 'src') {
-      if (scheme === 'data' && isAllowedDataImageUrl(trimmed)) return trimmed;
-      if (isAllowedWebviewImageUrl(trimmed)) return trimmed;
-    }
-
-    return '';
-  };
-
-  return (
-    <ReactMarkdown
-      remarkPlugins={[remarkGfm, remarkBreaks]}
-      urlTransform={safeUrlTransform}
-      components={{
-        a: ({ href, children }) => <MarkdownLink href={href}>{children}</MarkdownLink>,
-        img: ({ src, alt }) => {
-          const cleanSrc = typeof src === 'string' ? src.trim() : '';
-          const cleanAlt = typeof alt === 'string' ? alt.trim() : '';
-          const label = cleanAlt || cleanSrc || 'image';
-
-          if (!cleanSrc) return <span className="text-stone-400">{label}</span>;
-
-          if (isAllowedDataImageUrl(cleanSrc) || isAllowedWebviewImageUrl(cleanSrc)) {
-            return (
-              <img
-                src={cleanSrc}
-                alt={cleanAlt}
-                className="max-w-full rounded-lg border border-white/[0.06] shadow-event my-2"
-              />
-            );
-          }
-
-          return <MarkdownLink href={src}>{label}</MarkdownLink>;
-        },
-        p: ({ children }) => <p className="mt-2 first:mt-0 leading-relaxed">{children}</p>,
-        ul: ({ children }) => <ul className="mt-2 first:mt-0 list-disc pl-6 space-y-1">{children}</ul>,
-        ol: ({ children }) => <ol className="mt-2 first:mt-0 list-decimal pl-6 space-y-1">{children}</ol>,
-        li: ({ children }) => <li className="leading-relaxed">{children}</li>,
-        blockquote: ({ children }) => (
-          <blockquote className="mt-2 first:mt-0 pl-3 border-l-2 border-white/[0.12] text-stone-300 italic">
-            {children}
-          </blockquote>
-        ),
-        hr: () => <hr className="my-3 border-white/[0.08]" />,
-        h1: ({ children }) => <h1 className="text-lg font-semibold mt-3 first:mt-0">{children}</h1>,
-        h2: ({ children }) => <h2 className="text-base font-semibold mt-3 first:mt-0">{children}</h2>,
-        h3: ({ children }) => <h3 className="text-sm font-semibold mt-3 first:mt-0">{children}</h3>,
-        pre: ({ children }) => <CodeBlock>{children}</CodeBlock>,
-        code: ({ className, children }) => (
-          <code
-            className={[
-              'px-1.5 py-0.5 rounded-md bg-black/25 border border-white/[0.06] font-mono text-xs text-stone-200',
-              typeof className === 'string' ? className : '',
-            ].filter(Boolean).join(' ')}
-          >
-            {children}
-          </code>
-        ),
-      }}
-    >
-      {text}
-    </ReactMarkdown>
-  );
-}
-
-function InlineFileReference({ path }: { path?: string }) {
-  if (!path) {
-    return <span className="font-mono text-xs text-stone-400">this path</span>;
-  }
-
-  const trimmedPath = path.replace(/[\\/]+$/, '');
-  const normalizedPath = trimmedPath.replaceAll('\\', '/');
-  const lastSlashIndex = normalizedPath.lastIndexOf('/');
-  const basename = lastSlashIndex >= 0 ? normalizedPath.slice(lastSlashIndex + 1) : normalizedPath;
-  const label = basename || normalizedPath || path;
-
-  return (
-    <Tooltip content={`Open ${path}`} position="top">
-      <button
-        type="button"
-        onClick={() => openWorkspaceFile(path)}
-        className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.06] hover:border-white/[0.1] text-xs font-mono text-brand-300 align-middle max-w-full transition-all duration-150 group"
-        aria-label={`Open ${path}`}
-      >
-        <span className="codicon codicon-file text-brand-400/70" />
-        <span className="truncate max-w-[16rem]">{label}</span>
-        <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
-      </button>
-    </Tooltip>
-  );
-}
-
-const normalizeDiffContent = (value: unknown): string | undefined => {
-  if (typeof value === 'string') return value;
-  if (value === null) return '';
-  return undefined;
-};
-
-function InlineFileDiffReference({ path, oldContent, newContent }: { path?: string; oldContent: unknown; newContent: unknown }) {
-  if (!path) {
-    return <span className="font-mono text-xs text-stone-400">this path</span>;
-  }
-
-  const trimmedPath = path.replace(/[\\/]+$/, '');
-  const normalizedPath = trimmedPath.replaceAll('\\', '/');
-  const lastSlashIndex = normalizedPath.lastIndexOf('/');
-  const basename = lastSlashIndex >= 0 ? normalizedPath.slice(lastSlashIndex + 1) : normalizedPath;
-  const label = basename || normalizedPath || path;
-
-  const oldText = normalizeDiffContent(oldContent);
-  const newText = normalizeDiffContent(newContent);
-  if (oldText === undefined || newText === undefined) {
-    return <InlineFileReference path={path} />;
-  }
-
-  return (
-    <Tooltip content={`View diff for ${path}`} position="top">
-      <button
-        type="button"
-        onClick={() => openWorkspaceDiff(path, oldText, newText, { preferGitHead: true })}
-        className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md bg-white/[0.06] hover:bg-white/[0.1] border border-white/[0.06] hover:border-white/[0.1] text-xs font-mono text-brand-300 align-middle max-w-full transition-all duration-150 group"
-        aria-label={`View diff for ${path}`}
-      >
-        <span className="codicon codicon-diff text-brand-400/70" />
-        <span className="truncate max-w-[16rem]">{label}</span>
-        <span className="codicon codicon-go-to-file opacity-40 group-hover:opacity-70 transition-opacity" />
-      </button>
-    </Tooltip>
-  );
-}
-
-const TerminalCommandPreview = ({ command }: { command?: string }): React.ReactElement | null => {
+const TerminalCommandPreview = ({ command }: { command?: string }): ReactElement | null => {
   if (!command) return null;
   return (
     <pre className="text-xs font-mono bg-black/30 border border-white/[0.04] rounded-lg p-3 overflow-x-auto text-stone-300">
@@ -365,115 +20,7 @@ const TerminalCommandPreview = ({ command }: { command?: string }): React.ReactE
   );
 };
 
-/** Renders human-readable summary for file_editor actions */
-export function FileEditorActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
-  if (!action) return null;
-  const command = getString(action.command);
-  if (!isFileEditorCommand(command)) return null;
-  const path = getString(action.path);
-
-  switch (command) {
-    case 'view': {
-      const rangeText = formatLineRange(parseLineRange(action.view_range));
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          <p>The agent wants to read</p>
-          <InlineFileReference path={path} />
-          {rangeText && <p className="text-xs opacity-70">Requested {rangeText}.</p>}
-        </div>
-      );
-    }
-    case 'create': {
-      const planned = formatCharCount(getCharCount(action.file_text));
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          <p>The agent wants to create</p>
-          <InlineFileReference path={path} />
-          {planned && <p className="text-xs opacity-70">They plan to write {planned}.</p>}
-        </div>
-      );
-    }
-    case 'insert': {
-      const planned = formatCharCount(getCharCount(action.new_str));
-      const insertLine = getNumber(action.insert_line);
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          <p>
-            The agent wants to insert text
-            {typeof insertLine === 'number' && (
-              <> at line {insertLine.toLocaleString()}</>
-            )}
-          </p>
-          <InlineFileReference path={path} />
-          {planned && <p className="text-xs opacity-70">They plan to insert {planned}.</p>}
-        </div>
-      );
-    }
-    case 'str_replace': {
-      const planned = formatCharCount(getCharCount(action.new_str));
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          <p>The agent wants to replace text in</p>
-          <InlineFileReference path={path} />
-          {planned && <p className="text-xs opacity-70">They plan to write {planned}.</p>}
-        </div>
-      );
-    }
-    default:
-      return null;
-  }
-}
-
-export function FileEditorObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
-  const path = getString(observation.path);
-  const command = getString(observation.command);
-  const prevExist = observation.prev_exist === true ? true : observation.prev_exist === false ? false : undefined;
-  const rawOld = observation.old_content;
-  const rawNew = observation.new_content;
-  const oldLength = getCharCount(rawOld);
-  const newLength = getCharCount(rawNew);
-  const summary = getString(observation.summary)?.trim();
-
-  if (!isFileEditorCommand(command)) return null;
-
-  switch (command) {
-    case 'view': {
-      const listedDirectory = rawOld === null && typeof rawNew === 'string';
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          <p>Agent {listedDirectory ? 'listed the contents of' : 'read'}</p>
-          <InlineFileReference path={path} />
-        </div>
-      );
-    }
-    case 'create': {
-      const sizeText = formatCharCount(newLength);
-      const verb = prevExist === true ? 'overwrote' : 'created';
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          <p>Agent {verb}</p>
-          <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
-          {sizeText && <p className="text-xs opacity-70">File now contains {sizeText}.</p>}
-        </div>
-      );
-    }
-    case 'insert':
-    case 'str_replace': {
-      const detail = formatSizeDelta(oldLength, newLength);
-      return (
-        <div className="text-sm leading-relaxed space-y-1">
-          {summary ? <p>{summary}</p> : <p>Agent {command === 'insert' ? 'inserted text into' : 'replaced text in'}</p>}
-          <InlineFileDiffReference path={path} oldContent={rawOld} newContent={rawNew} />
-          {detail && <p className="text-xs opacity-70">{detail}</p>}
-        </div>
-      );
-    }
-    default:
-      return null;
-  }
-}
-
-export function TerminalActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+export function TerminalActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
   if (!action) return null;
   const command = getString(action.command);
   return (
@@ -484,7 +31,7 @@ export function TerminalActionSummary({ action }: { action: JsonRecord | null })
   );
 }
 
-export function ThinkActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+export function ThinkActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
   if (!action) return null;
   const thought = getString(action.thought);
   if (!thought) return null;
@@ -506,7 +53,7 @@ export function TerminalObservationSummary({
   observation: JsonRecord;
   isExpanded: boolean;
   onToggle: () => void;
-}): React.ReactElement | null {
+}): ReactElement | null {
   const exitCodeNumber = getNumber(observation.exit_code);
   const exitCodeText = exitCodeNumber !== undefined ? exitCodeNumber.toString() : getString(observation.exit_code) ?? 'unknown';
   const metadata = observation.metadata;
@@ -536,7 +83,7 @@ export function TerminalObservationSummary({
 }
 
 /** Renders human-readable summary for glob action */
-export function GlobActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+export function GlobActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
   if (!action) return null;
   const pattern = getString(action.pattern);
   const searchPath = getString(action.path);
@@ -560,7 +107,7 @@ export function GlobActionSummary({ action }: { action: JsonRecord | null }): Re
 }
 
 /** Renders human-readable summary for glob observation */
-export function GlobObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+export function GlobObservationSummary({ observation }: { observation: JsonRecord }): ReactElement | null {
   const files = Array.isArray(observation.files) ? observation.files.filter((f): f is string => typeof f === 'string') : [];
   const pattern = getString(observation.pattern);
   const searchPath = getString(observation.searchPath);
@@ -601,7 +148,7 @@ export function GlobObservationSummary({ observation }: { observation: JsonRecor
 }
 
 /** Renders human-readable summary for grep action */
-export function GrepActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+export function GrepActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
   if (!action) return null;
   const pattern = getString(action.pattern);
   const searchPath = getString(action.path);
@@ -632,7 +179,7 @@ export function GrepActionSummary({ action }: { action: JsonRecord | null }): Re
 }
 
 /** Renders human-readable summary for grep observation */
-export function GrepObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+export function GrepObservationSummary({ observation }: { observation: JsonRecord }): ReactElement | null {
   const matches = Array.isArray(observation.matches) ? observation.matches.filter((f): f is string => typeof f === 'string') : [];
   const pattern = getString(observation.pattern);
   const searchPath = getString(observation.searchPath);
@@ -675,7 +222,7 @@ export function GrepObservationSummary({ observation }: { observation: JsonRecor
 }
 
 /** Renders human-readable summary for browser (web fetch) action */
-export function BrowserActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+export function BrowserActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
   if (!action) return null;
   const url = getString(action.url);
   const method = getString(action.method) ?? 'GET';
@@ -693,7 +240,7 @@ export function BrowserActionSummary({ action }: { action: JsonRecord | null }):
 }
 
 /** Renders human-readable summary for browser (web fetch) observation */
-export function BrowserObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+export function BrowserObservationSummary({ observation }: { observation: JsonRecord }): ReactElement | null {
   const url = getString(observation.url);
   const status = getNumber(observation.status);
   const content = getString(observation.content);
@@ -724,7 +271,7 @@ export function BrowserObservationSummary({ observation }: { observation: JsonRe
 }
 
 /** Renders human-readable summary for finish action */
-export function FinishActionSummary({ action }: { action: JsonRecord | null }): React.ReactElement | null {
+export function FinishActionSummary({ action }: { action: JsonRecord | null }): ReactElement | null {
   if (!action) return null;
   const message = getString(action.message);
   return (
@@ -738,7 +285,7 @@ export function FinishActionSummary({ action }: { action: JsonRecord | null }): 
 }
 
 /** Renders human-readable summary for finish observation */
-export function FinishObservationSummary({ observation }: { observation: JsonRecord }): React.ReactElement | null {
+export function FinishObservationSummary({ observation }: { observation: JsonRecord }): ReactElement | null {
   const message = getString(observation.message);
   return (
     <div className="text-sm leading-relaxed">
@@ -787,14 +334,14 @@ export function EventContainer({
   alignRight = false,
   onMouseLeave,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   accentColor: string;
   bgOpacity?: number;
   className?: string;
   index?: number;
   dataTestId?: string;
   alignRight?: boolean;
-  onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
+  onMouseLeave?: MouseEventHandler<HTMLDivElement>;
 }) {
   const animationDelay = `${index * 40}ms`;
   const bgOpacityPercent = Math.round(bgOpacity * 100);

--- a/src/webview-src/components/eventBlocks/shared.tsx
+++ b/src/webview-src/components/eventBlocks/shared.tsx
@@ -1,15 +1,13 @@
 import type { MouseEventHandler, ReactElement, ReactNode } from 'react';
 import { Tooltip } from '../Tooltip';
 import { InlineFileReference } from './fileEditorSummary';
+import { getNumber, getString } from './summaryUtils';
 
 export { openMarkdownLink, openWorkspaceDiff, openWorkspaceFile } from './openers';
 export { MarkdownMessage, stripEnvironmentInformationBlocks } from './markdown';
 export { FileEditorActionSummary, FileEditorObservationSummary } from './fileEditorSummary';
 
 type JsonRecord = Record<string, unknown>;
-
-const getString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
-const getNumber = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);
 
 const TerminalCommandPreview = ({ command }: { command?: string }): ReactElement | null => {
   if (!command) return null;

--- a/src/webview-src/components/eventBlocks/summaryUtils.ts
+++ b/src/webview-src/components/eventBlocks/summaryUtils.ts
@@ -1,0 +1,3 @@
+export const getString = (value: unknown): string | undefined => (typeof value === 'string' ? value : undefined);
+
+export const getNumber = (value: unknown): number | undefined => (typeof value === 'number' ? value : undefined);


### PR DESCRIPTION
## Summary
- Split `src/webview-src/components/eventBlocks/shared.tsx` into focused modules:
  - `openers.ts` for host open/open-diff/link messaging utilities.
  - `markdown.tsx` for markdown rendering, URL safety filtering, and clipboard code-block copy behavior.
  - `fileEditorSummary.tsx` for file-editor action/observation summary formatting/parsing and file/diff link UI.
- Keep `shared.tsx` as a thinner event-block aggregator for common styling tokens, `EventContainer`, and non-file-editor summary renderers.
- Preserve existing call sites by re-exporting extracted APIs from `shared.tsx`.
- Address follow-up review refinements by extracting duplicated scalar helpers to `summaryUtils.ts` and tightening `prev_exist` boolean normalization.

## Validation
- `npx eslint src/webview-src/components/eventBlocks/shared.tsx src/webview-src/components/eventBlocks/openers.ts src/webview-src/components/eventBlocks/markdown.tsx src/webview-src/components/eventBlocks/fileEditorSummary.tsx src/webview-src/components/eventBlocks/summaryUtils.ts`
- `npx vitest run src/webview-src/__tests__/fileEditorDiffLink.test.tsx src/webview-src/__tests__/stripEnvironmentInformationBlocks.test.ts src/webview-src/__tests__/App.render.test.tsx src/webview-src/__tests__/event.handlers.test.tsx`

### Bead
```json
[
  {
    "id": "oh-tab-zhwi.3.2",
    "title": "Fix: decompose eventBlocks/shared.tsx into focused render/util modules",
    "description": "src/webview-src/components/eventBlocks/shared.tsx currently mixes markdown rendering, clipboard helpers, link/open handlers, URL safety checks, and file-editor formatting/parsing. Split into focused modules (markdown rendering, host opener utilities, file-editor summary formatting).",
    "acceptance_criteria": "- shared.tsx shrinks and delegated modules have clear names.\\n- Existing event rendering tests remain green.\\n- Security-sensitive URL/clipboard behavior is preserved.",
    "notes": "Implementing in codex/oh-tab-zhwi.3.2-eventblocks-shared-split; worktree=/tmp/oh-tab-zhwi.3.2; PR #967: https://github.com/enyst/OpenHands-Tab/pull/967",
    "status": "in_progress",
    "priority": 3,
    "issue_type": "task",
    "created_at": "2026-02-05T22:42:29.199446+01:00",
    "updated_at": "2026-02-07T17:22:50.232823+01:00",
    "labels": [
      "architecture",
      "refactor",
      "ui",
      "webview"
    ],
    "dependencies": [
      {
        "id": "oh-tab-zhwi.3",
        "title": "Audit: webview UI architecture (src/webview-src/*)",
        "description": "Analyze React webview UI structure for component size, state ownership, duplication, and boundary clarity. Focus on App.tsx, LlmProfilesView.tsx, eventBlocks, and HAL flows.",
        "acceptance_criteria": "- Component-level findings documented with specific files/functions.\\n- Follow-up fix beads created for each prioritized issue.\\n- Existing bead alignment (e.g., oh-tab-agno) documented.",
        "status": "in_progress",
        "priority": 1,
        "issue_type": "task",
        "created_at": "2026-02-05T22:35:06.065334+01:00",
        "updated_at": "2026-02-05T23:05:38.312936+01:00",
        "labels": [
          "architecture",
          "audit",
          "ui",
          "webview"
        ],
        "dependency_type": "parent-child"
      }
    ]
  }
]
```

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-zhwi.3.2`.
- Final gate result: **APPROVED** on head `f442432` (message id 5117).
- Reviewer confirmed previous blockers were resolved, no remaining review threads, and required checks all green.
- Reviewer validation in detached worktree passed on targeted eslint + vitest suites for event-block modules.
