### PR TITLE
[oh-tab-da1w] Add UI E2E startup timing logs

### DIFF
--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -82,9 +82,10 @@ export async function run(): Promise<void> {
 
     const firstSelectorStartMs = Date.now();
     await webview.waitForSelector('[data-testid="header-totals-row"]', { timeoutMs: 45000, visible: true });
+    const firstSelectorNow = Date.now();
     console.log(
-      `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${Date.now() - firstSelectorStartMs}ms ` +
-      `(suite_elapsed=${Date.now() - suiteStartMs}ms)`
+      `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${firstSelectorNow - firstSelectorStartMs}ms ` +
+      `(suite_elapsed=${firstSelectorNow - suiteStartMs}ms)`
     );
 
     // Context picker: open, select a file if options appear, close.

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -84,8 +84,7 @@ export async function run(): Promise<void> {
     await webview.waitForSelector('[data-testid="header-totals-row"]', { timeoutMs: 45000, visible: true });
     const firstSelectorNow = Date.now();
     console.log(
-      `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${firstSelectorNow - firstSelectorStartMs}ms ` +
-      `(suite_elapsed=${firstSelectorNow - suiteStartMs}ms)`
+      `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${firstSelectorNow - firstSelectorStartMs}ms (suite_elapsed=${firstSelectorNow - suiteStartMs}ms)`
     );
 
     // Context picker: open, select a file if options appear, close.

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -11,6 +11,7 @@ import { connectToWebviewCdp } from './helpers/uiHarness';
 export async function run(): Promise<void> {
   if (process.env.E2E_UI !== '1') return;
 
+  const suiteStartMs = Date.now();
   const portRaw = process.env.E2E_CDP_PORT;
   const port = portRaw ? Number(portRaw) : 0;
   if (!port) {
@@ -50,11 +51,15 @@ export async function run(): Promise<void> {
   let closeWebview: (() => Promise<void>) | null = null;
 
   try {
+    const openCommandsStartMs = Date.now();
     await vscode.commands.executeCommand('workbench.action.focusSideBar');
     await vscode.commands.executeCommand('workbench.view.extension.openhands');
     await vscode.commands.executeCommand('openhands.agent.focus');
 
     await vscode.commands.executeCommand('openhands.open');
+    console.log(`[e2e/uiFlowsUi:suite] open/focus commands completed in ${Date.now() - openCommandsStartMs}ms`);
+
+    const diagnosticsReadyStartMs = Date.now();
     const diag = await waitForDiagnostics({
       label: 'chat view ready',
       timeoutMs: 20000,
@@ -68,11 +73,19 @@ export async function run(): Promise<void> {
           diag.chat?.e2eInfo?.pathname
         ),
     });
+    console.log(`[e2e/uiFlowsUi:suite] diagnostics ready in ${Date.now() - diagnosticsReadyStartMs}ms`);
 
+    const cdpConnectStartMs = Date.now();
     const webview = await connectToWebviewCdp({ port, timeoutMs: 45000, webviewInfo: diag.chat?.e2eInfo ?? undefined });
+    console.log(`[e2e/uiFlowsUi:suite] CDP connected in ${Date.now() - cdpConnectStartMs}ms`);
     closeWebview = webview.close;
 
+    const firstSelectorStartMs = Date.now();
     await webview.waitForSelector('[data-testid="header-totals-row"]', { timeoutMs: 45000, visible: true });
+    console.log(
+      `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${Date.now() - firstSelectorStartMs}ms ` +
+      `(suite_elapsed=${Date.now() - suiteStartMs}ms)`
+    );
 
     // Context picker: open, select a file if options appear, close.
     // Note: in CI the workspace file list can be empty; we skip selection when no options

--- a/tests/e2e/uiFlowsUi.test.ts
+++ b/tests/e2e/uiFlowsUi.test.ts
@@ -22,7 +22,6 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
 
     const maxAttempts = 3;
     const runTestsOverallStart = Date.now();
-    let runTestsCompleted = false;
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       const port = await getAvailablePort();
       const attemptStart = Date.now();
@@ -54,7 +53,6 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
         console.log(
           `[e2e/uiFlowsUi] runTests attempt ${attempt}/${maxAttempts} succeeded in ${attemptElapsedMs}ms (total=${totalElapsedMs}ms)`
         );
-        runTestsCompleted = true;
         break;
       } catch (error) {
         const attemptElapsedMs = Date.now() - attemptStart;
@@ -64,15 +62,14 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
           `[e2e/uiFlowsUi] runTests attempt ${attempt}/${maxAttempts} failed in ${attemptElapsedMs}ms (port_conflict=${isPortConflict})`
         );
         if (!isPortConflict || attempt === maxAttempts) {
+          const totalElapsedMs = Date.now() - runTestsOverallStart;
+          console.warn(
+            `[e2e/uiFlowsUi] runTests terminating after attempt ${attempt}/${maxAttempts} (elapsed=${totalElapsedMs}ms)`
+          );
           throw error;
         }
         console.warn(`UI E2E run failed due to port conflict (attempt ${attempt}/${maxAttempts}); retrying...`);
       }
-    }
-    if (!runTestsCompleted) {
-      console.warn(
-        `[e2e/uiFlowsUi] runTests did not complete after ${maxAttempts} attempts (elapsed=${Date.now() - runTestsOverallStart}ms)`
-      );
     }
 
     assert.ok(true);

--- a/tests/e2e/uiFlowsUi.test.ts
+++ b/tests/e2e/uiFlowsUi.test.ts
@@ -21,8 +21,12 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
     await ensureVsCodeArgvJson(userDataDir);
 
     const maxAttempts = 3;
+    const runTestsOverallStart = Date.now();
+    let runTestsCompleted = false;
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       const port = await getAvailablePort();
+      const attemptStart = Date.now();
+      console.log(`[e2e/uiFlowsUi] runTests attempt ${attempt}/${maxAttempts} starting (cdp_port=${port})`);
       try {
         await runTests({
           vscodeExecutablePath,
@@ -44,15 +48,30 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
             E2E_CDP_PORT: String(port),
           },
         });
+        const attemptElapsedMs = Date.now() - attemptStart;
+        const totalElapsedMs = Date.now() - runTestsOverallStart;
+        console.log(
+          `[e2e/uiFlowsUi] runTests attempt ${attempt}/${maxAttempts} succeeded in ${attemptElapsedMs}ms (total=${totalElapsedMs}ms)`
+        );
+        runTestsCompleted = true;
         break;
       } catch (error) {
+        const attemptElapsedMs = Date.now() - attemptStart;
         const message = error instanceof Error ? error.message : String(error);
         const isPortConflict = /EADDRINUSE|address already in use|EADDRNOTAVAIL/i.test(message);
+        console.warn(
+          `[e2e/uiFlowsUi] runTests attempt ${attempt}/${maxAttempts} failed in ${attemptElapsedMs}ms (port_conflict=${isPortConflict})`
+        );
         if (!isPortConflict || attempt === maxAttempts) {
           throw error;
         }
         console.warn(`UI E2E run failed due to port conflict (attempt ${attempt}/${maxAttempts}); retrying...`);
       }
+    }
+    if (!runTestsCompleted) {
+      console.warn(
+        `[e2e/uiFlowsUi] runTests did not complete after ${maxAttempts} attempts (elapsed=${Date.now() - runTestsOverallStart}ms)`
+      );
     }
 
     assert.ok(true);

--- a/tests/e2e/uiFlowsUi.test.ts
+++ b/tests/e2e/uiFlowsUi.test.ts
@@ -48,8 +48,9 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
             E2E_CDP_PORT: String(port),
           },
         });
