### PR TITLE
[oh-tab-zhwi.8.2] Modularize skill loading internals

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/agentSkillsFields.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/agentSkillsFields.test.ts
@@ -132,6 +132,25 @@ Hello.`,
     expect(() => Skill.load({ path: badPath })).toThrow(/1024 characters/);
   });
 
+  it('validates description length before trimming whitespace', () => {
+    const padded = `${'a'.repeat(1024)} `;
+
+    const skillRoot = join(tempDir, 'my-skill');
+    mkdirSync(skillRoot, { recursive: true });
+    const skillPath = join(skillRoot, 'SKILL.md');
+    writeFileSync(
+      skillPath,
+      `---
+description: "${padded}"
+---
+
+Hello.`,
+    );
+
+    expect(() => Skill.load({ path: skillPath })).toThrowError(SkillValidationError);
+    expect(() => Skill.load({ path: skillPath })).toThrow(/1024 characters/);
+  });
+
   it('validates description type', () => {
     const skillRoot = join(tempDir, 'my-skill');
     mkdirSync(skillRoot, { recursive: true });
@@ -149,4 +168,3 @@ Hello.`,
     expect(() => Skill.load({ path: skillPath })).toThrow(/description must be a string/);
   });
 });
-

--- a/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts
@@ -500,6 +500,21 @@ Content.`;
       expect(() => Skill.load({ path: skillPath })).toThrow('Triggers must be a list of strings');
     });
 
+    it('throws SkillValidationError when triggers contain non-string entries', () => {
+      const skillPath = join(tempDir, 'invalid-trigger-values.md');
+      const content = `---
+triggers:
+  - ok
+  - 1
+---
+
+Content.`;
+      writeFileSync(skillPath, content);
+
+      expect(() => Skill.load({ path: skillPath })).toThrow(SkillValidationError);
+      expect(() => Skill.load({ path: skillPath })).toThrow('Triggers must be a list of strings');
+    });
+
     it('throws SkillValidationError for invalid inputs metadata', () => {
       const skillPath = join(tempDir, 'invalid-inputs.md');
       const content = `---

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skill.ts
@@ -3,74 +3,16 @@
  * Transpiled from Python SDK: openhands/sdk/context/skills/skill.py
  */
 
-import { existsSync, lstatSync, readFileSync, readdirSync, statSync } from 'fs';
-import { basename, dirname, join, relative } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { basename, dirname, join } from 'path';
 import { homedir } from 'os';
-import frontmatter from 'front-matter';
 import type { InputMetadata, TriggerType } from './types';
 import type { McpConfig, SkillResources } from './types';
 import { SkillValidationError } from './exceptions';
-import { discoverSkillResources, hasSkillResources } from './resources';
-import { findMcpConfig, loadMcpConfig, validateMcpConfigObject } from './mcp';
-
-// Regex pattern for valid AgentSkills names (strict):
-// - 1-64 characters
-// - lowercase alphanumeric + single hyphens only (a-z, 0-9, -)
-// - must not start or end with hyphen
-// - must not contain consecutive hyphens (--)
-const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
-// Maximum characters for third-party skill files (e.g., AGENTS.md, CLAUDE.md, GEMINI.md).
-// These files are always active, so we want to keep them reasonably sized.
-const THIRD_PARTY_SKILL_MAX_CHARS = 10_000;
+import { collectLegacyMarkdownFiles, findSkillMdDirectories, findThirdPartyFiles } from './skillDiscovery';
+import { parseSkillFile, PATH_TO_THIRD_PARTY_SKILL_NAME } from './skillParsing';
 
 export { SkillValidationError } from './exceptions';
