### PR TITLE
[oh-tab-89p8] Re-run review-thread gate on review events

### DIFF
--- a/.github/workflows/review-thread-gate.yml
+++ b/.github/workflows/review-thread-gate.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [ develop ]
     types: [opened, synchronize, reopened, ready_for_review, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
 
 permissions:
   contents: read
@@ -15,7 +21,7 @@ concurrency:
 
 jobs:
   unresolved-review-threads:
-    if: github.event_name == 'pull_request'
+    if: github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Fail when unresolved review threads remain (unless waived)

--- a/.github/workflows/review-thread-gate.yml
+++ b/.github/workflows/review-thread-gate.yml
@@ -8,34 +8,64 @@ on:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:
     types: [created, edited, deleted]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate
+        required: true
+        type: number
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  group: review-thread-gate-${{ github.event.pull_request.number || github.sha }}
+  group: review-thread-gate-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.sha }}
   cancel-in-progress: true
 
 jobs:
   unresolved-review-threads:
-    if: github.event.pull_request.base.ref == 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Fail when unresolved review threads remain (unless waived)
         uses: actions/github-script@v8
         with:
           script: |
-            const pr = context.payload.pull_request;
-            if (!pr) {
-              core.info('No pull_request payload available; skipping.');
+            const payloadPrNumber = context.payload.pull_request?.number;
+            const dispatchPrNumber = Number.parseInt(String(context.payload.inputs?.pr_number ?? ''), 10);
+            const prNumber = payloadPrNumber ?? (Number.isFinite(dispatchPrNumber) ? dispatchPrNumber : null);
+            if (!prNumber) {
+              core.setFailed('No pull request number found in event payload. For workflow_dispatch, provide pr_number.');
               return;
             }
 
-            const waiverMatch = pr.body?.match(/review-thread-waiver\s*:\s*(.+)/i);
-            const waiverReason = waiverMatch?.[1]?.trim() || null;
+            const metadataQuery = `
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    baseRefName
+                    body
+                  }
+                }
+              }
+            `;
+            const metadataResult = await github.graphql(metadataQuery, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              number: prNumber,
+            });
+            const pullRequest = metadataResult.repository.pullRequest;
+            if (!pullRequest) {
+              core.setFailed(`Pull request #${prNumber} was not found.`);
+              return;
+            }
+            if (pullRequest.baseRefName !== 'develop') {
+              core.info(`Skipping pull request #${prNumber} because base branch is '${pullRequest.baseRefName}', not 'develop'.`);
+              return;
+            }
+
+            const waiverMatch = pullRequest.body?.match(/review-thread-waiver\s*:\s*(.+)/i);
+            const waiverReason = waiverMatch?.[1]?.trim() ?? null;
 
             const unresolved = [];
             let cursor = null;
@@ -70,7 +100,7 @@ jobs:
               const result = await github.graphql(query, {
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                number: pr.number,
+                number: prNumber,
                 cursor,
               });
 

--- a/docs/review_thread_gate_investigation.md
+++ b/docs/review_thread_gate_investigation.md
@@ -1,0 +1,41 @@
+# Review Thread Gate Investigation (`oh-tab-89p8`)
+
+## Summary
+
+PR #969 exposed a timing gap where `unresolved-review-threads` could remain green after new AI review threads were created. This was not a GraphQL/query logic bug in the gate job. It was an event trigger coverage issue.
+
+## Evidence Timeline (PR #969)
+
+All times UTC on 2026-02-07.
+
+| Time | Event |
+| --- | --- |
+| 16:59:20 | `Review Thread Gate` run `21783582163` starts on head `0770a10` |
+| 16:59:29 | Same run completes `success` |
+| 17:01:10 | `Review Thread Gate` run `21783612499` starts on head `0770a10` |
+| 17:01:17 | Same run completes `success` |
+| 17:02:23 | Gemini inline review thread created (`discussion_r2777787350`) |
+| 17:04:13 | CodeRabbit inline review thread created (`discussion_r2777791648`) |
+| 17:04:14 | Additional CodeRabbit inline review threads created (`discussion_r2777791655`, `discussion_r2777791658`) |
+| 17:06:59 | Reviewer message (`PinkStone`, Agent Mail `#5137`) confirms unresolved threads are present and blocks merge |
+| 17:09:54 | `Review Thread Gate` run `21783740976` starts on new head `9dafd30` and fails (unresolved threads detected) |
+| 17:11:31 | `Review Thread Gate` run `21783765526` starts on head `83bf9fa` and later passes after thread resolution |
+
+## Root Cause
+
+The workflow originally triggered only on `pull_request` activity (`opened`, `synchronize`, `reopened`, `ready_for_review`, `edited`). AI review threads could be created after the most recent `pull_request`-triggered run, with no immediate rerun of the gate.
+
+## Fix
+
+Extended `.github/workflows/review-thread-gate.yml` triggers to include review activity:
+
+- `pull_request_review` (`submitted`, `edited`, `dismissed`)
+- `pull_request_review_comment` (`created`, `edited`, `deleted`)
+- `pull_request_review_thread` (`resolved`, `unresolved`)
+
+Also tightened job scope to base branch `develop` at the job `if:` level (`github.event.pull_request.base.ref == 'develop'`) so all supported review events use a consistent gate condition.
+
+## Operational Guidance
+
+- Keep `unresolved-review-threads` as a required status check.
+- Continue the manual final pass in GitHub "Files changed" before merge, since review-thread resolution is still a human process step even with improved event coverage.

