### PR TITLE
release: 0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhands-tab",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhands-tab",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "bundleDependencies": [
         "ws"
       ],
@@ -14142,7 +14142,7 @@
     },
     "packages/agent-sdk": {
       "name": "@smolpaws/agent-sdk",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenHands Tab",
   "publisher": "openhands",
   "icon": "media/icons/openhands-icon.png",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A VS Code extension to interact with OpenHands agents in a dedicated sidebar chat view",
   "license": "MIT",
   "workspaces": [

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smolpaws/agent-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "TypeScript models and guards for the OpenHands agent-sdk wire protocol",
   "license": "MIT",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Prepares the 0.9.0 release by bumping versions:

- `package.json` / `package-lock.json` → 0.9.0
- `packages/agent-sdk/package.json` → 0.9.0

CI should package a VSIX artifact on this PR.

### Release notes (draft)
See the visual recap (changes since 0.8.0):
- https://enyst.github.io/OpenHands-Tab/recap-since-0.8.0.html

### After merge
Per `docs/release-process.md`:
1) Squash-merge this PR into `develop`
2) Tag the resulting `develop` HEAD as `0.9.0` (no `v` prefix)
3) Push the tag and publish the draft GitHub Release created by CI

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/993" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.9.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->