### PR TITLE
refactor: prefer remote workspace conversations

### DIFF
--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -3,7 +3,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type { Event } from '../types';
-import type { AgentServerWorkspace } from '../../workspace';
+import { Workspace, type AgentServerWorkspace } from '../../workspace';
+import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
 import { saveProfile } from '../llm';
 import { ConfirmRisky } from '../security/confirmationPolicy';
 import { LLMSecurityAnalyzer } from '../security/analyzer';
@@ -1252,25 +1253,7 @@ describe('RemoteConversation', () => {
         resolveWarmup = resolve;
       });
     });
-    const workspaceClient = {
-      kind: 'apple',
-      root: '/workspace/project',
-      allowPath: vi.fn(),
-      isPathAllowed: vi.fn(() => true),
-      resolvePath: vi.fn((targetPath: string) => targetPath),
-      readFile: vi.fn(),
-      readFileBytes: vi.fn(),
-      writeFile: vi.fn(),
-      remove: vi.fn(),
-      list: vi.fn(),
-      ensureDirectory: vi.fn(),
-      runCommand: vi.fn(),
-      gitStatus: vi.fn(),
-      gitDiff: vi.fn(),
-      isAlive,
-      pause: vi.fn(),
-      resume: vi.fn(),
-    } as unknown as AgentServerWorkspace;
+    vi.spyOn(RemoteWorkspace.prototype, 'isAlive').mockImplementation(isAlive);
 
     const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith('/api/conversations')) {
@@ -1287,10 +1270,12 @@ describe('RemoteConversation', () => {
 
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
     const conversation = new RemoteConversation({
-      serverUrl: 'http://localhost:3000',
       settings: baseSettings,
-      workspace: { kind: 'apple', working_dir: '/workspace/project' },
-      workspaceClient,
+      workspace: Workspace({
+        kind: 'apple',
+        serverUrl: 'http://localhost:3000',
+        root: '/workspace/project',
+      }) as AgentServerWorkspace,
     });
 
     await expect(conversation.startNewConversation()).resolves.toBe('conv-1');

--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import type { Event } from '../types';
-import type { BaseWorkspace } from '../../workspace';
+import type { AgentServerWorkspace } from '../../workspace';
 import { saveProfile } from '../llm';
 import { ConfirmRisky } from '../security/confirmationPolicy';
 import { LLMSecurityAnalyzer } from '../security/analyzer';
@@ -115,12 +115,13 @@ describe('RemoteConversation', () => {
       await conversation.restoreConversation('abc');
       expect(conversation.getStatus()).toBe('connecting');
 
-      vi.advanceTimersByTime(10_001);
+      await vi.advanceTimersByTimeAsync(10_001);
 
       expect(conversation.getStatus()).toBe('offline');
       expect(statuses).toContain('connecting');
       expect(statuses).toContain('offline');
       expect(errors.length).toBeGreaterThanOrEqual(1);
+      conversation.disconnect();
     } finally {
       vi.useRealTimers();
     }
@@ -223,7 +224,7 @@ describe('RemoteConversation', () => {
       expect(url).toContain('/api/conversations');
       const body = JSON.parse(init?.body ?? '{}');
       expect(body.agent.kind).toBe('Agent');
-      expect(body.workspace).toEqual({ working_dir: process.cwd() });
+      expect(body.workspace).toEqual({ kind: 'local', working_dir: process.cwd() });
       expect(body.secrets).toEqual({
         ELEVENLABS_API_KEY: { kind: 'StaticSecret', value: 'xi-example123' },
         GITHUB_TOKEN: { kind: 'StaticSecret', value: 'ghp_example123' },
@@ -1151,9 +1152,13 @@ describe('RemoteConversation', () => {
 
   it('warms a provided workspace client before starting a conversation', async () => {
     const isAlive = vi.fn(async () => true);
-    const workspaceClient = {
+    const workspace = {
       kind: 'apple',
       root: '/workspace/project',
+      getServerUrl: vi.fn(() => 'http://localhost:3000'),
+      getAuthHeaders: vi.fn((extra?: Record<string, string>) => ({ 'Content-Type': 'application/json', ...extra })),
+      getRuntimeSessionApiKey: vi.fn(() => ''),
+      getConversationWorkspacePayload: vi.fn(() => ({ kind: 'local', working_dir: '/workspace/project' })),
       allowPath: vi.fn(),
       isPathAllowed: vi.fn(() => true),
       resolvePath: vi.fn((targetPath: string) => targetPath),
@@ -1169,7 +1174,7 @@ describe('RemoteConversation', () => {
       isAlive,
       pause: vi.fn(),
       resume: vi.fn(),
-    } as unknown as BaseWorkspace;
+    } as unknown as AgentServerWorkspace;
 
     const fetchMock = vi.fn(async (url: string) => {
       expect(isAlive).toHaveBeenCalled();
@@ -1187,10 +1192,8 @@ describe('RemoteConversation', () => {
 
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
     const conversation = new RemoteConversation({
-      serverUrl: 'http://localhost:3000',
       settings: baseSettings,
-      workspace: { kind: 'apple', working_dir: '/workspace/project' },
-      workspaceClient,
+      workspace,
     });
 
     await expect(conversation.startNewConversation()).resolves.toBe('conv-1');
@@ -1199,9 +1202,13 @@ describe('RemoteConversation', () => {
 
   it('fails before starting a conversation when a provided workspace client is not alive', async () => {
     const isAlive = vi.fn(async () => false);
-    const workspaceClient = {
+    const workspace = {
       kind: 'apple',
       root: '/workspace/project',
+      getServerUrl: vi.fn(() => 'http://localhost:3000'),
+      getAuthHeaders: vi.fn(() => ({ 'Content-Type': 'application/json' })),
+      getRuntimeSessionApiKey: vi.fn(() => ''),
+      getConversationWorkspacePayload: vi.fn(() => ({ kind: 'local', working_dir: '/workspace/project' as const })),
       allowPath: vi.fn(),
       isPathAllowed: vi.fn(() => true),
       resolvePath: vi.fn((targetPath: string) => targetPath),
@@ -1217,17 +1224,15 @@ describe('RemoteConversation', () => {
       isAlive,
       pause: vi.fn(),
       resume: vi.fn(),
-    } as unknown as BaseWorkspace;
+    } as unknown as AgentServerWorkspace;
 
     const fetchMock = vi.fn();
     (globalThis as any).fetch = fetchMock;
 
     const { RemoteConversation } = await import('../conversation/RemoteConversation');
     const conversation = new RemoteConversation({
-      serverUrl: 'http://localhost:3000',
       settings: baseSettings,
-      workspace: { kind: 'apple', working_dir: '/workspace/project' },
-      workspaceClient,
+      workspace,
     });
 
     await expect(conversation.startNewConversation()).rejects.toThrow('External workspace server is not ready');
@@ -1237,11 +1242,16 @@ describe('RemoteConversation', () => {
 
   it('does not reconnect after disconnect when workspace warmup finishes late', async () => {
     let resolveWarmup: ((value: boolean) => void) | undefined;
-    const isAlive = vi.fn()
-      .mockResolvedValueOnce(true)
-      .mockImplementationOnce(async () => await new Promise<boolean>((resolve) => {
+    let isAliveCalls = 0;
+    const isAlive = vi.fn(async () => {
+      isAliveCalls += 1;
+      if (isAliveCalls === 1) {
+        return true;
+      }
+      return await new Promise<boolean>((resolve) => {
         resolveWarmup = resolve;
-      }));
+      });
+    });
     const workspaceClient = {
       kind: 'apple',
       root: '/workspace/project',
@@ -1260,7 +1270,7 @@ describe('RemoteConversation', () => {
       isAlive,
       pause: vi.fn(),
       resume: vi.fn(),
-    } as unknown as BaseWorkspace;
+    } as unknown as AgentServerWorkspace;
 
     const fetchMock = vi.fn(async (url: string) => {
       if (url.endsWith('/api/conversations')) {
@@ -1284,14 +1294,14 @@ describe('RemoteConversation', () => {
     });
 
     await expect(conversation.startNewConversation()).resolves.toBe('conv-1');
-    expect(wsInstances).toHaveLength(0);
+    const wsCountBeforeDisconnect = wsInstances.length;
 
     conversation.disconnect();
     resolveWarmup?.(true);
     await Promise.resolve();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(wsInstances).toHaveLength(0);
+    expect(wsInstances).toHaveLength(wsCountBeforeDisconnect);
   });
 
   it('does not include session_api_key in ws URL and uses ws headers for auth', async () => {

--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -224,7 +224,7 @@ describe('RemoteConversation', () => {
       expect(url).toContain('/api/conversations');
       const body = JSON.parse(init?.body ?? '{}');
       expect(body.agent.kind).toBe('Agent');
-      expect(body.workspace).toEqual({ kind: 'local', working_dir: process.cwd() });
+      expect(body.workspace).toEqual({ working_dir: process.cwd() });
       expect(body.secrets).toEqual({
         ELEVENLABS_API_KEY: { kind: 'StaticSecret', value: 'xi-example123' },
         GITHUB_TOKEN: { kind: 'StaticSecret', value: 'ghp_example123' },
@@ -1158,7 +1158,7 @@ describe('RemoteConversation', () => {
       getServerUrl: vi.fn(() => 'http://localhost:3000'),
       getAuthHeaders: vi.fn((extra?: Record<string, string>) => ({ 'Content-Type': 'application/json', ...extra })),
       getRuntimeSessionApiKey: vi.fn(() => ''),
-      getConversationWorkspacePayload: vi.fn(() => ({ kind: 'local', working_dir: '/workspace/project' })),
+      getConversationWorkspacePayload: vi.fn(() => ({ working_dir: '/workspace/project' })),
       allowPath: vi.fn(),
       isPathAllowed: vi.fn(() => true),
       resolvePath: vi.fn((targetPath: string) => targetPath),
@@ -1208,7 +1208,7 @@ describe('RemoteConversation', () => {
       getServerUrl: vi.fn(() => 'http://localhost:3000'),
       getAuthHeaders: vi.fn(() => ({ 'Content-Type': 'application/json' })),
       getRuntimeSessionApiKey: vi.fn(() => ''),
-      getConversationWorkspacePayload: vi.fn(() => ({ kind: 'local', working_dir: '/workspace/project' as const })),
+      getConversationWorkspacePayload: vi.fn(() => ({ working_dir: '/workspace/project' as const })),
       allowPath: vi.fn(),
       isPathAllowed: vi.fn(() => true),
       resolvePath: vi.fn((targetPath: string) => targetPath),

--- a/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { FileEditorTool } from '../../tools';
+import { isAgentServerWorkspace, Workspace } from '../../workspace';
 import type { Event } from '../types';
 import { isActionEvent, isMessageEvent, isObservationEvent } from '../types';
 import type { OpenHandsSettings } from '../types/settings';
@@ -71,6 +72,55 @@ describe('Conversation factory', () => {
     const conversation = Conversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
     expect(conversation.mode).toBe('remote');
     expect(conversation).toBeInstanceOf(RemoteConversation);
+  });
+
+  it('returns RemoteConversation when given a remote workspace', () => {
+    const conversation = Conversation({
+      settings: baseSettings,
+      workspace: Workspace({ kind: 'remote', serverUrl: 'http://localhost:3000', workingDir: '/workspace/project' }),
+    });
+    expect(conversation.mode).toBe('remote');
+    expect(conversation).toBeInstanceOf(RemoteConversation);
+  });
+
+  it('does not treat plain remote workspace payloads as runtime workspaces', () => {
+    expect(isAgentServerWorkspace({ kind: 'remote', working_dir: '/workspace/project' })).toBe(false);
+  });
+
+  it('keeps auth fresh on the serverUrl factory path when settings change', async () => {
+    let uploadCalls = 0;
+    const fetchMock = vi.fn((url: string, init?: { headers?: Record<string, string>; method?: string }) => {
+      if (url.includes('/api/file/upload')) {
+        expect(init?.method).toBe('POST');
+        uploadCalls += 1;
+        expect(init?.headers?.['X-Session-API-Key']).toBe(uploadCalls === 1 ? 'session-key-1' : 'session-key-2');
+        return Promise.resolve(new Response('', { status: 200 }));
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const conversation = Conversation({
+      serverUrl: 'http://localhost:3000',
+      settings: { ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key-1' } },
+      workspaceRoot: '/workspace',
+    });
+
+    expect(conversation).toBeInstanceOf(RemoteConversation);
+    const remoteConversation = conversation as RemoteConversation;
+    const workspace1 = remoteConversation.getWorkspace();
+
+    await workspace1.writeFile('notes.txt', 'hello');
+
+    remoteConversation.setSettings({
+      ...baseSettings,
+      secrets: { runtimeSessionApiKey: 'session-key-2' },
+    });
+    const workspace2 = remoteConversation.getWorkspace();
+    expect(workspace2).not.toBe(workspace1);
+
+    await workspace2.writeFile('notes.txt', 'hello');
   });
 
   it('supports local hello-world tool flow via Conversation()', async () => {

--- a/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
@@ -87,6 +87,17 @@ describe('Conversation factory', () => {
     expect(isAgentServerWorkspace({ kind: 'remote', working_dir: '/workspace/project' })).toBe(false);
   });
 
+  it('does not treat partial remote runtime objects as agent-server workspaces', () => {
+    expect(isAgentServerWorkspace({
+      kind: 'remote',
+      root: '/workspace/project',
+      getServerUrl: () => 'http://localhost:3000',
+      getAuthHeaders: () => ({}),
+      getRuntimeSessionApiKey: () => '',
+      getConversationWorkspacePayload: () => ({ working_dir: '/workspace/project' }),
+    })).toBe(false);
+  });
+
   it('keeps auth fresh on the serverUrl factory path when settings change', async () => {
     let uploadCalls = 0;
     const fetchMock = vi.fn((url: string, init?: { headers?: Record<string, string>; method?: string }) => {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -10,7 +10,10 @@ import type { ConfirmationPolicy } from '../security/confirmationPolicy';
 import type { SecurityAnalyzer } from '../security/analyzer';
 import { RemoteState } from './RemoteState';
 import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
-import type { BaseWorkspace } from '../../workspace/BaseWorkspace';
+import {
+  isAgentServerWorkspace,
+  type AgentServerWorkspace,
+} from '../../workspace/BaseWorkspace';
 import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from '../../workspace/types';
 import { resolveToolsWithDefaultTools } from './includeDefaultTools';
 import { normalizeRemoteUrl } from '../../shared/remoteUrl';
@@ -54,13 +57,12 @@ const toStaticSecret = (value: unknown): StaticSecret | undefined => {
 const normalizeRemoteServerUrl = normalizeRemoteUrl;
 
 export interface RemoteConversationOptions {
-  serverUrl: string;
   settings: OpenHandsSettings;
   workspaceRoot?: string;
   tools?: RemoteConversationTool[];
   includeDefaultTools?: boolean | string[];
-  workspace?: RemoteConversationWorkspace;
-  workspaceClient?: BaseWorkspace;
+  workspace?: AgentServerWorkspace | RemoteConversationWorkspace;
+  serverUrl?: string;
   conversationId?: string;
   profileStoreOptions?: LLMProfileStoreOptions;
 }
@@ -141,16 +143,16 @@ export class RemoteConversation extends EventEmitter {
   private readonly tools?: RemoteConversationTool[];
   private readonly includeDefaultTools?: boolean | string[];
   private readonly hasToolsOption: boolean;
-  private readonly workspace?: RemoteConversationWorkspace;
+  private readonly workspacePayload: RemoteConversationWorkspace;
   private readonly profileStoreOptions?: LLMProfileStoreOptions;
-  private externalWorkspaceClient?: BaseWorkspace;
+  private readonly ownsWorkspaceClient: boolean;
   private static readonly historyPageLimit = 100;
   private static readonly wsHandshakeTimeoutMs = 10_000;
   private static readonly httpTimeoutMs = 15_000;
   private useLegacyWsSessionKeyQueryAuth = false;
 
   readonly state: RemoteState;
-  private workspaceClient?: BaseWorkspace;
+  private workspaceClient: AgentServerWorkspace;
 
 
   private asRecord(value: unknown): Record<string, unknown> | null {
@@ -196,20 +198,19 @@ export class RemoteConversation extends EventEmitter {
   constructor(options: RemoteConversationOptions) {
     super();
     this.state = new RemoteState();
-
-    this.serverUrl = normalizeRemoteServerUrl(options.serverUrl);
     this.settings = options.settings;
-    const normalizedWorkspaceRoot = typeof options.workspaceRoot === 'string' && options.workspaceRoot.trim()
-      ? options.workspaceRoot.trim()
-      : undefined;
-    this.workspaceRoot = normalizedWorkspaceRoot ?? process.cwd();
     this.hasToolsOption = Object.prototype.hasOwnProperty.call(options, 'tools');
     this.tools = options.tools;
     this.includeDefaultTools = options.includeDefaultTools;
-    this.workspace = options.workspace;
     this.profileStoreOptions = options.profileStoreOptions;
-    this.externalWorkspaceClient = options.workspaceClient;
-    this.workspaceClient = options.workspaceClient;
+
+    const resolved = this.resolveWorkspaceOptions(options);
+    this.serverUrl = resolved.serverUrl;
+    this.workspaceRoot = resolved.workspaceRoot;
+    this.workspacePayload = resolved.workspacePayload;
+    this.workspaceClient = resolved.workspaceClient;
+    this.ownsWorkspaceClient = resolved.ownsWorkspaceClient;
+
     if (options.conversationId) {
       this.conversationId = options.conversationId;
       this.seenEventIds.clear();
@@ -229,18 +230,54 @@ export class RemoteConversation extends EventEmitter {
     }
   }
 
-  getWorkspace(): BaseWorkspace {
-    if (!this.workspaceClient) {
-      const rawWorkingDir = this.workspace?.['working_dir'];
-      const workingDir = typeof rawWorkingDir === 'string' ? rawWorkingDir : this.workspaceRoot;
-      const secrets = this.settings?.secrets;
-      this.workspaceClient = new RemoteWorkspace({
-        host: this.serverUrl,
-        cloudApiKey: secrets?.cloudApiKey,
-        runtimeSessionApiKey: secrets?.runtimeSessionApiKey,
-        workingDir,
-      });
+  private resolveWorkspaceOptions(options: RemoteConversationOptions): {
+    serverUrl: string;
+    workspaceRoot: string;
+    workspacePayload: RemoteConversationWorkspace;
+    workspaceClient: AgentServerWorkspace;
+    ownsWorkspaceClient: boolean;
+  } {
+    if (isAgentServerWorkspace(options.workspace)) {
+      const workspaceClient = options.workspace;
+      return {
+        serverUrl: normalizeRemoteServerUrl(workspaceClient.getServerUrl()),
+        workspaceRoot: workspaceClient.root,
+        workspacePayload: workspaceClient.getConversationWorkspacePayload(),
+        workspaceClient,
+        ownsWorkspaceClient: false,
+      };
     }
+
+    if (!options.serverUrl) {
+      throw new Error('RemoteConversation requires a remote workspace or serverUrl');
+    }
+
+    const normalizedWorkspaceRoot = typeof options.workspaceRoot === 'string' && options.workspaceRoot.trim()
+      ? options.workspaceRoot.trim()
+      : undefined;
+    const workspaceRoot = normalizedWorkspaceRoot ?? process.cwd();
+    const serverUrl = normalizeRemoteServerUrl(options.serverUrl);
+
+    return {
+      serverUrl,
+      workspaceRoot,
+      workspacePayload: options.workspace ?? { kind: 'local', working_dir: workspaceRoot },
+      workspaceClient: this.createOwnedWorkspaceClient(serverUrl, workspaceRoot),
+      ownsWorkspaceClient: true,
+    };
+  }
+
+  private createOwnedWorkspaceClient(serverUrl: string, workspaceRoot: string): AgentServerWorkspace {
+    const secrets = this.settings?.secrets;
+    return new RemoteWorkspace({
+      host: serverUrl,
+      cloudApiKey: secrets?.cloudApiKey,
+      runtimeSessionApiKey: secrets?.runtimeSessionApiKey,
+      workingDir: workspaceRoot,
+    });
+  }
+
+  getWorkspace(): AgentServerWorkspace {
     return this.workspaceClient;
   }
 
@@ -301,15 +338,17 @@ export class RemoteConversation extends EventEmitter {
       // Re-probe header auth after key rotations; fall back to legacy query auth only if needed.
       this.useLegacyWsSessionKeyQueryAuth = false;
     }
-    if (this.workspaceClient && oldApiKey !== newApiKey && !this.externalWorkspaceClient) {
-      this.workspaceClient = undefined;
+    if (oldApiKey !== newApiKey && this.ownsWorkspaceClient) {
+      this.workspaceClient = this.createOwnedWorkspaceClient(this.serverUrl, this.workspaceRoot);
     }
   }
 
   setServerUrl(url: string) {
+    if (!this.ownsWorkspaceClient) {
+      throw new Error('Cannot setServerUrl when RemoteConversation was created with an injected workspace');
+    }
     this.serverUrl = normalizeRemoteServerUrl(url);
-    this.externalWorkspaceClient = undefined;
-    this.workspaceClient = undefined;
+    this.workspaceClient = this.createOwnedWorkspaceClient(this.serverUrl, this.workspaceRoot);
     this.useLegacyWsSessionKeyQueryAuth = false;
   }
 
@@ -436,8 +475,6 @@ export class RemoteConversation extends EventEmitter {
         { name: 'file_editor' },
         { name: 'task_tracker' },
       ];
-      const workspace = this.workspace ?? { working_dir: this.workspaceRoot };
-
       const tools = resolveToolsWithDefaultTools({
         includeDefaultTools: this.includeDefaultTools,
         hasToolsOption: this.hasToolsOption,
@@ -451,7 +488,7 @@ export class RemoteConversation extends EventEmitter {
           tools,
           security_analyzer: s?.agent.enableSecurityAnalyzer ? ({ kind: 'LLMSecurityAnalyzer' } satisfies RemoteSecurityAnalyzerPayload) : undefined,
         },
-        workspace,
+        workspace: this.workspacePayload,
         secrets: typedSecrets,
         confirmation_policy,
         max_iterations: clampedMaxIterations,
@@ -767,22 +804,11 @@ export class RemoteConversation extends EventEmitter {
   }
 
   private getAuthHeaders(): Record<string, string> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    const secrets = this.settings?.secrets;
-    const isCloud = isOpenHandsCloudServerUrl(this.serverUrl);
-    if (isCloud) {
-      const cloudApiKey = secrets?.cloudApiKey ?? '';
-      if (cloudApiKey) headers['Authorization'] = `Bearer ${cloudApiKey}`;
-      return headers;
-    }
-    const runtimeSessionApiKey = secrets?.runtimeSessionApiKey ?? '';
-    if (runtimeSessionApiKey) headers['X-Session-API-Key'] = runtimeSessionApiKey;
-    return headers;
+    return this.workspaceClient.getAuthHeaders({ 'Content-Type': 'application/json' });
   }
 
   private getRuntimeSessionApiKey(): string {
-    const runtimeSessionApiKey = this.settings?.secrets?.runtimeSessionApiKey;
-    return typeof runtimeSessionApiKey === 'string' ? runtimeSessionApiKey.trim() : '';
+    return this.workspaceClient.getRuntimeSessionApiKey();
   }
 
   private canUseLegacyWsSessionKeyQueryAuth(): boolean {
@@ -836,12 +862,12 @@ export class RemoteConversation extends EventEmitter {
   }
 
   private getApiBaseUrl(): string {
-    return this.serverUrl;
+    return this.workspaceClient.getServerUrl();
   }
 
   private async ensureServerReady(): Promise<void> {
-    if (!this.externalWorkspaceClient) return;
-    const isAlive = await this.externalWorkspaceClient.isAlive();
+    if (this.workspaceClient.kind !== 'apple') return;
+    const isAlive = await this.workspaceClient.isAlive();
     if (!isAlive) {
       throw new Error('External workspace server is not ready');
     }
@@ -868,22 +894,22 @@ export class RemoteConversation extends EventEmitter {
 
   private connect() {
     if (!this.conversationId) return;
-    if (this.externalWorkspaceClient) {
-      const connectAttemptId = ++this.connectAttemptId;
-      void this.ensureServerReady().then(() => {
-        if (this.connectAttemptId !== connectAttemptId) return;
-        if (!this.conversationId) return;
-        this.openWebSocketConnection();
-      }).catch((error) => {
-        if (this.connectAttemptId !== connectAttemptId) return;
-        const err = error instanceof Error ? error : new Error(String(error));
-        this.emit('error', err);
-        this.setStatus('offline');
-        this.scheduleReconnect();
-      });
+    if (this.workspaceClient.kind !== 'apple') {
+      this.openWebSocketConnection();
       return;
     }
-    this.openWebSocketConnection();
+    const connectAttemptId = ++this.connectAttemptId;
+    void this.ensureServerReady().then(() => {
+      if (this.connectAttemptId !== connectAttemptId) return;
+      if (!this.conversationId) return;
+      this.openWebSocketConnection();
+    }).catch((error) => {
+      if (this.connectAttemptId !== connectAttemptId) return;
+      const err = error instanceof Error ? error : new Error(String(error));
+      this.emit('error', err);
+      this.setStatus('offline');
+      this.scheduleReconnect();
+    });
   }
 
   private openWebSocketConnection() {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -255,7 +255,10 @@ export class RemoteConversation extends EventEmitter {
     const normalizedWorkspaceRoot = typeof options.workspaceRoot === 'string' && options.workspaceRoot.trim()
       ? options.workspaceRoot.trim()
       : undefined;
-    const workspaceRoot = normalizedWorkspaceRoot ?? process.cwd();
+    const payloadWorkingDir = typeof options.workspace?.working_dir === 'string' && options.workspace.working_dir.trim()
+      ? options.workspace.working_dir.trim()
+      : undefined;
+    const workspaceRoot = normalizedWorkspaceRoot ?? payloadWorkingDir ?? process.cwd();
     const serverUrl = normalizeRemoteServerUrl(options.serverUrl);
 
     return {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -35,7 +35,7 @@ export type RemoteConversationTool = {
 };
 
 export type RemoteConversationWorkspace = {
-  kind: string;
+  kind?: string;
   [key: string]: unknown;
 };
 
@@ -261,7 +261,7 @@ export class RemoteConversation extends EventEmitter {
     return {
       serverUrl,
       workspaceRoot,
-      workspacePayload: options.workspace ?? { kind: 'local', working_dir: workspaceRoot },
+      workspacePayload: options.workspace ?? { working_dir: workspaceRoot },
       workspaceClient: this.createOwnedWorkspaceClient(serverUrl, workspaceRoot),
       ownsWorkspaceClient: true,
     };

--- a/packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
@@ -53,6 +53,18 @@ describe('RemoteConversation workspaceRoot', () => {
     expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/cwd');
   });
 
+  it('uses workspace.working_dir when the legacy serverUrl path provides one', () => {
+    vi.spyOn(process, 'cwd').mockReturnValue('/cwd');
+
+    const conversation = new RemoteConversation({
+      serverUrl: 'http://localhost:3000',
+      settings: makeSettings(),
+      workspace: { working_dir: ' /payload-root ' },
+    });
+
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/payload-root');
+  });
+
   it('uses the injected remote workspace root when provided', () => {
     const conversation = new RemoteConversation({
       settings: makeSettings(),

--- a/packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { OpenHandsSettings } from '../../types/settings';
 import { RemoteConversation } from '../RemoteConversation';
+import { Workspace } from '../../../workspace';
 
 const makeSettings = (): OpenHandsSettings => ({
   llm: {},
@@ -51,5 +52,17 @@ describe('RemoteConversation workspaceRoot', () => {
 
     expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/cwd');
   });
-});
 
+  it('uses the injected remote workspace root when provided', () => {
+    const conversation = new RemoteConversation({
+      settings: makeSettings(),
+      workspace: Workspace({
+        kind: 'remote',
+        serverUrl: 'http://localhost:3000',
+        workingDir: '/workspace/injected',
+      }),
+    });
+
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/workspace/injected');
+  });
+});

--- a/packages/agent-sdk/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk/src/sdk/conversation/index.ts
@@ -4,7 +4,10 @@ import type { AgentContext } from '../context';
 import type { SecretRegistry } from '../runtime';
 import type { AgentHook } from '../runtime/hooks';
 import type { SecretStorage } from 'vscode';
-import type { BaseWorkspace } from '../../workspace';
+import {
+  isAgentServerWorkspace,
+  type BaseWorkspace,
+} from '../../workspace';
 import { LocalConversation } from './LocalConversation';
 import { RemoteConversation } from './RemoteConversation';
 
@@ -33,12 +36,22 @@ export interface ConversationFactoryOptions {
 }
 
 export function Conversation(options: ConversationFactoryOptions): ConversationInstance {
+  if (options.workspace && isAgentServerWorkspace(options.workspace)) {
+    return new RemoteConversation({
+      settings: options.settings,
+      workspace: options.workspace,
+      conversationId: options.conversationId,
+      tools: options.tools,
+      includeDefaultTools: options.includeDefaultTools,
+    }) as ConversationInstance;
+  }
   if (options.serverUrl) {
     return new RemoteConversation({
       serverUrl: options.serverUrl,
       settings: options.settings,
       workspaceRoot: options.workspaceRoot,
       conversationId: options.conversationId,
+      tools: options.tools,
       includeDefaultTools: options.includeDefaultTools,
     }) as ConversationInstance;
   }

--- a/packages/agent-sdk/src/workspace/AppleWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/AppleWorkspace.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import type { BaseWorkspace } from './BaseWorkspace';
+import type { AgentServerWorkspace, ConversationWorkspacePayload } from './BaseWorkspace';
 import { RemoteWorkspace } from './RemoteWorkspace';
 import type {
   CommandOptions,
@@ -54,7 +54,7 @@ const isNonEmptyString = (value: unknown): value is string =>
  * require a dedicated runtime control surface in that managed-container mode
  * and will throw until that exists.
  */
-export class AppleWorkspace implements BaseWorkspace {
+export class AppleWorkspace implements AgentServerWorkspace {
   readonly kind = 'apple' as const;
   readonly root: string;
 
@@ -119,6 +119,18 @@ export class AppleWorkspace implements BaseWorkspace {
 
   getServerUrl(): string {
     return this.serverUrl;
+  }
+
+  getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
+    return this.remote.getAuthHeaders(extra);
+  }
+
+  getRuntimeSessionApiKey(): string {
+    return this.remote.getRuntimeSessionApiKey();
+  }
+
+  getConversationWorkspacePayload(): ConversationWorkspacePayload {
+    return this.remote.getConversationWorkspacePayload();
   }
 
   allowPath(targetPath: string): void {

--- a/packages/agent-sdk/src/workspace/AppleWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/AppleWorkspace.ts
@@ -118,7 +118,7 @@ export class AppleWorkspace implements AgentServerWorkspace {
   }
 
   getServerUrl(): string {
-    return this.serverUrl;
+    return this.remote.getServerUrl();
   }
 
   getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {

--- a/packages/agent-sdk/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/BaseWorkspace.ts
@@ -3,7 +3,6 @@ import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding }
 export type WorkspaceKind = 'local' | 'remote' | 'apple';
 export type RemoteWorkspaceKind = 'remote' | 'apple';
 export type ConversationWorkspacePayload = {
-  kind: 'local';
   working_dir: string;
 };
 

--- a/packages/agent-sdk/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/BaseWorkspace.ts
@@ -1,6 +1,11 @@
 import type { CommandOptions, CommandResult, DirectoryEntry, WorkspaceEncoding } from './types';
 
 export type WorkspaceKind = 'local' | 'remote' | 'apple';
+export type RemoteWorkspaceKind = 'remote' | 'apple';
+export type ConversationWorkspacePayload = {
+  kind: 'local';
+  working_dir: string;
+};
 
 export interface BaseWorkspace {
   kind: WorkspaceKind;
@@ -26,4 +31,28 @@ export interface BaseWorkspace {
   pause(): Promise<void>;
   resume(): Promise<void>;
 
+}
+
+export interface AgentServerWorkspace extends BaseWorkspace {
+  kind: RemoteWorkspaceKind;
+  getServerUrl(): string;
+  getAuthHeaders(extra?: Record<string, string>): Record<string, string>;
+  getRuntimeSessionApiKey(): string;
+  getConversationWorkspacePayload(): ConversationWorkspacePayload;
+}
+
+export function isAgentServerWorkspace(
+  workspace: unknown,
+): workspace is AgentServerWorkspace {
+  if (typeof workspace !== 'object' || workspace === null) {
+    return false;
+  }
+  const candidate = workspace as Record<string, unknown>;
+  return (
+    (candidate.kind === 'remote' || candidate.kind === 'apple') &&
+    typeof candidate.getServerUrl === 'function' &&
+    typeof candidate.getAuthHeaders === 'function' &&
+    typeof candidate.getRuntimeSessionApiKey === 'function' &&
+    typeof candidate.getConversationWorkspacePayload === 'function'
+  );
 }

--- a/packages/agent-sdk/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/BaseWorkspace.ts
@@ -49,6 +49,22 @@ export function isAgentServerWorkspace(
   const candidate = workspace as Record<string, unknown>;
   return (
     (candidate.kind === 'remote' || candidate.kind === 'apple') &&
+    typeof candidate.root === 'string' &&
+    typeof candidate.allowPath === 'function' &&
+    typeof candidate.isPathAllowed === 'function' &&
+    typeof candidate.resolvePath === 'function' &&
+    typeof candidate.readFile === 'function' &&
+    typeof candidate.readFileBytes === 'function' &&
+    typeof candidate.writeFile === 'function' &&
+    typeof candidate.remove === 'function' &&
+    typeof candidate.list === 'function' &&
+    typeof candidate.ensureDirectory === 'function' &&
+    typeof candidate.runCommand === 'function' &&
+    typeof candidate.gitStatus === 'function' &&
+    typeof candidate.gitDiff === 'function' &&
+    typeof candidate.isAlive === 'function' &&
+    typeof candidate.pause === 'function' &&
+    typeof candidate.resume === 'function' &&
     typeof candidate.getServerUrl === 'function' &&
     typeof candidate.getAuthHeaders === 'function' &&
     typeof candidate.getRuntimeSessionApiKey === 'function' &&

--- a/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import type { BaseWorkspace } from './BaseWorkspace';
+import type { AgentServerWorkspace } from './BaseWorkspace';
 import type {
   CommandOptions,
   CommandResult,
@@ -97,7 +97,7 @@ const isBashOutputItem = (value: unknown): value is BashOutputItem => {
   return true;
 };
 
-export class RemoteWorkspace implements BaseWorkspace {
+export class RemoteWorkspace implements AgentServerWorkspace {
   readonly kind = 'remote' as const;
   readonly root: string;
 
@@ -131,6 +131,21 @@ export class RemoteWorkspace implements BaseWorkspace {
     this.runtimeId = typeof options.runtimeId === 'string' && options.runtimeId.trim() ? options.runtimeId.trim() : undefined;
 
     this.allowedRoots.add(this.root);
+  }
+
+  getServerUrl(): string {
+    return this.host;
+  }
+
+  getRuntimeSessionApiKey(): string {
+    return this.runtimeSessionApiKey ?? '';
+  }
+
+  getConversationWorkspacePayload(): { kind: 'local'; working_dir: string } {
+    return {
+      kind: 'local',
+      working_dir: this.root,
+    };
   }
 
   allowPath(targetPath: string): void {
@@ -420,7 +435,7 @@ export class RemoteWorkspace implements BaseWorkspace {
     }
   }
 
-  private getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
+  getAuthHeaders(extra: Record<string, string> = {}): Record<string, string> {
     const headers: Record<string, string> = { ...extra };
     if (isOpenHandsCloudServerUrl(this.host)) {
       if (this.cloudApiKey) headers['Authorization'] = `Bearer ${this.cloudApiKey}`;

--- a/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
@@ -141,9 +141,8 @@ export class RemoteWorkspace implements AgentServerWorkspace {
     return this.runtimeSessionApiKey ?? '';
   }
 
-  getConversationWorkspacePayload(): { kind: 'local'; working_dir: string } {
+  getConversationWorkspacePayload(): { working_dir: string } {
     return {
-      kind: 'local',
       working_dir: this.root,
     };
   }


### PR DESCRIPTION
## Summary
- introduce an `AgentServerWorkspace` runtime interface for remote and Apple workspaces
- make `Conversation()` prefer workspace-based dispatch while keeping the legacy `serverUrl` fallback
- refactor `RemoteConversation` to derive server URL, auth headers, and conversation workspace payload from the injected workspace, following the Python SDK shape more closely

## Notes
- Follows the merged Apple workspace foundation from #1002.
- Keeps backward compatibility for current callers that still pass `serverUrl` directly.

## Validation
- `npm run build:types -w @smolpaws/agent-sdk`
- `npm run typecheck`
- `npm run lint`
- `npx vitest run packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RemoteConversation can be created with an injected workspace (workspace parameter), allowing explicit workspace roots and optional serverUrl.

* **Refactor**
  * Public workspace surface expanded with methods for server URL, auth headers, session key, and payload.
  * Ownership model improved to support injected vs owned workspace clients and more flexible initialization.

* **Tests**
  * Added and updated tests covering workspace injection, factory behavior, lifecycle, and timing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Devin flagged a real URL-normalization issue in the injected `AppleWorkspace` path; that was fixed by delegating `getServerUrl()` to the normalized `RemoteWorkspace` host.
- CodeRabbit flagged three real follow-up issues after the refactor: legacy payload `working_dir` needed to drive the owned workspace root, `isAgentServerWorkspace()` needed to validate the full runtime contract, and the late-warmup regression test needed to target the actual `RemoteWorkspace` path. All three were fixed in `81a03f3`.
- Gemini’s remaining inline comments were affirmative only. All inline review threads are resolved.
- Final local validation on the merged branch head: `npm run build:types -w @smolpaws/agent-sdk`, `npm run lint -w @smolpaws/agent-sdk`, `npm run typecheck`, and `npx vitest run packages/agent-sdk/src/sdk/conversation/RemoteConversation.test.ts packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts`.
