### PR TITLE
[oh-tab-ycg2.1] Extract Agent conversation-error detail helper

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1082,6 +1082,7 @@ export class Agent extends EventEmitter {
       message,
       debug: this.debug,
       settings: this.options.settings,
+      profileStoreOptions: this.options.profileStoreOptions,
     });
     const maskedDetail = this.secretMasker.maskText(detail);
     return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail: maskedDetail } as Event;

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -47,6 +47,7 @@ import { deepTruncate, truncateToolMessage } from './toolResultTruncation';
 import { SecretMasker } from './secretMasker';
 import { ToolSummarizer } from './toolSummarizer';
 import { buildChatRequestWithCondensation, tryCondenseConversation as tryCondenseConversationWithDeps } from './condensation';
+import { buildConversationErrorDetail } from './conversationErrorDetail';
 import {
   resolveCondensationBudget,
   shouldRetryWithCondensationAfterError,
@@ -1077,49 +1078,11 @@ export class Agent extends EventEmitter {
   private toConversationErrorEvent(error: unknown, options?: { code?: string; message?: string }): Event {
     const message = options?.message ?? stringifyErrorWithCause(error);
     const code = options?.code ?? classifyConversationErrorCode(message);
-    const detail = (() => {
-      if (!this.debug) return message;
-
-      const model = toOptionalNonEmptyString(this.options.settings?.llm?.model);
-      const profileId = toOptionalNonEmptyString(this.options.settings?.llm?.profileId);
-      const configuredBaseUrl = toOptionalNonEmptyString(this.options.settings?.llm?.baseUrl);
-      const configuredProvider = this.options.settings?.llm?.provider ?? undefined;
-      const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
-      const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
-      const configuredApiKey = toOptionalNonEmptyString(this.options.settings?.secrets?.llmApiKey);
-      const apiKeyStatus = configuredApiKey ? 'set' : 'unset';
-      const mode = this.options.settings?.serverUrl ? 'remote' : 'local';
-      const serverUrl = toOptionalNonEmptyString(this.options.settings?.serverUrl);
-
-      const contextParts = [
-        `mode=${mode}`,
-        `llm.model=${model ?? '(unset)'}`,
-        `llm.provider=${provider}`,
-        `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
-        `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
-        `llm.apiKeyStatus=${apiKeyStatus}`,
-      ];
-      if (profileId) {
-        contextParts.push(`llm.profileId=${profileId}`);
-
-        if (isSafeProfileId(profileId)) {
-          try {
-            const profile = loadProfile(profileId);
-            const profileModel = toOptionalNonEmptyString(profile.config.model);
-            const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
-            const effectiveProfileProvider =
-              profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
-            contextParts.push(`llm.effectiveProvider=${effectiveProfileProvider}`);
-            contextParts.push(`llm.effectiveModel=${profileModel ?? '(unset)'}`);
-          } catch {
-            // best-effort: profile may be missing or unreadable
-          }
-        }
-      }
-      if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
-
-      return `${message} (${contextParts.join(', ')})`;
-    })();
+    const detail = buildConversationErrorDetail({
+      message,
+      debug: this.debug,
+      settings: this.options.settings,
+    });
     const maskedDetail = this.secretMasker.maskText(detail);
     return { kind: 'ConversationErrorEvent', source: 'agent', ...(code ? { code } : {}), detail: maskedDetail } as Event;
   }

--- a/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/__tests__/Agent.profile-api-key.test.ts
@@ -207,4 +207,57 @@ describe('Agent profile api key selection', () => {
       fs.rmSync(tmpHome, { recursive: true, force: true });
     }
   });
+
+  it('uses profileStoreOptions when formatting ConversationErrorEvent detail in debug mode', async () => {
+    const tmpHome = makeTempDir('agent-profile-error-detail-store-');
+    const customProfilesRoot = path.join(tmpHome, 'custom-profiles');
+    fs.mkdirSync(customProfilesRoot, { recursive: true });
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+
+    try {
+      process.env.HOME = tmpHome;
+      process.env.USERPROFILE = tmpHome;
+      vi.resetModules();
+
+      const [{ saveProfile }, { Agent }] = await Promise.all([
+        import('../../llm'),
+        import('../Agent'),
+      ]);
+
+      // Default profile location (under HOME) intentionally conflicts with custom profile store.
+      saveProfile('p1', {
+        provider: 'openai',
+        model: 'gpt-5-mini',
+      });
+      // Custom profile store should win when profileStoreOptions is provided.
+      saveProfile(
+        'p1',
+        {
+          provider: 'anthropic',
+          model: 'claude-3-5-sonnet',
+        },
+        { rootDir: customProfilesRoot },
+      );
+
+      const agent = new Agent({
+        workspaceRoot: tmpHome,
+        profileStoreOptions: { rootDir: customProfilesRoot },
+        settings: {
+          agent: { debug: true },
+          llm: { profileId: 'p1' },
+          secrets: {},
+        } as any,
+      });
+
+      const event = (agent as any).toConversationErrorEvent(new Error('boom')) as { kind?: string; detail?: string };
+      expect(event.kind).toBe('ConversationErrorEvent');
+      expect(event.detail).toContain('llm.effectiveProvider=anthropic');
+      expect(event.detail).toContain('llm.effectiveModel=claude-3-5-sonnet');
+    } finally {
+      process.env.HOME = originalHome;
+      process.env.USERPROFILE = originalUserProfile;
+      fs.rmSync(tmpHome, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/agent-sdk-ts/src/sdk/runtime/conversationErrorDetail.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/conversationErrorDetail.ts
@@ -1,0 +1,54 @@
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, loadProfile } from '../llm';
+import type { OpenHandsSettings } from '../types/settings';
+import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
+
+type BuildConversationErrorDetailParams = {
+  message: string;
+  debug: boolean;
+  settings: OpenHandsSettings | undefined;
+};
+
+export function buildConversationErrorDetail(params: BuildConversationErrorDetailParams): string {
+  const { message, debug, settings } = params;
+  if (!debug) return message;
+
+  const model = toOptionalNonEmptyString(settings?.llm?.model);
+  const profileId = toOptionalNonEmptyString(settings?.llm?.profileId);
+  const configuredBaseUrl = toOptionalNonEmptyString(settings?.llm?.baseUrl);
+  const configuredProvider = settings?.llm?.provider ?? undefined;
+  const provider = configuredProvider ?? detectProviderFromBaseUrl(configuredBaseUrl);
+  const effectiveBaseUrl = configuredBaseUrl ?? DEFAULT_PROVIDER_BASE_URLS[provider] ?? DEFAULT_PROVIDER_BASE_URLS.openai;
+  const configuredApiKey = toOptionalNonEmptyString(settings?.secrets?.llmApiKey);
+  const apiKeyStatus = configuredApiKey ? 'set' : 'unset';
+  const mode = settings?.serverUrl ? 'remote' : 'local';
+  const serverUrl = toOptionalNonEmptyString(settings?.serverUrl);
+
+  const contextParts = [
+    `mode=${mode}`,
+    `llm.model=${model ?? '(unset)'}`,
+    `llm.provider=${provider}`,
+    `llm.baseUrl=${configuredBaseUrl ?? '(default)'}`,
+    `llm.effectiveBaseUrl=${effectiveBaseUrl}`,
+    `llm.apiKeyStatus=${apiKeyStatus}`,
+  ];
+  if (profileId) {
+    contextParts.push(`llm.profileId=${profileId}`);
+
+    if (isSafeProfileId(profileId)) {
+      try {
+        const profile = loadProfile(profileId);
+        const profileModel = toOptionalNonEmptyString(profile.config.model);
+        const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
+        const effectiveProfileProvider =
+          profile.config.provider ?? detectProviderFromBaseUrl(profileBaseUrl ?? configuredBaseUrl);
+        contextParts.push(`llm.effectiveProvider=${effectiveProfileProvider}`);
+        contextParts.push(`llm.effectiveModel=${profileModel ?? '(unset)'}`);
+      } catch {
+        // best-effort: profile may be missing or unreadable
+      }
+    }
+  }
+  if (serverUrl) contextParts.push(`serverUrl=${serverUrl}`);
+
+  return `${message} (${contextParts.join(', ')})`;
+}

--- a/packages/agent-sdk-ts/src/sdk/runtime/conversationErrorDetail.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/conversationErrorDetail.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, loadProfile } from '../llm';
+import { DEFAULT_PROVIDER_BASE_URLS, detectProviderFromBaseUrl, loadProfile, type LLMProfileStoreOptions } from '../llm';
 import type { OpenHandsSettings } from '../types/settings';
 import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 
@@ -6,10 +6,11 @@ type BuildConversationErrorDetailParams = {
   message: string;
   debug: boolean;
   settings: OpenHandsSettings | undefined;
+  profileStoreOptions: LLMProfileStoreOptions | undefined;
 };
 
 export function buildConversationErrorDetail(params: BuildConversationErrorDetailParams): string {
-  const { message, debug, settings } = params;
+  const { message, debug, settings, profileStoreOptions } = params;
   if (!debug) return message;
 
   const model = toOptionalNonEmptyString(settings?.llm?.model);
@@ -36,7 +37,7 @@ export function buildConversationErrorDetail(params: BuildConversationErrorDetai
 
     if (isSafeProfileId(profileId)) {
       try {
-        const profile = loadProfile(profileId);
+        const profile = loadProfile(profileId, profileStoreOptions);
         const profileModel = toOptionalNonEmptyString(profile.config.model);
         const profileBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl);
         const effectiveProfileProvider =


### PR DESCRIPTION
## Summary
- extract `ConversationErrorEvent` detail/context formatting from `Agent.ts` into a focused runtime helper (`conversationErrorDetail.ts`)
- keep `Agent.toConversationErrorEvent` focused on message/classification + masking + event creation
- preserve existing debug/non-debug detail behavior and profile-aware effective provider/model context output

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
oh-tab-ycg2.1: Extract Agent conversation-error detail formatting helper
Status: in_progress
Priority: P3
Type: task
Assignee: LilacCastle
Created: 2026-02-07 23:51
Updated: 2026-02-07 23:51

Description:
Behavior-preserving refactor: move Agent.toConversationErrorEvent detail/context assembly into a focused runtime helper module so Agent.ts keeps runtime orchestration responsibilities and reduces inline diagnostics coupling.

Notes:
Starting implementation slice: extract conversation-error detail formatting from Agent.ts into helper module.

Acceptance Criteria:
- Agent delegates conversation-error detail/context formatting to a focused helper module.
- Error message masking/classification behavior remains unchanged.
- lint, typecheck, tests, and e2e remain green.

Labels: [agent-sdk-ts refactor runtime tech-debt]

Depends on (1):
  → oh-tab-ycg2: (tech debt) Refactor agent-sdk-ts Agent.ts responsibilities [P3]
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/985" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


### Review
- Reviewer gate (Agent Mail thread `oh-tab-ycg2.1`) completed with explicit fallback reviewer approval from `FuchsiaPond` after final green checks.
- Gemini inline thread flagged missing `profileStoreOptions` propagation in the new helper; addressed in follow-up commit `5facff7` and thread resolved.
- Added regression coverage to verify debug ConversationError detail uses custom profile store roots.
- Final gate confirmation: Agent Mail message `#5286` (`[oh-tab-ycg2.1] APPROVED: PR #985 final gate pass on 5facff7`).
