### PR TITLE
[oh-tab-zhwi.9.3] Modularize FileEditorTool internals

### DIFF
--- a/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
+++ b/packages/agent-sdk-ts/src/tools/FileEditorTool.ts
@@ -1,170 +1,27 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { z } from 'zod';
 import type { ToolContext } from './types';
 import { ZodTool } from './zod-tool';
+import type { FileEditorResult } from './fileEditor/shared';
+import {
+  IMAGE_EXTENSIONS,
+  MAX_FILE_SIZE_BYTES,
+  MAX_OUTPUT_CHARS,
+  PDF_EXTENSION,
+} from './fileEditor/shared';
+import { fileEditorSchema, type FileEditorArgs, TOOL_DESCRIPTION } from './fileEditor/schema';
+import { addLineNumbers, applyViewRange, isProbablyBinary, truncateContent } from './fileEditor/textTransforms';
+import { UndoHistoryManager, exceedsUndoHistorySizeCap } from './fileEditor/undoHistory';
+import { isBinaryExtension, viewDirectory, viewImage } from './fileEditor/viewHandlers';
 
-type FileEditorContent = { type: 'text'; text: string } | { type: 'image'; image_urls?: string[]; detail?: string };
+export type { FileEditorResult } from './fileEditor/shared';
+export { MAX_OUTPUT_CHARS, OUTPUT_CLIP_MARKER } from './fileEditor/shared';
 
