### PR TITLE
[oh-tab-ycg2.2] Extract Agent system-prompt LLM context resolver

### DIFF
--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -11,7 +11,6 @@ import {
   DEFAULT_PROVIDER_BASE_URLS,
   detectProviderFromBaseUrl,
   getEffectiveLlmConfigForCondensation as resolveCondensationLlmConfig,
-  loadProfile,
   wouldExceedMaxInputTokens,
 } from '../llm';
 import type { ActionEvent, BashEvent, ConversationStateUpdateEvent, Event, Message, MessageEvent, ObservationEvent, TextContent, ToolCall } from '../types';
@@ -41,13 +40,14 @@ import {
   sanitizeMessageForDebug,
 } from './textSanitizers';
 import { formatToolMessageText } from './toolMessageFormatting';
-import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
+import { toOptionalNonEmptyString } from './settingsUtils';
 import { createLlmClientFromSettings as createLlmClientFromSettingsFromConfig } from './createLlmClientFromSettings';
 import { deepTruncate, truncateToolMessage } from './toolResultTruncation';
 import { SecretMasker } from './secretMasker';
 import { ToolSummarizer } from './toolSummarizer';
 import { buildChatRequestWithCondensation, tryCondenseConversation as tryCondenseConversationWithDeps } from './condensation';
 import { buildConversationErrorDetail } from './conversationErrorDetail';
