### PR TITLE
[oh-tab-b7qq.1] Extract core command registrations from extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { resolveConversationStoreRoot } from './extension/conversationStoreRoot'
 import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
+import { registerCoreCommands } from './extension/coreCommands';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
 import { collectEnvironmentInfo } from './shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from './shared/uri';
@@ -590,18 +591,6 @@ export function activate(context: vscode.ExtensionContext) {
     },
   }).ensureConversationAndConnection;
 
-  const open = vscode.commands.registerCommand('openhands.open', async () => {
-    try {
-      // VS Code auto-creates a focus command for views: `<viewId>.focus`
-      await vscode.commands.executeCommand('openhands.agent.focus');
-    } catch {
-      // Fallback: open the container and reveal the view if already resolved
-      await vscode.commands.executeCommand('workbench.view.extension.openhands');
-      chatView?.show?.(true);
-    }
-    await ensureConversationAndConnection();
-  });
-
   const explainSelection = registerExplainSelectionCommand({
     getConversation: () => conversation,
     getConversationMode: () => conversationMode,
@@ -662,44 +651,10 @@ export function activate(context: vscode.ExtensionContext) {
     summarizeWithLocalLlm,
   });
 
-  const startNew = vscode.commands.registerCommand('openhands.startNewConversation', async () => {
-    await ensureConversationAndConnection();
-    sentTestEvents.length = 0;
-    printedExitFor.clear();
-    await conversation?.startNewConversation();
-  });
-
-  const configure = vscode.commands.registerCommand('openhands.configure', async () => {
-    // Open VS Code settings page for OpenHands extension
-    await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
-  });
-
-  const toggleVerboseOutput = vscode.commands.registerCommand('openhands.toggleVerboseOutput', async () => {
-    const cfg = vscode.workspace.getConfiguration();
-    const current = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
-    const next: OutputVerbosity = current === 'verbose' ? 'minimal' : 'verbose';
-    await cfg.update('openhands.logging.verbosity', next, vscode.ConfigurationTarget.Global);
-    outputVerbosity = next;
-    verboseEventLogging =
-      outputVerbosity === 'verbose' ||
-      Boolean(cfg.get<boolean>('openhands.agent.debug')) ||
-      Boolean(cfg.get<boolean>('openhands.devBridge.enabled'));
-    outputLogger?.info(`[settings] Output verbosity set to ${next}`);
-    if (next === 'verbose') {
-      outputLogger?.show(true);
-    }
-    void vscode.window.showInformationMessage(`OpenHands output verbosity: ${next}`);
-  });
-
   const secretCommands = registerSecretCommands({
     context,
     secrets,
     getConversation: () => conversation,
-  });
-
-  const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {
-    await ensureConversationAndConnection();
-    conversation?.reconnect();
   });
 
   // Clear terminal references when the user closes the OpenHands terminal
