### PR TITLE
docs: add SDK npm release steps

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -91,6 +91,18 @@ It will **not** match `vX.Y.Z` unless the workflow is changed.
    - Open the draft release in GitHub and add release notes (highlights, breaking changes, compatibility).
    - **Include contributors**: Add a "Contributors" section listing everyone who contributed to this release. Use `git shortlog -sne <previous-tag>..HEAD` to generate the list, or use GitHub's "Generate release notes" feature as a starting point.
    - Publish the release.
+7. Publish the SDK package to npm (when the SDK version changed for this release):
+   - This repo bundles the SDK into the extension, but `@smolpaws/agent-sdk` is also released separately on npm.
+   - Preflight (safe, non-publishing) from `packages/agent-sdk`:
+     - `cd packages/agent-sdk`
+     - `npm whoami` (confirm the intended npm account is logged in)
+     - `node -p "require('./package.json').name + '@' + require('./package.json').version"`
+     - `npm view @smolpaws/agent-sdk version --json` (confirm the registry is still on the previous version)
+     - `npm pack --dry-run` (verifies package contents/tarball without publishing)
+   - Publish:
+     - `npm publish --access public`
+   - Verify:
+     - `npm view @smolpaws/agent-sdk version --json` (should now match `X.Y.Z`)
 
 ## 4) Publishing to marketplaces (optional)
 
@@ -122,6 +134,9 @@ Token / org setup varies by publisher; document the exact token name/location in
    - Extension activates.
    - Basic chat flow works (local + remote, if applicable).
    - No missing-module errors.
+3. If the SDK version changed and was published to npm:
+   - Verify `npm view @smolpaws/agent-sdk version --json` returns the release version.
+   - (Optional) install-test in a temp dir: `npm i @smolpaws/agent-sdk@X.Y.Z`
 
 ## 6) Rollback / hotfix procedure
 


### PR DESCRIPTION
## Summary
- document when and how to publish `@smolpaws/agent-sdk` during a release
- add npm preflight and verification steps to the release checklist
- add post-release verification for SDK npm publishes

## Testing
- not run (docs-only)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/998" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

No end-user-facing changes in this release. This update refines internal documentation for the SDK release workflow and publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->