### PR TITLE
[oh-tab-puxi] Harden context picker loading in UI E2E

### DIFF
--- a/src/webview/host/__tests__/workspaceFiles.test.ts
+++ b/src/webview/host/__tests__/workspaceFiles.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { listWorkspaceFiles } from '../workspaceFiles';
+
+describe('listWorkspaceFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (vscode as any).__resetMocks?.();
+    (vscode.workspace as any).workspaceFolders = [{ uri: { fsPath: '/test/workspace' } }];
+    (vscode.workspace as any).findFiles = vi.fn(async () => []);
+    (vscode.workspace as any).asRelativePath = vi.fn((uri: { path?: string; fsPath?: string }) => uri.path ?? uri.fsPath ?? '');
+  });
+
+  it('returns empty when there is no workspace folder', async () => {
+    (vscode.workspace as any).workspaceFolders = [];
+
+    await expect(listWorkspaceFiles()).resolves.toEqual([]);
+    expect((vscode.workspace as any).findFiles).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates and sorts files', async () => {
+    (vscode.workspace as any).findFiles = vi.fn(async () => [{ path: 'z.ts' }, { path: 'a.ts' }, { path: 'z.ts' }]);
+
+    await expect(listWorkspaceFiles()).resolves.toEqual(['a.ts', 'z.ts']);
+    expect((vscode.workspace as any).findFiles).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the first file query is empty', async () => {
+    (vscode.workspace as any).findFiles = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ path: 'README.md' }]);
+
+    await expect(listWorkspaceFiles()).resolves.toEqual(['README.md']);
+    expect((vscode.workspace as any).findFiles).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/webview/host/workspaceFiles.ts
+++ b/src/webview/host/workspaceFiles.ts
@@ -1,5 +1,11 @@
 import * as vscode from 'vscode';
 