@@ -712,14 +667,43 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  const pause = vscode.commands.registerCommand('openhands.pauseCurrentRun', async () => {
-    await ensureConversationAndConnection();
-    await conversation?.pause();
-  });
-
-  const resume = vscode.commands.registerCommand('openhands.resumeCurrentRun', async () => {
-    await ensureConversationAndConnection();
-    await conversation?.resume();
+  const coreCommands = registerCoreCommands({
+    ensureConversationAndConnection: () => ensureConversationAndConnection(),
+    focusOpenHandsView: async () => {
+      try {
+        // VS Code auto-creates a focus command for views: `<viewId>.focus`
+        await vscode.commands.executeCommand('openhands.agent.focus');
+      } catch {
+        // Fallback: open the container and reveal the view if already resolved
+        await vscode.commands.executeCommand('workbench.view.extension.openhands');
+        chatView?.show?.(true);
+      }
+    },
+    startNewConversation: async () => {
+      await ensureConversationAndConnection();
+      sentTestEvents.length = 0;
+      printedExitFor.clear();
+      await conversation?.startNewConversation();
+    },
+    reconnectConversation: async () => {
+      await ensureConversationAndConnection();
+      conversation?.reconnect();
+    },
+    pauseConversation: async () => {
+      await ensureConversationAndConnection();
+      await conversation?.pause();
+    },
+    resumeConversation: async () => {
+      await ensureConversationAndConnection();
+      await conversation?.resume();
+    },
+    setOutputVerbosity: (verbosity) => {
+      outputVerbosity = verbosity;
+    },
+    setVerboseEventLogging: (verbose) => {
+      verboseEventLogging = verbose;
+    },
+    getOutputLogger: () => outputLogger,
   });
 
   // Listen for runtime configuration changes
@@ -768,19 +752,13 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(onConfigurationChange));
 
   context.subscriptions.push(
-    open,
+    ...coreCommands,
     explainSelection,
     cloudLogin,
     cloudLogout,
     ...diagnosticsCommands,
     ...halCommands,
-    startNew,
-    configure,
-    toggleVerboseOutput,
     ...secretCommands,
-    reconnect,
-    pause,
-    resume
   );
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -668,8 +668,7 @@ export function activate(context: vscode.ExtensionContext) {
   );
 
   const coreCommands = registerCoreCommands({
-    ensureConversationAndConnection: () => ensureConversationAndConnection(),
-    focusOpenHandsView: async () => {
+    openCommand: async () => {
       try {
         // VS Code auto-creates a focus command for views: `<viewId>.focus`
         await vscode.commands.executeCommand('openhands.agent.focus');
@@ -678,6 +677,7 @@ export function activate(context: vscode.ExtensionContext) {
         await vscode.commands.executeCommand('workbench.view.extension.openhands');
         chatView?.show?.(true);
       }
+      await ensureConversationAndConnection();
     },
     startNewConversation: async () => {
       await ensureConversationAndConnection();

--- a/src/extension/coreCommands.ts
+++ b/src/extension/coreCommands.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+import { normalizeOutputVerbosity, type OutputLogger, type OutputVerbosity } from './outputLogger';
+
+type CoreCommandDeps = {
+  ensureConversationAndConnection: () => Promise<void>;
+  focusOpenHandsView: () => Promise<void>;
+  startNewConversation: () => Promise<void>;
+  reconnectConversation: () => Promise<void>;
+  pauseConversation: () => Promise<void>;
+  resumeConversation: () => Promise<void>;
+  setOutputVerbosity: (verbosity: OutputVerbosity) => void;
+  setVerboseEventLogging: (verbose: boolean) => void;
+  getOutputLogger: () => OutputLogger | undefined;
+};
+
+export function registerCoreCommands({
+  ensureConversationAndConnection,
+  focusOpenHandsView,
+  startNewConversation,
+  reconnectConversation,
+  pauseConversation,
+  resumeConversation,
+  setOutputVerbosity,
+  setVerboseEventLogging,
+  getOutputLogger,
+}: CoreCommandDeps): vscode.Disposable[] {
+  const open = vscode.commands.registerCommand('openhands.open', async () => {
+    await focusOpenHandsView();
+    await ensureConversationAndConnection();
+  });
+
+  const startNew = vscode.commands.registerCommand('openhands.startNewConversation', async () => {
+    await startNewConversation();
+  });
+
+  const configure = vscode.commands.registerCommand('openhands.configure', async () => {
+    await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:openhands.openhands-tab');
+  });
+
+  const toggleVerboseOutput = vscode.commands.registerCommand('openhands.toggleVerboseOutput', async () => {
+    const cfg = vscode.workspace.getConfiguration();
+    const current = normalizeOutputVerbosity(cfg.get<string>('openhands.logging.verbosity'));
+    const next: OutputVerbosity = current === 'verbose' ? 'minimal' : 'verbose';
+    await cfg.update('openhands.logging.verbosity', next, vscode.ConfigurationTarget.Global);
+
+    setOutputVerbosity(next);
+    setVerboseEventLogging(
+      next === 'verbose' ||
+        Boolean(cfg.get<boolean>('openhands.agent.debug')) ||
+        Boolean(cfg.get<boolean>('openhands.devBridge.enabled'))
+    );
+
+    const outputLogger = getOutputLogger();
+    outputLogger?.info(`[settings] Output verbosity set to ${next}`);
+    if (next === 'verbose') {
+      outputLogger?.show(true);
+    }
+
+    void vscode.window.showInformationMessage(`OpenHands output verbosity: ${next}`);
+  });
+
+  const reconnect = vscode.commands.registerCommand('openhands.reconnect', async () => {
+    await reconnectConversation();
+  });
+
+  const pause = vscode.commands.registerCommand('openhands.pauseCurrentRun', async () => {
+    await pauseConversation();
+  });
+
+  const resume = vscode.commands.registerCommand('openhands.resumeCurrentRun', async () => {
+    await resumeConversation();
+  });
+
+  return [open, startNew, configure, toggleVerboseOutput, reconnect, pause, resume];
+}

--- a/src/extension/coreCommands.ts
+++ b/src/extension/coreCommands.ts
@@ -2,8 +2,7 @@ import * as vscode from 'vscode';
 import { normalizeOutputVerbosity, type OutputLogger, type OutputVerbosity } from './outputLogger';
 
 type CoreCommandDeps = {
-  ensureConversationAndConnection: () => Promise<void>;
-  focusOpenHandsView: () => Promise<void>;
+  openCommand: () => Promise<void>;
   startNewConversation: () => Promise<void>;
   reconnectConversation: () => Promise<void>;
   pauseConversation: () => Promise<void>;
@@ -14,8 +13,7 @@ type CoreCommandDeps = {
 };
 
 export function registerCoreCommands({
-  ensureConversationAndConnection,
-  focusOpenHandsView,
+  openCommand,
   startNewConversation,
   reconnectConversation,
   pauseConversation,
@@ -25,8 +23,7 @@ export function registerCoreCommands({
   getOutputLogger,
 }: CoreCommandDeps): vscode.Disposable[] {
   const open = vscode.commands.registerCommand('openhands.open', async () => {
-    await focusOpenHandsView();
-    await ensureConversationAndConnection();
+    await openCommand();
   });
 
   const startNew = vscode.commands.registerCommand('openhands.startNewConversation', async () => {


### PR DESCRIPTION
## Summary
- extract core extension command registrations into `src/extension/coreCommands.ts`
- keep command ids and command behavior unchanged
- simplify `activate()` wiring in `src/extension.ts` by delegating to `registerCoreCommands(...)`

## Validation
- `npm run lint -- src/extension.ts src/extension/coreCommands.ts`
- `npx vitest run src/__tests__/extension.activation.test.ts src/__tests__/extension.commands.test.ts src/__tests__/extension.chatView.test.ts src/__tests__/extension.deactivation.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
id: oh-tab-b7qq.1
title: Extract core command registrations from extension.ts
status: in_progress
priority: 3
type: task
assignee: LilacCastle
labels: extension, refactor, tech-debt

description:
Behavior-preserving refactor: move the core command registrations (open/start/configure/toggle-verbosity/reconnect/pause/resume) out of src/extension.ts into a dedicated extension module so activate() stays focused on wiring.

acceptance_criteria:
- src/extension.ts delegates core command registration to a focused helper module.
- Public command ids and behavior remain unchanged.
- Extension/unit tests for command wiring remain green.

notes:
Picked up for implementation; proceeding with branch+PR+review workflow.
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/977" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated core command registration and handling into a single, unified command hub to streamline conversation controls and UI actions while preserving existing behaviors.
* **New Features**
  * Improved verbosity toggle: switching verbosity updates logging behavior, surfaces the logger when verbose, and shows a confirmation message.
* **Chores**
  * Simplified activation wiring to register core commands as a grouped set of disposables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer gate approval received in Agent Mail thread `oh-tab-b7qq.1` from `OrangeSnow`.
- Final approval message: `[oh-tab-b7qq.1] APPROVED: PR #977 final gate pass on b11e2c4`.
- Gate snapshot at approval: required checks green (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`), unresolved review threads `0`, `CodeRabbit` success.
- Follow-up from Gemini inline suggestion was applied (`openCommand` encapsulation) and the thread was resolved before final approval.
