### PR TITLE
[oh-tab-b7qq.5] Group chatViewProvider dependency contract

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -317,13 +317,22 @@ export function activate(context: vscode.ExtensionContext) {
         clearQueuedUserEditNotes: fileEditNoteTracker.clearQueuedUserEditNotes,
         flushConversationEventBacklog,
         onRenderedEventsResponse: (requestId, info) => {
-          pendingRenderedEventsRequests.get(requestId)?.(info);
+          const handler = pendingRenderedEventsRequests.get(requestId);
+          if (!handler) return;
+          pendingRenderedEventsRequests.delete(requestId);
+          handler(info);
         },
         onUiStateResponse: (requestId, info) => {
-          pendingUiStateRequests.get(requestId)?.(info);
+          const handler = pendingUiStateRequests.get(requestId);
+          if (!handler) return;
+          pendingUiStateRequests.delete(requestId);
+          handler(info);
         },
         onHalStateResponse: (requestId, info) => {
-          pendingHalStateRequests.get(requestId)?.(info);
+          const handler = pendingHalStateRequests.get(requestId);
+          if (!handler) return;
+          pendingHalStateRequests.delete(requestId);
+          handler(info);
         },
       },
       logging: {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -277,53 +277,61 @@ export function activate(context: vscode.ExtensionContext) {
     registerChatViewProvider({
       context,
       secretRegistry: secrets,
-      getQueuedUserEditNotes: fileEditNoteTracker.getQueuedUserEditNotes,
-      clearQueuedUserEditNotes: fileEditNoteTracker.clearQueuedUserEditNotes,
-      getConversation: () => conversation,
-      getConversationMode: () => conversationMode,
-      getConversationStoreRoot: () => conversationStoreRoot,
-      resolveConversationStoreRoot: () =>
-        resolveConversationStoreRoot({ context, getOutputChannel: () => outputChannel, renderError }),
-      setChatView: (view) => {
-        chatView = view;
+      conversation: {
+        getConversation: () => conversation,
+        getConversationMode: () => conversationMode,
+        getConversationStoreRoot: () => conversationStoreRoot,
+        resolveConversationStoreRoot: () =>
+          resolveConversationStoreRoot({ context, getOutputChannel: () => outputChannel, renderError }),
+        ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
+        pauseConversation: async () => {
+          await conversation?.pause();
+        },
       },
-      setChatWebviewReady: (ready) => {
-        chatWebviewReady = ready;
+      state: {
+        setChatView: (view) => {
+          chatView = view;
+        },
+        setChatWebviewReady: (ready) => {
+          chatWebviewReady = ready;
+        },
+        setChatWebviewE2EReady: (ready) => {
+          chatWebviewE2EReady = ready;
+        },
+        setChatWebviewE2EInfo: (info) => {
+          chatWebviewE2EInfo = info;
+        },
+        setChatLastConversationId: (conversationId) => {
+          chatLastConversationId = conversationId;
+        },
+        setChatLastSeenSeq: (lastSeenSeq) => {
+          chatLastSeenSeq = lastSeenSeq;
+        },
+        setLastKnownLlmLabel: (label) => {
+          lastKnownLlmLabel = label;
+        },
+        getLastKnownLlmLabel: () => lastKnownLlmLabel,
       },
-      setChatWebviewE2EReady: (ready) => {
-        chatWebviewE2EReady = ready;
+      messages: {
+        getQueuedUserEditNotes: fileEditNoteTracker.getQueuedUserEditNotes,
+        clearQueuedUserEditNotes: fileEditNoteTracker.clearQueuedUserEditNotes,
+        flushConversationEventBacklog,
+        onRenderedEventsResponse: (requestId, info) => {
+          pendingRenderedEventsRequests.get(requestId)?.(info);
+        },
+        onUiStateResponse: (requestId, info) => {
+          pendingUiStateRequests.get(requestId)?.(info);
+        },
+        onHalStateResponse: (requestId, info) => {
+          pendingHalStateRequests.get(requestId)?.(info);
+        },
       },
-      setChatWebviewE2EInfo: (info) => {
-        chatWebviewE2EInfo = info;
+      logging: {
+        isDevBridgeEnabled: () => devBridgeLogger.isEnabled(),
+        getOutputChannel: () => outputChannel,
+        fileLog: devBridgeLogger.fileLog,
+        renderError,
       },
-      setChatLastConversationId: (conversationId) => {
-        chatLastConversationId = conversationId;
-      },
-      setChatLastSeenSeq: (lastSeenSeq) => {
-        chatLastSeenSeq = lastSeenSeq;
-      },
-      setLastKnownLlmLabel: (label) => {
-        lastKnownLlmLabel = label;
-      },
-      getLastKnownLlmLabel: () => lastKnownLlmLabel,
-      flushConversationEventBacklog,
-      onRenderedEventsResponse: (requestId, info) => {
-        pendingRenderedEventsRequests.get(requestId)?.(info);
-      },
-      onUiStateResponse: (requestId, info) => {
-        pendingUiStateRequests.get(requestId)?.(info);
-      },
-      onHalStateResponse: (requestId, info) => {
-        pendingHalStateRequests.get(requestId)?.(info);
-      },
-      isDevBridgeEnabled: () => devBridgeLogger.isEnabled(),
-      getOutputChannel: () => outputChannel,
-      fileLog: devBridgeLogger.fileLog,
-      ensureConversationAndConnection: (options) => ensureConversationAndConnection(options),
-      pauseConversation: async () => {
-        await conversation?.pause();
-      },
-      renderError,
     })
   );
 

--- a/src/extension/chatViewProvider.ts
+++ b/src/extension/chatViewProvider.ts
@@ -31,34 +31,42 @@ type UiStateSnapshot = {
 type RegisterChatViewProviderDeps = {
   context: vscode.ExtensionContext;
   secretRegistry: SecretRegistry;
-  getQueuedUserEditNotes: () => string[];
-  clearQueuedUserEditNotes: () => void;
-  getConversation: () => ConversationInstance | undefined;
-  getConversationMode: () => 'local' | 'remote';
-  getConversationStoreRoot: () => string | undefined;
-  resolveConversationStoreRoot: () => Promise<string>;
-  setChatView: (view: vscode.WebviewView | undefined) => void;
-  setChatWebviewReady: (ready: boolean) => void;
-  setChatWebviewE2EReady: (ready: boolean) => void;
-  setChatWebviewE2EInfo: (info: WebviewE2EInfo | null) => void;
-  setChatLastConversationId: (conversationId: string | undefined) => void;
-  setChatLastSeenSeq: (lastSeenSeq: number | undefined) => void;
-  setLastKnownLlmLabel: (label: string | null) => void;
-  getLastKnownLlmLabel: () => string | null;
-  flushConversationEventBacklog: (args: {
-    postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
-    clientConversationId?: string;
-    clientLastSeenSeq?: number;
-  }) => void;
-  onRenderedEventsResponse: (requestId: string, info: RenderedEventsInfo) => void;
-  onUiStateResponse: (requestId: string, info: UiStateSnapshot) => void;
-  onHalStateResponse: (requestId: string, info: HalStateSnapshot) => void;
-  isDevBridgeEnabled: () => boolean;
-  getOutputChannel: () => vscode.OutputChannel | undefined;
-  fileLog: (line: string) => void;
-  ensureConversationAndConnection: (options?: EnsureConversationOptions) => Promise<void>;
-  pauseConversation: () => Promise<void>;
-  renderError: (err: unknown) => string;
+  conversation: {
+    getConversation: () => ConversationInstance | undefined;
+    getConversationMode: () => 'local' | 'remote';
+    getConversationStoreRoot: () => string | undefined;
+    resolveConversationStoreRoot: () => Promise<string>;
+    ensureConversationAndConnection: (options?: EnsureConversationOptions) => Promise<void>;
+    pauseConversation: () => Promise<void>;
+  };
+  state: {
+    setChatView: (view: vscode.WebviewView | undefined) => void;
+    setChatWebviewReady: (ready: boolean) => void;
+    setChatWebviewE2EReady: (ready: boolean) => void;
+    setChatWebviewE2EInfo: (info: WebviewE2EInfo | null) => void;
+    setChatLastConversationId: (conversationId: string | undefined) => void;
+    setChatLastSeenSeq: (lastSeenSeq: number | undefined) => void;
+    setLastKnownLlmLabel: (label: string | null) => void;
+    getLastKnownLlmLabel: () => string | null;
+  };
+  messages: {
+    getQueuedUserEditNotes: () => string[];
+    clearQueuedUserEditNotes: () => void;
+    flushConversationEventBacklog: (args: {
+      postMessage: (message: HostToWebviewMessage) => Thenable<boolean>;
+      clientConversationId?: string;
+      clientLastSeenSeq?: number;
+    }) => void;
+    onRenderedEventsResponse: (requestId: string, info: RenderedEventsInfo) => void;
+    onUiStateResponse: (requestId: string, info: UiStateSnapshot) => void;
+    onHalStateResponse: (requestId: string, info: HalStateSnapshot) => void;
+  };
+  logging: {
+    isDevBridgeEnabled: () => boolean;
+    getOutputChannel: () => vscode.OutputChannel | undefined;
+    fileLog: (line: string) => void;
+    renderError: (err: unknown) => string;
+  };
 };
 
 export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vscode.Disposable {
@@ -70,30 +78,30 @@ export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vs
         context: deps.context,
         host: { postMessage: (message) => view.webview.postMessage(message) },
         secretRegistry: deps.secretRegistry,
-        getQueuedUserEditNotes: deps.getQueuedUserEditNotes,
-        clearQueuedUserEditNotes: deps.clearQueuedUserEditNotes,
-        getConversation: deps.getConversation,
-        getConversationMode: deps.getConversationMode,
-        getConversationStoreRoot: deps.getConversationStoreRoot,
-        resolveConversationStoreRoot: deps.resolveConversationStoreRoot,
+        getQueuedUserEditNotes: deps.messages.getQueuedUserEditNotes,
+        clearQueuedUserEditNotes: deps.messages.clearQueuedUserEditNotes,
+        getConversation: deps.conversation.getConversation,
+        getConversationMode: deps.conversation.getConversationMode,
+        getConversationStoreRoot: deps.conversation.getConversationStoreRoot,
+        resolveConversationStoreRoot: deps.conversation.resolveConversationStoreRoot,
         setWebviewReadyState: (conversationId, lastSeenSeq) => {
-          deps.setChatWebviewReady(true);
-          deps.setChatLastConversationId(conversationId);
-          deps.setChatLastSeenSeq(lastSeenSeq);
+          deps.state.setChatWebviewReady(true);
+          deps.state.setChatLastConversationId(conversationId);
+          deps.state.setChatLastSeenSeq(lastSeenSeq);
         },
-        setWebviewE2EReady: deps.setChatWebviewE2EReady,
-        setWebviewE2EInfo: deps.setChatWebviewE2EInfo,
-        setLastKnownLlmLabel: deps.setLastKnownLlmLabel,
-        getLastKnownLlmLabel: deps.getLastKnownLlmLabel,
-        flushConversationEventBacklog: deps.flushConversationEventBacklog,
-        onRenderedEventsResponse: deps.onRenderedEventsResponse,
-        onUiStateResponse: deps.onUiStateResponse,
+        setWebviewE2EReady: deps.state.setChatWebviewE2EReady,
+        setWebviewE2EInfo: deps.state.setChatWebviewE2EInfo,
+        setLastKnownLlmLabel: deps.state.setLastKnownLlmLabel,
+        getLastKnownLlmLabel: deps.state.getLastKnownLlmLabel,
+        flushConversationEventBacklog: deps.messages.flushConversationEventBacklog,
+        onRenderedEventsResponse: deps.messages.onRenderedEventsResponse,
+        onUiStateResponse: deps.messages.onUiStateResponse,
         onHalStateResponse: (requestId, info) => {
           const mode = isHalMode(info.mode) ? info.mode : DEFAULT_HAL_STATE.mode;
           const phase = isHalPhase(info.phase) ? info.phase : DEFAULT_HAL_STATE.phase;
           const eye = isHalEye(info.eye) ? info.eye : DEFAULT_HAL_STATE.eye;
           const decision = isHalDecision(info.decision) ? info.decision : null;
-          deps.onHalStateResponse(requestId, {
+          deps.messages.onHalStateResponse(requestId, {
             enabled: info.enabled === true,
             mode,
             phase,
@@ -103,19 +111,21 @@ export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vs
             lastError: typeof info.lastError === 'string' ? info.lastError : null,
           });
         },
-        isDevBridgeEnabled: deps.isDevBridgeEnabled,
-        getOutputChannel: deps.getOutputChannel,
-        fileLog: deps.fileLog,
+        isDevBridgeEnabled: deps.logging.isDevBridgeEnabled,
+        getOutputChannel: deps.logging.getOutputChannel,
+        fileLog: deps.logging.fileLog,
       }),
     onResolved: (view) => {
-      deps.setChatView(view);
-      deps.setChatWebviewReady(false);
-      deps.setChatWebviewE2EReady(false);
-      deps.setChatWebviewE2EInfo(null);
+      deps.state.setChatView(view);
+      deps.state.setChatWebviewReady(false);
+      deps.state.setChatWebviewE2EReady(false);
+      deps.state.setChatWebviewE2EInfo(null);
       lastChatViewVisibility = Boolean(view.visible);
 
-      void deps.ensureConversationAndConnection({ uiJustCreated: true }).catch((err: unknown) => {
-        deps.getOutputChannel()?.appendLine(`[error] ensureConversationAndConnection failed: ${deps.renderError(err)}`);
+      void deps.conversation.ensureConversationAndConnection({ uiJustCreated: true }).catch((err: unknown) => {
+        deps.logging.getOutputChannel()?.appendLine(
+          `[error] ensureConversationAndConnection failed: ${deps.logging.renderError(err)}`
+        );
       });
     },
     onVisibilityChange: (_view, visible) => {
@@ -124,9 +134,9 @@ export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vs
       lastChatViewVisibility = isVisible;
 
       if (!isVisible) {
-        void deps.pauseConversation().catch((err) => {
-          deps.getOutputChannel()?.appendLine(
-            `[pause] Failed to auto-pause when chat view was hidden: ${deps.renderError(err)}`
+        void deps.conversation.pauseConversation().catch((err) => {
+          deps.logging.getOutputChannel()?.appendLine(
+            `[pause] Failed to auto-pause when chat view was hidden: ${deps.logging.renderError(err)}`
           );
         });
       }
@@ -134,19 +144,19 @@ export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vs
     onDisposed: () => {
       const shouldPauseOnDispose = lastChatViewVisibility !== false;
       if (shouldPauseOnDispose) {
-        void deps.pauseConversation().catch((err) => {
-          deps.getOutputChannel()?.appendLine(
-            `[pause] Failed to auto-pause when chat view was disposed: ${deps.renderError(err)}`
+        void deps.conversation.pauseConversation().catch((err) => {
+          deps.logging.getOutputChannel()?.appendLine(
+            `[pause] Failed to auto-pause when chat view was disposed: ${deps.logging.renderError(err)}`
           );
         });
       }
 
-      deps.setChatView(undefined);
-      deps.setChatWebviewReady(false);
-      deps.setChatWebviewE2EReady(false);
-      deps.setChatWebviewE2EInfo(null);
-      deps.setChatLastConversationId(undefined);
-      deps.setChatLastSeenSeq(undefined);
+      deps.state.setChatView(undefined);
+      deps.state.setChatWebviewReady(false);
+      deps.state.setChatWebviewE2EReady(false);
+      deps.state.setChatWebviewE2EInfo(null);
+      deps.state.setChatLastConversationId(undefined);
+      deps.state.setChatLastSeenSeq(undefined);
       lastChatViewVisibility = undefined;
     },
   });


### PR DESCRIPTION
## Summary
- regroup `registerChatViewProvider` dependencies into cohesive contracts (`conversation`, `state`, `messages`, `logging`)
- keep module behavior unchanged while reducing coupling/noise in `src/extension/chatViewProvider.ts`
- simplify `src/extension.ts` call-site wiring for chat view provider registration

## Validation
- `npm run lint -- src/extension.ts src/extension/chatViewProvider.ts`
- `npx vitest run src/__tests__/extension.activation.test.ts src/__tests__/extension.deactivation.test.ts src/__tests__/extension.commands.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
id: oh-tab-b7qq.5
title: Group chatViewProvider dependency contract
status: in_progress
priority: 3
type: task
assignee: LilacCastle
labels: extension, refactor, tech-debt, webview

description:
Behavior-preserving refactor: reduce coupling in src/extension/chatViewProvider.ts by grouping related dependency fields (state setters/getters/response callbacks) into cohesive nested contracts.

acceptance_criteria:
- registerChatViewProvider deps are grouped into cohesive sub-objects (state, handlers, services) with no behavior change.
- src/extension.ts call site is simpler and clearer.
- lint, typecheck, tests, and e2e remain green.

notes:
Picked up for implementation; proceeding with branch+PR+review workflow.
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/981" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal API configuration structure into logical groupings for improved code maintainability and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Agent Mail roasted-review gate completed in thread `oh-tab-b7qq.5`.
- Explicit decision: `APPROVED` by `OrangeSnow` (fallback reviewer) after primary reviewer inactivity.
- Approval message: `#5258` with final gate checks (`build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`, `unresolved-review-threads`), `0` unresolved threads, and `CodeRabbit` success.
- CodeRabbit inline finding about pending request-map cleanup was fixed in follow-up commit `5ea72d4` and thread resolved.