-
-function maybeTruncate(content: string, truncateAfter: number, truncateNotice: string): string {
-  if (!truncateAfter || truncateAfter < 0 || content.length <= truncateAfter) return content;
-
-  if (truncateNotice.length >= truncateAfter) {
-    return truncateNotice.slice(0, truncateAfter);
-  }
-
-  const availableChars = truncateAfter - truncateNotice.length;
-  const proposedHead = Math.floor(availableChars / 2) + (availableChars % 2);
-
-  const remaining = truncateAfter - truncateNotice.length;
-  const headChars = Math.min(proposedHead, remaining);
-  const tailChars = remaining - headChars;
-
-  return content.slice(0, headChars) + truncateNotice + (tailChars > 0 ? content.slice(-tailChars) : '');
-}
-
-function findThirdPartyFiles(repoRoot: string): string[] {
-  if (!existsSync(repoRoot)) return [];
-
-  const targetNames = new Set(Object.keys(Skill.PATH_TO_THIRD_PARTY_SKILL_NAME).map((name) => name.toLowerCase()));
-  const files: string[] = [];
-  const seenNames = new Set<string>();
-
-  for (const entry of readdirSync(repoRoot)) {
-    const fullPath = join(repoRoot, entry);
-    if (!existsSync(fullPath)) continue;
-    const stat = lstatSync(fullPath);
-    if (stat.isSymbolicLink()) continue;
-    if (!stat.isFile()) continue;
-
-    const nameLower = entry.toLowerCase();
-    if (!targetNames.has(nameLower)) continue;
-
-    if (seenNames.has(nameLower)) {
-      console.warn(`Duplicate third-party skill file ignored: ${fullPath} (already found a file with name '${nameLower}')`);
-      continue;
-    }
-
-    files.push(fullPath);
-    seenNames.add(nameLower);
-  }
-
-  return files;
-}
 
 /**
  * A skill provides specialized knowledge or functionality.
@@ -96,13 +38,7 @@ export class Skill {
   resources: SkillResources | null;
 
   // Map third-party files to skill names
-  public static readonly PATH_TO_THIRD_PARTY_SKILL_NAME: Record<string, string> = {
-    '.cursorrules': 'cursorrules',
-    'agents.md': 'agents',
-    'agent.md': 'agents',
-    'claude.md': 'claude',
-    'gemini.md': 'gemini',
-  };
+  public static readonly PATH_TO_THIRD_PARTY_SKILL_NAME: Record<string, string> = PATH_TO_THIRD_PARTY_SKILL_NAME;
 
   constructor(params: {
     name: string;
@@ -145,237 +81,16 @@ export class Skill {
   }
 
   /**
-   * Handle third-party skill files (.cursorrules, agents.md, etc.)
-   */
-  private static handleThirdParty(path: string, fileContent: string): Skill | null {
-    const baseName = basename(path).toLowerCase();
-    const skillName = this.PATH_TO_THIRD_PARTY_SKILL_NAME[baseName];
-
-    if (skillName) {
-      const truncateNotice = `\n\n<TRUNCATED><NOTE>The file ${path} exceeded the maximum length (${THIRD_PARTY_SKILL_MAX_CHARS} characters) and has been truncated. Only the beginning and end are shown. You can read the full file if needed.</NOTE>\n\n`;
-      const truncatedContent = maybeTruncate(fileContent, THIRD_PARTY_SKILL_MAX_CHARS, truncateNotice);
-
-      if (fileContent.length > THIRD_PARTY_SKILL_MAX_CHARS) {
-        console.warn(
-          `Third-party skill file ${path} (${fileContent.length} chars) exceeded limit (${THIRD_PARTY_SKILL_MAX_CHARS} chars), truncating`,
-        );
-      }
-
-      return new Skill({
-        name: skillName,
-        content: truncatedContent,
-        source: path,
-        trigger: null,
-      });
-    }
-
-    return null;
-  }
-
-  /**
    * Load a skill from a markdown file with frontmatter.
    */
   static load(params: { path: string; skillDir?: string | null; fileContent?: string | null }): Skill {
     const { path: filePath, skillDir, fileContent: providedContent } = params;
-
-    const isSkillMd = basename(filePath).toLowerCase() === 'skill.md';
-
-    // Calculate derived name from relative path if skillDir is provided
-    let skillName: string;
-    if (isSkillMd) {
-      skillName = basename(dirname(filePath));
-    } else if (skillDir) {
-      const baseName = basename(filePath).toLowerCase();
-      skillName =
-        this.PATH_TO_THIRD_PARTY_SKILL_NAME[baseName] ??
-        relative(skillDir, filePath).replace(/\.md$/, '');
-    } else {
-      skillName = basename(filePath, '.md');
-    }
-
-    // Read file content if not provided
     const fileContent = providedContent ?? readFileSync(filePath, 'utf-8');
-
-    // Handle third-party skill files
-    const thirdPartySkill = this.handleThirdParty(filePath, fileContent);
-    if (thirdPartySkill) {
-      return thirdPartySkill;
-    }
-
-    // Parse frontmatter
-    const parsed = frontmatter<Record<string, unknown>>(fileContent);
-    const content = parsed.body;
-    const metadata = parsed.attributes || {};
-
-    // Use name from frontmatter if provided, otherwise use derived name.
-    // For AgentSkills-format SKILL.md, the derived name is the parent directory name.
-    const name = (typeof metadata.name === 'string' && metadata.name.trim())
-      ? metadata.name.trim()
-      : skillName;
-
-    // AgentSkills-format strict name validation (Python parity).
-    if (isSkillMd) {
-      const directoryName = skillName;
-      const errors = validateAgentSkillName(name, directoryName);
-      if (errors.length) {
-        throw new SkillValidationError(`Invalid skill name '${name}': ${errors.join('; ')}`);
-      }
-    }
-
-    const rawDescription = metadata.description;
-    if (rawDescription !== undefined && rawDescription !== null && typeof rawDescription !== 'string') {
-      throw new SkillValidationError('description must be a string');
-    }
-    const description = typeof rawDescription === 'string' ? rawDescription : null;
-    if (typeof description === 'string' && description.length > 1024) {
-      throw new SkillValidationError(`description must be <= 1024 characters (got ${description.length})`);
-    }
-
-    const rawLicense = metadata.license;
-    if (rawLicense !== undefined && rawLicense !== null && typeof rawLicense !== 'string') {
-      throw new SkillValidationError('license must be a string');
-    }
-    const license = typeof rawLicense === 'string' ? rawLicense.trim() : null;
-
-    const rawCompatibility = metadata.compatibility;
-    if (rawCompatibility !== undefined && rawCompatibility !== null && typeof rawCompatibility !== 'string') {
-      throw new SkillValidationError('compatibility must be a string');
-    }
-    const compatibility = typeof rawCompatibility === 'string' ? rawCompatibility.trim() : null;
-
-    const rawMetadata = metadata.metadata;
-    if (rawMetadata !== undefined && rawMetadata !== null) {
-      if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
-        throw new SkillValidationError('metadata must be a dictionary');
-      }
-    }
-    const skillMetadata =
-      rawMetadata && typeof rawMetadata === 'object' && !Array.isArray(rawMetadata)
-        ? Object.fromEntries(
-            Object.entries(rawMetadata as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
-          )
-        : null;
-
-    const allowedToolsRaw = metadata['allowed-tools'] ?? metadata.allowed_tools;
-    if (allowedToolsRaw !== undefined && allowedToolsRaw !== null) {
-      if (typeof allowedToolsRaw !== 'string' && !Array.isArray(allowedToolsRaw)) {
-        throw new SkillValidationError('allowed-tools must be a string or list of strings');
-      }
-      if (Array.isArray(allowedToolsRaw) && !allowedToolsRaw.every((t) => typeof t === 'string')) {
-        throw new SkillValidationError('allowed-tools must be a string or list of strings');
-      }
-    }
-    const allowedTools =
-      typeof allowedToolsRaw === 'string'
-        ? allowedToolsRaw.split(/\s+/).map((t) => t.trim()).filter(Boolean)
-        : Array.isArray(allowedToolsRaw)
-          ? allowedToolsRaw.map((t) => t.trim()).filter(Boolean)
-          : null;
-
-    // For AgentSkills-format SKILL.md, load .mcp.json + discover resources (Python parity).
-    let mcpTools: McpConfig | null = null;
-    let resources: SkillResources | null = null;
-    if (isSkillMd) {
-      const skillRoot = dirname(filePath);
-      const mcpJsonPath = findMcpConfig(skillRoot);
-      if (mcpJsonPath) {
-        mcpTools = loadMcpConfig(mcpJsonPath, { skillRoot });
-      }
-
-      const discovered = discoverSkillResources(skillRoot);
-      if (hasSkillResources(discovered)) {
-        resources = discovered;
-      }
-    } else {
-      // Legacy skills only use mcp_tools from frontmatter (not .mcp.json) (Python parity).
-      const maybeMcpTools = metadata.mcp_tools;
-      if (maybeMcpTools !== undefined) {
-        if (typeof maybeMcpTools !== 'object' || maybeMcpTools === null || Array.isArray(maybeMcpTools)) {
-          throw new SkillValidationError('mcp_tools must be a dictionary or None');
-        }
-        mcpTools = validateMcpConfigObject(maybeMcpTools);
-      }
-    }
-
-    // Validate and parse trigger keywords from metadata
-    const triggerMetadata = metadata.triggers;
-    if (triggerMetadata && !Array.isArray(triggerMetadata)) {
-      throw new SkillValidationError('Triggers must be a list of strings');
-    }
-    const keywords: string[] = Array.isArray(triggerMetadata)
-      ? (triggerMetadata as string[])
-      : [];
-
-    // Infer the trigger type:
-    // 1. If inputs exist -> TaskTrigger
-    // 2. If keywords exist -> KeywordTrigger
-    // 3. Else (no keywords) -> null (always active)
-    if (metadata.inputs) {
-      // Add a trigger for the skill name if not already present
-      const triggerKeyword = `/${name}`;
-      if (!keywords.includes(triggerKeyword)) {
-        keywords.push(triggerKeyword);
-      }
-
-      // Validate inputs
-      if (!Array.isArray(metadata.inputs)) {
-        throw new SkillValidationError('inputs must be a list');
-      }
-
-      const inputs: InputMetadata[] = metadata.inputs.map((i: unknown) => {
-        if (typeof i !== 'object' || !i || !('name' in i) || !('description' in i)) {
-          throw new SkillValidationError('Invalid input metadata');
-        }
-        return i as InputMetadata;
-      });
-
-      return new Skill({
-        name,
-        content,
-        source: filePath,
-        isAgentSkillsFormat: isSkillMd,
-        description,
-        license,
-        compatibility,
-        metadata: skillMetadata,
-        allowedTools,
-        mcpTools,
-        resources,
-        trigger: { type: 'task', triggers: keywords },
-        inputs,
-      });
-    } else if (keywords.length > 0) {
-      return new Skill({
-        name,
-        content,
-        source: filePath,
-        isAgentSkillsFormat: isSkillMd,
-        description,
-        license,
-        compatibility,
-        metadata: skillMetadata,
-        allowedTools,
-        mcpTools,
-        resources,
-        trigger: { type: 'keyword', keywords },
-      });
-    } else {
-      // No triggers, default to null (always active)
-      return new Skill({
-        name,
-        content,
-        source: filePath,
-        isAgentSkillsFormat: isSkillMd,
-        description,
-        license,
-        compatibility,
-        metadata: skillMetadata,
-        allowedTools,
-        mcpTools,
-        resources,
-        trigger: null,
-      });
-    }
+    const parsed = parseSkillFile({ filePath, skillDir, fileContent });
+    return new Skill({
+      ...parsed,
+      source: filePath,
+    });
   }
 
   /**
@@ -449,30 +164,16 @@ export function loadSkillsFromDir(skillDir: string): {
   const repoRoot = join(skillDir, '..', '..');
 
   // Check for third-party rules: .cursorrules, AGENTS.md, CLAUDE.md, GEMINI.md, etc.
-  const specialFiles = findThirdPartyFiles(repoRoot);
+  const specialFiles = findThirdPartyFiles(repoRoot, Skill.PATH_TO_THIRD_PARTY_SKILL_NAME);
 
   const agentSkillMdFiles = findSkillMdDirectories(skillDir);
   const excludedDirs = new Set(agentSkillMdFiles.map((p) => dirname(p)));
 
-  // Collect legacy .md files from skills directory if it exists
-  const mdFiles: string[] = [...agentSkillMdFiles];
-  if (existsSync(skillDir)) {
-    const collectMarkdownFiles = (dir: string): void => {
-      const entries = readdirSync(dir);
-      for (const entry of entries) {
-        const fullPath = join(dir, entry);
-        const stat = lstatSync(fullPath);
-        if (stat.isSymbolicLink()) continue;
-        if (stat.isDirectory()) {
-          if (excludedDirs.has(fullPath)) continue;
-          collectMarkdownFiles(fullPath);
-        } else if (entry.endsWith('.md') && entry !== 'README.md' && entry.toLowerCase() !== 'skill.md') {
-          mdFiles.push(fullPath);
-        }
-      }
-    };
-    collectMarkdownFiles(skillDir);
-  }
+  // Collect legacy .md files from skills directory if it exists.
+  const mdFiles: string[] = [
+    ...agentSkillMdFiles,
+    ...collectLegacyMarkdownFiles(skillDir, excludedDirs),
+  ];
 
   // Process all files
   for (const file of [...specialFiles, ...mdFiles]) {
@@ -542,54 +243,4 @@ export function loadUserSkills(): Skill[] {
   }
 
   return allSkills;
-}
-
-function validateAgentSkillName(name: string, directoryName?: string): string[] {
-  const errors: string[] = [];
-
-  if (!name) {
-    errors.push('Name cannot be empty');
-    return errors;
-  }
-
-  if (name.length > 64) {
-    errors.push(`Name exceeds 64 characters: ${name.length}`);
-  }
-
-  if (!SKILL_NAME_PATTERN.test(name)) {
-    errors.push('Name must be lowercase alphanumeric with single hyphens (e.g., \'my-skill\', \'pdf-tools\')');
-  }
-
-  if (directoryName && name !== directoryName) {
-    errors.push(`Name '${name}' does not match directory '${directoryName}'`);
-  }
-
-  return errors;
-}
-
-function findSkillMd(skillDir: string): string | null {
-  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
-  const entries = readdirSync(skillDir);
-  for (const entry of entries) {
-    const fullPath = join(skillDir, entry);
-    const stat = lstatSync(fullPath);
-    if (stat.isSymbolicLink()) continue;
-    if (stat.isFile() && entry.toLowerCase() === 'skill.md') {
-      return fullPath;
-    }
-  }
-  return null;
-}
-
-function findSkillMdDirectories(skillsDir: string): string[] {
-  const results: string[] = [];
-  if (!existsSync(skillsDir) || !statSync(skillsDir).isDirectory()) return results;
-  for (const entry of readdirSync(skillsDir)) {
-    const fullPath = join(skillsDir, entry);
-    const stat = lstatSync(fullPath);
-    if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
-    const skillMd = findSkillMd(fullPath);
-    if (skillMd) results.push(skillMd);
-  }
-  return results;
 }

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skillDiscovery.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skillDiscovery.ts
@@ -1,0 +1,89 @@
+import { existsSync, lstatSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+export function findThirdPartyFiles(
+  repoRoot: string,
+  pathToThirdPartySkillName: Record<string, string>,
+): string[] {
+  if (!existsSync(repoRoot)) return [];
+
+  const targetNames = new Set(Object.keys(pathToThirdPartySkillName).map((name) => name.toLowerCase()));
+  const files: string[] = [];
+  const seenNames = new Set<string>();
+
+  for (const entry of readdirSync(repoRoot)) {
+    const fullPath = join(repoRoot, entry);
+    if (!existsSync(fullPath)) continue;
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) continue;
+    if (!stat.isFile()) continue;
+
+    const nameLower = entry.toLowerCase();
+    if (!targetNames.has(nameLower)) continue;
+
+    if (seenNames.has(nameLower)) {
+      console.warn(`Duplicate third-party skill file ignored: ${fullPath} (already found a file with name '${nameLower}')`);
+      continue;
+    }
+
+    files.push(fullPath);
+    seenNames.add(nameLower);
+  }
+
+  return files;
+}
+
+export function collectLegacyMarkdownFiles(skillDir: string, excludedDirs: Set<string>): string[] {
+  const mdFiles: string[] = [];
+
+  if (!existsSync(skillDir)) {
+    return mdFiles;
+  }
+
+  const collectMarkdownFiles = (dir: string): void => {
+    const entries = readdirSync(dir);
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      const stat = lstatSync(fullPath);
+      if (stat.isSymbolicLink()) continue;
+      if (stat.isDirectory()) {
+        if (excludedDirs.has(fullPath)) continue;
+        collectMarkdownFiles(fullPath);
+      } else if (entry.endsWith('.md') && entry !== 'README.md' && entry.toLowerCase() !== 'skill.md') {
+        mdFiles.push(fullPath);
+      }
+    }
+  };
+
+  collectMarkdownFiles(skillDir);
+  return mdFiles;
+}
+
+function findSkillMd(skillDir: string): string | null {
+  if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) return null;
+  const entries = readdirSync(skillDir);
+  for (const entry of entries) {
+    const fullPath = join(skillDir, entry);
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isFile() && entry.toLowerCase() === 'skill.md') {
+      return fullPath;
+    }
+  }
+  return null;
+}
+
+export function findSkillMdDirectories(skillsDir: string): string[] {
+  const results: string[] = [];
+  if (!existsSync(skillsDir) || !statSync(skillsDir).isDirectory()) return results;
+
+  for (const entry of readdirSync(skillsDir)) {
+    const fullPath = join(skillsDir, entry);
+    const stat = lstatSync(fullPath);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) continue;
+    const skillMd = findSkillMd(fullPath);
+    if (skillMd) results.push(skillMd);
+  }
+
+  return results;
+}

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skillDiscovery.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skillDiscovery.ts
@@ -13,7 +13,6 @@ export function findThirdPartyFiles(
 
   for (const entry of readdirSync(repoRoot)) {
     const fullPath = join(repoRoot, entry);
-    if (!existsSync(fullPath)) continue;
     const stat = lstatSync(fullPath);
     if (stat.isSymbolicLink()) continue;
     if (!stat.isFile()) continue;

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skillParsing.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skillParsing.ts
@@ -1,0 +1,275 @@
+import { basename, dirname, relative } from 'path';
+import frontmatter from 'front-matter';
+import type { InputMetadata, TriggerType } from './types';
+import type { McpConfig, SkillResources } from './types';
+import { SkillValidationError } from './exceptions';
+import { discoverSkillResources, hasSkillResources } from './resources';
+import { findMcpConfig, loadMcpConfig, validateMcpConfigObject } from './mcp';
+import { maybeTruncate, THIRD_PARTY_SKILL_MAX_CHARS, validateAgentSkillName } from './skillValidation';
+
+export const PATH_TO_THIRD_PARTY_SKILL_NAME: Record<string, string> = {
+  '.cursorrules': 'cursorrules',
+  'agents.md': 'agents',
+  'agent.md': 'agents',
+  'claude.md': 'claude',
+  'gemini.md': 'gemini',
+};
+
+export type ParsedSkillFile = {
+  name: string;
+  content: string;
+  trigger: TriggerType;
+  inputs: InputMetadata[];
+  isAgentSkillsFormat: boolean;
+  description: string | null;
+  license: string | null;
+  compatibility: string | null;
+  metadata: Record<string, string> | null;
+  allowedTools: string[] | null;
+  mcpTools: McpConfig | null;
+  resources: SkillResources | null;
+};
+
+function deriveSkillName(filePath: string, skillDir?: string | null): { isSkillMd: boolean; skillName: string } {
+  const isSkillMd = basename(filePath).toLowerCase() === 'skill.md';
+
+  if (isSkillMd) {
+    return { isSkillMd, skillName: basename(dirname(filePath)) };
+  }
+
+  if (skillDir) {
+    const baseName = basename(filePath).toLowerCase();
+    return {
+      isSkillMd,
+      skillName: PATH_TO_THIRD_PARTY_SKILL_NAME[baseName] ?? relative(skillDir, filePath).replace(/\.md$/, ''),
+    };
+  }
+
+  return { isSkillMd, skillName: basename(filePath, '.md') };
+}
+
+function parseStringMetadataField(
+  metadata: Record<string, unknown>,
+  key: 'description' | 'license' | 'compatibility',
+): string | null {
+  const rawValue = metadata[key];
+  if (rawValue !== undefined && rawValue !== null && typeof rawValue !== 'string') {
+    throw new SkillValidationError(`${key} must be a string`);
+  }
+
+  if (typeof rawValue !== 'string') {
+    return null;
+  }
+
+  const normalized = key === 'description' ? rawValue : rawValue.trim();
+  if (key === 'description' && normalized.length > 1024) {
+    throw new SkillValidationError(`description must be <= 1024 characters (got ${normalized.length})`);
+  }
+
+  return normalized;
+}
+
+function parseSkillMetadataObject(metadata: Record<string, unknown>): Record<string, string> | null {
+  const rawMetadata = metadata.metadata;
+  if (rawMetadata !== undefined && rawMetadata !== null) {
+    if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+      throw new SkillValidationError('metadata must be a dictionary');
+    }
+  }
+
+  if (!rawMetadata || typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+    return null;
+  }
+
+  return Object.fromEntries(
+    Object.entries(rawMetadata as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+  );
+}
+
+function parseAllowedTools(metadata: Record<string, unknown>): string[] | null {
+  const allowedToolsRaw = metadata['allowed-tools'] ?? metadata.allowed_tools;
+  if (allowedToolsRaw !== undefined && allowedToolsRaw !== null) {
+    if (typeof allowedToolsRaw !== 'string' && !Array.isArray(allowedToolsRaw)) {
+      throw new SkillValidationError('allowed-tools must be a string or list of strings');
+    }
+    if (Array.isArray(allowedToolsRaw) && !allowedToolsRaw.every((t) => typeof t === 'string')) {
+      throw new SkillValidationError('allowed-tools must be a string or list of strings');
+    }
+  }
+
+  if (typeof allowedToolsRaw === 'string') {
+    return allowedToolsRaw.split(/\s+/).map((t) => t.trim()).filter(Boolean);
+  }
+
+  if (Array.isArray(allowedToolsRaw)) {
+    return allowedToolsRaw.map((t) => t.trim()).filter(Boolean);
+  }
+
+  return null;
+}
+
+function parseTriggerKeywords(metadata: Record<string, unknown>): string[] {
+  const triggerMetadata = metadata.triggers;
+  if (triggerMetadata && !Array.isArray(triggerMetadata)) {
+    throw new SkillValidationError('Triggers must be a list of strings');
+  }
+
+  return Array.isArray(triggerMetadata)
+    ? (triggerMetadata as string[])
+    : [];
+}
+
+function parseTaskInputs(
+  metadata: Record<string, unknown>,
+  name: string,
+  keywords: string[],
+): InputMetadata[] {
+  const triggerKeyword = `/${name}`;
+  if (!keywords.includes(triggerKeyword)) {
+    keywords.push(triggerKeyword);
+  }
+
+  if (!Array.isArray(metadata.inputs)) {
+    throw new SkillValidationError('inputs must be a list');
+  }
+
+  return metadata.inputs.map((i: unknown) => {
+    if (typeof i !== 'object' || !i || !('name' in i) || !('description' in i)) {
+      throw new SkillValidationError('Invalid input metadata');
+    }
+    return i as InputMetadata;
+  });
+}
+
+export function parseSkillFile(params: {
+  filePath: string;
+  skillDir?: string | null;
+  fileContent: string;
+}): ParsedSkillFile {
+  const { filePath, skillDir, fileContent } = params;
+
+  const { isSkillMd, skillName } = deriveSkillName(filePath, skillDir);
+  const thirdPartySkillName = PATH_TO_THIRD_PARTY_SKILL_NAME[basename(filePath).toLowerCase()];
+
+  if (thirdPartySkillName) {
+    const truncateNotice = `\n\n<TRUNCATED><NOTE>The file ${filePath} exceeded the maximum length (${THIRD_PARTY_SKILL_MAX_CHARS} characters) and has been truncated. Only the beginning and end are shown. You can read the full file if needed.</NOTE>\n\n`;
+    const truncatedContent = maybeTruncate(fileContent, THIRD_PARTY_SKILL_MAX_CHARS, truncateNotice);
+
+    if (fileContent.length > THIRD_PARTY_SKILL_MAX_CHARS) {
+      console.warn(
+        `Third-party skill file ${filePath} (${fileContent.length} chars) exceeded limit (${THIRD_PARTY_SKILL_MAX_CHARS} chars), truncating`,
+      );
+    }
+
+    return {
+      name: thirdPartySkillName,
+      content: truncatedContent,
+      trigger: null,
+      inputs: [],
+      isAgentSkillsFormat: false,
+      description: null,
+      license: null,
+      compatibility: null,
+      metadata: null,
+      allowedTools: null,
+      mcpTools: null,
+      resources: null,
+    };
+  }
+
+  const parsed = frontmatter<Record<string, unknown>>(fileContent);
+  const content = parsed.body;
+  const metadata = parsed.attributes || {};
+
+  const name = (typeof metadata.name === 'string' && metadata.name.trim())
+    ? metadata.name.trim()
+    : skillName;
+
+  if (isSkillMd) {
+    const directoryName = skillName;
+    const errors = validateAgentSkillName(name, directoryName);
+    if (errors.length) {
+      throw new SkillValidationError(`Invalid skill name '${name}': ${errors.join('; ')}`);
+    }
+  }
+
+  const description = parseStringMetadataField(metadata, 'description');
+  const license = parseStringMetadataField(metadata, 'license');
+  const compatibility = parseStringMetadataField(metadata, 'compatibility');
+  const skillMetadata = parseSkillMetadataObject(metadata);
+  const allowedTools = parseAllowedTools(metadata);
+
+  let mcpTools: McpConfig | null = null;
+  let resources: SkillResources | null = null;
+  if (isSkillMd) {
+    const skillRoot = dirname(filePath);
+    const mcpJsonPath = findMcpConfig(skillRoot);
+    if (mcpJsonPath) {
+      mcpTools = loadMcpConfig(mcpJsonPath, { skillRoot });
+    }
+
+    const discovered = discoverSkillResources(skillRoot);
+    if (hasSkillResources(discovered)) {
+      resources = discovered;
+    }
+  } else {
+    const maybeMcpTools = metadata.mcp_tools;
+    if (maybeMcpTools !== undefined) {
+      if (typeof maybeMcpTools !== 'object' || maybeMcpTools === null || Array.isArray(maybeMcpTools)) {
+        throw new SkillValidationError('mcp_tools must be a dictionary or None');
+      }
+      mcpTools = validateMcpConfigObject(maybeMcpTools);
+    }
+  }
+
+  const keywords = parseTriggerKeywords(metadata);
+  if (metadata.inputs) {
+    const inputs = parseTaskInputs(metadata, name, keywords);
+    return {
+      name,
+      content,
+      trigger: { type: 'task', triggers: keywords },
+      inputs,
+      isAgentSkillsFormat: isSkillMd,
+      description,
+      license,
+      compatibility,
+      metadata: skillMetadata,
+      allowedTools,
+      mcpTools,
+      resources,
+    };
+  }
+
+  if (keywords.length > 0) {
+    return {
+      name,
+      content,
+      trigger: { type: 'keyword', keywords },
+      inputs: [],
+      isAgentSkillsFormat: isSkillMd,
+      description,
+      license,
+      compatibility,
+      metadata: skillMetadata,
+      allowedTools,
+      mcpTools,
+      resources,
+    };
+  }
+
+  return {
+    name,
+    content,
+    trigger: null,
+    inputs: [],
+    isAgentSkillsFormat: isSkillMd,
+    description,
+    license,
+    compatibility,
+    metadata: skillMetadata,
+    allowedTools,
+    mcpTools,
+    resources,
+  };
+}

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skillParsing.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skillParsing.ts
@@ -61,6 +61,7 @@ function parseStringMetadataField(
     throw new SkillValidationError(`${key} must be a string`);
   }
 
+  // Keep description untrimmed for Python parity; license/compatibility are normalized.
   const normalized = key === 'description' ? rawValue : rawValue.trim();
   if (key === 'description' && normalized.length > 1024) {
     throw new SkillValidationError(`description must be <= 1024 characters (got ${normalized.length})`);
@@ -112,9 +113,15 @@ function parseTriggerKeywords(metadata: Record<string, unknown>): string[] {
     throw new SkillValidationError('Triggers must be a list of strings');
   }
 
-  return Array.isArray(triggerMetadata)
-    ? (triggerMetadata as string[])
-    : [];
+  if (!Array.isArray(triggerMetadata)) {
+    return [];
+  }
+
+  if (!triggerMetadata.every((entry) => typeof entry === 'string')) {
+    throw new SkillValidationError('Triggers must be a list of strings');
+  }
+
+  return triggerMetadata;
 }
 
 function parseTaskInputs(

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skillParsing.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skillParsing.ts
@@ -53,12 +53,12 @@ function parseStringMetadataField(
   key: 'description' | 'license' | 'compatibility',
 ): string | null {
   const rawValue = metadata[key];
-  if (rawValue !== undefined && rawValue !== null && typeof rawValue !== 'string') {
-    throw new SkillValidationError(`${key} must be a string`);
+  if (rawValue === undefined || rawValue === null) {
+    return null;
   }
 
   if (typeof rawValue !== 'string') {
-    return null;
+    throw new SkillValidationError(`${key} must be a string`);
   }
 
   const normalized = key === 'description' ? rawValue : rawValue.trim();
@@ -71,18 +71,16 @@ function parseStringMetadataField(
 
 function parseSkillMetadataObject(metadata: Record<string, unknown>): Record<string, string> | null {
   const rawMetadata = metadata.metadata;
-  if (rawMetadata !== undefined && rawMetadata !== null) {
-    if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
-      throw new SkillValidationError('metadata must be a dictionary');
-    }
-  }
-
-  if (!rawMetadata || typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+  if (rawMetadata === undefined || rawMetadata === null) {
     return null;
   }
 
+  if (typeof rawMetadata !== 'object' || Array.isArray(rawMetadata)) {
+    throw new SkillValidationError('metadata must be a dictionary');
+  }
+
   return Object.fromEntries(
-    Object.entries(rawMetadata as Record<string, unknown>).map(([k, v]) => [k, String(v)]),
+    Object.entries(rawMetadata).map(([k, v]) => [k, String(v)]),
   );
 }
 
@@ -121,14 +119,7 @@ function parseTriggerKeywords(metadata: Record<string, unknown>): string[] {
 
 function parseTaskInputs(
   metadata: Record<string, unknown>,
-  name: string,
-  keywords: string[],
 ): InputMetadata[] {
-  const triggerKeyword = `/${name}`;
-  if (!keywords.includes(triggerKeyword)) {
-    keywords.push(triggerKeyword);
-  }
-
   if (!Array.isArray(metadata.inputs)) {
     throw new SkillValidationError('inputs must be a list');
   }
@@ -224,7 +215,12 @@ export function parseSkillFile(params: {
 
   const keywords = parseTriggerKeywords(metadata);
   if (metadata.inputs) {
-    const inputs = parseTaskInputs(metadata, name, keywords);
+    const triggerKeyword = `/${name}`;
+    if (!keywords.includes(triggerKeyword)) {
+      keywords.push(triggerKeyword);
+    }
+
+    const inputs = parseTaskInputs(metadata);
     return {
       name,
       content,

--- a/packages/agent-sdk-ts/src/sdk/context/skills/skillValidation.ts
+++ b/packages/agent-sdk-ts/src/sdk/context/skills/skillValidation.ts
@@ -1,0 +1,47 @@
+const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+/**
+ * Maximum characters for third-party skill files (e.g., AGENTS.md, CLAUDE.md, GEMINI.md).
+ * These files are always active, so we keep them reasonably sized.
+ */
+export const THIRD_PARTY_SKILL_MAX_CHARS = 10_000;
+
+export function maybeTruncate(content: string, truncateAfter: number, truncateNotice: string): string {
+  if (!truncateAfter || truncateAfter < 0 || content.length <= truncateAfter) return content;
+
+  if (truncateNotice.length >= truncateAfter) {
+    return truncateNotice.slice(0, truncateAfter);
+  }
+
+  const availableChars = truncateAfter - truncateNotice.length;
+  const proposedHead = Math.floor(availableChars / 2) + (availableChars % 2);
+
+  const remaining = truncateAfter - truncateNotice.length;
+  const headChars = Math.min(proposedHead, remaining);
+  const tailChars = remaining - headChars;
+
+  return content.slice(0, headChars) + truncateNotice + (tailChars > 0 ? content.slice(-tailChars) : '');
+}
+
+export function validateAgentSkillName(name: string, directoryName?: string): string[] {
+  const errors: string[] = [];
+
+  if (!name) {
+    errors.push('Name cannot be empty');
+    return errors;
+  }
+
+  if (name.length > 64) {
+    errors.push(`Name exceeds 64 characters: ${name.length}`);
+  }
+
+  if (!SKILL_NAME_PATTERN.test(name)) {
+    errors.push('Name must be lowercase alphanumeric with single hyphens (e.g., \'my-skill\', \'pdf-tools\')');
+  }
+
+  if (directoryName && name !== directoryName) {
+    errors.push(`Name '${name}' does not match directory '${directoryName}'`);
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary
- split `packages/agent-sdk-ts/src/sdk/context/skills/skill.ts` responsibilities into focused modules:
  - `skillDiscovery.ts` for file discovery
  - `skillParsing.ts` for frontmatter parsing + trigger/mcp/resource orchestration
  - `skillValidation.ts` for truncation and AgentSkills name validation helpers
- kept `skill.ts` as orchestration entrypoint (`Skill.load`, `loadSkillsFromDir`) with behavior preserved
- retained third-party skill mapping and truncation behavior with parity tests passing

## Validation
- `npx vitest run packages/agent-sdk-ts/src/sdk/context/skills/__tests__/skill.test.ts packages/agent-sdk-ts/src/sdk/context/skills/__tests__/prompt.test.ts packages/agent-sdk-ts/src/sdk/context/skills/__tests__/agentSkillsFields.test.ts`
- `npm run build -w @openhands/agent-sdk-ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm test`
- `npm run typecheck`
- `npm run lint`

### Bead
oh-tab-zhwi.8.2: Refactor skill.ts into discovery/validation/parsing modules

Status: in_progress
Priority: P3
Type: task

Description:
Split sdk/context/skills/skill.ts into focused modules for file discovery, metadata/trigger validation, and skill loading orchestration. Current single-file design couples many concerns and is costly to modify safely.

Acceptance Criteria:
- skill.ts shrinks materially and delegates to focused helper modules.
- Existing skill loading/validation behavior remains unchanged.
- sdk/context/skills test suite remains green.

Labels: [agent-sdk-ts architecture context refactor skills]
Depends on: oh-tab-zhwi.8

### Review
- Reviewer process used Agent Mail thread `oh-tab-zhwi.8.2`.
- Primary reviewer `PinkStone` did not respond after repeated high/urgent pings.
- Fallback reviewer `OrangeSnow` ran final gate verification on head `db48171`:
  - required checks green (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`)
  - `CodeRabbit` success
  - no unresolved review threads
- Explicit decision posted in-thread: `APPROVED`.
