### PR TITLE
release: 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhands-tab",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhands-tab",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "bundleDependencies": [
         "ws"
       ],
@@ -14142,7 +14142,7 @@
     },
     "packages/agent-sdk": {
       "name": "@smolpaws/agent-sdk",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenHands Tab",
   "publisher": "openhands",
   "icon": "media/icons/openhands-icon.png",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A VS Code extension to interact with OpenHands agents in a dedicated sidebar chat view",
   "license": "MIT",
   "workspaces": [

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smolpaws/agent-sdk",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "TypeScript models and guards for the OpenHands agent-sdk wire protocol",
   "license": "MIT",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- bump the OpenHands-Tab extension version to `0.9.1`
- bump `@smolpaws/agent-sdk` to `0.9.1` in the workspace package and lockfile
- cut the release branch required by the documented release flow before tagging

## Verification
- npm registry now reports `@smolpaws/agent-sdk@0.9.1`
- SDK publish preflight: `npm pack --dry-run`
- GitHub CI on this PR passed: `build`, `test`, `e2e`, `e2e-ui`, `agent-server-e2e`

## Notes
- The SDK npm package was already published as `0.9.1` to unblock downstream queued-run adoption.
- This PR is the repository-side version/tagging step needed to complete the OpenHands-Tab `0.9.1` release flow documented in `docs/release-process.md`.

### Review
- Devin Review reported no issues.
- Gemini Code Assist only posted its auto-summary comment; `/gemini review` was retriggered and no inline or top-level findings arrived during the wait window.
- CodeRabbit was rate-limited with an ETA over the repo's 10-minute wait threshold, so it was not re-triggered.
- A local OpenHands roasted review was started from a clean worktree, but the CLI session did not emit a final review message before merge time; no actionable findings were produced.
- Final pre-merge GitHub pass: no unresolved review threads remained.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1000" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
