### PR TITLE
[oh-tab-wrp2] Guard review-thread pagination for missing PR race

### DIFF
--- a/.github/workflows/review-thread-gate.yml
+++ b/.github/workflows/review-thread-gate.yml
@@ -104,7 +104,16 @@ jobs:
                 cursor,
               });
 
-              const page = result.repository.pullRequest.reviewThreads;
+              const pagedPullRequest = result.repository?.pullRequest;
+              if (!pagedPullRequest) {
+                core.setFailed(
+                  `Pull request #${prNumber} became unavailable while reading review threads. ` +
+                  'Re-run the workflow if the PR still exists.',
+                );
+                return;
+              }
+
+              const page = pagedPullRequest.reviewThreads;
               for (const thread of page.nodes) {
                 if (thread.isResolved) continue;
                 const firstComment = thread.comments.nodes[0];


### PR DESCRIPTION
## Summary
- add a defensive null guard before dereferencing `result.repository.pullRequest.reviewThreads` in the review-thread gate workflow
- fail with an explicit actionable error message containing the PR number when the PR disappears between metadata and pagination queries
- preserve existing happy-path behavior

## Validation
- `~/go/bin/actionlint .github/workflows/review-thread-gate.yml`
- `gh workflow view .github/workflows/review-thread-gate.yml`

### Bead
oh-tab-wrp2: Harden review-thread-gate GraphQL pagination against rare PR deletion race
Status: in_progress
Priority: P3
Type: chore
Created: 2026-02-07 19:54
Updated: 2026-02-07 20:38

Description:
CodeRabbit surfaced a low-probability edge case in PR #970: during unresolved-thread pagination, result.repository.pullRequest is assumed non-null after metadata lookup. If the PR disappears between metadata query and pagination query, the script could throw before emitting a clear failure reason. Add a null guard and fail with actionable message.

Acceptance Criteria:
- In .github/workflows/review-thread-gate.yml, guard result.repository.pullRequest before reading reviewThreads.
- If null, fail with a clear message including PR number.
- Keep existing happy-path behavior unchanged.
- Validate with actionlint and workflow syntax review.

Labels: [ci review-hygiene robustness]

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/973" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review workflow reliability with improved error handling for edge cases in automated review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer: `PinkStone` via Agent Mail thread `oh-tab-wrp2`.
- Reviewer validated workflow delta and reran local checks (`actionlint` + `gh workflow view`) on head `c4a223e`.
- Final gate result: `APPROVED` on head `c4a223ecb953dd8996a893736d63a09c6d5ce46f` after all required checks were green and unresolved review threads were 0.