-        const attemptElapsedMs = Date.now() - attemptStart;
-        const totalElapsedMs = Date.now() - runTestsOverallStart;
+        const now = Date.now();
+        const attemptElapsedMs = now - attemptStart;
+        const totalElapsedMs = now - runTestsOverallStart;
         console.log(
           `[e2e/uiFlowsUi] runTests attempt ${attempt}/${maxAttempts} succeeded in ${attemptElapsedMs}ms (total=${totalElapsedMs}ms)`
         );


### PR DESCRIPTION
## Summary
- add explicit timing logs around `runTests(...)` attempts in `tests/e2e/uiFlowsUi.test.ts`
- add suite-side startup timing logs in `tests/e2e/suite/uiFlowsUi.ts` for:
  - VS Code focus/open command phase
  - diagnostics readiness wait (`waitForDiagnostics`)
  - CDP connection
  - first UI selector visibility (`[data-testid="header-totals-row"]`)
- keep behavior unchanged (logging only) while making CI startup bottlenecks measurable

## Validation
- `npx eslint tests/e2e/uiFlowsUi.test.ts tests/e2e/suite/uiFlowsUi.ts`
- `npx tsc -p tests/e2e/tsconfig.suite.json`
- `npx tsc -p tsconfig.e2e.json`
- `npx mocha tests/e2e/out/uiFlowsUi.test.js` *(E2E_UI gate => test pending in local run)*

### Bead
oh-tab-da1w: Add timing logs for VS Code launch + UI E2E startup
Status: in_progress
Priority: P2
Type: task
Created: 2026-01-29 16:39
Updated: 2026-02-07 19:58

Description:
Add explicit timing logs in UI E2E runner (around runTests/diagnostics/first selector) to quantify VS Code launch and webview attach time in CI logs.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/971" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added runtime timing instrumentation and diagnostics logging to UI end-to-end tests.
  * Implemented step-level timing metrics for various test operations including command execution and UI interactions.
  * Enhanced test retry tracking with per-attempt and total elapsed time reporting.
  * Added console output for improved test execution visibility and performance diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-da1w`.
- Iteration summary:
  - Initial timing-log implementation accepted functionally.
  - Addressed Gemini timing consistency suggestions (single `Date.now()` snapshots + single-template selector log).
  - Addressed Devin follow-up by removing unreachable `runTestsCompleted` branch and moving terminal warning to the final throw path.
  - Resolved all related review threads.
- Final reviewer decision: **APPROVED** on head `fd2c2cd` (Agent Mail message `#5175`).
- Final gate status at approval: required checks green (`unresolved-review-threads`, `build`, `test`, `agent-server-e2e`, `e2e`, `e2e-ui`, `CodeRabbit`).
