### PR TITLE
Document SDK ownership and boundary decisions

### DIFF
--- a/packages/agent-sdk/AGENTS.md
+++ b/packages/agent-sdk/AGENTS.md
@@ -262,7 +262,7 @@ npm run lint -w @smolpaws/agent-sdk -- --fix
 ## Coding Guidelines
 - Match the repository defaults: TypeScript (ES2022), 2-space indentation, single quotes, and trailing semicolons.
 - Keep runtime-facing types colocated with their guards to guarantee parity between compilation and runtime validation.
-- The SDK primarily serves the OpenHands VS Code extension, so it is fine to depend on VS Code types or semantics when doing so makes integration simpler.
+- Avoid introducing new VS Code-only runtime dependencies into the shared SDK surface. If a feature needs VS Code-specific behavior, keep it optional or adapter-shaped so non-extension consumers can still reuse the same runtime package.
 - Each layer should be independently testable with minimal cross-layer dependencies.
 
 

--- a/packages/agent-sdk/AGENTS.md
+++ b/packages/agent-sdk/AGENTS.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-> Scope: VS Code Extension only — this SDK is intended to run inside VSCode for use of the OpenHands-Tab extension; standalone usage or non‑VS Code API integrations are not in scope.
+The `@smolpaws/agent-sdk` package is the canonical source for the shared TypeScript OpenHands runtime used across OpenHands-Tab, smolpaws, and enyst-smolpaws.
 
-The `@smolpaws/agent-sdk` package is a complete TypeScript implementation for building AI agents with OpenHands on VSCode. It provides a runtime layer for agent orchestration, LLM integration, tool execution, workspace management, and full protocol type definitions.
+It still contains optional VS Code-specific integrations for the extension host, but the runtime itself is no longer treated as VS Code-only. Non-extension consumers should reuse this package rather than forking runtime behavior into app-specific copies.
 
 ## Architecture
 

--- a/packages/agent-sdk/docs/python-parity.md
+++ b/packages/agent-sdk/docs/python-parity.md
@@ -1,6 +1,6 @@
 # Python ↔︎ TypeScript SDK parity guide
 
-This document compares the Python `agent-sdk` (reference implementation) with the TypeScript `@smolpaws/agent-sdk` (VS Code-focused SDK). Note that agent-sdk is basically a transpilation of the Python agent-sdk. It highlights where interfaces align, where behavior diverges, and what is missing for parity. Mermaid diagrams summarize key classes and relationships in each layer.
+This document compares the Python `agent-sdk` (reference implementation) with the TypeScript `@smolpaws/agent-sdk` (canonical TypeScript runtime source). Note that the TypeScript SDK is effectively a transpilation-oriented sibling of the Python agent-sdk. It highlights where interfaces align, where behavior diverges, and what is missing for parity. Mermaid diagrams summarize key classes and relationships in each layer.
 
 ## Audit scope (oh-tab-0rq)
 

--- a/packages/agent-sdk/docs/python-parity.md
+++ b/packages/agent-sdk/docs/python-parity.md
@@ -1,6 +1,6 @@
 # Python ↔︎ TypeScript SDK parity guide
 
-This document compares the Python `agent-sdk` (reference implementation) with the TypeScript `@smolpaws/agent-sdk` (canonical TypeScript runtime source). Note that the TypeScript SDK is effectively a transpilation-oriented sibling of the Python agent-sdk. It highlights where interfaces align, where behavior diverges, and what is missing for parity. Mermaid diagrams summarize key classes and relationships in each layer.
+This document compares the Python `agent-sdk` (reference implementation) with the TypeScript `@smolpaws/agent-sdk` (canonical TypeScript runtime source). Note that the TypeScript SDK is effectively a behaviorally aligned sibling of the Python agent-sdk rather than a mechanical transpilation pipeline. It highlights where interfaces align, where behavior diverges, and what is missing for parity. Mermaid diagrams summarize key classes and relationships in each layer.
 
 ## Audit scope (oh-tab-0rq)
 