-export interface FileEditorResult {
-  command: 'view' | 'create' | 'str_replace' | 'insert' | 'undo_edit';
-  path?: string;
-  prev_exist?: boolean;
-  old_content?: string | null;
-  new_content?: string | null;
-  content?: FileEditorContent[];
-}
-
-const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
-const MAX_INLINE_IMAGE_BASE64_CHARS = 4 * 1024 * 1024;
-const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
-const PDF_EXTENSION = '.pdf';
-export const MAX_OUTPUT_CHARS = 50_000;
-export const OUTPUT_CLIP_MARKER = '<response clipped>';
-
-const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format
-* State is persistent across command calls and discussions with the user
-* If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists non-hidden files and directories up to 2 levels deep
-* The \`create\` command cannot be used if the specified \`path\` already exists as a file
-* The \`undo_edit\` command undoes the most recent edit for a \`path\` (including undoing a create)
-* Files larger than 10MB are rejected
-* If a \`command\` generates a long output, it will be truncated and marked with \`<response clipped>\`
-* This tool can be used for creating and editing files in plain-text format.
-
-
-Before using this tool:
-1. Use the view tool to understand the file's contents and context
-2. Verify the directory path is correct (only applicable when creating new files):
-   - Use the view tool to verify the parent directory exists and is the correct location
-
-When making edits:
-   - Ensure the edit results in idiomatic, correct code
-   - Do not leave the code in a broken state
-   - Prefer workspace-relative paths; absolute paths are allowed when they resolve inside the workspace (or other explicitly-allowed roots)
-
-CRITICAL REQUIREMENTS FOR USING THIS TOOL:
-
-1. EXACT MATCHING: The \`old_str\` parameter must match EXACTLY a substring of the file, including all whitespace and indentation. It may span multiple lines. The tool will fail if \`old_str\` matches multiple locations or doesn't match exactly.
-
-2. UNIQUENESS: The \`old_str\` must uniquely identify a single instance in the file:
-   - Include sufficient context before and after the change point (3-5 lines recommended)
-   - If not unique, the replacement will not be performed
-
-3. REPLACEMENT: The \`new_str\` parameter should contain the edited lines that replace the \`old_str\`. Both strings must be different.
-
-Remember: when making multiple file edits in a row to the same file, you should prefer to send all edits in a single message with multiple calls to this tool, rather than multiple messages with a single call each.
-`;
-
-const fileEditorSchema = z
-  .object({
-    command: z
-      .enum(['view', 'create', 'str_replace', 'insert', 'undo_edit'])
-      .describe('The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.'),
-    path: z
-      .string()
-      .describe('Workspace-relative path (preferred), or absolute path that resolves inside the workspace (or other explicitly-allowed roots).'),
-    file_text: z
-      .string()
-      .optional()
-      .describe('Required parameter of `create` command, with the content of the file to be created.'),
-    old_str: z
-      .string()
-      .optional()
-      .describe('Required parameter of `str_replace` command containing the string in `path` to replace.'),
-    new_str: z
-      .string()
-      .optional()
-      .describe('Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.'),
-    insert_line: z
-      .number()
-      .int()
-      .min(0)
-      .optional()
-      .describe('Line number to insert `new_str` after. Line numbers are 1-based. Use `insert_line: 0` to insert at the beginning of the file.'),
-    view_range: z
-      .array(z.number().int())
-      .length(2)
-      .optional()
-      .describe('Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.'),
-  })
-  .superRefine((value, ctx) => {
-    if (value.command === 'create' && value.file_text === undefined) {
-      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'file_text is required for create', path: ['file_text'] });
-    }
-    if (value.command === 'str_replace') {
-      if (value.old_str === undefined) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str is required for str_replace', path: ['old_str'] });
-      } else if (value.old_str.length === 0) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str must be non-empty for str_replace', path: ['old_str'] });
-      }
-    }
-    if (value.command === 'insert') {
-      if (value.new_str === undefined) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'new_str is required for insert', path: ['new_str'] });
-      }
-      if (value.insert_line === undefined) {
-        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'insert_line is required for insert', path: ['insert_line'] });
-      }
-    }
-  });
-
-const applyViewRange = (content: string, viewRange?: number[]): string => {
-  if (!viewRange || viewRange.length !== 2) return content;
-  const [start, end] = viewRange;
-  const lines = content.split(/\r?\n/);
-  const slice = lines.slice(start - 1, end === -1 ? undefined : end);
-  return slice.join('\n');
-};
-
-const addLineNumbers = (content: string): string => {
-  const lines = content.split(/\r?\n/);
-  return lines.map((line, idx) => `${idx + 1}\t${line}`).join('\n');
-};
-
-const truncateContent = (content: string, maxChars = MAX_OUTPUT_CHARS): string => {
-  if (content.length <= maxChars) return content;
-  const minRequired = OUTPUT_CLIP_MARKER.length + 2;
-  if (maxChars < minRequired) {
-    return content.slice(0, maxChars);
-  }
-  const available = maxChars - OUTPUT_CLIP_MARKER.length - 2;
-  const half = Math.max(0, Math.floor(available / 2));
-  const head = content.slice(0, half);
-  const tail = content.slice(content.length - half);
-  return `${head}\n${OUTPUT_CLIP_MARKER}\n${tail}`;
-};
-
-const isProbablyBinary = (buffer: Buffer): boolean => {
-  if (buffer.length === 0) return false;
-  const sampleSize = Math.min(buffer.length, 8000);
-  let suspiciousBytes = 0;
-  for (let i = 0; i < sampleSize; i++) {
-    const byte = buffer[i];
-    if (byte === 0) return true;
-    // Count control chars excluding common whitespace (\t \n \r).
-    if ((byte < 7 || (byte > 13 && byte < 32) || byte === 127) && byte !== 9 && byte !== 10 && byte !== 13) {
-      suspiciousBytes++;
-    }
-  }
-  return suspiciousBytes / sampleSize > 0.3;
-};
-
-type UndoEntry = {
-  prevExist: boolean;
-  oldContent: string | null;
-  byteSize: number;
-};
-
-const MAX_UNDO_ENTRIES_PER_PATH = 10;
-const MAX_UNDO_PATHS = 100;
-const MAX_UNDO_BYTES_TOTAL = 100 * 1024 * 1024;
-
-export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, FileEditorResult> {
+export class FileEditorTool extends ZodTool<FileEditorArgs, FileEditorResult> {
   readonly name = 'file_editor';
   readonly description = TOOL_DESCRIPTION;
   readonly schema = fileEditorSchema;
-  private readonly undoHistory = new Map<string, UndoEntry[]>();
-  private undoBytesTotal = 0;
+  private readonly undoHistory = new UndoHistoryManager();
   private readonly maxOutputChars: number;
 
   override getEnhancedDescription(workspaceRoot: string): string {
@@ -189,7 +46,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
     }
   }
 
-  async execute(args: z.infer<typeof fileEditorSchema>, context: ToolContext): Promise<FileEditorResult> {
+  async execute(args: FileEditorArgs, context: ToolContext): Promise<FileEditorResult> {
     const ws = context.workspace;
     const resolved = ws.resolvePath(args.path);
     const extension = path.extname(resolved).toLowerCase();
@@ -198,12 +55,12 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
       case 'view': {
         const stat = await fs.stat(resolved);
         if (stat.isDirectory()) {
-          const { text } = await this.viewDirectory(resolved, ws);
+          const { text } = await viewDirectory(resolved, ws, this.maxOutputChars);
           return { command: 'view', path: resolved, prev_exist: true, old_content: null, new_content: text };
         }
         const buffer = await this.readValidatedFile(resolved, extension, ws);
         if (IMAGE_EXTENSIONS.has(extension)) {
-          return this.viewImage(resolved, extension, buffer);
+          return viewImage(resolved, extension, buffer);
         }
         const content = buffer.toString('utf8');
         const ranged = applyViewRange(content, args.view_range);
@@ -223,7 +80,7 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
           throw new Error(`create failed: file is too large (${mb.toFixed(1)}MB). Maximum allowed size is 10MB.`);
         }
         await ws.writeFile(resolved, fileText);
-        this.pushUndo(resolved, { prevExist: false, oldContent: null, byteSize: 0 });
+        this.undoHistory.push(resolved, { prevExist: false, oldContent: null, byteSize: 0 });
         return {
           command: 'create',
           path: resolved,
@@ -252,11 +109,11 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         }
         const updated = prev.replace(oldStr, args.new_str ?? '');
         const undoByteSize = Math.max(buffer.length, prev.length * 2);
-        if (undoByteSize > MAX_UNDO_BYTES_TOTAL) {
+        if (exceedsUndoHistorySizeCap(undoByteSize)) {
           throw new Error('str_replace failed: undo snapshot exceeds total undo history size cap');
         }
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: undoByteSize });
+        this.undoHistory.push(resolved, { prevExist: true, oldContent: prev, byteSize: undoByteSize });
         return { command: 'str_replace', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'insert': {
@@ -271,34 +128,26 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
         lines.splice(index, 0, insertion);
         const updated = lines.join('\n');
         const undoByteSize = Math.max(buffer.length, prev.length * 2);
-        if (undoByteSize > MAX_UNDO_BYTES_TOTAL) {
+        if (exceedsUndoHistorySizeCap(undoByteSize)) {
           throw new Error('insert failed: undo snapshot exceeds total undo history size cap');
         }
         await ws.writeFile(resolved, updated);
-        this.pushUndo(resolved, { prevExist: true, oldContent: prev, byteSize: undoByteSize });
+        this.undoHistory.push(resolved, { prevExist: true, oldContent: prev, byteSize: undoByteSize });
         return { command: 'insert', path: resolved, prev_exist: true, old_content: prev, new_content: updated };
       }
       case 'undo_edit': {
         const current = await this.readOptionalFile(resolved, ws);
-
-        const stack = this.undoHistory.get(resolved);
-        if (!stack || stack.length === 0) {
+        const undo = this.undoHistory.peek(resolved);
+        if (!undo) {
           throw new Error('undo_edit failed: no edit history for path');
         }
-
-        const undo = stack[stack.length - 1];
 
         if (!undo.prevExist) {
           await this.removeCreatedFile(resolved);
         } else {
           await ws.writeFile(resolved, undo.oldContent ?? '');
         }
-
-        stack.pop();
-        this.undoBytesTotal -= undo.byteSize;
-        if (stack.length === 0) {
-          this.undoHistory.delete(resolved);
-        }
+        this.undoHistory.discardLatest(resolved);
 
         if (!undo.prevExist) {
           return { command: 'undo_edit', path: resolved, prev_exist: undo.prevExist, old_content: current, new_content: null };
@@ -314,159 +163,10 @@ export class FileEditorTool extends ZodTool<z.infer<typeof fileEditorSchema>, Fi
 
   private async readValidatedFile(absPath: string, extension: string, workspace: ToolContext['workspace']): Promise<Buffer> {
     const buffer = await workspace.readFileBytes(absPath, { maxBytes: MAX_FILE_SIZE_BYTES });
-    const binaryAllowed = IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION;
-    if (!binaryAllowed && isProbablyBinary(buffer)) {
+    if (!isBinaryExtension(extension) && isProbablyBinary(buffer)) {
       throw new Error('File appears to be binary and this file type cannot be read or edited by this tool.');
     }
     return buffer;
-  }
-
-  private async viewDirectory(absPath: string, workspace: ToolContext['workspace']): Promise<{ text: string }> {
-    const workspaceRoot = workspace.root;
-    const toDisplayPath = (absolutePath: string): string => {
-      const relative = path.relative(workspaceRoot, absolutePath);
-      if (!relative || relative === '') return '.';
-      if (relative.startsWith('..') || path.isAbsolute(relative)) return absolutePath;
-      return relative;
-    };
-
-    const topEntries = await workspace.list(absPath);
-    const hiddenCount = topEntries.filter((entry) => entry.name.startsWith('.')).length;
-
-    const visibleTop = topEntries
-      .filter((entry) => !entry.name.startsWith('.'))
-      .map((entry) => ({ name: entry.name, abs: entry.path, isDir: entry.isDirectory }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-
-    const displayRoot = toDisplayPath(absPath);
-    const lines: string[] = [`d ${displayRoot}`];
-
-    for (const entry of visibleTop) {
-      const displayEntry = toDisplayPath(entry.abs);
-      lines.push(`${entry.isDir ? 'd' : 'f'} ${displayEntry}`);
-      if (!entry.isDir) continue;
-
-      let childEntries: Awaited<ReturnType<ToolContext['workspace']['list']>>;
-      try {
-        childEntries = await workspace.list(entry.abs);
-      } catch {
-        lines.push(`skipped unreadable: ${displayEntry}`);
-        continue;
-      }
-      const visibleChildren = childEntries
-        .filter((child) => !child.name.startsWith('.'))
-        .map((child) => ({ name: child.name, abs: child.path, isDir: child.isDirectory }))
-        .sort((a, b) => a.name.localeCompare(b.name));
-      for (const child of visibleChildren) {
-        const displayChild = toDisplayPath(child.abs);
-        lines.push(`${child.isDir ? 'd' : 'f'} ${displayChild}`);
-      }
-    }
-
-    const header = `Here's the files and directories up to 2 levels deep in ${displayRoot}, excluding hidden items:\n`;
-    const body = lines.join('\n');
-    const hiddenNote =
-      hiddenCount > 0
-        ? `\n\n${hiddenCount} hidden files/directories in the top-level directory are excluded. You can use 'ls -la ${displayRoot}' to see them.`
-        : '';
-    return { text: truncateContent(`${header}${body}${hiddenNote}`, this.maxOutputChars) };
-  }
-
-  private viewImage(absPath: string, extension: string, buffer: Buffer): FileEditorResult {
-    const mime = (() => {
-      switch (extension) {
-        case '.png':
-          return 'image/png';
-        case '.jpg':
-        case '.jpeg':
-          return 'image/jpeg';
-        case '.gif':
-          return 'image/gif';
-        case '.webp':
-          return 'image/webp';
-        case '.bmp':
-          return 'image/bmp';
-        default:
-          return 'image/png';
-      }
-    })();
-    const estimatedBase64Length = Math.ceil(buffer.length / 3) * 4;
-    if (estimatedBase64Length > MAX_INLINE_IMAGE_BASE64_CHARS) {
-      const mb = buffer.length / 1024 / 1024;
-      const inlineLimitBytes = Math.floor(MAX_INLINE_IMAGE_BASE64_CHARS * 3 / 4);
-      const inlineLimitMb = inlineLimitBytes / 1024 / 1024;
-      const text = `Image file ${absPath} is too large to inline (${mb.toFixed(1)}MB). Files up to 10MB are allowed, but inline image previews are capped at ~${inlineLimitMb.toFixed(1)}MB.`;
-      return {
-        command: 'view',
-        path: absPath,
-        prev_exist: true,
-        old_content: null,
-        new_content: text,
-        content: [{ type: 'text', text }],
-      };
-    }
-
-    const imageBase64 = buffer.toString('base64');
-    const imageUrl = `data:${mime};base64,${imageBase64}`;
-    const text = `Image file ${absPath} read successfully. Displaying image content.`;
-    return {
-      command: 'view',
-      path: absPath,
-      prev_exist: true,
-      old_content: null,
-      new_content: text,
-      content: [{ type: 'text', text }, { type: 'image', image_urls: [imageUrl] }],
-    };
-  }
-
-  private pushUndo(resolvedPath: string, entry: UndoEntry): void {
-    const stack = this.undoHistory.get(resolvedPath) ?? [];
-    stack.push(entry);
-    this.undoBytesTotal += entry.byteSize;
-    while (stack.length > MAX_UNDO_ENTRIES_PER_PATH) {
-      const removed = stack.shift();
-      if (removed) {
-        this.undoBytesTotal -= removed.byteSize;
-      }
-    }
-    this.undoHistory.delete(resolvedPath);
-    this.undoHistory.set(resolvedPath, stack);
-    while (this.undoHistory.size > MAX_UNDO_PATHS) {
-      this.dropOldestUndoPath();
-    }
-    while (this.undoBytesTotal > MAX_UNDO_BYTES_TOTAL) {
-      if (this.dropOldestUndoPath(resolvedPath)) continue;
-      if (this.dropOldestUndoEntryForPath(resolvedPath)) continue;
-      break;
-    }
-  }
-
-  private dropOldestUndoPath(excludePath?: string): boolean {
-    for (const key of this.undoHistory.keys()) {
-      if (excludePath && key === excludePath) continue;
-
-      const stack = this.undoHistory.get(key);
-      if (stack) {
-        for (const entry of stack) {
-          this.undoBytesTotal -= entry.byteSize;
-        }
-      }
-      this.undoHistory.delete(key);
-      return true;
-    }
-    return false;
-  }
-
-  private dropOldestUndoEntryForPath(resolvedPath: string): boolean {
-    const stack = this.undoHistory.get(resolvedPath);
-    if (!stack || stack.length <= 1) return false;
-
-    const lastIndex = stack.length - 1;
-    const index = stack.slice(0, lastIndex).findIndex((entry) => entry.byteSize > 0);
-    if (index === -1) return false;
-    const [removed] = stack.splice(index, 1);
-    this.undoBytesTotal -= removed.byteSize;
-    return true;
   }
 
   private async readOptionalFile(absPath: string, workspace: ToolContext['workspace']): Promise<string | null> {

--- a/packages/agent-sdk-ts/src/tools/fileEditor/schema.ts
+++ b/packages/agent-sdk-ts/src/tools/fileEditor/schema.ts
@@ -1,0 +1,89 @@
+import { z } from 'zod';
+
+export const TOOL_DESCRIPTION = `Custom editing tool for viewing, creating and editing files in plain-text format
+* State is persistent across command calls and discussions with the user
+* If \`path\` is a text file, \`view\` displays the result of applying \`cat -n\`. If \`path\` is a directory, \`view\` lists non-hidden files and directories up to 2 levels deep
+* The \`create\` command cannot be used if the specified \`path\` already exists as a file
+* The \`undo_edit\` command undoes the most recent edit for a \`path\` (including undoing a create)
+* Files larger than 10MB are rejected
+* If a \`command\` generates a long output, it will be truncated and marked with \`<response clipped>\`
+* This tool can be used for creating and editing files in plain-text format.
+
+
+Before using this tool:
+1. Use the view tool to understand the file's contents and context
+2. Verify the directory path is correct (only applicable when creating new files):
+   - Use the view tool to verify the parent directory exists and is the correct location
+
+When making edits:
+   - Ensure the edit results in idiomatic, correct code
+   - Do not leave the code in a broken state
+   - Prefer workspace-relative paths; absolute paths are allowed when they resolve inside the workspace (or other explicitly-allowed roots)
+
+CRITICAL REQUIREMENTS FOR USING THIS TOOL:
+
+1. EXACT MATCHING: The \`old_str\` parameter must match EXACTLY a substring of the file, including all whitespace and indentation. It may span multiple lines. The tool will fail if \`old_str\` matches multiple locations or doesn't match exactly.
+
+2. UNIQUENESS: The \`old_str\` must uniquely identify a single instance in the file:
+   - Include sufficient context before and after the change point (3-5 lines recommended)
+   - If not unique, the replacement will not be performed
+
+3. REPLACEMENT: The \`new_str\` parameter should contain the edited lines that replace the \`old_str\`. Both strings must be different.
+
+Remember: when making multiple file edits in a row to the same file, you should prefer to send all edits in a single message with multiple calls to this tool, rather than multiple messages with a single call each.
+`;
+
+export const fileEditorSchema = z
+  .object({
+    command: z
+      .enum(['view', 'create', 'str_replace', 'insert', 'undo_edit'])
+      .describe('The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.'),
+    path: z
+      .string()
+      .describe('Workspace-relative path (preferred), or absolute path that resolves inside the workspace (or other explicitly-allowed roots).'),
+    file_text: z
+      .string()
+      .optional()
+      .describe('Required parameter of `create` command, with the content of the file to be created.'),
+    old_str: z
+      .string()
+      .optional()
+      .describe('Required parameter of `str_replace` command containing the string in `path` to replace.'),
+    new_str: z
+      .string()
+      .optional()
+      .describe('Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.'),
+    insert_line: z
+      .number()
+      .int()
+      .min(0)
+      .optional()
+      .describe('Line number to insert `new_str` after. Line numbers are 1-based. Use `insert_line: 0` to insert at the beginning of the file.'),
+    view_range: z
+      .array(z.number().int())
+      .length(2)
+      .optional()
+      .describe('Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.'),
+  })
+  .superRefine((value, ctx) => {
+    if (value.command === 'create' && value.file_text === undefined) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'file_text is required for create', path: ['file_text'] });
+    }
+    if (value.command === 'str_replace') {
+      if (value.old_str === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str is required for str_replace', path: ['old_str'] });
+      } else if (value.old_str.length === 0) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'old_str must be non-empty for str_replace', path: ['old_str'] });
+      }
+    }
+    if (value.command === 'insert') {
+      if (value.new_str === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'new_str is required for insert', path: ['new_str'] });
+      }
+      if (value.insert_line === undefined) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: 'insert_line is required for insert', path: ['insert_line'] });
+      }
+    }
+  });
+
+export type FileEditorArgs = z.infer<typeof fileEditorSchema>;

