### PR TITLE
[oh-tab-b7qq.2] Extract welcome secret-status sync from extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,4 @@
 import * as vscode from 'vscode';
-import { SettingsManager } from './settings/SettingsManager';
-import { VscodeSettingsAdapter } from './settings/VscodeSettingsAdapter';
 import { type HalStateSnapshot, isHalMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
 import { DEFAULT_HAL_STATE } from './shared/halDefaults';
 import { maskSecretsInText } from './shared/maskSecrets';
@@ -24,10 +22,10 @@ import { registerSecretCommands } from './extension/secretCommands';
 import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { registerCoreCommands } from './extension/coreCommands';
+import { registerWelcomeSecretStatusSync } from './extension/welcomeSecretStatusSync';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
 import { collectEnvironmentInfo } from './shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from './shared/uri';
-import { computeWelcomeSecretStatus } from './shared/welcomeSecretStatus';
 import { registerCloudLoginCommand } from './extension/cloudLoginCommand';
 import { registerCloudLogoutCommand } from './extension/cloudLogoutCommand';
 import type { CloudBootstrapResult } from './cloud/cloudRemoteBootstrap';
@@ -384,44 +382,14 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  let lastWelcomeSecretStatus: { hasProviderKey: boolean; hasGeminiKey: boolean } | null = null;
-  let welcomeSecretStatusTimer: ReturnType<typeof setTimeout> | null = null;
-
-  const postWelcomeSecretStatus = async (): Promise<void> => {
-    if (!chatView) return;
-    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
-    const settings = await settingsMgr.get();
-    const status = await computeWelcomeSecretStatus({ context, settings });
-    if (
-      lastWelcomeSecretStatus &&
-      lastWelcomeSecretStatus.hasProviderKey === status.hasProviderKey &&
-      lastWelcomeSecretStatus.hasGeminiKey === status.hasGeminiKey
-    ) {
-      return;
-    }
-    lastWelcomeSecretStatus = status;
-    void chatView.webview.postMessage({ type: 'welcomeSecretStatus', ...status } satisfies HostToWebviewMessage);
-  };
-
-  const scheduleWelcomeSecretStatusUpdate = () => {
-    if (welcomeSecretStatusTimer) clearTimeout(welcomeSecretStatusTimer);
-    welcomeSecretStatusTimer = setTimeout(() => {
-      welcomeSecretStatusTimer = null;
-      void postWelcomeSecretStatus().catch((err: unknown) => {
-        outputChannel?.appendLine(`[welcome] Failed to compute secret status: ${renderError(err)}`);
-      });
-    }, 150);
-  };
-
-  // Watch SecretStorage so welcome-page onboarding prompts reflect current key state.
-  const secretsOnDidChange = (context.secrets as unknown as { onDidChange?: vscode.Event<{ key: string }> }).onDidChange;
-  if (typeof secretsOnDidChange === 'function') {
-    context.subscriptions.push(
-      secretsOnDidChange(() => {
-        scheduleWelcomeSecretStatusUpdate();
-      })
-    );
-  }
+  context.subscriptions.push(
+    registerWelcomeSecretStatusSync({
+      context,
+      getChatView: () => chatView,
+      getOutputChannel: () => outputChannel,
+      renderError,
+    })
+  );
 
   // Enable dev bridge only for Development/Test extension modes or with user setting
   const mode = context.extensionMode;

--- a/src/extension/welcomeSecretStatusSync.ts
+++ b/src/extension/welcomeSecretStatusSync.ts
@@ -17,6 +17,7 @@ export function registerWelcomeSecretStatusSync({
   getOutputChannel,
   renderError,
 }: WelcomeSecretStatusSyncDeps): vscode.Disposable {
+  const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
   let lastWelcomeSecretStatus: { hasProviderKey: boolean; hasGeminiKey: boolean } | null = null;
   let welcomeSecretStatusTimer: ReturnType<typeof setTimeout> | null = null;
   const subscriptions: vscode.Disposable[] = [];
@@ -25,7 +26,6 @@ export function registerWelcomeSecretStatusSync({
     const chatView = getChatView();
     if (!chatView) return;
 
-    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
     const settings = await settingsMgr.get();
     const status = await computeWelcomeSecretStatus({ context, settings });
     if (

--- a/src/extension/welcomeSecretStatusSync.ts
+++ b/src/extension/welcomeSecretStatusSync.ts
@@ -1,0 +1,75 @@
+import * as vscode from 'vscode';
+import { SettingsManager } from '../settings/SettingsManager';
+import { VscodeSettingsAdapter } from '../settings/VscodeSettingsAdapter';
+import { computeWelcomeSecretStatus } from '../shared/welcomeSecretStatus';
+import type { HostToWebviewMessage } from '../shared/webviewMessages';
+
+type WelcomeSecretStatusSyncDeps = {
+  context: vscode.ExtensionContext;
+  getChatView: () => vscode.WebviewView | undefined;
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  renderError: (err: unknown) => string;
+};
+
+export function registerWelcomeSecretStatusSync({
+  context,
+  getChatView,
+  getOutputChannel,
+  renderError,
+}: WelcomeSecretStatusSyncDeps): vscode.Disposable {
+  let lastWelcomeSecretStatus: { hasProviderKey: boolean; hasGeminiKey: boolean } | null = null;
+  let welcomeSecretStatusTimer: ReturnType<typeof setTimeout> | null = null;
+  const subscriptions: vscode.Disposable[] = [];
+
+  const postWelcomeSecretStatus = async (): Promise<void> => {
+    const chatView = getChatView();
+    if (!chatView) return;
+
+    const settingsMgr = new SettingsManager(new VscodeSettingsAdapter(context));
+    const settings = await settingsMgr.get();
+    const status = await computeWelcomeSecretStatus({ context, settings });
+    if (
+      lastWelcomeSecretStatus &&
+      lastWelcomeSecretStatus.hasProviderKey === status.hasProviderKey &&
+      lastWelcomeSecretStatus.hasGeminiKey === status.hasGeminiKey
+    ) {
+      return;
+    }
+
+    lastWelcomeSecretStatus = status;
+    void chatView.webview.postMessage({ type: 'welcomeSecretStatus', ...status } satisfies HostToWebviewMessage);
+  };
+
+  const scheduleWelcomeSecretStatusUpdate = () => {
+    if (welcomeSecretStatusTimer) clearTimeout(welcomeSecretStatusTimer);
+    welcomeSecretStatusTimer = setTimeout(() => {
+      welcomeSecretStatusTimer = null;
+      void postWelcomeSecretStatus().catch((err: unknown) => {
+        getOutputChannel()?.appendLine(`[welcome] Failed to compute secret status: ${renderError(err)}`);
+      });
+    }, 150);
+  };
+
+  // Watch SecretStorage so welcome-page onboarding prompts reflect current key state.
+  const secretsOnDidChange = (context.secrets as unknown as { onDidChange?: vscode.Event<{ key: string }> })
+    .onDidChange;
+  if (typeof secretsOnDidChange === 'function') {
+    subscriptions.push(
+      secretsOnDidChange(() => {
+        scheduleWelcomeSecretStatusUpdate();
+      })
+    );
+  }
+
+  return {
+    dispose: () => {
+      if (welcomeSecretStatusTimer) {
+        clearTimeout(welcomeSecretStatusTimer);
+        welcomeSecretStatusTimer = null;
+      }
+      for (const subscription of subscriptions) {
+        subscription.dispose();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- extract welcome secret-status sync/debounce and SecretStorage watcher logic from `src/extension.ts`
- add focused helper module `src/extension/welcomeSecretStatusSync.ts`
- keep payload/behavior unchanged while reducing `activate()` clutter

## Validation
- `npm run lint -- src/extension.ts src/extension/welcomeSecretStatusSync.ts`
- `npx vitest run src/__tests__/extension.settingsModes.test.ts src/__tests__/extension.activation.test.ts src/__tests__/extension.commands.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
id: oh-tab-b7qq.2
title: Extract welcome secret-status sync from extension.ts
status: in_progress
priority: 3
type: task
assignee: LilacCastle
labels: extension, refactor, tech-debt

description:
Behavior-preserving refactor: move welcome secret-status polling/debounce and SecretStorage change wiring out of src/extension.ts into a focused extension module.

acceptance_criteria:
- src/extension.ts delegates welcome secret-status sync setup to a dedicated helper module.
- welcomeSecretStatus behavior and message payloads remain unchanged.
- extension tests related to welcome/settings remain green.

notes:
Picked up for implementation; proceeding with branch+PR+review workflow.
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/978" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


### Review
- Reviewer gate approval received in Agent Mail thread `oh-tab-b7qq.2` from `OrangeSnow`.
- Final approval message: `[oh-tab-b7qq.2] APPROVED: PR #978 final gate pass on 0fadf56`.
- Gate snapshot at approval: required checks green (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`), unresolved review threads `0`, `CodeRabbit` success.
- Gemini review suggestion (single `SettingsManager` instance reuse) was applied and the thread was resolved before final approval.
