### PR TITLE
[oh-tab-b7qq.4] Extract chat view provider wiring from extension.ts

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
-import { type HalStateSnapshot, isHalMode, isHalDecision, isHalEye, isHalPhase } from './shared/halTypes';
-import { DEFAULT_HAL_STATE } from './shared/halDefaults';
+import { type HalStateSnapshot } from './shared/halTypes';
 import { maskSecretsInText } from './shared/maskSecrets';
 import { safeStringify } from './shared/safeStringify';
 import { getGlobalStorageBaseDir } from './shared/pastedImages';
@@ -24,6 +23,7 @@ import { createHalConfigurationChangeHandler } from './extension/halConfiguratio
 import { registerCoreCommands } from './extension/coreCommands';
 import { registerWelcomeSecretStatusSync } from './extension/welcomeSecretStatusSync';
 import { mirrorTerminalEventToLocalTerminal } from './extension/localTerminalMirror';
+import { registerChatViewProvider } from './extension/chatViewProvider';
 import { formatEnvironmentInformation } from './shared/environmentInformation';
 import { collectEnvironmentInfo } from './shared/collectEnvironmentInfo';
 import { getFileBackedFsPath } from './shared/uri';
@@ -45,10 +45,8 @@ import {
   isBashCommand,
   isBashOutput,
 } from '@openhands/agent-sdk-ts';
-import { OpenHandsChatViewProvider } from './sidebar/OpenHandsChatViewProvider';
 import { attachConversationListeners } from './conversation/host/attachConversationListeners';
 import { createConfigurationChangeHandler } from './settings/host/createConfigurationChangeHandler';
-import { createWebviewMessageHandler } from './webview/host/createWebviewMessageHandler';
 
 let chatView: vscode.WebviewView | undefined;
 let conversation: ConversationInstance | undefined;
@@ -275,110 +273,57 @@ export function activate(context: vscode.ExtensionContext) {
     await ensureConversationAndConnectionDelegate(options);
   }
 