--- a/packages/agent-sdk-ts/src/tools/fileEditor/shared.ts
+++ b/packages/agent-sdk-ts/src/tools/fileEditor/shared.ts
@@ -1,0 +1,17 @@
+export type FileEditorContent = { type: 'text'; text: string } | { type: 'image'; image_urls?: string[]; detail?: string };
+
+export interface FileEditorResult {
+  command: 'view' | 'create' | 'str_replace' | 'insert' | 'undo_edit';
+  path?: string;
+  prev_exist?: boolean;
+  old_content?: string | null;
+  new_content?: string | null;
+  content?: FileEditorContent[];
+}
+
+export const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+export const MAX_INLINE_IMAGE_BASE64_CHARS = 4 * 1024 * 1024;
+export const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+export const PDF_EXTENSION = '.pdf';
+export const MAX_OUTPUT_CHARS = 50_000;
+export const OUTPUT_CLIP_MARKER = '<response clipped>';

--- a/packages/agent-sdk-ts/src/tools/fileEditor/textTransforms.ts
+++ b/packages/agent-sdk-ts/src/tools/fileEditor/textTransforms.ts
@@ -1,0 +1,42 @@
+import { MAX_OUTPUT_CHARS, OUTPUT_CLIP_MARKER } from './shared';
+
+export const applyViewRange = (content: string, viewRange?: number[]): string => {
+  if (!viewRange || viewRange.length !== 2) return content;
+  const [start, end] = viewRange;
+  const lines = content.split(/\r?\n/);
+  const slice = lines.slice(start - 1, end === -1 ? undefined : end);
+  return slice.join('\n');
+};
+
+export const addLineNumbers = (content: string): string => {
+  const lines = content.split(/\r?\n/);
+  return lines.map((line, idx) => `${idx + 1}\t${line}`).join('\n');
+};
+
+export const truncateContent = (content: string, maxChars = MAX_OUTPUT_CHARS): string => {
+  if (content.length <= maxChars) return content;
+  const minRequired = OUTPUT_CLIP_MARKER.length + 2;
+  if (maxChars < minRequired) {
+    return content.slice(0, maxChars);
+  }
+  const available = maxChars - OUTPUT_CLIP_MARKER.length - 2;
+  const half = Math.max(0, Math.floor(available / 2));
+  const head = content.slice(0, half);
+  const tail = content.slice(content.length - half);
+  return `${head}\n${OUTPUT_CLIP_MARKER}\n${tail}`;
+};
+
+export const isProbablyBinary = (buffer: Buffer): boolean => {
+  if (buffer.length === 0) return false;
+  const sampleSize = Math.min(buffer.length, 8000);
+  let suspiciousBytes = 0;
+  for (let i = 0; i < sampleSize; i++) {
+    const byte = buffer[i];
+    if (byte === 0) return true;
+    // Count control chars excluding common whitespace (\t \n \r).
+    if ((byte < 7 || (byte > 13 && byte < 32) || byte === 127) && byte !== 9 && byte !== 10 && byte !== 13) {
+      suspiciousBytes++;
+    }
+  }
+  return suspiciousBytes / sampleSize > 0.3;
+};