+import { resolveSystemPromptLlmContext } from './systemPromptLlmContext';
 import {
   resolveCondensationBudget,
   shouldRetryWithCondensationAfterError,
@@ -1006,26 +1006,10 @@ export class Agent extends EventEmitter {
       systemPrompt = systemPrompt.replace(SECURITY_RISK_ASSESSMENT_SECTION, '');
     }
     if (this.agentContext) {
-      const settings = this.options.settings?.llm;
-      const profileId = toOptionalNonEmptyString(settings?.profileId);
-      let llmModel = toOptionalNonEmptyString(settings?.model) ?? null;
-      let llmProvider = toOptionalNonEmptyString(settings?.provider) ?? null;
-      let llmBaseUrl = toOptionalNonEmptyString(settings?.baseUrl) ?? null;
-
-      // When profileId is set, raw model/provider/baseUrl can be intentionally cleared (profiles-first).
-      // Load the profile config (when safe) so vendor-specific repo skills are gated correctly.
-      if (profileId && isSafeProfileId(profileId)) {
-        try {
-          const profile = loadProfile(profileId, this.options.profileStoreOptions);
-          llmModel = toOptionalNonEmptyString(profile.config.model) ?? llmModel;
-          llmProvider = toOptionalNonEmptyString(profile.config.provider) ?? llmProvider;
-          llmBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl) ?? llmBaseUrl;
-        } catch {
-          // Best-effort: profile loading failures will surface elsewhere when creating the LLM client.
-        }
-      }
-
-      llmProvider = llmProvider ?? detectProviderFromBaseUrl(llmBaseUrl ?? undefined);
+      const { llmModel, llmProvider, llmBaseUrl } = resolveSystemPromptLlmContext(
+        this.options.settings,
+        this.options.profileStoreOptions,
+      );
       const suffix = this.agentContext.getSystemMessageSuffix({
         secretNames: this.secrets.getRegisteredNames(),
         llmModel,

--- a/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/Agent.ts
@@ -1007,7 +1007,7 @@ export class Agent extends EventEmitter {
     }
     if (this.agentContext) {
       const { llmModel, llmProvider, llmBaseUrl } = resolveSystemPromptLlmContext(
-        this.options.settings,
+        this.options.settings?.llm,
         this.options.profileStoreOptions,
       );
       const suffix = this.agentContext.getSystemMessageSuffix({

--- a/packages/agent-sdk-ts/src/sdk/runtime/systemPromptLlmContext.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/systemPromptLlmContext.ts
@@ -1,0 +1,36 @@
+import { detectProviderFromBaseUrl, loadProfile, type LLMProfileStoreOptions } from '../llm';
+import type { OpenHandsSettings } from '../types/settings';
+import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
+
+export type SystemPromptLlmContext = {
+  llmModel: string | null;
+  llmProvider: string | null;
+  llmBaseUrl: string | null;
+};
+
+export function resolveSystemPromptLlmContext(
+  settings: OpenHandsSettings | undefined,
+  profileStoreOptions: LLMProfileStoreOptions | undefined,
+): SystemPromptLlmContext {
+  const llmSettings = settings?.llm;
+  const profileId = toOptionalNonEmptyString(llmSettings?.profileId);
+  let llmModel = toOptionalNonEmptyString(llmSettings?.model) ?? null;
+  let llmProvider = toOptionalNonEmptyString(llmSettings?.provider) ?? null;
+  let llmBaseUrl = toOptionalNonEmptyString(llmSettings?.baseUrl) ?? null;
+
+  // When profileId is set, raw model/provider/baseUrl can be intentionally cleared (profiles-first).
+  // Load the profile config (when safe) so vendor-specific repo skills are gated correctly.
+  if (profileId && isSafeProfileId(profileId)) {
+    try {
+      const profile = loadProfile(profileId, profileStoreOptions);
+      llmModel = toOptionalNonEmptyString(profile.config.model) ?? llmModel;
+      llmProvider = toOptionalNonEmptyString(profile.config.provider) ?? llmProvider;
+      llmBaseUrl = toOptionalNonEmptyString(profile.config.baseUrl) ?? llmBaseUrl;
+    } catch {
+      // Best-effort: profile loading failures will surface elsewhere when creating the LLM client.
+    }
+  }
+
+  llmProvider = llmProvider ?? detectProviderFromBaseUrl(llmBaseUrl ?? undefined);
+  return { llmModel, llmProvider, llmBaseUrl };
+}

--- a/packages/agent-sdk-ts/src/sdk/runtime/systemPromptLlmContext.ts
+++ b/packages/agent-sdk-ts/src/sdk/runtime/systemPromptLlmContext.ts
@@ -1,5 +1,5 @@
 import { detectProviderFromBaseUrl, loadProfile, type LLMProfileStoreOptions } from '../llm';
-import type { OpenHandsSettings } from '../types/settings';
+import type { LLMSettings } from '../types/settings';
 import { isSafeProfileId, toOptionalNonEmptyString } from './settingsUtils';
 
 export type SystemPromptLlmContext = {
@@ -9,10 +9,9 @@ export type SystemPromptLlmContext = {
 };
 
 export function resolveSystemPromptLlmContext(
-  settings: OpenHandsSettings | undefined,
+  llmSettings: LLMSettings | undefined,
   profileStoreOptions: LLMProfileStoreOptions | undefined,
 ): SystemPromptLlmContext {
-  const llmSettings = settings?.llm;
   const profileId = toOptionalNonEmptyString(llmSettings?.profileId);
   let llmModel = toOptionalNonEmptyString(llmSettings?.model) ?? null;
   let llmProvider = toOptionalNonEmptyString(llmSettings?.provider) ?? null;


### PR DESCRIPTION
## Summary
- extract profile-aware system-prompt LLM context resolution from `Agent.buildSystemPrompt` into `systemPromptLlmContext.ts`
- keep `buildSystemPrompt` focused on composing prompt text and suffix/tool summaries
- preserve provider/model/baseUrl fallback behavior and profile-store-aware profile loading

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run e2e`

### Bead
```text
oh-tab-ycg2.2: Extract Agent system-prompt LLM context resolver
Status: in_progress
Priority: P3
Type: task
Assignee: LilacCastle
Created: 2026-02-08 00:08
Updated: 2026-02-08 00:08

Description:
Behavior-preserving refactor: move the profile-aware llmModel/provider/baseUrl resolution logic in Agent.buildSystemPrompt into a dedicated runtime helper to reduce Agent.ts responsibilities and keep prompt assembly focused.

Notes:
Starting implementation slice: extract profile-aware system prompt LLM context resolution from Agent.buildSystemPrompt into helper.

Acceptance Criteria:
- Agent delegates system-prompt LLM context resolution to a focused helper module.
- Provider/model/baseUrl fallback behavior (including profileStoreOptions usage) remains unchanged.
- lint, typecheck, tests, and e2e remain green.

Labels: [agent-sdk-ts refactor runtime tech-debt]

Depends on (1):
  → oh-tab-ycg2: (tech debt) Refactor agent-sdk-ts Agent.ts responsibilities [P3]
```

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified LLM configuration resolution to make system prompt assembly more consistent.
* **Bug Fixes**
  * Reduced interruptions from profile-loading failures by falling back gracefully to available LLM settings, improving reliability when selecting model/provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Reviewer gate (Agent Mail thread `oh-tab-ycg2.2`) completed with explicit fallback approval from `FuchsiaPond` after all required checks were green.
- Gemini inline feedback requested narrowing helper input surface; addressed in follow-up commit `4ed552d` and both review threads were resolved.
- Final gate confirmation: Agent Mail message `#5292` (`[oh-tab-ycg2.2] APPROVED: PR #986 final gate pass on 4ed552d`).