+const WORKSPACE_FILES_RETRY_DELAYS_MS = [200, 400] as const;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export async function listWorkspaceFiles(limit = 500): Promise<string[]> {
   if (!vscode.workspace.workspaceFolders || vscode.workspace.workspaceFolders.length === 0) {
     return [];
@@ -7,7 +13,12 @@ export async function listWorkspaceFiles(limit = 500): Promise<string[]> {
   try {
     // Exclude common directories, build artifacts, and all dotfiles/dotdirs
     const excludePattern = '{**/node_modules/**,**/dist/**,**/out/**,**/build/**,**/__pycache__/**,**/coverage/**,**/tmp/**,**/temp/**,**/.*}';
-    const uris = await vscode.workspace.findFiles('**/*', excludePattern, limit);
+    let uris = await vscode.workspace.findFiles('**/*', excludePattern, limit);
+    for (const delayMs of WORKSPACE_FILES_RETRY_DELAYS_MS) {
+      if (uris.length > 0) break;
+      await sleep(delayMs);
+      uris = await vscode.workspace.findFiles('**/*', excludePattern, limit);
+    }
     const unique = new Set<string>();
     for (const uri of uris) {
       const relative = vscode.workspace.asRelativePath(uri, false);
@@ -21,4 +32,3 @@ export async function listWorkspaceFiles(limit = 500): Promise<string[]> {
     return [];
   }
 }
-

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -15,7 +15,7 @@ Each test file orchestrates a VS Code instance and runs a specific test suite:
 - **messaging.test.ts**: Tests message events and rendering
 - **uiFlows.test.ts**: Tests UI flows via command-driven harness (non-UI automation)
 - **uiFlowsUi.test.ts**: UI-driven smoke test using CDP (gated by `E2E_UI=1`). The context picker
-  selection is skipped if no workspace file options appear within the timeout (see bead `oh-tab-puxi`).
+  now retries once if options are initially empty and fails with diagnostics if options still do not load.
 - **serverSelection.test.ts**: Tests server selection and local/remote mode switching
 - **llmSwitching.test.ts**: Tests switching LLM provider/model/api mode (local, mock server)
 - **confirmation.test.ts**: Tests action confirmation workflow with security levels

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -87,46 +87,63 @@ export async function run(): Promise<void> {
       `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${firstSelectorNow - firstSelectorStartMs}ms (suite_elapsed=${firstSelectorNow - suiteStartMs}ms)`
     );
 
-    // Context picker: open, select a file if options appear, close.
-    // Note: in CI the workspace file list can be empty; we skip selection when no options
-    // appear within the timeout (tracked in bead oh-tab-puxi).
+    // Context picker: open, select a file, close.
     await webview.click('[data-testid="open-context-picker"]');
     await webview.waitForSelector('[data-testid="context-picker"]', { timeoutMs: 15000, visible: true });
 
     const optionSelector = '[data-testid="context-picker"] [role="option"]';
-    let hasContextOptions = false;
-    try {
-      await pollUntil(async () => (await webview.count(optionSelector)) > 0, 15000);
-      hasContextOptions = true;
-    } catch (error) {
-      const debug = await webview.evaluate(() => {
+    const captureContextDebug = async () => {
+      const dom = await webview.evaluate(() => {
         if (typeof document === 'undefined') return { readyState: 'no-document' };
         const picker = document.querySelector('[data-testid="context-picker"]');
         const options = document.querySelectorAll('[data-testid="context-picker"] [role="option"]').length;
         const text = picker?.textContent?.trim() ?? '';
         return { readyState: document.readyState, options, textSample: text.slice(0, 200) };
       });
-      console.warn('UI E2E: Context picker has no options; skipping selection.', debug, error);
-    }
+      const uiState = await vscode.commands.executeCommand('openhands._queryUiState');
+      const diagnostics = await vscode.commands.executeCommand('openhands._diagnostics');
+      return { dom, uiState, diagnostics };
+    };
 
-    if (hasContextOptions) {
-      const selectedLabel = await webview.evaluate(() => {
-        if (typeof document === 'undefined') return null;
-        const shadowRoot = document.body?.shadowRoot ?? null;
-        const options = Array.from(document.querySelectorAll('[data-testid="context-picker"] [role="option"]'))
-          .concat(Array.from(shadowRoot?.querySelectorAll('[data-testid="context-picker"] [role="option"]') ?? []));
-        const first = options.find((option) => option.getAttribute('aria-label'));
-        if (!first) return null;
-        (first as HTMLElement).click();
-        return first.getAttribute('aria-label');
-      });
-      if (!selectedLabel) {
-        throw new Error('Context picker options available but no selectable label found');
+    try {
+      await pollUntil(async () => (await webview.count(optionSelector)) > 0, 15000);
+    } catch (firstError) {
+      const firstDebug = await captureContextDebug();
+      console.warn('UI E2E: Context picker has no options on first open; retrying once.', firstDebug, firstError);
+
+      await webview.click('[data-testid="open-context-picker"]');
+      await pollUntil(async () => (await webview.count('[data-testid="context-picker"]')) === 0, 15000);
+      await webview.click('[data-testid="open-context-picker"]');
+      await webview.waitForSelector('[data-testid="context-picker"]', { timeoutMs: 15000, visible: true });
+
+      try {
+        await pollUntil(async () => (await webview.count(optionSelector)) > 0, 15000);
+      } catch (retryError) {
+        const retryDebug = await captureContextDebug();
+        throw new Error(
+          `UI E2E: Context picker had no options after retry. ` +
+          `first=${JSON.stringify(firstDebug)} retry=${JSON.stringify(retryDebug)} ` +
+          `error=${retryError instanceof Error ? retryError.message : String(retryError)}`
+        );
       }
-
-      const selectedOptionSelector = `[role="option"][aria-label="${selectedLabel}"]`;
-      await pollUntil(async () => (await webview.getAttribute(selectedOptionSelector, 'aria-selected')) === 'true', 15000);
     }
+
+    const selectedLabel = await webview.evaluate(() => {
+      if (typeof document === 'undefined') return null;
+      const shadowRoot = document.body?.shadowRoot ?? null;
+      const options = Array.from(document.querySelectorAll('[data-testid="context-picker"] [role="option"]'))
+        .concat(Array.from(shadowRoot?.querySelectorAll('[data-testid="context-picker"] [role="option"]') ?? []));
+      const first = options.find((option) => option.getAttribute('aria-label'));
+      if (!first) return null;
+      (first as HTMLElement).click();
+      return first.getAttribute('aria-label');
+    });
+    if (!selectedLabel) {
+      throw new Error('Context picker options available but no selectable label found');
+    }
+
+    const selectedOptionSelector = `[role="option"][aria-label="${selectedLabel}"]`;
+    await pollUntil(async () => (await webview.getAttribute(selectedOptionSelector, 'aria-selected')) === 'true', 15000);
 
     await webview.click('[data-testid="open-context-picker"]');
     await pollUntil(async () => (await webview.count('[data-testid="context-picker"]')) === 0, 15000);

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -142,7 +142,8 @@ export async function run(): Promise<void> {
       throw new Error('Context picker options available but no selectable label found');
     }
 
-    const selectedOptionSelector = `[role="option"][aria-label="${selectedLabel}"]`;
+    const escapedLabel = selectedLabel.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    const selectedOptionSelector = `[role="option"][aria-label="${escapedLabel}"]`;
     await pollUntil(async () => (await webview.getAttribute(selectedOptionSelector, 'aria-selected')) === 'true', 15000);
 
     await webview.click('[data-testid="open-context-picker"]');


### PR DESCRIPTION
## Summary
- add bounded retries to `listWorkspaceFiles()` so a single early empty `findFiles()` result no longer leaves the context picker empty
- add host-side unit coverage for workspace file listing behavior (empty workspace, dedupe/sort, retry path)
- change UI E2E context-picker flow to retry once and then fail with diagnostics instead of silently skipping selection
- update E2E README to reflect new retry+fail behavior

## Validation
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npx mocha tests/e2e/out/uiFlowsUi.test.js` (pending without `E2E_UI=1` as expected)

### Bead
oh-tab-puxi: Investigate UI E2E context picker empty options in CI
Status: in_progress
Priority: P2
Type: task
Created: 2026-01-29 17:45
Updated: 2026-02-07 20:15

Description:
Track why UI E2E context picker sometimes has zero options in CI and decide whether to enforce selection or keep skip fallback. Consider workspace file list limits, E2E fixture files, and readiness signaling.

Labels: [investigate]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added automatic retry when workspace file listings are empty and made the context picker retry once before failing.
  * Captures richer diagnostics on context-picker failures to aid troubleshooting.

* **Tests**
  * Added unit tests covering workspace file listing, deduplication, sorting, and retry behavior.
  * Updated UI test flow docs and end-to-end behavior to reflect the retry and diagnostic changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-puxi`.
- Initial gate result: `BLOCKED` on head `a312b082fde5123f9edd0a9705393e82bfcdc377` due unresolved CodeRabbit thread at `tests/e2e/suite/uiFlowsUi.ts:146` ([discussion](https://github.com/enyst/OpenHands-Tab/pull/972#discussion_r2777966571)).
- Follow-up applied: commit `fe4d3669db1ef8d6710c9807401e4f3e99b43be4` escaped `selectedLabel` before interpolating into the CSS selector; thread resolved; targeted lint/tsc rerun.
- Final gate result: `APPROVED` from `PinkStone` on head `fe4d366f359f99fdd7231a1b934a0f677cc39899` after all required checks were green and unresolved review threads were 0.
