### PR TITLE
feat: route browser tools through agent-browser

### DIFF
--- a/docs/agent-sdk-architecture.md
+++ b/docs/agent-sdk-architecture.md
@@ -1233,7 +1233,7 @@ console.log(result.content);  // Response body
 - Scrolling and history (`browser_scroll`, `browser_go_back`)
 - Tab management (`browser_list_tabs`, `browser_switch_tab`, `browser_close_tab`)
 
-**Notes**: These tools mirror the Python `browser_use` schemas and share stubbed execution that returns the requested action payload for unit validation.
+**Notes**: These tools keep the Python-compatible `browser_use`-style tool names, but the local TypeScript runtime now routes them through the `agent-browser` CLI. The current local path preserves index-based schemas by caching refs from `browser_get_state`, while unsupported tab-specific actions fail explicitly instead of pretending to succeed.
 
 ### DelegateTool
 

--- a/packages/agent-sdk/AGENTS.md
+++ b/packages/agent-sdk/AGENTS.md
@@ -154,7 +154,7 @@ Agent tool implementations:
   - Navigation, clicks, typing, scrolling
   - Page state/content retrieval with optional screenshots
   - Tab management (list, switch, close)
-  - Mirrors Python `browser_use` schemas with stubbed execution
+  - Mirrors Python `browser_use` tool names while routing the local TypeScript path through `agent-browser`
 
 - **`PlanningFileEditorTool`** - Restricted file editor for planning
   - View/create/str_replace/insert commands

--- a/packages/agent-sdk/src/tools/BrowserUseTool.ts
+++ b/packages/agent-sdk/src/tools/BrowserUseTool.ts
@@ -19,11 +19,18 @@ export interface BrowserUseResult {
   note?: string;
 }
 