-  let lastChatViewVisibility: boolean | undefined;
-
-  const chatViewProvider = new OpenHandsChatViewProvider(context, {
-    createMessageHandler: (view) =>
-      createWebviewMessageHandler({
-        context,
-        host: { postMessage: (message) => view.webview.postMessage(message) },
-        secretRegistry: secrets,
-        getQueuedUserEditNotes: fileEditNoteTracker.getQueuedUserEditNotes,
-        clearQueuedUserEditNotes: fileEditNoteTracker.clearQueuedUserEditNotes,
-        getConversation: () => conversation,
-        getConversationMode: () => conversationMode,
-        getConversationStoreRoot: () => conversationStoreRoot,
-        resolveConversationStoreRoot: () =>
-          resolveConversationStoreRoot({ context, getOutputChannel: () => outputChannel, renderError }),
-        setWebviewReadyState: (conversationId, lastSeenSeq) => {
-          chatWebviewReady = true;
-          chatLastConversationId = conversationId;
-          chatLastSeenSeq = lastSeenSeq;
-        },
-        setWebviewE2EReady: (ready) => {
-          chatWebviewE2EReady = ready;
-        },
-        setWebviewE2EInfo: (info) => {
-          chatWebviewE2EInfo = info;
-        },
-        setLastKnownLlmLabel: (label) => {
-          lastKnownLlmLabel = label;
-        },
-        getLastKnownLlmLabel: () => lastKnownLlmLabel,
-        flushConversationEventBacklog,
-        onRenderedEventsResponse: (requestId, info) => {
-          pendingRenderedEventsRequests.get(requestId)?.(info);
-        },
-        onUiStateResponse: (requestId, info) => {
-          pendingUiStateRequests.get(requestId)?.(info);
-        },
-        onHalStateResponse: (requestId, info) => {
-          const mode = isHalMode(info.mode) ? info.mode : DEFAULT_HAL_STATE.mode;
-          const phase = isHalPhase(info.phase) ? info.phase : DEFAULT_HAL_STATE.phase;
-          const eye = isHalEye(info.eye) ? info.eye : DEFAULT_HAL_STATE.eye;
-          const decision = isHalDecision(info.decision) ? info.decision : null;
-          pendingHalStateRequests.get(requestId)?.({
-            enabled: info.enabled === true,
-            mode,
-            phase,
-            eye,
-            stepIndex: typeof info.stepIndex === 'number' ? info.stepIndex : null,
-            decision,
-            lastError: typeof info.lastError === 'string' ? info.lastError : null,
-          });
-        },
-        isDevBridgeEnabled: () => devBridgeLogger.isEnabled(),
-        getOutputChannel: () => outputChannel,
-        fileLog: devBridgeLogger.fileLog,
-      }),
-    onResolved: (view) => {
-      chatView = view;
-      chatWebviewReady = false;
-      chatWebviewE2EReady = false;
-      chatWebviewE2EInfo = null;
-      lastChatViewVisibility = Boolean(view.visible);
-      void ensureConversationAndConnection({ uiJustCreated: true }).catch((err: unknown) => {
-        outputChannel?.appendLine(`[error] ensureConversationAndConnection failed: ${renderError(err)}`);
-      });
-    },
-    onVisibilityChange: (_view, visible) => {
-      const isVisible = Boolean(visible);
-      if (lastChatViewVisibility === isVisible) return;
-      lastChatViewVisibility = isVisible;
-
-      if (!isVisible) {
-        void (async () => {
-          try {
-            await conversation?.pause();
-          } catch (err) {
-            outputChannel?.appendLine(`[pause] Failed to auto-pause when chat view was hidden: ${renderError(err)}`);
-          }
-        })();
-      }
-    },
-    onDisposed: () => {
-      const shouldPauseOnDispose = lastChatViewVisibility !== false;
-      if (shouldPauseOnDispose) {
-        void (async () => {
-          try {
-            await conversation?.pause();
-          } catch (err) {
-            outputChannel?.appendLine(`[pause] Failed to auto-pause when chat view was disposed: ${renderError(err)}`);
-          }
-        })();
-      }
-      chatView = undefined;
-      chatWebviewReady = false;
-      chatWebviewE2EReady = false;
-      chatWebviewE2EInfo = null;
-      chatLastConversationId = undefined;
-      chatLastSeenSeq = undefined;
-      lastChatViewVisibility = undefined;
-    },
-  });
   context.subscriptions.push(
-    vscode.window.registerWebviewViewProvider('openhands.agent', chatViewProvider, {
-      webviewOptions: { retainContextWhenHidden: true },
+    registerChatViewProvider({
+      context,
+      secretRegistry: secrets,
+      getQueuedUserEditNotes: fileEditNoteTracker.getQueuedUserEditNotes,
+      clearQueuedUserEditNotes: fileEditNoteTracker.clearQueuedUserEditNotes,
+      getConversation: () => conversation,
+      getConversationMode: () => conversationMode,
+      getConversationStoreRoot: () => conversationStoreRoot,
+      resolveConversationStoreRoot: () =>
+        resolveConversationStoreRoot({ context, getOutputChannel: () => outputChannel, renderError }),
+      setChatView: (view) => {
+        chatView = view;
+      },
+      setChatWebviewReady: (ready) => {
+        chatWebviewReady = ready;
+      },
+      setChatWebviewE2EReady: (ready) => {
+        chatWebviewE2EReady = ready;
+      },
+      setChatWebviewE2EInfo: (info) => {
+        chatWebviewE2EInfo = info;
+      },
+      setChatLastConversationId: (conversationId) => {
+        chatLastConversationId = conversationId;
+      },
+      setChatLastSeenSeq: (lastSeenSeq) => {
+        chatLastSeenSeq = lastSeenSeq;
+      },
+      setLastKnownLlmLabel: (label) => {
+        lastKnownLlmLabel = label;
+      },
+      getLastKnownLlmLabel: () => lastKnownLlmLabel,
+      flushConversationEventBacklog,
+      onRenderedEventsResponse: (requestId, info) => {
+        pendingRenderedEventsRequests.get(requestId)?.(info);
+      },
+      onUiStateResponse: (requestId, info) => {
+        pendingUiStateRequests.get(requestId)?.(info);
+      },
+      onHalStateResponse: (requestId, info) => {
+        pendingHalStateRequests.get(requestId)?.(info);
+      },
+      isDevBridgeEnabled: () => devBridgeLogger.isEnabled(),
+      getOutputChannel: () => outputChannel,
+      fileLog: devBridgeLogger.fileLog,
+      ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
+      pauseConversation: async () => {
+        await conversation?.pause();
+      },
+      renderError,
     })
   );
 

--- a/src/extension/chatViewProvider.ts
+++ b/src/extension/chatViewProvider.ts
@@ -1,0 +1,157 @@
+import * as vscode from 'vscode';
+import { type ConversationInstance, type SecretRegistry } from '@openhands/agent-sdk-ts';
+import { DEFAULT_HAL_STATE } from '../shared/halDefaults';
+import { type HalStateSnapshot, isHalDecision, isHalEye, isHalMode, isHalPhase } from '../shared/halTypes';
+import type { HostToWebviewMessage, WebviewE2EInfo } from '../shared/webviewMessages';
+import { OpenHandsChatViewProvider } from '../sidebar/OpenHandsChatViewProvider';
+import { createWebviewMessageHandler } from '../webview/host/createWebviewMessageHandler';
+import type { EnsureConversationOptions } from './conversationLifecycle';
+
+type RenderedEventsInfo = {
+  count: number;
+  eventTypes: string[];
+  events?: Array<{ type: string; marker?: string; toolCallId?: string }>;
+};
+
+type UiStateSnapshot = {
+  input: string;
+  showContextPicker: boolean;
+  showSkillsPopover: boolean;
+  showHistory: boolean;
+  workspaceFilesCount: number;
+  selectedContextFiles: string[];
+  skillsCount: number;
+  attachmentsCount: number;
+  hasWelcomeProviderKey: boolean;
+  hasWelcomeGeminiKey: boolean;
+  showWelcomeProviderKeyMessage: boolean;
+  showWelcomeGeminiKeyMessage: boolean;
+};
+
+type RegisterChatViewProviderDeps = {
+  context: vscode.ExtensionContext;
+  secretRegistry: SecretRegistry;
+  getQueuedUserEditNotes: () => string[];
+  clearQueuedUserEditNotes: () => void;
+  getConversation: () => ConversationInstance | undefined;
+  getConversationMode: () => 'local' | 'remote';
+  getConversationStoreRoot: () => string | undefined;
+  resolveConversationStoreRoot: () => Promise<string>;
+  setChatView: (view: vscode.WebviewView | undefined) => void;
+  setChatWebviewReady: (ready: boolean) => void;
+  setChatWebviewE2EReady: (ready: boolean) => void;
+  setChatWebviewE2EInfo: (info: WebviewE2EInfo | null) => void;
+  setChatLastConversationId: (conversationId: string | undefined) => void;
+  setChatLastSeenSeq: (lastSeenSeq: number | undefined) => void;
+  setLastKnownLlmLabel: (label: string | null) => void;
+  getLastKnownLlmLabel: () => string | null;
+  flushConversationEventBacklog: (args: {
+    postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
+    clientConversationId?: string;
+    clientLastSeenSeq?: number;
+  }) => void;
+  onRenderedEventsResponse: (requestId: string, info: RenderedEventsInfo) => void;
+  onUiStateResponse: (requestId: string, info: UiStateSnapshot) => void;
+  onHalStateResponse: (requestId: string, info: HalStateSnapshot) => void;
+  isDevBridgeEnabled: () => boolean;
+  getOutputChannel: () => vscode.OutputChannel | undefined;
+  fileLog: (line: string) => void;
+  ensureConversationAndConnection: (options?: EnsureConversationOptions) => Promise<void>;
+  pauseConversation: () => Promise<void>;
+  renderError: (err: unknown) => string;
+};
+
+export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vscode.Disposable {
+  let lastChatViewVisibility: boolean | undefined;
+
+  const chatViewProvider = new OpenHandsChatViewProvider(deps.context, {
+    createMessageHandler: (view) =>
+      createWebviewMessageHandler({
+        context: deps.context,
+        host: { postMessage: (message) => view.webview.postMessage(message) },
+        secretRegistry: deps.secretRegistry,
+        getQueuedUserEditNotes: deps.getQueuedUserEditNotes,
+        clearQueuedUserEditNotes: deps.clearQueuedUserEditNotes,
+        getConversation: deps.getConversation,
+        getConversationMode: deps.getConversationMode,
+        getConversationStoreRoot: deps.getConversationStoreRoot,
+        resolveConversationStoreRoot: deps.resolveConversationStoreRoot,
+        setWebviewReadyState: (conversationId, lastSeenSeq) => {
+          deps.setChatWebviewReady(true);
+          deps.setChatLastConversationId(conversationId);
+          deps.setChatLastSeenSeq(lastSeenSeq);
+        },
+        setWebviewE2EReady: deps.setChatWebviewE2EReady,
+        setWebviewE2EInfo: deps.setChatWebviewE2EInfo,
+        setLastKnownLlmLabel: deps.setLastKnownLlmLabel,
+        getLastKnownLlmLabel: deps.getLastKnownLlmLabel,
+        flushConversationEventBacklog: deps.flushConversationEventBacklog,
+        onRenderedEventsResponse: deps.onRenderedEventsResponse,
+        onUiStateResponse: deps.onUiStateResponse,
+        onHalStateResponse: (requestId, info) => {
+          const mode = isHalMode(info.mode) ? info.mode : DEFAULT_HAL_STATE.mode;
+          const phase = isHalPhase(info.phase) ? info.phase : DEFAULT_HAL_STATE.phase;
+          const eye = isHalEye(info.eye) ? info.eye : DEFAULT_HAL_STATE.eye;
+          const decision = isHalDecision(info.decision) ? info.decision : null;
+          deps.onHalStateResponse(requestId, {
+            enabled: info.enabled === true,
+            mode,
+            phase,
+            eye,
+            stepIndex: typeof info.stepIndex === 'number' ? info.stepIndex : null,
+            decision,
+            lastError: typeof info.lastError === 'string' ? info.lastError : null,
+          });
+        },
+        isDevBridgeEnabled: deps.isDevBridgeEnabled,
+        getOutputChannel: deps.getOutputChannel,
+        fileLog: deps.fileLog,
+      }),
+    onResolved: (view) => {
+      deps.setChatView(view);
+      deps.setChatWebviewReady(false);
+      deps.setChatWebviewE2EReady(false);
+      deps.setChatWebviewE2EInfo(null);
+      lastChatViewVisibility = Boolean(view.visible);
+
+      void deps.ensureConversationAndConnection({ uiJustCreated: true }).catch((err: unknown) => {
+        deps.getOutputChannel()?.appendLine(`[error] ensureConversationAndConnection failed: ${deps.renderError(err)}`);
+      });
+    },
+    onVisibilityChange: (_view, visible) => {
+      const isVisible = Boolean(visible);
+      if (lastChatViewVisibility === isVisible) return;
+      lastChatViewVisibility = isVisible;
+
+      if (!isVisible) {
+        void deps.pauseConversation().catch((err) => {
+          deps.getOutputChannel()?.appendLine(
+            `[pause] Failed to auto-pause when chat view was hidden: ${deps.renderError(err)}`
+          );
+        });
+      }
+    },
+    onDisposed: () => {
+      const shouldPauseOnDispose = lastChatViewVisibility !== false;
+      if (shouldPauseOnDispose) {
+        void deps.pauseConversation().catch((err) => {
+          deps.getOutputChannel()?.appendLine(
+            `[pause] Failed to auto-pause when chat view was disposed: ${deps.renderError(err)}`
+          );
+        });
+      }
+
+      deps.setChatView(undefined);
+      deps.setChatWebviewReady(false);
+      deps.setChatWebviewE2EReady(false);
+      deps.setChatWebviewE2EInfo(null);
+      deps.setChatLastConversationId(undefined);
+      deps.setChatLastSeenSeq(undefined);
+      lastChatViewVisibility = undefined;
+    },
+  });
+
+  return vscode.window.registerWebviewViewProvider('openhands.agent', chatViewProvider, {
+    webviewOptions: { retainContextWhenHidden: true },
+  });
+}


### PR DESCRIPTION
## Summary
- extract chat view provider/message-handler wiring from `src/extension.ts` into `src/extension/chatViewProvider.ts`
- keep webview resolve/visibility/dispose lifecycle behavior unchanged (including auto-pause semantics)
- keep webview-ready state normalization and `ensureConversationAndConnection({ uiJustCreated: true })` trigger behavior intact

## Validation
- `npm run lint -- src/extension.ts src/extension/chatViewProvider.ts`
- `npx vitest run src/__tests__/extension.activation.test.ts src/__tests__/extension.deactivation.test.ts src/__tests__/extension.commands.test.ts src/__tests__/webviewMessageHandler.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
id: oh-tab-b7qq.4
title: Extract chat view provider wiring from extension.ts
status: in_progress
priority: 3
type: task
assignee: LilacCastle
labels: extension, refactor, tech-debt, webview

description:
Behavior-preserving refactor: move OpenHandsChatViewProvider construction and lifecycle callbacks (resolve/visibility/dispose) from src/extension.ts into a dedicated helper module that returns provider + registration disposable.

acceptance_criteria:
- src/extension.ts delegates chat view provider creation/wiring to a focused helper module.
- Chat readiness/visibility/dispose behavior and ensureConversationAndConnection trigger remain unchanged.
- extension/webview tests and e2e remain green.

notes:
Picked up for implementation; proceeding with branch+PR+review workflow.
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/980" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


### Review
- Agent Mail roasted-review gate completed in thread `oh-tab-b7qq.4`.
- Explicit decision: `APPROVED` by `OrangeSnow` (fallback reviewer) after primary reviewer inactivity.
- Approval message: `#5252` with final gate checks (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`), `0` unresolved threads, and `CodeRabbit` success.
- Gemini inline design-scope comment was replied to with rationale and the thread resolved in PR.
