### PR TITLE
feat: add apple workspace foundation

### DIFF
--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -587,6 +587,7 @@ describe('RemoteConversation', () => {
 
     await expect(conversation.askAgent('What is 2+2?')).resolves.toBe('4');
     expect(received).toEqual([]);
+    conversation.disconnect();
   });
 
   it('askAgent throws when server returns null JSON', async () => {
@@ -619,6 +620,7 @@ describe('RemoteConversation', () => {
     await conversation.restoreConversation('abc');
 
     await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('askAgent: server response missing "response"');
+    conversation.disconnect();
   });
 
   it('askAgent throws when server response is missing "response"', async () => {
@@ -651,6 +653,7 @@ describe('RemoteConversation', () => {
     await conversation.restoreConversation('abc');
 
     await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('askAgent: server response missing "response"');
+    conversation.disconnect();
   });
 
   it('askAgent throws on non-2xx response', async () => {
@@ -683,6 +686,7 @@ describe('RemoteConversation', () => {
     await conversation.restoreConversation('abc');
 
     await expect(conversation.askAgent('What is 2+2?')).rejects.toThrow('Failed to ask agent (HTTP 503): unavailable');
+    conversation.disconnect();
   });
 
   it('generateTitle posts /generate_title and returns the title', async () => {
@@ -1229,6 +1233,65 @@ describe('RemoteConversation', () => {
     await expect(conversation.startNewConversation()).rejects.toThrow('External workspace server is not ready');
     expect(isAlive).toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('does not reconnect after disconnect when workspace warmup finishes late', async () => {
+    let resolveWarmup: ((value: boolean) => void) | undefined;
+    const isAlive = vi.fn()
+      .mockResolvedValueOnce(true)
+      .mockImplementationOnce(async () => await new Promise<boolean>((resolve) => {
+        resolveWarmup = resolve;
+      }));
+    const workspaceClient = {
+      kind: 'apple',
+      root: '/workspace/project',
+      allowPath: vi.fn(),
+      isPathAllowed: vi.fn(() => true),
+      resolvePath: vi.fn((targetPath: string) => targetPath),
+      readFile: vi.fn(),
+      readFileBytes: vi.fn(),
+      writeFile: vi.fn(),
+      remove: vi.fn(),
+      list: vi.fn(),
+      ensureDirectory: vi.fn(),
+      runCommand: vi.fn(),
+      gitStatus: vi.fn(),
+      gitDiff: vi.fn(),
+      isAlive,
+      pause: vi.fn(),
+      resume: vi.fn(),
+    } as unknown as BaseWorkspace;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/api/conversations')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'conv-1' }),
+          text: async () => '',
+        } as any;
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      workspace: { kind: 'apple', working_dir: '/workspace/project' },
+      workspaceClient,
+    });
+
+    await expect(conversation.startNewConversation()).resolves.toBe('conv-1');
+    expect(wsInstances).toHaveLength(0);
+
+    conversation.disconnect();
+    resolveWarmup?.(true);
+    await Promise.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(wsInstances).toHaveLength(0);
   });
 
   it('does not include session_api_key in ws URL and uses ws headers for auth', async () => {

--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type { Event } from '../types';
+import type { BaseWorkspace } from '../../workspace';
 import { saveProfile } from '../llm';
 import { ConfirmRisky } from '../security/confirmationPolicy';
 import { LLMSecurityAnalyzer } from '../security/analyzer';
@@ -1142,6 +1143,54 @@ describe('RemoteConversation', () => {
     const ws = getEventWS();
     expect(ws.url).toMatch(/^ws:\/\/localhost:3000\/sockets\/events\/abc\?/);
     expect(ws.url).toContain('resend_all=true');
+  });
+
+  it('warms a provided workspace client before starting a conversation', async () => {
+    const isAlive = vi.fn(async () => true);
+    const workspaceClient = {
+      kind: 'apple',
+      root: '/workspace/project',
+      allowPath: vi.fn(),
+      isPathAllowed: vi.fn(() => true),
+      resolvePath: vi.fn((targetPath: string) => targetPath),
+      readFile: vi.fn(),
+      readFileBytes: vi.fn(),
+      writeFile: vi.fn(),
+      remove: vi.fn(),
+      list: vi.fn(),
+      ensureDirectory: vi.fn(),
+      runCommand: vi.fn(),
+      gitStatus: vi.fn(),
+      gitDiff: vi.fn(),
+      isAlive,
+      pause: vi.fn(),
+      resume: vi.fn(),
+    } as unknown as BaseWorkspace;
+
+    const fetchMock = vi.fn(async (url: string) => {
+      expect(isAlive).toHaveBeenCalled();
+      if (url.endsWith('/api/conversations')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ id: 'conv-1' }),
+          text: async () => '',
+        } as any;
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      workspace: { kind: 'apple', working_dir: '/workspace/project' },
+      workspaceClient,
+    });
+
+    await expect(conversation.startNewConversation()).resolves.toBe('conv-1');
+    expect(isAlive).toHaveBeenCalled();
   });
 
   it('does not include session_api_key in ws URL and uses ws headers for auth', async () => {

--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -1193,6 +1193,44 @@ describe('RemoteConversation', () => {
     expect(isAlive).toHaveBeenCalled();
   });
 
+  it('fails before starting a conversation when a provided workspace client is not alive', async () => {
+    const isAlive = vi.fn(async () => false);
+    const workspaceClient = {
+      kind: 'apple',
+      root: '/workspace/project',
+      allowPath: vi.fn(),
+      isPathAllowed: vi.fn(() => true),
+      resolvePath: vi.fn((targetPath: string) => targetPath),
+      readFile: vi.fn(),
+      readFileBytes: vi.fn(),
+      writeFile: vi.fn(),
+      remove: vi.fn(),
+      list: vi.fn(),
+      ensureDirectory: vi.fn(),
+      runCommand: vi.fn(),
+      gitStatus: vi.fn(),
+      gitDiff: vi.fn(),
+      isAlive,
+      pause: vi.fn(),
+      resume: vi.fn(),
+    } as unknown as BaseWorkspace;
+
+    const fetchMock = vi.fn();
+    (globalThis as any).fetch = fetchMock;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: baseSettings,
+      workspace: { kind: 'apple', working_dir: '/workspace/project' },
+      workspaceClient,
+    });
+
+    await expect(conversation.startNewConversation()).rejects.toThrow('External workspace server is not ready');
+    expect(isAlive).toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it('does not include session_api_key in ws URL and uses ws headers for auth', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toContain('/events/search');

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -839,7 +839,10 @@ export class RemoteConversation extends EventEmitter {
 
   private async ensureServerReady(): Promise<void> {
     if (!this.externalWorkspaceClient) return;
-    await this.externalWorkspaceClient.isAlive();
+    const isAlive = await this.externalWorkspaceClient.isAlive();
+    if (!isAlive) {
+      throw new Error('External workspace server is not ready');
+    }
   }
 
   private async requestApi(path: string, init: RequestInit): Promise<Response> {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -136,6 +136,7 @@ export class RemoteConversation extends EventEmitter {
     RemoteConversation.reconnectRetryMaxMs,
     RemoteConversation.reconnectMaxRetries,
   );
+  private connectAttemptId = 0;
   private readonly workspaceRoot: string;
   private readonly tools?: RemoteConversationTool[];
   private readonly includeDefaultTools?: boolean | string[];
@@ -726,6 +727,7 @@ export class RemoteConversation extends EventEmitter {
   }
 
   disconnect() {
+    this.connectAttemptId += 1;
     this.clearWsHandshakeTimer();
     this.clearReconnect();
     if (this.ws) {
@@ -867,10 +869,13 @@ export class RemoteConversation extends EventEmitter {
   private connect() {
     if (!this.conversationId) return;
     if (this.externalWorkspaceClient) {
+      const connectAttemptId = ++this.connectAttemptId;
       void this.ensureServerReady().then(() => {
+        if (this.connectAttemptId !== connectAttemptId) return;
         if (!this.conversationId) return;
         this.openWebSocketConnection();
       }).catch((error) => {
+        if (this.connectAttemptId !== connectAttemptId) return;
         const err = error instanceof Error ? error : new Error(String(error));
         this.emit('error', err);
         this.setStatus('offline');

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -60,6 +60,7 @@ export interface RemoteConversationOptions {
   tools?: RemoteConversationTool[];
   includeDefaultTools?: boolean | string[];
   workspace?: RemoteConversationWorkspace;
+  workspaceClient?: BaseWorkspace;
   conversationId?: string;
   profileStoreOptions?: LLMProfileStoreOptions;
 }
@@ -141,13 +142,14 @@ export class RemoteConversation extends EventEmitter {
   private readonly hasToolsOption: boolean;
   private readonly workspace?: RemoteConversationWorkspace;
   private readonly profileStoreOptions?: LLMProfileStoreOptions;
+  private externalWorkspaceClient?: BaseWorkspace;
   private static readonly historyPageLimit = 100;
   private static readonly wsHandshakeTimeoutMs = 10_000;
   private static readonly httpTimeoutMs = 15_000;
   private useLegacyWsSessionKeyQueryAuth = false;
 
   readonly state: RemoteState;
-  private workspaceClient?: RemoteWorkspace;
+  private workspaceClient?: BaseWorkspace;
 
 
   private asRecord(value: unknown): Record<string, unknown> | null {
@@ -205,6 +207,8 @@ export class RemoteConversation extends EventEmitter {
     this.includeDefaultTools = options.includeDefaultTools;
     this.workspace = options.workspace;
     this.profileStoreOptions = options.profileStoreOptions;
+    this.externalWorkspaceClient = options.workspaceClient;
+    this.workspaceClient = options.workspaceClient;
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
@@ -216,7 +220,7 @@ export class RemoteConversation extends EventEmitter {
           return;
         }
         if (this.conversationId === options.conversationId) {
-          this.connect();
+          void this.connect();
         }
       }).catch((err) => {
         this.emit('error', err instanceof Error ? err : new Error(String(err)));
@@ -296,13 +300,14 @@ export class RemoteConversation extends EventEmitter {
       // Re-probe header auth after key rotations; fall back to legacy query auth only if needed.
       this.useLegacyWsSessionKeyQueryAuth = false;
     }
-    if (this.workspaceClient && oldApiKey !== newApiKey) {
+    if (this.workspaceClient && oldApiKey !== newApiKey && !this.externalWorkspaceClient) {
       this.workspaceClient = undefined;
     }
   }
 
   setServerUrl(url: string) {
     this.serverUrl = normalizeRemoteServerUrl(url);
+    this.externalWorkspaceClient = undefined;
     this.workspaceClient = undefined;
     this.useLegacyWsSessionKeyQueryAuth = false;
   }
@@ -475,7 +480,7 @@ export class RemoteConversation extends EventEmitter {
         throw new Error('Server response missing conversation ID. Check agent-server logs.');
       }
       this.emit('conversationStarted', this.conversationId);
-      this.connect();
+      void this.connect();
       return this.conversationId;
     } catch (e) {
       const errorMsg = e instanceof Error ? e.message : String(e);
@@ -501,7 +506,7 @@ export class RemoteConversation extends EventEmitter {
       this.setStatus('offline');
       return;
     }
-    this.connect();
+    void this.connect();
   }
 
   async pause() {
@@ -735,7 +740,7 @@ export class RemoteConversation extends EventEmitter {
     this.clearReconnect();
     this.reconnectBackoffPolicy.resetForManualReconnect();
     if (this.conversationId) {
-      this.connect();
+      void this.connect();
     }
   }
 
@@ -806,7 +811,9 @@ export class RemoteConversation extends EventEmitter {
       }
       return;
     }
-    this.reconnectTimer = setTimeout(() => this.connect(), decision.delayMs);
+    this.reconnectTimer = setTimeout(() => {
+      void this.connect();
+    }, decision.delayMs);
   }
 
   private clearWsHandshakeTimer() {
@@ -830,7 +837,13 @@ export class RemoteConversation extends EventEmitter {
     return this.serverUrl;
   }
 
+  private async ensureServerReady(): Promise<void> {
+    if (!this.externalWorkspaceClient) return;
+    await this.externalWorkspaceClient.isAlive();
+  }
+
   private async requestApi(path: string, init: RequestInit): Promise<Response> {
+    await this.ensureServerReady();
     return this.fetchWithTimeout(`${this.getApiBaseUrl()}${path}`, init, RemoteConversation.httpTimeoutMs);
   }
 
@@ -849,6 +862,23 @@ export class RemoteConversation extends EventEmitter {
   }
 
   private connect() {
+    if (!this.conversationId) return;
+    if (this.externalWorkspaceClient) {
+      void this.ensureServerReady().then(() => {
+        if (!this.conversationId) return;
+        this.openWebSocketConnection();
+      }).catch((error) => {
+        const err = error instanceof Error ? error : new Error(String(error));
+        this.emit('error', err);
+        this.setStatus('offline');
+        this.scheduleReconnect();
+      });
+      return;
+    }
+    this.openWebSocketConnection();
+  }
+
+  private openWebSocketConnection() {
     if (!this.conversationId) return;
     const base = this.getApiBaseUrl();
     const usedLegacyWsSessionKeyQueryAuth = this.useLegacyWsSessionKeyQueryAuth;
@@ -908,7 +938,7 @@ export class RemoteConversation extends EventEmitter {
         } catch (closeErr) {
           void closeErr;
         }
-        this.connect();
+        void this.connect();
         return;
       }
       this.clearWsHandshakeTimer();

--- a/packages/agent-sdk/src/workspace/AppleWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/AppleWorkspace.ts
@@ -1,0 +1,331 @@
+import { spawn } from 'child_process';
+import type { BaseWorkspace } from './BaseWorkspace';
+import { RemoteWorkspace } from './RemoteWorkspace';
+import type {
+  CommandOptions,
+  CommandResult,
+  DirectoryEntry,
+  WorkspaceEncoding,
+} from './types';
+
+export interface AppleWorkspaceMount {
+  hostPath: string;
+  containerPath: string;
+  readonly?: boolean;
+}
+
+export interface AppleWorkspaceOptions {
+  root?: string;
+  serverUrl?: string;
+  hostPort?: number;
+  serverPort?: number;
+  serverImage?: string;
+  startupCommand?: string[];
+  volumes?: AppleWorkspaceMount[];
+  forwardEnv?: string[];
+  containerBinary?: string;
+  startupTimeoutMs?: number;
+  pollIntervalMs?: number;
+  httpTimeoutMs?: number;
+  runtimeSessionApiKey?: string;
+  cloudApiKey?: string;
+  runtimeApiUrl?: string;
+  runtimeApiKey?: string;
+  runtimeId?: string;
+}
+
+const DEFAULT_ROOT = '/workspace';
+const DEFAULT_SERVER_PORT = 8000;
+const DEFAULT_STARTUP_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+const sleep = async (ms: number): Promise<void> =>
+  await new Promise((resolve) => setTimeout(resolve, ms));
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim().length > 0;
+
+export class AppleWorkspace implements BaseWorkspace {
+  readonly kind = 'apple' as const;
+  readonly root: string;
+
+  private readonly remote: RemoteWorkspace;
+  private readonly serverUrl: string;
+  private readonly serverImage?: string;
+  private readonly hostPort?: number;
+  private readonly serverPort: number;
+  private readonly startupCommand?: string[];
+  private readonly volumes: AppleWorkspaceMount[];
+  private readonly forwardEnv: string[];
+  private readonly containerBinary: string;
+  private readonly startupTimeoutMs: number;
+  private readonly pollIntervalMs: number;
+
+  private process: ReturnType<typeof spawn> | null = null;
+  private startupPromise: Promise<void> | null = null;
+  private stopped = false;
+
+  constructor(options: AppleWorkspaceOptions) {
+    this.root = isNonEmptyString(options.root) ? options.root.trim() : DEFAULT_ROOT;
+    this.serverUrl = isNonEmptyString(options.serverUrl)
+      ? options.serverUrl.trim().replace(/\/+$/, '')
+      : `http://127.0.0.1:${AppleWorkspace.requireHostPort(options.hostPort)}`;
+    this.serverImage = isNonEmptyString(options.serverImage) ? options.serverImage.trim() : undefined;
+    this.hostPort = options.hostPort;
+    this.serverPort = typeof options.serverPort === 'number' && Number.isFinite(options.serverPort)
+      ? Math.max(1, Math.trunc(options.serverPort))
+      : DEFAULT_SERVER_PORT;
+    this.startupCommand = Array.isArray(options.startupCommand) && options.startupCommand.length > 0
+      ? options.startupCommand
+      : undefined;
+    this.volumes = Array.isArray(options.volumes) ? options.volumes : [];
+    this.forwardEnv = Array.isArray(options.forwardEnv) ? options.forwardEnv.filter(isNonEmptyString) : [];
+    this.containerBinary = isNonEmptyString(options.containerBinary) ? options.containerBinary.trim() : 'container';
+    this.startupTimeoutMs = typeof options.startupTimeoutMs === 'number' && Number.isFinite(options.startupTimeoutMs)
+      ? Math.max(1, Math.trunc(options.startupTimeoutMs))
+      : DEFAULT_STARTUP_TIMEOUT_MS;
+    this.pollIntervalMs = typeof options.pollIntervalMs === 'number' && Number.isFinite(options.pollIntervalMs)
+      ? Math.max(0, Math.trunc(options.pollIntervalMs))
+      : DEFAULT_POLL_INTERVAL_MS;
+
+    this.remote = new RemoteWorkspace({
+      host: this.serverUrl,
+      cloudApiKey: options.cloudApiKey,
+      runtimeSessionApiKey: options.runtimeSessionApiKey,
+      workingDir: this.root,
+      pollIntervalMs: options.pollIntervalMs,
+      httpTimeoutMs: options.httpTimeoutMs,
+      runtimeApiUrl: options.runtimeApiUrl,
+      runtimeApiKey: options.runtimeApiKey,
+      runtimeId: options.runtimeId,
+    });
+  }
+
+  private static requireHostPort(hostPort: number | undefined): number {
+    if (typeof hostPort !== 'number' || !Number.isFinite(hostPort)) {
+      throw new Error('AppleWorkspace requires either serverUrl or hostPort');
+    }
+    return Math.max(1, Math.trunc(hostPort));
+  }
+
+  getServerUrl(): string {
+    return this.serverUrl;
+  }
+
+  allowPath(targetPath: string): void {
+    this.remote.allowPath(targetPath);
+  }
+
+  isPathAllowed(targetPath: string): boolean {
+    return this.remote.isPathAllowed(targetPath);
+  }
+
+  resolvePath(targetPath: string): string {
+    return this.remote.resolvePath(targetPath);
+  }
+
+  async readFile(targetPath: string, encoding?: WorkspaceEncoding): Promise<string> {
+    await this.ensureStarted();
+    return await this.remote.readFile(targetPath, encoding);
+  }
+
+  async readFileBytes(targetPath: string, options?: { maxBytes?: number }): Promise<Buffer> {
+    await this.ensureStarted();
+    return await this.remote.readFileBytes(targetPath, options);
+  }
+
+  async writeFile(targetPath: string, content: string | Buffer): Promise<void> {
+    await this.ensureStarted();
+    await this.remote.writeFile(targetPath, content);
+  }
+
+  async remove(targetPath: string): Promise<void> {
+    await this.ensureStarted();
+    await this.remote.remove(targetPath);
+  }
+
+  async list(targetPath?: string): Promise<DirectoryEntry[]> {
+    await this.ensureStarted();
+    return await this.remote.list(targetPath);
+  }
+
+  async ensureDirectory(targetPath: string): Promise<string> {
+    await this.ensureStarted();
+    return await this.remote.ensureDirectory(targetPath);
+  }
+
+  async runCommand(command: string, options?: CommandOptions): Promise<CommandResult> {
+    await this.ensureStarted();
+    return await this.remote.runCommand(command, options);
+  }
+
+  async gitStatus(): Promise<CommandResult> {
+    await this.ensureStarted();
+    return await this.remote.gitStatus();
+  }
+
+  async gitDiff(paths?: string[]): Promise<CommandResult> {
+    await this.ensureStarted();
+    return await this.remote.gitDiff(paths);
+  }
+
+  async isAlive(): Promise<boolean> {
+    if (this.serverImage) {
+      await this.ensureStarted();
+    }
+    return await this.remote.isAlive();
+  }
+
+  async pause(): Promise<void> {
+    if (!this.serverImage) {
+      await this.remote.pause();
+      return;
+    }
+    throw new Error('AppleWorkspace.pause is not supported yet without a runtime API control surface');
+  }
+
+  async resume(): Promise<void> {
+    if (!this.serverImage) {
+      await this.remote.resume();
+      return;
+    }
+    throw new Error('AppleWorkspace.resume is not supported yet without a runtime API control surface');
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    const child = this.process;
+    this.process = null;
+    this.startupPromise = null;
+    if (!child) return;
+
+    await new Promise<void>((resolve) => {
+      const cleanup = () => {
+        child.off('close', onClose);
+        child.off('error', onError);
+        resolve();
+      };
+      const onClose = () => cleanup();
+      const onError = () => cleanup();
+      child.once('close', onClose);
+      child.once('error', onError);
+      child.kill('SIGTERM');
+      setTimeout(() => {
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          // Ignore double-kill errors.
+        }
+        cleanup();
+      }, 2_000).unref();
+    });
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (!this.serverImage) return;
+    if (this.stopped) {
+      throw new Error('AppleWorkspace was stopped and cannot be restarted');
+    }
+    if (!this.startupPromise) {
+      this.startupPromise = this.startServer();
+    }
+    await this.startupPromise;
+  }
+
+  private buildContainerArgs(): string[] {
+    if (!this.serverImage || !this.hostPort) {
+      throw new Error('AppleWorkspace container startup requires serverImage + hostPort');
+    }
+
+    const args: string[] = [
+      'run',
+      '--rm',
+      '-p',
+      `${this.hostPort}:${this.serverPort}`,
+    ];
+
+    for (const mount of this.volumes) {
+      if (mount.readonly) {
+        args.push(
+          '--mount',
+          `type=bind,source=${mount.hostPath},target=${mount.containerPath},readonly`,
+        );
+      } else {
+        args.push('-v', `${mount.hostPath}:${mount.containerPath}`);
+      }
+    }
+
+    for (const key of this.forwardEnv) {
+      const value = process.env[key];
+      if (typeof value === 'string') {
+        args.push('-e', `${key}=${value}`);
+      }
+    }
+
+    args.push(this.serverImage);
+    if (this.startupCommand) {
+      args.push(...this.startupCommand);
+    }
+
+    return args;
+  }
+
+  private async startServer(): Promise<void> {
+    const args = this.buildContainerArgs();
+    const startupErrors: string[] = [];
+
+    const child = spawn(this.containerBinary, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    this.process = child;
+
+    child.stderr.on('data', (chunk: Buffer | string) => {
+      startupErrors.push(chunk.toString());
+      if (startupErrors.length > 20) {
+        startupErrors.shift();
+      }
+    });
+
+    const childExitPromise = new Promise<never>((_, reject) => {
+      child.once('error', (error) => {
+        reject(error);
+      });
+      child.once('close', (code) => {
+        this.process = null;
+        reject(new Error(`AppleWorkspace container exited before becoming healthy (code ${String(code)})`));
+      });
+    });
+
+    const waitForHealth = async (): Promise<void> => {
+      const deadline = Date.now() + this.startupTimeoutMs;
+      while (Date.now() < deadline) {
+        if (await this.remote.isAlive()) {
+          return;
+        }
+        await sleep(this.pollIntervalMs);
+      }
+
+      const details = startupErrors.join('').trim();
+      throw new Error(
+        details
+          ? `AppleWorkspace startup timed out: ${details}`
+          : 'AppleWorkspace startup timed out waiting for /health',
+      );
+    };
+
+    try {
+      await Promise.race([waitForHealth(), childExitPromise]);
+    } catch (error) {
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // Ignore cleanup failures.
+      }
+      this.process = null;
+      this.startupPromise = null;
+      throw error;
+    }
+  }
+}
+
+export default AppleWorkspace;

--- a/packages/agent-sdk/src/workspace/AppleWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/AppleWorkspace.ts
@@ -45,6 +45,15 @@ const sleep = async (ms: number): Promise<void> =>
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0;
 
+/**
+ * Apple Container-backed remote workspace.
+ *
+ * When `serverImage` is configured, this workspace owns the container lifecycle
+ * for the nested runner surface. File and command operations are proxied through
+ * the remote runtime once it becomes healthy. `pause()` and `resume()` still
+ * require a dedicated runtime control surface in that managed-container mode
+ * and will throw until that exists.
+ */
 export class AppleWorkspace implements BaseWorkspace {
   readonly kind = 'apple' as const;
   readonly root: string;
@@ -176,6 +185,10 @@ export class AppleWorkspace implements BaseWorkspace {
     return await this.remote.isAlive();
   }
 
+  /**
+   * Managed AppleWorkspace containers do not yet expose a runtime pause API.
+   * Use an attached remote workspace until that control surface exists.
+   */
   async pause(): Promise<void> {
     if (!this.serverImage) {
       await this.remote.pause();
@@ -184,6 +197,10 @@ export class AppleWorkspace implements BaseWorkspace {
     throw new Error('AppleWorkspace.pause is not supported yet without a runtime API control surface');
   }
 
+  /**
+   * Managed AppleWorkspace containers do not yet expose a runtime resume API.
+   * Use an attached remote workspace until that control surface exists.
+   */
   async resume(): Promise<void> {
     if (!this.serverImage) {
       await this.remote.resume();
@@ -257,7 +274,7 @@ export class AppleWorkspace implements BaseWorkspace {
 
     for (const key of this.forwardEnv) {
       const value = process.env[key];
-      if (typeof value === 'string') {
+      if (isNonEmptyString(value)) {
         args.push('-e', `${key}=${value}`);
       }
     }
@@ -290,9 +307,10 @@ export class AppleWorkspace implements BaseWorkspace {
       child.once('error', (error) => {
         reject(error);
       });
-      child.once('close', (code) => {
+      child.once('close', (code, signal) => {
         this.process = null;
-        reject(new Error(`AppleWorkspace container exited before becoming healthy (code ${String(code)})`));
+        const exitInfo = signal ? `signal ${signal}` : `code ${String(code)}`;
+        reject(new Error(`AppleWorkspace container exited before becoming healthy (${exitInfo})`));
       });
     });
 

--- a/packages/agent-sdk/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/BaseWorkspace.ts
@@ -1,6 +1,6 @@
 import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
 
-export type WorkspaceKind = 'local' | 'remote';
+export type WorkspaceKind = 'local' | 'remote' | 'apple';
 
 export interface BaseWorkspace {
   kind: WorkspaceKind;

--- a/packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts
+++ b/packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts
@@ -16,6 +16,7 @@ describe('AppleWorkspace', () => {
   beforeEach(() => {
     spawnMock.mockReset();
     process.env.APPLE_WORKSPACE_TEST_TOKEN = 'secret-token';
+    process.env.APPLE_WORKSPACE_EMPTY_TOKEN = '';
   });
 
   afterEach(() => {
@@ -25,6 +26,7 @@ describe('AppleWorkspace', () => {
     } else {
       delete process.env.APPLE_WORKSPACE_TEST_TOKEN;
     }
+    delete process.env.APPLE_WORKSPACE_EMPTY_TOKEN;
   });
 
   it('builds Apple Container args from the workspace config', async () => {
@@ -81,5 +83,21 @@ describe('AppleWorkspace', () => {
     await expect(workspace.isAlive()).resolves.toBe(true);
     expect(spawnMock).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips empty forwarded env values', async () => {
+    const { AppleWorkspace } = await import('..');
+
+    const workspace = new AppleWorkspace({
+      root: '/workspace/project',
+      hostPort: 3100,
+      serverImage: 'smolpaws-agent-server:dev',
+      startupCommand: ['node', '/app/dist/runner.js', '--port', '8000'],
+      forwardEnv: ['APPLE_WORKSPACE_TEST_TOKEN', 'APPLE_WORKSPACE_EMPTY_TOKEN'],
+    });
+
+    const args = (workspace as unknown as { buildContainerArgs: () => string[] }).buildContainerArgs();
+    expect(args).toContain('APPLE_WORKSPACE_TEST_TOKEN=secret-token');
+    expect(args).not.toContain('APPLE_WORKSPACE_EMPTY_TOKEN=');
   });
 });

--- a/packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts
+++ b/packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.fn();
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  };
+});
+
+describe('AppleWorkspace', () => {
+  const originalEnvValue = process.env.APPLE_WORKSPACE_TEST_TOKEN;
+
+  beforeEach(() => {
+    spawnMock.mockReset();
+    process.env.APPLE_WORKSPACE_TEST_TOKEN = 'secret-token';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (typeof originalEnvValue === 'string') {
+      process.env.APPLE_WORKSPACE_TEST_TOKEN = originalEnvValue;
+    } else {
+      delete process.env.APPLE_WORKSPACE_TEST_TOKEN;
+    }
+  });
+
+  it('builds Apple Container args from the workspace config', async () => {
+    const { AppleWorkspace } = await import('..');
+
+    const workspace = new AppleWorkspace({
+      root: '/workspace/project',
+      hostPort: 3100,
+      serverImage: 'smolpaws-agent-server:dev',
+      startupCommand: ['node', '/app/dist/runner.js', '--port', '8000'],
+      volumes: [
+        { hostPath: '/Users/enyst/repos/demo', containerPath: '/workspace/project' },
+        { hostPath: '/Users/enyst/.config/smolpaws', containerPath: '/workspace/config', readonly: true },
+      ],
+      forwardEnv: ['APPLE_WORKSPACE_TEST_TOKEN'],
+    });
+
+    expect((workspace as unknown as { buildContainerArgs: () => string[] }).buildContainerArgs()).toEqual(
+      [
+        'run',
+        '--rm',
+        '-p',
+        '3100:8000',
+        '-v',
+        '/Users/enyst/repos/demo:/workspace/project',
+        '--mount',
+        'type=bind,source=/Users/enyst/.config/smolpaws,target=/workspace/config,readonly',
+        '-e',
+        'APPLE_WORKSPACE_TEST_TOKEN=secret-token',
+        'smolpaws-agent-server:dev',
+        'node',
+        '/app/dist/runner.js',
+        '--port',
+        '8000',
+      ],
+    );
+  });
+
+  it('attaches to an existing server url without spawning a container', async () => {
+    const { AppleWorkspace } = await import('..');
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      arrayBuffer: async () => new ArrayBuffer(0),
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const workspace = new AppleWorkspace({
+      serverUrl: 'http://127.0.0.1:3200',
+      root: '/workspace/project',
+    });
+
+    await expect(workspace.isAlive()).resolves.toBe(true);
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts
+++ b/packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { LocalWorkspace, RemoteWorkspace, Workspace } from '..';
+import { AppleWorkspace, LocalWorkspace, RemoteWorkspace, Workspace } from '..';
 
 describe('Workspace() factory', () => {
   it('creates a local workspace by default', () => {
@@ -12,5 +12,11 @@ describe('Workspace() factory', () => {
     const ws = Workspace({ kind: 'remote', serverUrl: 'http://example.com', workingDir: '/workspace/project' });
     expect(ws.kind).toBe('remote');
     expect(ws).toBeInstanceOf(RemoteWorkspace);
+  });
+
+  it('creates an apple workspace when kind=apple', () => {
+    const ws = Workspace({ kind: 'apple', hostPort: 3100, serverImage: 'smolpaws-agent-server:dev', root: '/workspace/project' });
+    expect(ws.kind).toBe('apple');
+    expect(ws).toBeInstanceOf(AppleWorkspace);
   });
 });

--- a/packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts
+++ b/packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts
@@ -1,9 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
 import { AppleWorkspace, LocalWorkspace, RemoteWorkspace, Workspace } from '..';
+
+const created: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(created.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  created.length = 0;
+});
 
 describe('Workspace() factory', () => {
   it('creates a local workspace by default', () => {
     const ws = Workspace();
+    expect(ws.kind).toBe('local');
+    expect(ws).toBeInstanceOf(LocalWorkspace);
+  });
+
+  it('creates a local workspace when kind is omitted but root is provided', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'workspace-factory-'));
+    created.push(root);
+    const ws = Workspace({ root });
     expect(ws.kind).toBe('local');
     expect(ws).toBeInstanceOf(LocalWorkspace);
   });

--- a/packages/agent-sdk/src/workspace/index.ts
+++ b/packages/agent-sdk/src/workspace/index.ts
@@ -48,7 +48,7 @@ export type WorkspaceFactoryOptions =
   };
 
 export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
-  if (!options || options.kind === 'local') {
+  if (!options || !options.kind || options.kind === 'local') {
     return new LocalWorkspace(options?.root);
   }
 

--- a/packages/agent-sdk/src/workspace/index.ts
+++ b/packages/agent-sdk/src/workspace/index.ts
@@ -1,14 +1,40 @@
 import type { BaseWorkspace } from './BaseWorkspace';
+import { AppleWorkspace } from './AppleWorkspace';
 import { LocalWorkspace } from './LocalWorkspace';
 import { RemoteWorkspace } from './RemoteWorkspace';
 
 export * from './BaseWorkspace';
 export * from './types';
+export * from './AppleWorkspace';
 export * from './LocalWorkspace';
 export * from './RemoteWorkspace';
 
 export type WorkspaceFactoryOptions =
   | { kind?: 'local'; root?: string }
+  | {
+    kind: 'apple';
+    root?: string;
+    serverUrl?: string;
+    hostPort?: number;
+    serverPort?: number;
+    serverImage?: string;
+    startupCommand?: string[];
+    volumes?: Array<{
+      hostPath: string;
+      containerPath: string;
+      readonly?: boolean;
+    }>;
+    forwardEnv?: string[];
+    containerBinary?: string;
+    startupTimeoutMs?: number;
+    pollIntervalMs?: number;
+    httpTimeoutMs?: number;
+    cloudApiKey?: string;
+    runtimeSessionApiKey?: string;
+    runtimeApiUrl?: string;
+    runtimeApiKey?: string;
+    runtimeId?: string;
+  }
   | {
     kind: 'remote';
     serverUrl: string;
@@ -22,18 +48,23 @@ export type WorkspaceFactoryOptions =
   };
 
 export function Workspace(options?: WorkspaceFactoryOptions): BaseWorkspace {
-  if (!options || options.kind !== 'remote') {
+  if (!options || options.kind === 'local') {
     return new LocalWorkspace(options?.root);
   }
 
-  const workingDir = options.workingDir ?? options.workspaceRoot;
+  if (options.kind === 'apple') {
+    return new AppleWorkspace(options);
+  }
+
+  const remoteOptions = options as Extract<WorkspaceFactoryOptions, { kind: 'remote' }>;
+  const workingDir = remoteOptions.workingDir ?? remoteOptions.workspaceRoot;
   return new RemoteWorkspace({
-    host: options.serverUrl,
-    cloudApiKey: options.cloudApiKey,
-    runtimeSessionApiKey: options.runtimeSessionApiKey,
+    host: remoteOptions.serverUrl,
+    cloudApiKey: remoteOptions.cloudApiKey,
+    runtimeSessionApiKey: remoteOptions.runtimeSessionApiKey,
     workingDir,
-    runtimeApiUrl: options.runtimeApiUrl,
-    runtimeApiKey: options.runtimeApiKey,
-    runtimeId: options.runtimeId,
+    runtimeApiUrl: remoteOptions.runtimeApiUrl,
+    runtimeApiKey: remoteOptions.runtimeApiKey,
+    runtimeId: remoteOptions.runtimeId,
   });
 }


### PR DESCRIPTION
## Summary
- add `AppleWorkspace` as a first-class workspace kind through the shared `Workspace()` factory
- let `RemoteConversation` warm an injected runtime workspace before issuing HTTP/WS calls
- cover the new workspace kind and startup behavior with focused tests

## Validation
- `npm run typecheck`
- `npm run lint`
- `npm run build:types -w @smolpaws/agent-sdk`
- `npx vitest run packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts`
- `npm test` *(still fails in pre-existing unrelated suites, including `TerminalTool.session`, `AskOracleTool`, `Agent.profile-api-key`, `FileEditorTool`, and `factory.gemini-profile-generation-config`)*

### Review
- Manual review completed against the final diff and focused SDK validation rerun locally before merge.
- Gemini, Devin, and CodeRabbit feedback were checked; the accurate points landed in follow-up commits (`56f3a6b`, `3c87e82`).
- Resolved inline threads covering `Workspace()` default-local behavior, Apple workspace readiness failure handling, and late warmup reconnect-after-disconnect behavior.
- CodeRabbit remained with an old pending top-level status after threads were resolved; the latest review-thread gate and all required CI checks were green.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/OpenHands-Tab/pull/1002" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