+type BrowserCommandResult = {
+  command: string[];
+  stdout: string;
+  stderr: string;
+  output: string;
+};
+
 type PreparedBrowserInvocation = {
   commands: string[][];
   invalidateCachedRefs?: boolean;
   note?: string;
-  transform?: (outputs: string[], context: ToolContext) => Pick<BrowserUseResult, 'output' | 'refs' | 'note'>;
+  transform?: (results: BrowserCommandResult[], context: ToolContext) => Pick<BrowserUseResult, 'output' | 'refs' | 'note'>;
 };
 
 const navigateSchema = z.object({
@@ -157,7 +164,7 @@ function resolveRefForIndex(index: number, context: ToolContext): string {
 async function runAgentBrowserCommand(
   commandArgs: string[],
   context: ToolContext,
-): Promise<{ command: string[]; output: string }> {
+): Promise<BrowserCommandResult> {
   const binary = resolveAgentBrowserBinary();
   try {
     const result = await execFileAsync(binary, commandArgs, {
@@ -171,6 +178,8 @@ async function runAgentBrowserCommand(
     const output = [stdout, stderr].filter(Boolean).join('\n');
     return {
       command: [binary, ...commandArgs],
+      stdout,
+      stderr,
       output: output || `Executed ${[binary, ...commandArgs].join(' ')}`,
     };
   } catch (error) {
@@ -208,15 +217,18 @@ abstract class BaseBrowserUseTool extends ZodTool<Record<string, unknown>, Brows
     if (prepared.invalidateCachedRefs) {
       snapshotRefsByWorkspace.delete(context.workspace as object);
     }
-    const outputs: string[] = [];
+    const results: BrowserCommandResult[] = [];
     const commands: string[][] = [];
     for (const commandArgs of prepared.commands) {
       const result = await runAgentBrowserCommand(commandArgs, context);
       commands.push(result.command);
-      outputs.push(result.output);
+      results.push(result);
     }
-    const transformed = prepared.transform?.(outputs, context) ?? {
-      output: outputs.filter(Boolean).join('\n\n'),
+    const transformed = prepared.transform?.(results, context) ?? {
+      output: results
+        .map((result) => result.output)
+        .filter(Boolean)
+        .join('\n\n'),
     };
     return {
       action: this.name,
@@ -292,11 +304,14 @@ export class BrowserGetStateTool extends BaseBrowserUseTool {
       commands: request.include_screenshot
         ? [['snapshot', '-i'], ['screenshot']]
         : [['snapshot', '-i']],
-      transform: (outputs, context) => {
-        const refs = parseSnapshotRefs(outputs[0] ?? '');
+      transform: (results, context) => {
+        const refs = parseSnapshotRefs(results[0]?.stdout ?? '');
         snapshotRefsByWorkspace.set(context.workspace as object, refs);
         return {
-          output: outputs.filter(Boolean).join('\n\n'),
+          output: results
+            .map((result) => result.output)
+            .filter(Boolean)
+            .join('\n\n'),
           refs,
           note:
             refs.length === 0
@@ -317,8 +332,8 @@ export class BrowserGetContentTool extends BaseBrowserUseTool {
     const request = args as z.infer<typeof getContentSchema>;
     return {
       commands: [['snapshot', '-c']],
-      transform: (outputs) => ({
-        output: (outputs[0] ?? '').slice(request.start_from_char),
+      transform: (results) => ({
+        output: (results[0]?.output ?? '').slice(request.start_from_char),
         note: request.extract_links
           ? 'extract_links is accepted for compatibility but agent-browser snapshot output is returned as-is.'
           : undefined,
@@ -361,13 +376,13 @@ export class BrowserListTabsTool extends BaseBrowserUseTool {
   protected prepareExecution(): PreparedBrowserInvocation {
     return {
       commands: [['get', 'title'], ['get', 'url']],
-      transform: (outputs) => ({
+      transform: (results) => ({
         output: JSON.stringify(
           [
             {
               tab_id: 'current',
-              title: outputs[0] ?? '',
-              url: outputs[1] ?? '',
+              title: results[0]?.output ?? '',
+              url: results[1]?.output ?? '',
             },
           ],
           null,

--- a/packages/agent-sdk/src/tools/BrowserUseTool.ts
+++ b/packages/agent-sdk/src/tools/BrowserUseTool.ts
@@ -1,18 +1,28 @@
+import { execFile } from 'child_process';
+import { promisify } from 'util';
 import { z } from 'zod';
 import type { ToolContext } from './types';
 import { ZodTool, booleanWithDefault } from './zod-tool';
 
+const execFileAsync = promisify(execFile);
+const AGENT_BROWSER_BIN_ENV = 'SMOLPAWS_AGENT_BROWSER_BIN';
+const DEFAULT_SCROLL_DISTANCE = '800';
+const snapshotRefsByWorkspace = new Map<string, string[]>();
+
 export interface BrowserUseResult {
   action: string;
   request: Record<string, unknown>;
-  note: string;
+  commands: string[][];
+  output: string;
+  refs?: string[];
+  note?: string;
 }
 
-const stubExecution = (name: string, args: Record<string, unknown>): BrowserUseResult => ({
-  action: name,
-  request: args,
-  note: 'Stubbed browser_use action executed',
-});
+type PreparedBrowserInvocation = {
+  commands: string[][];
+  note?: string;
+  transform?: (outputs: string[], context: ToolContext) => Pick<BrowserUseResult, 'output' | 'refs' | 'note'>;
+};
 
 const navigateSchema = z.object({
   url: z.string().url().describe('The URL to navigate to'),
@@ -24,7 +34,7 @@ const clickSchema = z.object({
     .number()
     .int()
     .min(0)
-    .describe('The index of the element to click (from browser_get_state).'),
+    .describe('The zero-based element index from the latest browser_get_state output.'),
   new_tab: booleanWithDefault(false).describe(
     'Whether to open any resulting navigation in a new tab. Default: false',
   ),
@@ -35,7 +45,7 @@ const typeSchema = z.object({
     .number()
     .int()
     .min(0)
-    .describe('The index of the input element (from browser_get_state).'),
+    .describe('The zero-based input index from the latest browser_get_state output.'),
   text: z.string().describe('The text to type.'),
 });
 
@@ -70,86 +80,135 @@ const closeTabSchema = z.object({
   tab_id: z.string().describe('4 Character Tab ID of the tab to close.'),
 });
 
-const BROWSER_NAVIGATE_DESCRIPTION = `Navigate to a URL in the browser.
+const BROWSER_NAVIGATE_DESCRIPTION = `Navigate to a URL in the local agent-browser session.
 
-This tool allows you to navigate to any web page. You can optionally open the URL in a new tab.
+This uses the local \`agent-browser\` CLI instead of the Python upstream's Docker-first \`browser_use\` path.
+The \`new_tab\` flag is accepted for compatibility but ignored because the local CLI currently drives one browser session.`;
 
-Parameters:
-- url: The URL to navigate to (required)
-- new_tab: Whether to open in a new tab (optional, default: false)
+const BROWSER_CLICK_DESCRIPTION = `Click an element in the local browser session.
 
-Examples:
-- Navigate to Google: url="https://www.google.com"
-- Open GitHub in new tab: url="https://github.com", new_tab=true`;
+Call \`browser_get_state\` first. This tool maps the requested zero-based index from that latest snapshot to the underlying \`agent-browser\` ref (for example \`@e2\`).`;
 
-const BROWSER_CLICK_DESCRIPTION = `Click an element on the page by its index.
+const BROWSER_TYPE_DESCRIPTION = `Fill an input in the local browser session.
 
-Use this tool to click on interactive elements like buttons, links, or form controls.
-The index comes from the browser_get_state tool output.
+Call \`browser_get_state\` first. This tool maps the requested zero-based index from that latest snapshot to the underlying \`agent-browser\` ref and then fills it with the provided text.`;
 
-Parameters:
-- index: The index of the element to click (from browser_get_state)
-- new_tab: Whether to open any resulting navigation in a new tab (optional)
+const BROWSER_GET_STATE_DESCRIPTION = `Capture the current local browser state using \`agent-browser snapshot -i\`.
 
-Important: Only use indices that appear in your current browser_get_state output.`;
+The returned output includes the raw snapshot and caches the ref order so later \`browser_click\` and \`browser_type\` calls can keep their Python-compatible index-based schema.`;
 
-const BROWSER_TYPE_DESCRIPTION = `Type text into an input field.
+const BROWSER_GET_CONTENT_DESCRIPTION = `Capture a compact page snapshot from the local browser session.
 
-Use this tool to enter text into form fields, search boxes, or other text input elements.
-The index comes from the browser_get_state tool output.
+This currently uses \`agent-browser snapshot -c\`. \`extract_links\` is accepted for compatibility but does not change the local output format.`;
 
-Parameters:
-- index: The index of the input element (from browser_get_state)
-- text: The text to type
+const BROWSER_SCROLL_DESCRIPTION = `Scroll the page in the local browser session.
 
-Important: Only use indices that appear in your current browser_get_state output.`;
+This maps to \`agent-browser scroll <direction> 800\`.`;
 
-const BROWSER_GET_STATE_DESCRIPTION = `Get the current state of the page including all interactive elements.
+const BROWSER_GO_BACK_DESCRIPTION = `Go back to the previous page in the local browser session.`;
 
-This tool returns the current page content with numbered interactive elements that you can
-click or type into. Use this frequently to understand what's available on the page.
+const BROWSER_LIST_TABS_DESCRIPTION = `Inspect the current local browser session.
 
-Parameters:
-- include_screenshot: Whether to include a screenshot (optional, default: false)`;
+The local \`agent-browser\` path currently exposes one active browser session rather than Python-style tab ids, so this returns a synthetic single-item listing.`;
 
-const BROWSER_GET_CONTENT_DESCRIPTION = `Extract the main content of the current page in clean markdown format. It has been filtered to remove noise and advertising content.
+const BROWSER_SWITCH_TAB_DESCRIPTION = `Switching tabs is not supported by the local \`agent-browser\` path yet.`;
 
-If the content was truncated and you need more information, use start_from_char parameter to continue from where truncation occurred.`;
+const BROWSER_CLOSE_TAB_DESCRIPTION = `Closing a specific tab is not supported by the local \`agent-browser\` path yet.`;
 
-const BROWSER_SCROLL_DESCRIPTION = `Scroll the page up or down.
+function resolveAgentBrowserBinary(): string {
+  const configured = process.env[AGENT_BROWSER_BIN_ENV]?.trim();
+  return configured && configured.length > 0 ? configured : 'agent-browser';
+}
 
-Use this tool to scroll through page content when elements are not visible or when you need
-to see more content.
+function parseSnapshotRefs(output: string): string[] {
+  const matches = output.match(/@e[\w-]+/g) ?? [];
+  const seen = new Set<string>();
+  const refs: string[] = [];
+  for (const match of matches) {
+    if (seen.has(match)) {
+      continue;
+    }
+    seen.add(match);
+    refs.push(match);
+  }
+  return refs;
+}
 
-Parameters:
-- direction: Direction to scroll - "up" or "down" (optional, default: "down")`;
+function combineNotes(...notes: Array<string | undefined>): string | undefined {
+  const combined = notes
+    .map((note) => note?.trim())
+    .filter((note): note is string => Boolean(note));
+  return combined.length > 0 ? combined.join('\n') : undefined;
+}
 
-const BROWSER_GO_BACK_DESCRIPTION = `Go back to the previous page in browser history.
+function resolveRefForIndex(index: number, context: ToolContext): string {
+  const refs = snapshotRefsByWorkspace.get(context.workspace.root) ?? [];
+  const ref = refs[index];
+  if (!ref) {
+    throw new Error(
+      `No cached browser_get_state ref for index ${index}. Call browser_get_state before browser interactions.`,
+    );
+  }
+  return ref;
+}
 
-Use this tool to navigate back to the previously visited page, similar to clicking the browser's back button.`;
-
-const BROWSER_LIST_TABS_DESCRIPTION = `List all open browser tabs.
-
-This tool shows all currently open tabs with their IDs, titles, and URLs. Use the tab IDs
-with browser_switch_tab or browser_close_tab.`;
-
-const BROWSER_SWITCH_TAB_DESCRIPTION = `Switch to a different browser tab.
-
-Use this tool to switch between open tabs. Get the tab_id from browser_list_tabs.
-
-Parameters:
-- tab_id: 4 Character Tab ID of the tab to switch to`;
-
-const BROWSER_CLOSE_TAB_DESCRIPTION = `Close a specific browser tab.
-
-Use this tool to close tabs you no longer need. Get the tab_id from browser_list_tabs.
-
-Parameters:
-- tab_id: 4 Character Tab ID of the tab to close`;
+async function runAgentBrowserCommand(
+  commandArgs: string[],
+  context: ToolContext,
+): Promise<{ command: string[]; output: string }> {
+  const binary = resolveAgentBrowserBinary();
+  try {
+    const result = await execFileAsync(binary, commandArgs, {
+      cwd: context.workspace.root,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const stdout = result.stdout?.trim() ?? '';
+    const stderr = result.stderr?.trim() ?? '';
+    const output = [stdout, stderr].filter(Boolean).join('\n');
+    return {
+      command: [binary, ...commandArgs],
+      output: output || `Executed ${[binary, ...commandArgs].join(' ')}`,
+    };
+  } catch (error) {
+    const err = error as { code?: string; stdout?: string; stderr?: string; message?: string };
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `agent-browser CLI not found. Install it and ensure it is on PATH, or set ${AGENT_BROWSER_BIN_ENV}.`,
+      );
+    }
+    const details = [err.stdout?.trim(), err.stderr?.trim(), err.message?.trim()]
+      .filter(Boolean)
+      .join('\n');
+    throw new Error(details || `agent-browser command failed: ${commandArgs.join(' ')}`);
+  }
+}
 
 abstract class BaseBrowserUseTool extends ZodTool<Record<string, unknown>, BrowserUseResult> {
-  async execute(args: Record<string, unknown>, _context: ToolContext): Promise<BrowserUseResult> {
-    return Promise.resolve(stubExecution(this.name, args));
+  protected abstract prepareExecution(
+    args: Record<string, unknown>,
+    context: ToolContext,
+  ): PreparedBrowserInvocation;
+
+  async execute(args: Record<string, unknown>, context: ToolContext): Promise<BrowserUseResult> {
+    const prepared = this.prepareExecution(args, context);
+    const outputs: string[] = [];
+    const commands: string[][] = [];
+    for (const commandArgs of prepared.commands) {
+      const result = await runAgentBrowserCommand(commandArgs, context);
+      commands.push(result.command);
+      outputs.push(result.output);
+    }
+    const transformed = prepared.transform?.(outputs, context) ?? {
+      output: outputs.filter(Boolean).join('\n\n'),
+    };
+    return {
+      action: this.name,
+      request: args,
+      commands,
+      output: transformed.output,
+      refs: transformed.refs,
+      note: combineNotes(prepared.note, transformed.note),
+    };
   }
 }
 
@@ -157,60 +216,168 @@ export class BrowserNavigateTool extends BaseBrowserUseTool {
   readonly name = 'browser_navigate';
   readonly description = BROWSER_NAVIGATE_DESCRIPTION;
   readonly schema = navigateSchema;
+
+  protected prepareExecution(args: Record<string, unknown>): PreparedBrowserInvocation {
+    const request = args as z.infer<typeof navigateSchema>;
+    return {
+      commands: [['open', request.url]],
+      note: request.new_tab
+        ? 'new_tab is ignored by the local agent-browser path and uses the current session.'
+        : undefined,
+    };
+  }
 }
 
 export class BrowserClickTool extends BaseBrowserUseTool {
   readonly name = 'browser_click';
   readonly description = BROWSER_CLICK_DESCRIPTION;
   readonly schema = clickSchema;
+
+  protected prepareExecution(
+    args: Record<string, unknown>,
+    context: ToolContext,
+  ): PreparedBrowserInvocation {
+    const request = args as z.infer<typeof clickSchema>;
+    return {
+      commands: [['click', resolveRefForIndex(request.index, context)]],
+      note: request.new_tab
+        ? 'new_tab is ignored by the local agent-browser path and uses the current session.'
+        : undefined,
+    };
+  }
 }
 
 export class BrowserTypeTool extends BaseBrowserUseTool {
   readonly name = 'browser_type';
   readonly description = BROWSER_TYPE_DESCRIPTION;
   readonly schema = typeSchema;
+
+  protected prepareExecution(
+    args: Record<string, unknown>,
+    context: ToolContext,
+  ): PreparedBrowserInvocation {
+    const request = args as z.infer<typeof typeSchema>;
+    return {
+      commands: [['fill', resolveRefForIndex(request.index, context), request.text]],
+    };
+  }
 }
 
 export class BrowserGetStateTool extends BaseBrowserUseTool {
   readonly name = 'browser_get_state';
   readonly description = BROWSER_GET_STATE_DESCRIPTION;
   readonly schema = getStateSchema;
+
+  protected prepareExecution(args: Record<string, unknown>): PreparedBrowserInvocation {
+    const request = args as z.infer<typeof getStateSchema>;
+    return {
+      commands: request.include_screenshot
+        ? [['snapshot', '-i'], ['screenshot']]
+        : [['snapshot', '-i']],
+      transform: (outputs, context) => {
+        const refs = parseSnapshotRefs(outputs[0] ?? '');
+        snapshotRefsByWorkspace.set(context.workspace.root, refs);
+        return {
+          output: outputs.filter(Boolean).join('\n\n'),
+          refs,
+          note:
+            refs.length === 0
+              ? 'No interactive refs were found in the latest snapshot.'
+              : undefined,
+        };
+      },
+    };
+  }
 }
 
 export class BrowserGetContentTool extends BaseBrowserUseTool {
   readonly name = 'browser_get_content';
   readonly description = BROWSER_GET_CONTENT_DESCRIPTION;
   readonly schema = getContentSchema;
+
+  protected prepareExecution(args: Record<string, unknown>): PreparedBrowserInvocation {
+    const request = args as z.infer<typeof getContentSchema>;
+    return {
+      commands: [['snapshot', '-c']],
+      transform: (outputs) => ({
+        output: (outputs[0] ?? '').slice(request.start_from_char),
+        note: request.extract_links
+          ? 'extract_links is accepted for compatibility but agent-browser snapshot output is returned as-is.'
+          : undefined,
+      }),
+    };
+  }
 }
 
 export class BrowserScrollTool extends BaseBrowserUseTool {
   readonly name = 'browser_scroll';
   readonly description = BROWSER_SCROLL_DESCRIPTION;
   readonly schema = scrollSchema;
+
+  protected prepareExecution(args: Record<string, unknown>): PreparedBrowserInvocation {
+    const request = args as z.infer<typeof scrollSchema>;
+    return {
+      commands: [['scroll', request.direction, DEFAULT_SCROLL_DISTANCE]],
+    };
+  }
 }
 
 export class BrowserGoBackTool extends BaseBrowserUseTool {
   readonly name = 'browser_go_back';
   readonly description = BROWSER_GO_BACK_DESCRIPTION;
   readonly schema = goBackSchema;
+
+  protected prepareExecution(): PreparedBrowserInvocation {
+    return {
+      commands: [['back']],
+    };
+  }
 }
 
 export class BrowserListTabsTool extends BaseBrowserUseTool {
   readonly name = 'browser_list_tabs';
   readonly description = BROWSER_LIST_TABS_DESCRIPTION;
   readonly schema = listTabsSchema;
+
+  protected prepareExecution(): PreparedBrowserInvocation {
+    return {
+      commands: [['get', 'title'], ['get', 'url']],
+      transform: (outputs) => ({
+        output: JSON.stringify(
+          [
+            {
+              tab_id: 'current',
+              title: outputs[0] ?? '',
+              url: outputs[1] ?? '',
+            },
+          ],
+          null,
+          2,
+        ),
+        note: 'Local agent-browser currently exposes a single active browser session.',
+      }),
+    };
+  }
 }
 
 export class BrowserSwitchTabTool extends BaseBrowserUseTool {
   readonly name = 'browser_switch_tab';
   readonly description = BROWSER_SWITCH_TAB_DESCRIPTION;
   readonly schema = switchTabSchema;
+
+  protected prepareExecution(): PreparedBrowserInvocation {
+    throw new Error('browser_switch_tab is not supported by the local agent-browser path yet.');
+  }
 }
 
 export class BrowserCloseTabTool extends BaseBrowserUseTool {
   readonly name = 'browser_close_tab';
   readonly description = BROWSER_CLOSE_TAB_DESCRIPTION;
   readonly schema = closeTabSchema;
+
+  protected prepareExecution(): PreparedBrowserInvocation {
+    throw new Error('browser_close_tab is not supported by the local agent-browser path yet.');
+  }
 }
 
 export const browserUseTools = [
@@ -225,4 +392,3 @@ export const browserUseTools = [
   BrowserSwitchTabTool,
   BrowserCloseTabTool,
 ];
-

--- a/packages/agent-sdk/src/tools/BrowserUseTool.ts
+++ b/packages/agent-sdk/src/tools/BrowserUseTool.ts
@@ -130,15 +130,15 @@ function resolveAgentBrowserBinary(): string {
 }
 
 function parseSnapshotRefs(output: string): string[] {
-  const matches = output.match(/@e[\w-]+/g) ?? [];
   const seen = new Set<string>();
   const refs: string[] = [];
-  for (const match of matches) {
-    if (seen.has(match)) {
+  for (const match of output.matchAll(/(?:@|ref=)(e[\w-]+)/g)) {
+    const ref = `@${match[1]}`;
+    if (seen.has(ref)) {
       continue;
     }
-    seen.add(match);
-    refs.push(match);
+    seen.add(ref);
+    refs.push(ref);
   }
   return refs;
 }

--- a/packages/agent-sdk/src/tools/BrowserUseTool.ts
+++ b/packages/agent-sdk/src/tools/BrowserUseTool.ts
@@ -7,7 +7,7 @@ import { ZodTool, booleanWithDefault } from './zod-tool';
 const execFileAsync = promisify(execFile);
 const AGENT_BROWSER_BIN_ENV = 'SMOLPAWS_AGENT_BROWSER_BIN';
 const DEFAULT_SCROLL_DISTANCE = '800';
-const snapshotRefsByWorkspace = new Map<string, string[]>();
+const snapshotRefsByWorkspace = new WeakMap<object, string[]>();
 
 export interface BrowserUseResult {
   action: string;
@@ -142,7 +142,7 @@ function combineNotes(...notes: Array<string | undefined>): string | undefined {
 }
 
 function resolveRefForIndex(index: number, context: ToolContext): string {
-  const refs = snapshotRefsByWorkspace.get(context.workspace.root) ?? [];
+  const refs = snapshotRefsByWorkspace.get(context.workspace as object) ?? [];
   const ref = refs[index];
   if (!ref) {
     throw new Error(
@@ -276,7 +276,7 @@ export class BrowserGetStateTool extends BaseBrowserUseTool {
         : [['snapshot', '-i']],
       transform: (outputs, context) => {
         const refs = parseSnapshotRefs(outputs[0] ?? '');
-        snapshotRefsByWorkspace.set(context.workspace.root, refs);
+        snapshotRefsByWorkspace.set(context.workspace as object, refs);
         return {
           output: outputs.filter(Boolean).join('\n\n'),
           refs,

--- a/packages/agent-sdk/src/tools/BrowserUseTool.ts
+++ b/packages/agent-sdk/src/tools/BrowserUseTool.ts
@@ -6,6 +6,7 @@ import { ZodTool, booleanWithDefault } from './zod-tool';
 
 const execFileAsync = promisify(execFile);
 const AGENT_BROWSER_BIN_ENV = 'SMOLPAWS_AGENT_BROWSER_BIN';
+const AGENT_BROWSER_TIMEOUT_MS = 30_000;
 const DEFAULT_SCROLL_DISTANCE = '800';
 const snapshotRefsByWorkspace = new WeakMap<object, string[]>();
 
@@ -20,6 +21,7 @@ export interface BrowserUseResult {
 
 type PreparedBrowserInvocation = {
   commands: string[][];
+  invalidateCachedRefs?: boolean;
   note?: string;
   transform?: (outputs: string[], context: ToolContext) => Pick<BrowserUseResult, 'output' | 'refs' | 'note'>;
 };
@@ -161,6 +163,8 @@ async function runAgentBrowserCommand(
     const result = await execFileAsync(binary, commandArgs, {
       cwd: context.workspace.root,
       maxBuffer: 10 * 1024 * 1024,
+      timeout: AGENT_BROWSER_TIMEOUT_MS,
+      killSignal: 'SIGKILL',
     });
     const stdout = result.stdout?.trim() ?? '';
     const stderr = result.stderr?.trim() ?? '';
@@ -170,11 +174,21 @@ async function runAgentBrowserCommand(
       output: output || `Executed ${[binary, ...commandArgs].join(' ')}`,
     };
   } catch (error) {
-    const err = error as { code?: string; stdout?: string; stderr?: string; message?: string };
+    const err = error as {
+      code?: string;
+      killed?: boolean;
+      signal?: string | null;
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
     if (err.code === 'ENOENT') {
       throw new Error(
         `agent-browser CLI not found. Install it and ensure it is on PATH, or set ${AGENT_BROWSER_BIN_ENV}.`,
       );
+    }
+    if (err.killed || err.signal === 'SIGKILL') {
+      throw new Error(`agent-browser command timed out after 30s: ${commandArgs.join(' ')}`);
     }
     const details = [err.stdout?.trim(), err.stderr?.trim(), err.message?.trim()]
       .filter(Boolean)
@@ -191,6 +205,9 @@ abstract class BaseBrowserUseTool extends ZodTool<Record<string, unknown>, Brows
 
   async execute(args: Record<string, unknown>, context: ToolContext): Promise<BrowserUseResult> {
     const prepared = this.prepareExecution(args, context);
+    if (prepared.invalidateCachedRefs) {
+      snapshotRefsByWorkspace.delete(context.workspace as object);
+    }
     const outputs: string[] = [];
     const commands: string[][] = [];
     for (const commandArgs of prepared.commands) {
@@ -221,6 +238,7 @@ export class BrowserNavigateTool extends BaseBrowserUseTool {
     const request = args as z.infer<typeof navigateSchema>;
     return {
       commands: [['open', request.url]],
+      invalidateCachedRefs: true,
       note: request.new_tab
         ? 'new_tab is ignored by the local agent-browser path and uses the current session.'
         : undefined,
@@ -330,6 +348,7 @@ export class BrowserGoBackTool extends BaseBrowserUseTool {
   protected prepareExecution(): PreparedBrowserInvocation {
     return {
       commands: [['back']],
+      invalidateCachedRefs: true,
     };
   }
 }

--- a/packages/agent-sdk/src/tools/BrowserUseTool.ts
+++ b/packages/agent-sdk/src/tools/BrowserUseTool.ts
@@ -333,7 +333,7 @@ export class BrowserGetContentTool extends BaseBrowserUseTool {
     return {
       commands: [['snapshot', '-c']],
       transform: (results) => ({
-        output: (results[0]?.output ?? '').slice(request.start_from_char),
+        output: (results[0]?.stdout ?? '').slice(request.start_from_char),
         note: request.extract_links
           ? 'extract_links is accepted for compatibility but agent-browser snapshot output is returned as-is.'
           : undefined,
@@ -381,8 +381,8 @@ export class BrowserListTabsTool extends BaseBrowserUseTool {
           [
             {
               tab_id: 'current',
-              title: results[0]?.output ?? '',
-              url: results[1]?.output ?? '',
+              title: results[0]?.stdout ?? '',
+              url: results[1]?.stdout ?? '',
             },
           ],
           null,

--- a/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
@@ -107,6 +107,30 @@ if (args[0] === 'snapshot' && args[1] === '-i') {
     process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
   };
 
+  const createNoisyStructuredAgentBrowser = async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-browser-structured-warning-'));
+    created.push(dir);
+    const scriptPath = path.join(dir, 'agent-browser-structured-warning.js');
+    const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'snapshot' && args[1] === '-c') {
+  process.stdout.write('compact structured content');
+  process.stderr.write('stderr content warning');
+} else if (args[0] === 'get' && args[1] === 'title') {
+  process.stdout.write('Clean title');
+  process.stderr.write('stderr title warning');
+} else if (args[0] === 'get' && args[1] === 'url') {
+  process.stdout.write('https://example.com/clean');
+  process.stderr.write('stderr url warning');
+} else {
+  process.stdout.write(args.join(' '));
+}
+`;
+    await fs.promises.writeFile(scriptPath, script, 'utf8');
+    await fs.promises.chmod(scriptPath, 0o755);
+    process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
+  };
+
   it('validates and executes browser navigation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -152,6 +176,26 @@ if (args[0] === 'snapshot' && args[1] === '-i') {
     expect(result.output).toContain('"tab_id": "current"');
     expect(result.output).toContain('https://example.com/current');
     expect(result.note).toContain('single active browser session');
+  }, 15000);
+
+  it('uses stdout only for structured content and tab fields', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createNoisyStructuredAgentBrowser();
+    const contentTool = new BrowserGetContentTool();
+    const tabsTool = new BrowserListTabsTool();
+
+    const contentResult = await contentTool.execute(
+      contentTool.validate({ extract_links: false, start_from_char: 8 }),
+      { workspace },
+    );
+    expect(contentResult.output).toBe('structured content');
+    expect(contentResult.output).not.toContain('stderr');
+
+    const tabsResult = await tabsTool.execute(tabsTool.validate({}), { workspace });
+    expect(tabsResult.output).toContain('"title": "Clean title"');
+    expect(tabsResult.output).toContain('"url": "https://example.com/clean"');
+    expect(tabsResult.output).not.toContain('stderr');
   }, 15000);
 
   it('fails browser_click when refs are not cached yet', async () => {

--- a/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
@@ -5,10 +5,12 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
   BrowserClickTool,
+  BrowserCloseTabTool,
   BrowserGetContentTool,
   BrowserGetStateTool,
   BrowserListTabsTool,
   BrowserNavigateTool,
+  BrowserSwitchTabTool,
   DelegateTool,
   GlobTool,
   GrepTool,
@@ -73,6 +75,20 @@ if (args[0] === 'snapshot' && args[1] === '-i') {
     process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
   };
 
+  const createSlowAgentBrowser = async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-browser-slow-'));
+    created.push(dir);
+    const scriptPath = path.join(dir, 'agent-browser-slow.js');
+    const script = `#!/usr/bin/env node
+setTimeout(() => {
+  process.stdout.write('finished late');
+}, 35_000);
+`;
+    await fs.promises.writeFile(scriptPath, script, 'utf8');
+    await fs.promises.chmod(scriptPath, 0o755);
+    process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
+  };
+
   it('validates and executes browser navigation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -119,6 +135,57 @@ if (args[0] === 'snapshot' && args[1] === '-i') {
     expect(result.output).toContain('https://example.com/current');
     expect(result.note).toContain('single active browser session');
   }, 15000);
+
+  it('fails browser_click when refs are not cached yet', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createFakeAgentBrowser();
+    const clickTool = new BrowserClickTool();
+    await expect(clickTool.execute(clickTool.validate({ index: 0 }), { workspace })).rejects.toThrow(
+      /Call browser_get_state before browser interactions/,
+    );
+  }, 15000);
+
+  it('invalidates cached refs after page-changing navigation', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createFakeAgentBrowser();
+    const stateTool = new BrowserGetStateTool();
+    const navigateTool = new BrowserNavigateTool();
+    const clickTool = new BrowserClickTool();
+
+    await stateTool.execute(stateTool.validate({ include_screenshot: false }), { workspace });
+    await navigateTool.execute(navigateTool.validate({ url: 'https://example.com/next' }), { workspace });
+
+    await expect(clickTool.execute(clickTool.validate({ index: 0 }), { workspace })).rejects.toThrow(
+      /Call browser_get_state before browser interactions/,
+    );
+  }, 15000);
+
+  it('fails explicitly for unsupported tab actions', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createFakeAgentBrowser();
+    const switchTabTool = new BrowserSwitchTabTool();
+    const closeTabTool = new BrowserCloseTabTool();
+
+    await expect(switchTabTool.execute(switchTabTool.validate({ tab_id: 'abcd' }), { workspace })).rejects.toThrow(
+      /not supported/,
+    );
+    await expect(closeTabTool.execute(closeTabTool.validate({ tab_id: 'abcd' }), { workspace })).rejects.toThrow(
+      /not supported/,
+    );
+  }, 15000);
+
+  it('times out hung agent-browser commands', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createSlowAgentBrowser();
+    const tool = new BrowserNavigateTool();
+    await expect(tool.execute(tool.validate({ url: 'https://example.com' }), { workspace })).rejects.toThrow(
+      /timed out after 30s/,
+    );
+  }, 40000);
 });
 
 describe('DelegateTool', () => {

--- a/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import {
+  BrowserClickTool,
+  BrowserGetContentTool,
+  BrowserGetStateTool,
+  BrowserListTabsTool,
   BrowserNavigateTool,
   DelegateTool,
   GlobTool,
@@ -21,23 +25,100 @@ const makeWorkspace = async () => {
 };
 
 const created: string[] = [];
+const previousAgentBrowserBin = process.env.SMOLPAWS_AGENT_BROWSER_BIN;
 
 afterEach(async () => {
   await Promise.all(created.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
   created.length = 0;
+  if (previousAgentBrowserBin === undefined) {
+    delete process.env.SMOLPAWS_AGENT_BROWSER_BIN;
+  } else {
+    process.env.SMOLPAWS_AGENT_BROWSER_BIN = previousAgentBrowserBin;
+  }
 });
 
 describe('BrowserUse toolset', () => {
+  const createFakeAgentBrowser = async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-browser-stub-'));
+    created.push(dir);
+    const scriptPath = path.join(dir, 'agent-browser-stub.js');
+    const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'snapshot' && args[1] === '-i') {
+  process.stdout.write('button Save @e1\\ntextbox Name @e2\\nlink Docs @e3\\n');
+} else if (args[0] === 'snapshot' && args[1] === '-c') {
+  process.stdout.write('compact snapshot output with links and content');
+} else if (args[0] === 'screenshot') {
+  process.stdout.write('/tmp/agent-browser-shot.png');
+} else if (args[0] === 'click') {
+  process.stdout.write('clicked ' + args[1]);
+} else if (args[0] === 'fill') {
+  process.stdout.write('filled ' + args[1] + ' ' + args.slice(2).join(' '));
+} else if (args[0] === 'open') {
+  process.stdout.write('opened ' + args[1]);
+} else if (args[0] === 'get' && args[1] === 'title') {
+  process.stdout.write('Example title');
+} else if (args[0] === 'get' && args[1] === 'url') {
+  process.stdout.write('https://example.com/current');
+} else if (args[0] === 'scroll') {
+  process.stdout.write('scrolled ' + args[1] + ' ' + args[2]);
+} else if (args[0] === 'back') {
+  process.stdout.write('went back');
+} else {
+  process.stdout.write(args.join(' '));
+}
+`;
+    await fs.promises.writeFile(scriptPath, script, 'utf8');
+    await fs.promises.chmod(scriptPath, 0o755);
+    process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
+  };
+
   it('validates and executes browser navigation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
+    await createFakeAgentBrowser();
     const tool = new BrowserNavigateTool();
     const args = tool.validate({ url: 'https://example.com' });
     expect(args.new_tab).toBe(false);
     const result = await tool.execute(args, { workspace });
     expect(result.action).toBe('browser_navigate');
     expect(result.request.url).toBe('https://example.com');
-  });
+    expect(result.output).toContain('opened https://example.com');
+  }, 15000);
+
+  it('maps browser interaction indices through the latest snapshot refs', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createFakeAgentBrowser();
+    const stateTool = new BrowserGetStateTool();
+    const clickTool = new BrowserClickTool();
+    const typeTool = new BrowserGetContentTool();
+
+    const stateResult = await stateTool.execute(stateTool.validate({ include_screenshot: true }), { workspace });
+    expect(stateResult.refs).toEqual(['@e1', '@e2', '@e3']);
+    expect(stateResult.output).toContain('/tmp/agent-browser-shot.png');
+
+    const clickResult = await clickTool.execute(clickTool.validate({ index: 1 }), { workspace });
+    expect(clickResult.output).toContain('clicked @e2');
+
+    const contentResult = await typeTool.execute(
+      typeTool.validate({ extract_links: true, start_from_char: 8 }),
+      { workspace },
+    );
+    expect(contentResult.output).toBe('snapshot output with links and content');
+    expect(contentResult.note).toContain('extract_links is accepted for compatibility');
+  }, 15000);
+
+  it('returns a synthetic single-tab listing for the local agent-browser path', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createFakeAgentBrowser();
+    const tool = new BrowserListTabsTool();
+    const result = await tool.execute(tool.validate({}), { workspace });
+    expect(result.output).toContain('"tab_id": "current"');
+    expect(result.output).toContain('https://example.com/current');
+    expect(result.note).toContain('single active browser session');
+  }, 15000);
 });
 
 describe('DelegateTool', () => {

--- a/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
@@ -92,7 +92,7 @@ if (args[0] === 'snapshot' && args[1] === '-i') {
     await createFakeAgentBrowser();
     const stateTool = new BrowserGetStateTool();
     const clickTool = new BrowserClickTool();
-    const typeTool = new BrowserGetContentTool();
+    const getContentTool = new BrowserGetContentTool();
 
     const stateResult = await stateTool.execute(stateTool.validate({ include_screenshot: true }), { workspace });
     expect(stateResult.refs).toEqual(['@e1', '@e2', '@e3']);
@@ -101,8 +101,8 @@ if (args[0] === 'snapshot' && args[1] === '-i') {
     const clickResult = await clickTool.execute(clickTool.validate({ index: 1 }), { workspace });
     expect(clickResult.output).toContain('clicked @e2');
 
-    const contentResult = await typeTool.execute(
-      typeTool.validate({ extract_links: true, start_from_char: 8 }),
+    const contentResult = await getContentTool.execute(
+      getContentTool.validate({ extract_links: true, start_from_char: 8 }),
       { workspace },
     );
     expect(contentResult.output).toBe('snapshot output with links and content');

--- a/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
@@ -96,7 +96,7 @@ setTimeout(() => {
     const script = `#!/usr/bin/env node
 const args = process.argv.slice(2);
 if (args[0] === 'snapshot' && args[1] === '-i') {
-  process.stdout.write('button Save @e1\\ntextbox Name @e2\\n');
+  process.stdout.write('button Save [ref=e1]\\ntextbox Name [ref=e2]\\n');
   process.stderr.write('warning: skipped stale ref @e999\\n');
 } else {
   process.stdout.write(args.join(' '));

--- a/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
@@ -89,6 +89,24 @@ setTimeout(() => {
     process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
   };
 
+  const createWarningAgentBrowser = async () => {
+    const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'agent-browser-warning-'));
+    created.push(dir);
+    const scriptPath = path.join(dir, 'agent-browser-warning.js');
+    const script = `#!/usr/bin/env node
+const args = process.argv.slice(2);
+if (args[0] === 'snapshot' && args[1] === '-i') {
+  process.stdout.write('button Save @e1\\ntextbox Name @e2\\n');
+  process.stderr.write('warning: skipped stale ref @e999\\n');
+} else {
+  process.stdout.write(args.join(' '));
+}
+`;
+    await fs.promises.writeFile(scriptPath, script, 'utf8');
+    await fs.promises.chmod(scriptPath, 0o755);
+    process.env.SMOLPAWS_AGENT_BROWSER_BIN = scriptPath;
+  };
+
   it('validates and executes browser navigation', async () => {
     const { workspace, dir } = await makeWorkspace();
     created.push(dir);
@@ -142,6 +160,22 @@ setTimeout(() => {
     await createFakeAgentBrowser();
     const clickTool = new BrowserClickTool();
     await expect(clickTool.execute(clickTool.validate({ index: 0 }), { workspace })).rejects.toThrow(
+      /Call browser_get_state before browser interactions/,
+    );
+  }, 15000);
+
+  it('parses cached refs from snapshot stdout only', async () => {
+    const { workspace, dir } = await makeWorkspace();
+    created.push(dir);
+    await createWarningAgentBrowser();
+    const stateTool = new BrowserGetStateTool();
+    const clickTool = new BrowserClickTool();
+
+    const stateResult = await stateTool.execute(stateTool.validate({ include_screenshot: false }), { workspace });
+    expect(stateResult.refs).toEqual(['@e1', '@e2']);
+    expect(stateResult.output).toContain('warning: skipped stale ref @e999');
+
+    await expect(clickTool.execute(clickTool.validate({ index: 2 }), { workspace })).rejects.toThrow(
       /Call browser_get_state before browser interactions/,
     );
   }, 15000);


### PR DESCRIPTION
## Summary
- replace the stubbed `BrowserUseTool` execution path with real local `agent-browser` CLI integration
- preserve the Python-compatible browser tool names while caching `browser_get_state` refs for index-based click/type compatibility
- update SDK docs and focused tests to reflect the local `agent-browser` runtime path

## Verification
- npx vitest run packages/agent-sdk/src/tools/__tests__/new-tools.test.ts
- npm run build -w @smolpaws/agent-sdk
- npm run lint -w @smolpaws/agent-sdk
- npm run typecheck
- npm test *(fails in pre-existing unrelated suites: `FileEditorTool`, `TerminalTool.session`, `AskOracleTool` timeouts/session cases)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1001" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser tools now run via the local agent-browser CLI for real browser automation, improving multi-step interactions and reliability.
  * Better ref resolution and multi-command batching for navigation, clicking, typing, content capture, and tab listing.
  * Unsupported tab-specific actions now fail explicitly instead of appearing to succeed.

* **Documentation**
  * Architecture and SDK docs updated to reflect agent-browser routing and local runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Review
- OpenHands roasted review: Agent Mail MCP was unavailable in this environment, so I ran `/codereview-roasted pr 1001` locally in a clean tmux worktree and re-ran it after the follow-up commits. Review focus stayed on the new `agent-browser` subprocess contract and the BrowserUse test surface.
- Gemini: fixed the workspace-scoped ref cache collision and the misleading `typeTool` test variable.
- CodeRabbit: fixed cache invalidation after navigation, added a subprocess timeout, added failure-path coverage, broadened snapshot ref parsing to accept both `@e...` and `ref=e...` formats, and switched structured content/tab fields to read `stdout` so stderr cannot leak into user-facing payload fields. I declined the per-tool revalidation suggestion because `packages/agent-sdk/src/sdk/runtime/Agent.ts` already validates tool args before `tool.execute(...)`, and changing only BrowserUseTool would diverge from the shared `ZodTool` contract.
- Devin: fixed the stderr-ref poisoning risk by parsing cached refs from snapshot stdout only while preserving combined output for user-visible command results.