--- a/packages/agent-sdk/docs/runtime-convergence.md
+++ b/packages/agent-sdk/docs/runtime-convergence.md
@@ -1,0 +1,74 @@
+# TypeScript runtime convergence notes
+
+This document records the current ownership and boundary decisions for the TypeScript OpenHands runtime shared across:
+
+- `OpenHands-Tab/packages/agent-sdk`
+- `smolpaws`
+- `enyst-smolpaws`
+
+It exists so these repos converge on one runtime story before any larger repository move.
+
+## Canonical ownership model
+
+`OpenHands-Tab/packages/agent-sdk` is the canonical source for the shared TypeScript runtime.
+
+That scope includes:
+
+- agent orchestration primitives
+- local and remote conversation clients
+- persistence helpers
+- local and remote workspace clients
+- built-in tool definitions
+- remote wire-format expectations used by TypeScript clients
+
+The application repos should treat this package as shared infrastructure rather than maintain their own long-lived forks of runtime behavior.
+
+### Application roles
+
+- `smolpaws`
+  - WhatsApp ingress and container-side execution shell
+  - consumes the published SDK package in `container/agent-runner`
+- `enyst-smolpaws`
+  - GitHub ingress plus Fastify runner / agent-server shell
+  - consumes the published SDK package and implements the remote server surface expected by `RemoteConversation` and `RemoteWorkspace`
+- `OpenHands-Tab/packages/agent-sdk`
+  - canonical TypeScript runtime and client contract source
+
+## Boundary decision for phase 1
+
+The runtime is not being forced into a full VS Code extraction before convergence work lands.
+
+Phase 1 keeps the current optional VS Code integration in place while converging the shared remote contract and browser story. New work should avoid introducing additional hard VS Code assumptions into the runtime layer.
+
+## Audited VS Code-coupled touchpoints
+
+These are the main places where the shared runtime still knows about VS Code-specific behavior:
+
+1. `src/sdk/runtime/SecretRegistry.ts`
+   - optional `SecretStorage` integration
+   - optional `require("vscode")` access path
+2. `src/tools/IntegratedTerminalRunner.ts`
+   - VS Code pseudoterminal integration
+   - spawn fallback for non-VS Code execution
+3. `src/workspace/LocalWorkspace.ts`
+   - optional VS Code workspace-root discovery
+4. `src/sdk/conversation/LocalConversation.ts`
+   - constructor paths that accept VS Code secret storage through `SecretRegistry`
+
+These touchpoints are intentionally tracked here so they can be extracted behind adapters later if they start blocking packaging or runtime reuse.
+
+## Current distribution path
+
+The current shared distribution path is the published package:
+
+- package name: `@smolpaws/agent-sdk`
+
+Near-term convergence should keep the package release flow centered on this repo and version the consuming apps against that published package, rather than introducing repo-local copies of runtime logic.
+
+## What still remains after this document
+
+This note does not finish convergence by itself. The main open items after ownership/boundary clarification are:
+
+- replacing the stubbed browser-use path with one real browser implementation
+- finishing the remaining remote agent-server parity edges in `enyst-smolpaws`
+- deciding whether the repositories should eventually be consolidated once interfaces stop moving


### PR DESCRIPTION
## Summary
- document `packages/agent-sdk` as the canonical shared TypeScript runtime source
- record the current VS Code-coupled touchpoints instead of pretending the package is extension-only
- note the current published-package distribution path used by the convergence work

## Validation
- documentation-only change
- reviewed against the active convergence plan and the current cross-repo runtime usage in smolpaws and enyst-smolpaws
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/997" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the agent SDK as the canonical TypeScript runtime shared across multiple applications while maintaining optional VS Code integrations.
  * Updated documentation to reflect the TypeScript SDK's role as the authoritative runtime source.
  * Added documentation outlining runtime convergence strategy, ownership structure, and distribution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->