--- a/packages/agent-sdk-ts/src/tools/fileEditor/undoHistory.ts
+++ b/packages/agent-sdk-ts/src/tools/fileEditor/undoHistory.ts
@@ -1,0 +1,91 @@
+export type UndoEntry = {
+  prevExist: boolean;
+  oldContent: string | null;
+  byteSize: number;
+};
+
+const MAX_UNDO_ENTRIES_PER_PATH = 10;
+const MAX_UNDO_PATHS = 100;
+const MAX_UNDO_BYTES_TOTAL = 100 * 1024 * 1024;
+
+export class UndoHistoryManager {
+  private readonly history = new Map<string, UndoEntry[]>();
+  private bytesTotal = 0;
+
+  push(path: string, entry: UndoEntry): void {
+    const stack = this.history.get(path) ?? [];
+    stack.push(entry);
+    this.bytesTotal += entry.byteSize;
+
+    while (stack.length > MAX_UNDO_ENTRIES_PER_PATH) {
+      const removed = stack.shift();
+      if (removed) {
+        this.bytesTotal -= removed.byteSize;
+      }
+    }
+
+    this.history.delete(path);
+    this.history.set(path, stack);
+
+    while (this.history.size > MAX_UNDO_PATHS) {
+      this.dropOldestPath();
+    }
+
+    while (this.bytesTotal > MAX_UNDO_BYTES_TOTAL) {
+      if (this.dropOldestPath(path)) continue;
+      if (this.dropOldestEntryForPath(path)) continue;
+      break;
+    }
+  }
+
+  peek(path: string): UndoEntry | null {
+    const stack = this.history.get(path);
+    if (!stack || stack.length === 0) return null;
+    return stack[stack.length - 1];
+  }
+
+  discardLatest(path: string): void {
+    const stack = this.history.get(path);
+    if (!stack || stack.length === 0) return;
+
+    const removed = stack.pop();
+    if (removed) {
+      this.bytesTotal -= removed.byteSize;
+    }
+
+    if (stack.length === 0) {
+      this.history.delete(path);
+    }
+  }
+
+  private dropOldestPath(excludePath?: string): boolean {
+    for (const key of this.history.keys()) {
+      if (excludePath && key === excludePath) continue;
+
+      const stack = this.history.get(key);
+      if (stack) {
+        for (const entry of stack) {
+          this.bytesTotal -= entry.byteSize;
+        }
+      }
+      this.history.delete(key);
+      return true;
+    }
+    return false;
+  }
+
+  private dropOldestEntryForPath(path: string): boolean {
+    const stack = this.history.get(path);
+    if (!stack || stack.length <= 1) return false;
+
+    const lastIndex = stack.length - 1;
+    const index = stack.slice(0, lastIndex).findIndex((entry) => entry.byteSize > 0);
+    if (index === -1) return false;
+
+    const [removed] = stack.splice(index, 1);
+    this.bytesTotal -= removed.byteSize;
+    return true;
+  }
+}
+
+export const exceedsUndoHistorySizeCap = (undoByteSize: number): boolean => undoByteSize > MAX_UNDO_BYTES_TOTAL;

