### PR TITLE
[oh-tab-zhwi.6.4] Resolve PR #949 unresolved review-thread follow-up

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts
@@ -3,7 +3,7 @@ import { isConversationStateUpdateEvent } from '../types';
 import { EventLog } from './EventLog';
 import type { ConversationPersistence } from './persistence';
 import type { AgentState } from './stateTypes';
-export type { AgentState } from './stateTypes';
+export type { AgentState };
 
 export interface ConversationStateOptions {
   eventLog?: EventLog;

--- a/packages/agent-sdk-ts/src/sdk/types/index.ts
+++ b/packages/agent-sdk-ts/src/sdk/types/index.ts
@@ -4,10 +4,13 @@ import type {
   Content,
   ImageContent,
   Message,
+  RedactedThinkingBlock,
   ResponsesReasoningItem,
+  Role,
   SecurityRisk,
   SourceType,
   TextContent,
+  ThinkingBlock,
   ThinkingBlockEvent,
   ToolCall,
 } from './messageTypes';
@@ -24,7 +27,7 @@ export type {
   ThinkingBlock,
   ThinkingBlockEvent,
   ToolCall,
-} from './messageTypes';
+};
 
 export interface EventBase {
   id?: string;


### PR DESCRIPTION
## Summary
- follow-up cleanup for unresolved PR #949 review threads
- `packages/agent-sdk-ts/src/sdk/runtime/ConversationState.ts`
  - consolidate AgentState import/export to avoid repeating module path
- `packages/agent-sdk-ts/src/sdk/types/index.ts`
  - consolidate message type imports and re-export the imported symbols (instead of re-exporting directly from module path)

## Validation
- `npx vitest run packages/agent-sdk-ts/src/sdk/runtime/__tests__/ConversationState.test.ts packages/agent-sdk-ts/src/sdk/types/__tests__/typeGuards.test.ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run build -w @openhands/agent-sdk-ts`

### Bead
oh-tab-zhwi.6.4: Post-merge cleanup: resolve PR #949 unresolved review threads

Status: in_progress
Priority: P3
Type: task

Description:
PR #949 merged with two unresolved Gemini review threads (discussion_r2771319797 and discussion_r2771319804) requesting import/re-export cleanup in sdk/runtime/ConversationState.ts and sdk/types/index.ts. Create a small follow-up that applies or intentionally declines each suggestion with rationale, then resolve/close the corresponding review threads for audit hygiene.

Acceptance Criteria:
- Follow-up PR addresses both unresolved PR #949 review comments or documents explicit rationale for no-code-change.
- Review threads discussion_r2771319797 and discussion_r2771319804 are resolved/closed with traceable comments.
- lint/typecheck/tests stay green for changed scope.

### Review
- Reviewer process used Agent Mail thread `oh-tab-zhwi.6.4`.
- Primary reviewer `PinkStone` did not respond after repeated high/urgent pings.
- Fallback reviewer `OrangeSnow` ran final gate verification on head `bbd9908`:
  - required checks green (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`)
  - `CodeRabbit` success
  - no unresolved review threads
- Follow-up objective for PR #949 hygiene was verified complete:
  - threads `discussion_r2771319797` and `discussion_r2771319804` were replied to with traceable context and resolved.
- Explicit decision posted in-thread: `APPROVED`.
