### PR TITLE
feat: add public queued-run conversation api

### DIFF
--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -221,6 +221,8 @@ describe('RemoteConversation', () => {
     const fetchMock = vi.fn(async (url: string, init?: any) => {
       expect(url).toContain('/api/conversations');
       const body = JSON.parse(init?.body ?? '{}');
+      expect(body.agent.kind).toBe('Agent');
+      expect(body.workspace).toEqual({ working_dir: process.cwd() });
       expect(body.secrets).toEqual({
         ELEVENLABS_API_KEY: { kind: 'StaticSecret', value: 'xi-example123' },
         GITHUB_TOKEN: { kind: 'StaticSecret', value: 'ghp_example123' },
@@ -265,6 +267,7 @@ describe('RemoteConversation', () => {
     const fetchMock = vi.fn(async (url: string, init?: any) => {
       expect(url).toContain('/api/conversations');
       const body = JSON.parse(init?.body ?? '{}');
+      expect(body.agent.kind).toBe('Agent');
       if (enableSecurityAnalyzer) {
         expect(body.agent.security_analyzer).toEqual({ kind: 'LLMSecurityAnalyzer' });
       } else {
@@ -326,6 +329,7 @@ describe('RemoteConversation', () => {
       conversation.disconnect();
 
       expect(id).toBe('conv-1');
+      expect(capturedReq?.agent?.kind).toBe('Agent');
       expect(capturedReq?.agent?.llm?.usage_id).toBe('agent');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
@@ -388,6 +392,7 @@ describe('RemoteConversation', () => {
       conversation.disconnect();
 
       expect(id).toBe('conv-1');
+      expect(capturedReq?.agent?.kind).toBe('Agent');
       const llm = capturedReq?.agent?.llm ?? {};
       expect(llm.usage_id).toBe('agent');
       expect(llm.model).toBe('profile-model');

--- a/packages/agent-sdk/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/LocalConversation.test.ts
@@ -269,6 +269,25 @@ describe('LocalConversation', () => {
     expect(events.some((e) => isMessageEvent(e) && e.source === 'agent')).toBe(false);
   });
 
+  it('runs queued user messages without duplicating them', async () => {
+    const llm = new FakeLLM([[{ type: 'text', text: 'Queued work handled' }, { type: 'finish' }]]);
+    const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, tools: createDefaultTools() });
+
+    const events: Event[] = [];
+    conversation.on('event', (e: Event) => events.push(e));
+
+    await conversation.startNewConversation();
+    await conversation.sendUserMessage('Environment note', { run: false });
+    await conversation.runPending();
+
+    const userMessages = events.filter((e): e is MessageEvent => isMessageEvent(e) && e.source === 'user');
+    expect(userMessages).toHaveLength(1);
+    expect(userMessages[0].llm_message.content[0]).toEqual({ type: 'text', text: 'Environment note' });
+
+    const assistantMessages = events.filter((e): e is MessageEvent => isMessageEvent(e) && e.source === 'agent');
+    expect(assistantMessages.at(-1)?.llm_message.content[0]).toEqual({ type: 'text', text: 'Queued work handled' });
+  });
+
   it('attaches extendedContent to user messages and includes it in the LLM request', async () => {
     const llm = new RecordingLLM();
     const conversation = new LocalConversation({ settings: baseSettings, llmClient: llm, tools: createDefaultTools() });

--- a/packages/agent-sdk/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/LocalConversation.ts
@@ -266,7 +266,10 @@ export class LocalConversation extends EventEmitter {
   }
 
   async runPending(): Promise<void> {
-    if (!this.conversationId) return;
+    if (!this.conversationId) {
+      this.emit('error', new Error('Cannot run pending: no active conversation. Start a new conversation first.'));
+      return;
+    }
     this.hasUserMessage = true;
     await this.agent.runPending();
   }

--- a/packages/agent-sdk/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/LocalConversation.ts
@@ -11,6 +11,7 @@ import {
 } from '../runtime';
 import type { LLMClient } from '../llm';
 import type { BashEvent, Event, TextContent } from '../types';
+import { isMessageEvent } from '../types';
 import { clearRawLlmFieldsWhenProfileSelected } from '../types/settings';
 import type { OpenHandsSettings } from '../types/settings';
 import type { ToolDefinition } from '../types/tools';
@@ -270,8 +271,15 @@ export class LocalConversation extends EventEmitter {
       this.emit('error', new Error('Cannot run pending: no active conversation. Start a new conversation first.'));
       return;
     }
-    this.hasUserMessage = true;
-    await this.agent.runPending();
+    await this.lock.acquire(async () => {
+      const events = this.events.list();
+      const lastEvent = events[events.length - 1];
+      if (!isMessageEvent(lastEvent) || lastEvent.source !== 'user') {
+        return;
+      }
+      this.hasUserMessage = true;
+      await this.agent.runPending();
+    });
   }
 
   setConfirmationPolicy(policy: ConfirmationPolicy): Promise<void> {

--- a/packages/agent-sdk/src/sdk/conversation/LocalConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/LocalConversation.ts
@@ -265,6 +265,12 @@ export class LocalConversation extends EventEmitter {
     await this.agent.resume();
   }
 
+  async runPending(): Promise<void> {
+    if (!this.conversationId) return;
+    this.hasUserMessage = true;
+    await this.agent.runPending();
+  }
+
   setConfirmationPolicy(policy: ConfirmationPolicy): Promise<void> {
     this.agent.setConfirmationPolicy(policy);
     return Promise.resolve();

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
@@ -330,4 +330,48 @@ describe('RemoteConversation', () => {
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('surfaces runPending HTTP failures from POST /api/conversations/:id/run', async () => {
+    const connectSpy = vi
+      .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')
+      .mockImplementation(() => {});
+
+    const fetchSpy = vi.fn((url: string, init?: RequestInit) => {
+      if (url === 'http://localhost:3000/api/conversations') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'conv-run-pending-failure' }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      if (url === 'http://localhost:3000/api/conversations/conv-run-pending-failure/run') {
+        expect(init?.method).toBe('POST');
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve('server exploded'),
+        } as unknown as Response);
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+    });
+
+    await conversation.startNewConversation();
+
+    await expect(conversation.runPending()).rejects.toThrow(
+      'Failed to run pending conversation work (HTTP 500): server exploded'
+    );
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
@@ -113,10 +113,7 @@ describe('RemoteConversation', () => {
     expect(typeof init?.body).toBe('string');
     const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
     expect(parsed.agent.kind).toBe('Agent');
-    expect(parsed.agent.tools).toEqual([
-      { name: 'GlobTool', params: { pattern: '**/*.ts' } },
-      { name: 'TerminalTool' },
-    ]);
+    expect(parsed.agent.tools).toEqual(tools);
     expect(parsed.workspace).toEqual(workspace);
   });
 
@@ -149,9 +146,9 @@ describe('RemoteConversation', () => {
     const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
     expect(parsed.agent.kind).toBe('Agent');
     expect(parsed.agent.tools).toEqual([
-      { name: 'TerminalTool' },
-      { name: 'FileEditorTool' },
-      { name: 'TaskTrackerTool' },
+      { name: 'terminal' },
+      { name: 'file_editor' },
+      { name: 'task_tracker' },
     ]);
     expect(parsed.workspace).toEqual({ working_dir: workspaceRoot });
   });
@@ -211,7 +208,7 @@ describe('RemoteConversation', () => {
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
     const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] } };
     expect(parsed.agent.kind).toBe('Agent');
-    expect(parsed.agent.tools).toEqual([{ name: 'TerminalTool' }]);
+    expect(parsed.agent.tools).toEqual([{ name: 'terminal' }]);
   });
 
   it('supports includeDefaultTools=true to merge defaults with provided tools', async () => {
@@ -242,10 +239,10 @@ describe('RemoteConversation', () => {
     const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] } };
     expect(parsed.agent.kind).toBe('Agent');
     expect(parsed.agent.tools).toEqual([
-      { name: 'TerminalTool' },
-      { name: 'FileEditorTool' },
-      { name: 'TaskTrackerTool' },
-      { name: 'GlobTool', params: { pattern: '**/*.ts' } },
+      { name: 'terminal' },
+      { name: 'file_editor' },
+      { name: 'task_tracker' },
+      { name: 'glob', params: { pattern: '**/*.ts' } },
     ]);
   });
 

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
@@ -111,8 +111,12 @@ describe('RemoteConversation', () => {
     expect(url).toBe('http://localhost:3000/api/conversations');
     expect(init?.method).toBe('POST');
     expect(typeof init?.body).toBe('string');
-    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
-    expect(parsed.agent.tools).toEqual(tools);
+    const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
+    expect(parsed.agent.kind).toBe('Agent');
+    expect(parsed.agent.tools).toEqual([
+      { name: 'GlobTool', params: { pattern: '**/*.ts' } },
+      { name: 'TerminalTool' },
+    ]);
     expect(parsed.workspace).toEqual(workspace);
   });
 
@@ -142,13 +146,14 @@ describe('RemoteConversation', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
     expect(url).toBe('http://localhost:3000/api/conversations');
-    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
+    const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] }; workspace: RemoteConversationWorkspace };
+    expect(parsed.agent.kind).toBe('Agent');
     expect(parsed.agent.tools).toEqual([
-      { name: 'terminal' },
-      { name: 'file_editor' },
-      { name: 'task_tracker' },
+      { name: 'TerminalTool' },
+      { name: 'FileEditorTool' },
+      { name: 'TaskTrackerTool' },
     ]);
-    expect(parsed.workspace).toEqual({ kind: 'LocalWorkspace', working_dir: workspaceRoot });
+    expect(parsed.workspace).toEqual({ working_dir: workspaceRoot });
   });
 
   it('supports includeDefaultTools=false to disable default tools when tools are omitted', async () => {
@@ -175,7 +180,8 @@ describe('RemoteConversation', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
-    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] } };
+    const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] } };
+    expect(parsed.agent.kind).toBe('Agent');
     expect(parsed.agent.tools).toEqual([]);
   });
 
@@ -203,8 +209,9 @@ describe('RemoteConversation', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
-    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] } };
-    expect(parsed.agent.tools).toEqual([{ name: 'terminal' }]);
+    const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] } };
+    expect(parsed.agent.kind).toBe('Agent');
+    expect(parsed.agent.tools).toEqual([{ name: 'TerminalTool' }]);
   });
 
   it('supports includeDefaultTools=true to merge defaults with provided tools', async () => {
@@ -232,12 +239,13 @@ describe('RemoteConversation', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit | undefined];
-    const parsed = JSON.parse(init?.body as string) as { agent: { tools: RemoteConversationTool[] } };
+    const parsed = JSON.parse(init?.body as string) as { agent: { kind: string; tools: RemoteConversationTool[] } };
+    expect(parsed.agent.kind).toBe('Agent');
     expect(parsed.agent.tools).toEqual([
-      { name: 'terminal' },
-      { name: 'file_editor' },
-      { name: 'task_tracker' },
-      { name: 'glob', params: { pattern: '**/*.ts' } },
+      { name: 'TerminalTool' },
+      { name: 'FileEditorTool' },
+      { name: 'TaskTrackerTool' },
+      { name: 'GlobTool', params: { pattern: '**/*.ts' } },
     ]);
   });
 

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts
@@ -284,4 +284,45 @@ describe('RemoteConversation', () => {
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('runs queued conversation work via POST /api/conversations/:id/run', async () => {
+    const connectSpy = vi
+      .spyOn(RemoteConversation.prototype as unknown as { connect: () => void }, 'connect')
+      .mockImplementation(() => {});
+
+    const fetchSpy = vi.fn((url: string, init?: RequestInit) => {
+      if (url === 'http://localhost:3000/api/conversations') {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ id: 'conv-run-pending' }),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      if (url === 'http://localhost:3000/api/conversations/conv-run-pending/run') {
+        expect(init?.method).toBe('POST');
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({}),
+          text: () => Promise.resolve(''),
+        } as unknown as Response);
+      }
+
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+    });
+
+    await conversation.startNewConversation();
+    await conversation.runPending();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -518,17 +518,11 @@ export class RemoteConversation extends EventEmitter {
   }
 
   async resume() {
-    if (!this.conversationId) {
-      this.emit('error', new Error('Cannot resume: no active conversation. Start a new conversation first.'));
-      return;
-    }
-    try {
-      const headers = this.getAuthHeaders();
-      const res = await this.requestApi(`/api/conversations/${this.conversationId}/run`, { method: 'POST', headers });
-      await this.assertApiOk(res, 'Failed to resume conversation');
-    } catch (e) {
-      this.emit('error', e instanceof Error ? e : new Error(String(e)));
-    }
+    await this.triggerRun('resume');
+  }
+
+  async runPending() {
+    await this.triggerRun('run pending conversation work');
   }
 
   async setConfirmationPolicy(policy: ConfirmationPolicy): Promise<void> {
@@ -748,6 +742,20 @@ export class RemoteConversation extends EventEmitter {
     if (this.status === s) return;
     this.status = s;
     this.emit('status', s);
+  }
+
+  private async triggerRun(actionLabel: string): Promise<void> {
+    if (!this.conversationId) {
+      this.emit('error', new Error(`Cannot ${actionLabel}: no active conversation. Start a new conversation first.`));
+      return;
+    }
+    try {
+      const headers = this.getAuthHeaders();
+      const res = await this.requestApi(`/api/conversations/${this.conversationId}/run`, { method: 'POST', headers });
+      await this.assertApiOk(res, `Failed to ${actionLabel}`);
+    } catch (e) {
+      this.emit('error', e instanceof Error ? e : new Error(String(e)));
+    }
   }
 
   private getAuthHeaders(): Record<string, string> {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -53,17 +53,6 @@ const toStaticSecret = (value: unknown): StaticSecret | undefined => {
 
 const normalizeRemoteServerUrl = normalizeRemoteUrl;
 
-const defaultRemoteToolNameToClassName = (name: string): string => {
-  const trimmed = name.trim();
-  if (!trimmed) return trimmed;
-  if (/^[A-Z][A-Za-z0-9]*Tool$/.test(trimmed)) return trimmed;
-  return trimmed
-    .split('_')
-    .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join('') + 'Tool';
-};
-
 export interface RemoteConversationOptions {
   serverUrl: string;
   settings: OpenHandsSettings;
@@ -448,10 +437,7 @@ export class RemoteConversation extends EventEmitter {
         hasToolsOption: this.hasToolsOption,
         defaultTools,
         providedTools: this.tools,
-      }).map((tool) => ({
-        ...tool,
-        name: defaultRemoteToolNameToClassName(tool.name),
-      }));
+      });
       const req = {
         agent: {
           kind: 'Agent',

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -53,6 +53,17 @@ const toStaticSecret = (value: unknown): StaticSecret | undefined => {
 
 const normalizeRemoteServerUrl = normalizeRemoteUrl;
 
+const defaultRemoteToolNameToClassName = (name: string): string => {
+  const trimmed = name.trim();
+  if (!trimmed) return trimmed;
+  if (/^[A-Z][A-Za-z0-9]*Tool$/.test(trimmed)) return trimmed;
+  return trimmed
+    .split('_')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join('') + 'Tool';
+};
+
 export interface RemoteConversationOptions {
   serverUrl: string;
   settings: OpenHandsSettings;
@@ -430,16 +441,20 @@ export class RemoteConversation extends EventEmitter {
         { name: 'file_editor' },
         { name: 'task_tracker' },
       ];
-      const workspace = this.workspace ?? { kind: 'LocalWorkspace', working_dir: this.workspaceRoot };
+      const workspace = this.workspace ?? { working_dir: this.workspaceRoot };
 
       const tools = resolveToolsWithDefaultTools({
         includeDefaultTools: this.includeDefaultTools,
         hasToolsOption: this.hasToolsOption,
         defaultTools,
         providedTools: this.tools,
-      });
+      }).map((tool) => ({
+        ...tool,
+        name: defaultRemoteToolNameToClassName(tool.name),
+      }));
       const req = {
         agent: {
+          kind: 'Agent',
           llm,
           tools,
           security_analyzer: s?.agent.enableSecurityAnalyzer ? ({ kind: 'LLMSecurityAnalyzer' } satisfies RemoteSecurityAnalyzerPayload) : undefined,
@@ -518,7 +533,7 @@ export class RemoteConversation extends EventEmitter {
   }
 
   async resume() {
-    await this.triggerRun('resume');
+    await this.triggerRun('resume conversation');
   }
 
   async runPending() {

--- a/packages/agent-sdk/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk/src/sdk/runtime/Agent.ts
@@ -17,6 +17,7 @@ import type { ActionEvent, BashEvent, ConversationStateUpdateEvent, Event, Messa
 import {
   isActionEvent,
   isAgentErrorEvent,
+  isMessageEvent,
   isObservationEvent,
   isPauseEvent,
   isSystemPromptEvent,
@@ -450,6 +451,22 @@ export class Agent extends EventEmitter {
     return this.lock.acquire(async () => {
       this.ensureSystemPrompt();
       this.pushUserMessage(input, { extraExtendedContent: options?.extraExtendedContent });
+      return this.runLoop();
+    });
+  }
+
+  async runPending(): Promise<Message | undefined> {
+    const events = this.events.list();
+    const lastEvent = events[events.length - 1];
+    if (!isMessageEvent(lastEvent) || lastEvent.source !== 'user') {
+      return undefined;
+    }
+
+    this.cancelled = false;
+    this.finished = false;
+    this.paused = false;
+    return this.lock.acquire(async () => {
+      this.ensureSystemPrompt();
       return this.runLoop();
     });
   }

--- a/tests/e2e/agentServerRemoteCloudBootstrap.test.ts
+++ b/tests/e2e/agentServerRemoteCloudBootstrap.test.ts
@@ -195,8 +195,8 @@ async function startMockSaasServer(params: {
         'X-Session-API-Key': params.runtimeSessionApiKey,
       },
       body: JSON.stringify({
-        agent: { llm: { model: 'gpt-4o-mini' }, tools: [] },
-        workspace: { kind: 'LocalWorkspace', working_dir: path.join(agentServerStateDir, 'workspace') },
+        agent: { kind: 'Agent', llm: { model: 'gpt-4o-mini' }, tools: [] },
+        workspace: { working_dir: path.join(agentServerStateDir, 'workspace') },
         max_iterations: 1,
       }),
     });


### PR DESCRIPTION
## Summary
- add a public `runPending()` entrypoint on the canonical TypeScript conversation/runtime path
- expose the same method on `RemoteConversation` by mapping it to the existing `/run` route
- add focused tests proving queued `run: false` turns can be resumed without duplicating the user message
- align remote conversation creation and the cloud bootstrap E2E harness with the current Python agent-server create payload requirements

## Verification
- `npx vitest run packages/agent-sdk/src/sdk/conversation/LocalConversation.test.ts packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts`
- `npm run compile`
- `npx tsc -p tests/e2e/tsconfig.suite.json`
- `npx tsc -p tsconfig.e2e.json`
- `npm run typecheck`
- GitHub CI: `build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`

## Context
This is the canonical follow-up to the temporary queued-idle `/run` fallback in `enyst/smolpaws`. Downstreams can adopt `conversation.runPending()` once this lands on the published SDK line.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/999" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability to execute pending and queued messages in conversations without additional user input
* **Bug Fixes**
  * Fixed issue preventing duplicate processing when handling queued user messages
* **Tests**
  * Enhanced test coverage for pending message execution scenarios with improved payload validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- OpenHands roasted review was run locally in a clean worktree. The substantive warning was that the PR had picked up an unversioned remote create-payload change (`agent.kind` / workspace shape) alongside the queued-run API. I validated that change against the current upstream Python agent-server, then aligned both the direct `RemoteConversation.startNewConversation()` path and the mock SaaS cloud-bootstrap harness to use the server-compatible payload.
- Gemini feedback was taken: `LocalConversation.runPending()` now emits a no-active-conversation error instead of silently returning.
- Devin feedback was taken: `RemoteConversation.resume()` keeps the existing `Failed to resume conversation ...` error wording.
- CodeRabbit feedback was taken where accurate: `LocalConversation.runPending()` now serializes on the local lock and no-ops unless the last event is a queued user message; `RemoteConversation.test.ts` now covers `/run` failure handling. The stale tool-name normalization thread was resolved after reverting the incompatible normalization.
- CodeRabbit rate-limit comments were non-actionable and were not treated as blockers.