--- a/docs/review_thread_gate_investigation.md
+++ b/docs/review_thread_gate_investigation.md
@@ -35,6 +35,23 @@ Extended `.github/workflows/review-thread-gate.yml` triggers to include review a
 
 Also tightened job scope to base branch `develop` at the job `if:` level (`github.event.pull_request.base.ref == 'develop'`) so all supported review events use a consistent gate condition.
 
+```yaml
+on:
+  pull_request:
+    branches: [develop]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request_review_comment:
+    types: [created, edited, deleted]
+  pull_request_review_thread:
+    types: [resolved, unresolved]
+
+jobs:
+  unresolved-review-threads:
+    if: github.event.pull_request.base.ref == 'develop'
+```
+
 ## Operational Guidance
 
 - Keep `unresolved-review-threads` as a required status check.

--- a/docs/review_thread_gate_investigation.md
+++ b/docs/review_thread_gate_investigation.md
@@ -31,9 +31,11 @@ Extended `.github/workflows/review-thread-gate.yml` triggers to include review a
 
 - `pull_request_review` (`submitted`, `edited`, `dismissed`)
 - `pull_request_review_comment` (`created`, `edited`, `deleted`)
-- `pull_request_review_thread` (`resolved`, `unresolved`)
+- `workflow_dispatch` with `pr_number` input as a manual rerun fallback when only thread resolution state changes
 
-Also tightened job scope to base branch `develop` at the job `if:` level (`github.event.pull_request.base.ref == 'develop'`) so all supported review events use a consistent gate condition.
+GitHub exposes `pull_request_review_thread` as a webhook event, but not as a supported Actions workflow trigger. Because of that, this guardrail relies on supported review/comment triggers plus manual dispatch for thread-state-only transitions.
+
+The job now resolves PR metadata directly and skips non-`develop` base branches in-script, so `pull_request` and manual dispatch paths use the same logic.
 
 ```yaml
 on:
@@ -44,15 +46,19 @@ on:
     types: [submitted, edited, dismissed]
   pull_request_review_comment:
     types: [created, edited, deleted]
-  pull_request_review_thread:
-    types: [resolved, unresolved]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        required: true
+        type: number
 
 jobs:
   unresolved-review-threads:
-    if: github.event.pull_request.base.ref == 'develop'
+    # Base branch guard is evaluated in-script after loading PR metadata.
 ```
 
 ## Operational Guidance
 
 - Keep `unresolved-review-threads` as a required status check.
 - Continue the manual final pass in GitHub "Files changed" before merge, since review-thread resolution is still a human process step even with improved event coverage.
+- If only thread resolution changed and no supported trigger fired, rerun via `workflow_dispatch` with the PR number.


### PR DESCRIPTION
## Summary
- rerun `Review Thread Gate` on review activity events (`pull_request_review`, `pull_request_review_comment`, `pull_request_review_thread`) so late AI/human inline threads retrigger the guardrail
- keep gate scope aligned to `develop` by checking `github.event.pull_request.base.ref` in the job condition
- add investigation write-up documenting PR #969 event ordering and root cause in `/docs/review_thread_gate_investigation.md`

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails on an unrelated existing timeout in `src/webview-src/__tests__/HistoryView.test.tsx` / "paginates conversations with Load more")*
- `npx vitest run src/webview-src/__tests__/App.advanced.test.tsx src/webview-src/__tests__/HistoryView.test.tsx` *(same existing `HistoryView` timeout remains; `App.advanced` passes)*

### Bead
oh-tab-89p8: Investigate unresolved-review-threads behavior with late AI review comments
Status: in_progress
Priority: P1
Type: task
Created: 2026-02-07 18:11
Updated: 2026-02-07 19:32

Description:
Investigation task (not confirmed bug): On PR #969, we observed a period where the unresolved-review-threads check was green while unresolved inline AI review threads were present. This may be due to timing/event ordering (e.g., comments posted after check execution) rather than workflow logic failure. Determine whether behavior is expected, race-related, or an actual guardrail defect.

Acceptance Criteria:
- Reproduce or disprove the timing scenario with documented timestamps/events (check run, comment creation, thread state).\n- Determine if current workflow/event triggers are sufficient for merge safety or need adjustment.\n- If defect confirmed, propose fix and test coverage; if expected behavior, document operational guidance (e.g., mandatory recheck conditions).

Labels: [architecture ci investigation review-hygiene]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/970" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved PR review gating: checks now run for additional review-related events and manual workflow runs, use provided PR number when available, and only enforce unresolved-review-threads on the develop branch with safe skip/info behavior when PR data is missing.

* **Documentation**
  * Added investigation and guidance explaining the timing issue, trigger coverage fix, and recommended operational steps (including manual reruns).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer: `PinkStone` (Agent Mail thread `oh-tab-89p8`).
- Initial gate blockers identified and addressed:
  - Unsupported `pull_request_review_thread` workflow trigger.
  - Doc wording mismatch around supported trigger behavior.
  - Unresolved AI review threads during intermediate heads.
- Resolution applied on head `869fc59`:
  - Removed unsupported trigger.
  - Added `workflow_dispatch` fallback with `pr_number` input.
  - Updated guard logic to load PR metadata and enforce `develop` base in-script.
  - Updated investigation doc to reflect supported trigger caveat and manual rerun guidance.
  - Resolved remaining review threads.
- Final reviewer decision: **APPROVED** for merge (Agent Mail messages `#5158`, `#5159`).
- Final gate state at approval: required checks green (`unresolved-review-threads`, `build`, `test`, `agent-server-e2e`, `e2e`, `e2e-ui`, `CodeRabbit`) and 0 unresolved review threads.
- Non-blocking follow-up filed by reviewer: `oh-tab-wrp2`.
