### PR TITLE
[oh-tab-b7qq.3] Extract local terminal mirroring from extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { summarizeWithLocalLlm } from './extension/summarizeWithLocalLlm';
 import { createHalConfigurationChangeHandler } from './extension/halConfigurationChangeHandler';
 import { registerCoreCommands } from './extension/coreCommands';
 import { registerWelcomeSecretStatusSync } from './extension/welcomeSecretStatusSync';
+import { mirrorTerminalEventToLocalTerminal } from './extension/localTerminalMirror';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
 import { collectEnvironmentInfo } from './shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from './shared/uri';
@@ -42,7 +43,6 @@ import {
   type BashEvent,
   type Event,
   isBashCommand,
-  isBashExit,
   isBashOutput,
 } from '@openhands/agent-sdk-ts';
 import { OpenHandsChatViewProvider } from './sidebar/OpenHandsChatViewProvider';
@@ -426,51 +426,30 @@ export function activate(context: vscode.ExtensionContext) {
       return;
     }
 
-    // Recreate terminal if not present or if the PTY has been closed
-    if (!terminal || !terminalLogPty || terminalLogPty.isClosed?.()) {
-      try {
-        const renderProgress =
-          vscode.workspace.getConfiguration().get<boolean>('openhands.terminal.renderProgress') ?? true;
-        terminalLogPty = new OpenHandsTerminalLogPseudoterminal({ renderProgress });
-        terminal = vscode.window.createTerminal({ name: 'OpenHands', pty: terminalLogPty });
-      } catch (e) {
-        console.error('[Terminal] Failed to create terminal log:', e);
-        terminal = undefined;
-        terminalLogPty = undefined;
-        return;
-      }
-    }
-
-    try {
-      if (isBashCommand(displayEvent)) {
-        // Add a spacer only if previous output didn't end with a newline
-        terminalLogPty.ensureNewline?.();
-        terminalLogPty.writeLine(`$ ${displayEvent.command}`);
-        if (displayEvent.command_id) printedExitFor.delete(displayEvent.command_id);
-      } else if (isBashOutput(displayEvent)) {
-        if (displayEvent.stdout) terminalLogPty.write(displayEvent.stdout);
-        if (displayEvent.stderr) terminalLogPty.write(displayEvent.stderr);
-        // Defensive: if exit_code is provided on output but no BashExit arrives, synthesize a footer once
-        const cid = 'command_id' in displayEvent ? (displayEvent as { command_id?: string }).command_id : undefined;
-        const code = 'exit_code' in displayEvent ? (displayEvent as { exit_code?: number }).exit_code : undefined;
-        if (cid && typeof code === 'number' && !printedExitFor.has(cid)) {
-          terminalLogPty.ensureNewline?.();
-          terminalLogPty.writeLine(`[Process exited with code ${code}]`);
-          markPrintedExitFor(cid);
+    const mirrored = mirrorTerminalEventToLocalTerminal({
+      event: displayEvent,
+      state: { terminal, terminalLogPty },
+      createTerminal: () => {
+        try {
+          const renderProgress =
+            vscode.workspace.getConfiguration().get<boolean>('openhands.terminal.renderProgress') ?? true;
+          const nextTerminalLogPty = new OpenHandsTerminalLogPseudoterminal({ renderProgress });
+          const nextTerminal = vscode.window.createTerminal({ name: 'OpenHands', pty: nextTerminalLogPty });
+          return { terminal: nextTerminal, terminalLogPty: nextTerminalLogPty };
+        } catch (e) {
+          console.error('[Terminal] Failed to create terminal log:', e);
+          return { terminal: undefined, terminalLogPty: undefined };
         }
-      } else if (isBashExit(displayEvent)) {
-        const cid = 'command_id' in displayEvent ? (displayEvent as { command_id?: string }).command_id : undefined;
-        if (!cid || !printedExitFor.has(cid)) {
-          terminalLogPty.ensureNewline?.();
-          terminalLogPty.writeLine(`[Process exited with code ${displayEvent.exit_code}]`);
-        }
-        if (cid) {
-          markPrintedExitFor(cid);
-        }
-      }
-    } catch (err) {
-      console.error(`[Terminal] Failed to write terminal event: ${renderError(err)}`);
-    }
+      },
+      hasPrintedExitFor: (commandId) => printedExitFor.has(commandId),
+      clearPrintedExitFor: (commandId) => {
+        printedExitFor.delete(commandId);
+      },
+      markPrintedExitFor,
+      renderError,
+    });
+    terminal = mirrored.terminal;
+    terminalLogPty = mirrored.terminalLogPty;
   };
 
   ensureConversationAndConnectionDelegate = createConversationLifecycleOrchestrator({

--- a/src/extension/localTerminalMirror.ts
+++ b/src/extension/localTerminalMirror.ts
@@ -1,0 +1,79 @@
+import * as vscode from 'vscode';
+import { OpenHandsTerminalLogPseudoterminal } from '../terminal/OpenHandsTerminalLogPseudoterminal';
+import {
+  type BashEvent,
+  isBashCommand,
+  isBashExit,
+  isBashOutput,
+} from '@openhands/agent-sdk-ts';
+
+type TerminalMirrorState = {
+  terminal: vscode.Terminal | undefined;
+  terminalLogPty: OpenHandsTerminalLogPseudoterminal | undefined;
+};
+
+type MirrorTerminalEventDeps = {
+  event: BashEvent;
+  state: TerminalMirrorState;
+  createTerminal: () => TerminalMirrorState;
+  hasPrintedExitFor: (commandId: string) => boolean;
+  clearPrintedExitFor: (commandId: string) => void;
+  markPrintedExitFor: (commandId: string) => void;
+  renderError: (err: unknown) => string;
+};
+
+export function mirrorTerminalEventToLocalTerminal({
+  event,
+  state,
+  createTerminal,
+  hasPrintedExitFor,
+  clearPrintedExitFor,
+  markPrintedExitFor,
+  renderError,
+}: MirrorTerminalEventDeps): TerminalMirrorState {
+  let { terminal, terminalLogPty } = state;
+
+  // Recreate terminal if not present or if the PTY has been closed.
+  if (!terminal || !terminalLogPty || terminalLogPty.isClosed?.()) {
+    const recreated = createTerminal();
+    terminal = recreated.terminal;
+    terminalLogPty = recreated.terminalLogPty;
+    if (!terminal || !terminalLogPty) {
+      return { terminal, terminalLogPty };
+    }
+  }
+
+  try {
+    if (isBashCommand(event)) {
+      // Add a spacer only if previous output didn't end with a newline.
+      terminalLogPty.ensureNewline?.();
+      terminalLogPty.writeLine(`$ ${event.command}`);
+      if (event.command_id) clearPrintedExitFor(event.command_id);
+    } else if (isBashOutput(event)) {
+      if (event.stdout) terminalLogPty.write(event.stdout);
+      if (event.stderr) terminalLogPty.write(event.stderr);
+
+      // Defensive: if exit_code is provided on output but no BashExit arrives, synthesize a footer once.
+      const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
+      const code = 'exit_code' in event ? (event as { exit_code?: number }).exit_code : undefined;
+      if (cid && typeof code === 'number' && !hasPrintedExitFor(cid)) {
+        terminalLogPty.ensureNewline?.();
+        terminalLogPty.writeLine(`[Process exited with code ${code}]`);
+        markPrintedExitFor(cid);
+      }
+    } else if (isBashExit(event)) {
+      const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
+      if (!cid || !hasPrintedExitFor(cid)) {
+        terminalLogPty.ensureNewline?.();
+        terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
+      }
+      if (cid) {
+        markPrintedExitFor(cid);
+      }
+    }
+  } catch (err) {
+    console.error(`[Terminal] Failed to write terminal event: ${renderError(err)}`);
+  }
+
+  return { terminal, terminalLogPty };
+}

--- a/src/extension/localTerminalMirror.ts
+++ b/src/extension/localTerminalMirror.ts
@@ -46,7 +46,7 @@ export function mirrorTerminalEventToLocalTerminal({
   try {
     if (isBashCommand(event)) {
       // Add a spacer only if previous output didn't end with a newline.
-      terminalLogPty.ensureNewline?.();
+      terminalLogPty.ensureNewline();
       terminalLogPty.writeLine(`$ ${event.command}`);
       if (event.command_id) clearPrintedExitFor(event.command_id);
     } else if (isBashOutput(event)) {
@@ -54,17 +54,17 @@ export function mirrorTerminalEventToLocalTerminal({
       if (event.stderr) terminalLogPty.write(event.stderr);
 
       // Defensive: if exit_code is provided on output but no BashExit arrives, synthesize a footer once.
-      const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
-      const code = 'exit_code' in event ? (event as { exit_code?: number }).exit_code : undefined;
+      const cid = event.command_id;
+      const code = event.exit_code;
       if (cid && typeof code === 'number' && !hasPrintedExitFor(cid)) {
-        terminalLogPty.ensureNewline?.();
+        terminalLogPty.ensureNewline();
         terminalLogPty.writeLine(`[Process exited with code ${code}]`);
         markPrintedExitFor(cid);
       }
     } else if (isBashExit(event)) {
-      const cid = 'command_id' in event ? (event as { command_id?: string }).command_id : undefined;
+      const cid = event.command_id;
       if (!cid || !hasPrintedExitFor(cid)) {
-        terminalLogPty.ensureNewline?.();
+        terminalLogPty.ensureNewline();
         terminalLogPty.writeLine(`[Process exited with code ${event.exit_code}]`);
       }
       if (cid) {


### PR DESCRIPTION
## Summary
- extract local terminal event mirror/writer logic from `src/extension.ts` into `src/extension/localTerminalMirror.ts`
- keep `handleTerminalEvent` as orchestration wrapper while reducing nested control flow
- preserve terminal output/exit rendering behavior for command/output/exit event variants

## Validation
- `npm run lint -- src/extension.ts src/extension/localTerminalMirror.ts`
- `npx vitest run src/__tests__/extension.activation.test.ts src/__tests__/extension.deactivation.test.ts src/__tests__/openHandsTerminalLogPseudoterminal.test.ts src/__tests__/extension.commands.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
id: oh-tab-b7qq.3
title: Extract local terminal event mirroring from extension.ts
status: in_progress
priority: 3
type: task
assignee: LilacCastle
labels: extension, refactor, tech-debt, terminal

description:
Behavior-preserving refactor: move local terminal event mirroring/writing logic from handleTerminalEvent in src/extension.ts into a dedicated helper module.

acceptance_criteria:
- src/extension.ts delegates local terminal mirror logic to a focused helper module.
- Terminal rendering behavior (command/output/exit handling) remains unchanged.
- terminal-related extension tests and e2e remain green.

notes:
Picked up for implementation; proceeding with branch+PR+review workflow.
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/979" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Terminal output handling is more reliable with centralized mirroring logic
  * Process exit codes and completion footers are displayed consistently
  * Reduced duplicate or missing exit messages across sessions
  * Enhanced error reporting for terminal interactions
  * Streamlined terminal lifecycle for improved stability and fewer interruptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Agent Mail roasted-review gate completed in thread `oh-tab-b7qq.3`.
- Explicit decision: `APPROVED` by `OrangeSnow` (fallback reviewer) after primary reviewer inactivity.
- Approval message: `#5247` with final gate checks (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`), `0` unresolved threads, and `CodeRabbit` success.