--- a/packages/agent-sdk-ts/src/tools/fileEditor/viewHandlers.ts
+++ b/packages/agent-sdk-ts/src/tools/fileEditor/viewHandlers.ts
@@ -5,6 +5,14 @@ import { IMAGE_EXTENSIONS, MAX_INLINE_IMAGE_BASE64_CHARS, PDF_EXTENSION } from '
 import { truncateContent } from './textTransforms';
 
 type Workspace = ToolContext['workspace'];
+type WorkspaceListEntry = Awaited<ReturnType<Workspace['list']>>[number];
+type VisibleEntry = { name: string; abs: string; isDir: boolean };
+
+const getSortedVisibleEntries = (entries: WorkspaceListEntry[]): VisibleEntry[] =>
+  entries
+    .filter((entry) => !entry.name.startsWith('.'))
+    .map((entry) => ({ name: entry.name, abs: entry.path, isDir: entry.isDirectory }))
+    .sort((a, b) => a.name.localeCompare(b.name));
 
 export const viewDirectory = async (
   absPath: string,
@@ -21,11 +29,7 @@ export const viewDirectory = async (
 
   const topEntries = await workspace.list(absPath);
   const hiddenCount = topEntries.filter((entry) => entry.name.startsWith('.')).length;
-
-  const visibleTop = topEntries
-    .filter((entry) => !entry.name.startsWith('.'))
-    .map((entry) => ({ name: entry.name, abs: entry.path, isDir: entry.isDirectory }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+  const visibleTop = getSortedVisibleEntries(topEntries);
 
   const displayRoot = toDisplayPath(absPath);
   const lines: string[] = [`d ${displayRoot}`];
@@ -42,10 +46,7 @@ export const viewDirectory = async (
       lines.push(`skipped unreadable: ${displayEntry}`);
       continue;
     }
-    const visibleChildren = childEntries
-      .filter((child) => !child.name.startsWith('.'))
-      .map((child) => ({ name: child.name, abs: child.path, isDir: child.isDirectory }))
-      .sort((a, b) => a.name.localeCompare(b.name));
+    const visibleChildren = getSortedVisibleEntries(childEntries);
     for (const child of visibleChildren) {
       const displayChild = toDisplayPath(child.abs);
       lines.push(`${child.isDir ? 'd' : 'f'} ${displayChild}`);

--- a/packages/agent-sdk-ts/src/tools/fileEditor/viewHandlers.ts
+++ b/packages/agent-sdk-ts/src/tools/fileEditor/viewHandlers.ts
@@ -1,0 +1,113 @@
+import path from 'path';
+import type { ToolContext } from '../types';
+import type { FileEditorResult } from './shared';
+import { IMAGE_EXTENSIONS, MAX_INLINE_IMAGE_BASE64_CHARS, PDF_EXTENSION } from './shared';
+import { truncateContent } from './textTransforms';
+
+type Workspace = ToolContext['workspace'];
+
+export const viewDirectory = async (
+  absPath: string,
+  workspace: Workspace,
+  maxOutputChars: number,
+): Promise<{ text: string }> => {
+  const workspaceRoot = workspace.root;
+  const toDisplayPath = (absolutePath: string): string => {
+    const relative = path.relative(workspaceRoot, absolutePath);
+    if (!relative || relative === '') return '.';
+    if (relative.startsWith('..') || path.isAbsolute(relative)) return absolutePath;
+    return relative;
+  };
+
+  const topEntries = await workspace.list(absPath);
+  const hiddenCount = topEntries.filter((entry) => entry.name.startsWith('.')).length;
+
+  const visibleTop = topEntries
+    .filter((entry) => !entry.name.startsWith('.'))
+    .map((entry) => ({ name: entry.name, abs: entry.path, isDir: entry.isDirectory }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const displayRoot = toDisplayPath(absPath);
+  const lines: string[] = [`d ${displayRoot}`];
+
+  for (const entry of visibleTop) {
+    const displayEntry = toDisplayPath(entry.abs);
+    lines.push(`${entry.isDir ? 'd' : 'f'} ${displayEntry}`);
+    if (!entry.isDir) continue;
+
+    let childEntries: Awaited<ReturnType<Workspace['list']>>;
+    try {
+      childEntries = await workspace.list(entry.abs);
+    } catch {
+      lines.push(`skipped unreadable: ${displayEntry}`);
+      continue;
+    }
+    const visibleChildren = childEntries
+      .filter((child) => !child.name.startsWith('.'))
+      .map((child) => ({ name: child.name, abs: child.path, isDir: child.isDirectory }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of visibleChildren) {
+      const displayChild = toDisplayPath(child.abs);
+      lines.push(`${child.isDir ? 'd' : 'f'} ${displayChild}`);
+    }
+  }
+
+  const header = `Here's the files and directories up to 2 levels deep in ${displayRoot}, excluding hidden items:\n`;
+  const body = lines.join('\n');
+  const hiddenNote =
+    hiddenCount > 0
+      ? `\n\n${hiddenCount} hidden files/directories in the top-level directory are excluded. You can use 'ls -la ${displayRoot}' to see them.`
+      : '';
+  return { text: truncateContent(`${header}${body}${hiddenNote}`, maxOutputChars) };
+};
+
+export const viewImage = (absPath: string, extension: string, buffer: Buffer): FileEditorResult => {
+  const mime = (() => {
+    switch (extension) {
+      case '.png':
+        return 'image/png';
+      case '.jpg':
+      case '.jpeg':
+        return 'image/jpeg';
+      case '.gif':
+        return 'image/gif';
+      case '.webp':
+        return 'image/webp';
+      case '.bmp':
+        return 'image/bmp';
+      default:
+        return 'image/png';
+    }
+  })();
+
+  const estimatedBase64Length = Math.ceil(buffer.length / 3) * 4;
+  if (estimatedBase64Length > MAX_INLINE_IMAGE_BASE64_CHARS) {
+    const mb = buffer.length / 1024 / 1024;
+    const inlineLimitBytes = Math.floor(MAX_INLINE_IMAGE_BASE64_CHARS * 3 / 4);
+    const inlineLimitMb = inlineLimitBytes / 1024 / 1024;
+    const text = `Image file ${absPath} is too large to inline (${mb.toFixed(1)}MB). Files up to 10MB are allowed, but inline image previews are capped at ~${inlineLimitMb.toFixed(1)}MB.`;
+    return {
+      command: 'view',
+      path: absPath,
+      prev_exist: true,
+      old_content: null,
+      new_content: text,
+      content: [{ type: 'text', text }],
+    };
+  }
+
+  const imageBase64 = buffer.toString('base64');
+  const imageUrl = `data:${mime};base64,${imageBase64}`;
+  const text = `Image file ${absPath} read successfully. Displaying image content.`;
+  return {
+    command: 'view',
+    path: absPath,
+    prev_exist: true,
+    old_content: null,
+    new_content: text,
+    content: [{ type: 'text', text }, { type: 'image', image_urls: [imageUrl] }],
+  };
+};
+
+export const isBinaryExtension = (extension: string): boolean =>
+  IMAGE_EXTENSIONS.has(extension) || extension === PDF_EXTENSION;


### PR DESCRIPTION
## Summary
- split `packages/agent-sdk-ts/src/tools/FileEditorTool.ts` into focused helpers under `packages/agent-sdk-ts/src/tools/fileEditor/`:
  - `schema.ts`: tool schema + description
  - `shared.ts`: shared types/constants
  - `textTransforms.ts`: view-range/line-number/truncation/binary-detection helpers
  - `viewHandlers.ts`: directory/image rendering helpers
  - `undoHistory.ts`: undo-history storage + pruning policy
- kept `FileEditorTool.ts` as the command orchestrator with preserved behavior and exported compatibility constants/types
- reduced `FileEditorTool.ts` from 492 lines to 192 lines

## Validation
- `npx vitest run packages/agent-sdk-ts/src/tools/__tests__/tools.test.ts packages/agent-sdk-ts/src/tools/__tests__/new-tools.test.ts`
- `npm run lint -w @openhands/agent-sdk-ts`
- `npm run build -w @openhands/agent-sdk-ts`

### Bead
oh-tab-zhwi.9.3: Refactor FileEditorTool into command handlers and undo manager

Status: in_progress
Priority: P3
Type: task

Description:
Split FileEditorTool responsibilities into focused helpers/modules (view/render helpers, edit command handlers, undo-history manager) while preserving tool behavior and schema contract.

Acceptance Criteria:
- FileEditorTool.ts shrinks materially and composes extracted helpers.
- Undo behavior and size/path caps remain unchanged.
- Existing file editor tests remain green.

### Review
- Reviewer process used Agent Mail thread `oh-tab-zhwi.9.3`.
- Primary reviewer `PinkStone` did not respond after repeated high/urgent pings.
- Fallback reviewer `OrangeSnow` ran final gate verification on head `b284be8`:
  - required checks green (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`)
  - `CodeRabbit` success
  - no unresolved review threads
- Explicit decision posted in-thread: `APPROVED`.
