### PR TITLE
feat: use refreshable remote workspaces

### DIFF
--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -225,7 +225,7 @@ describe('RemoteConversation', () => {
       expect(url).toContain('/api/conversations');
       const body = JSON.parse(init?.body ?? '{}');
       expect(body.agent.kind).toBe('Agent');
-      expect(body.workspace).toEqual({ working_dir: process.cwd() });
+      expect(body.workspace).toEqual({ working_dir: 'workspace/project' });
       expect(body.secrets).toEqual({
         ELEVENLABS_API_KEY: { kind: 'StaticSecret', value: 'xi-example123' },
         GITHUB_TOKEN: { kind: 'StaticSecret', value: 'ghp_example123' },

--- a/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts
@@ -1128,6 +1128,47 @@ describe('RemoteConversation', () => {
     await w3.writeFile('notes.txt', 'hello');
   });
 
+  it('refreshes auth on an injected workspace without replacing it', async () => {
+    let uploadCalls = 0;
+    const fetchMock = vi.fn(async (url: string, init?: any) => {
+      if (url.includes('/api/file/upload')) {
+        expect(init?.method).toBe('POST');
+        uploadCalls += 1;
+        expect(init?.headers?.['X-Session-API-Key']).toBe(uploadCalls === 1 ? 'session-key-1' : 'session-key-2');
+        return {
+          ok: true,
+          status: 200,
+          text: async () => '',
+        } as any;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const workspace = Workspace({
+      kind: 'remote',
+      serverUrl: 'http://localhost:3000',
+      workingDir: '/workspace',
+      runtimeSessionApiKey: 'session-key-1',
+    }) as AgentServerWorkspace;
+
+    const { RemoteConversation } = await import('../conversation/RemoteConversation');
+    const conversation = new RemoteConversation({
+      settings: { ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key-1' } },
+      workspace,
+    });
+
+    const w1 = conversation.getWorkspace();
+    await w1.writeFile('notes.txt', 'hello');
+
+    conversation.setSettings({ ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key-2' } });
+    const w2 = conversation.getWorkspace();
+    expect(w2).toBe(w1);
+
+    await w2.writeFile('notes.txt', 'hello');
+  });
+
   it('normalizes serverUrl without protocol for HTTP and WebSocket', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toMatch(/^http:\/\/localhost:3000\//);
@@ -1160,6 +1201,7 @@ describe('RemoteConversation', () => {
       getAuthHeaders: vi.fn((extra?: Record<string, string>) => ({ 'Content-Type': 'application/json', ...extra })),
       getRuntimeSessionApiKey: vi.fn(() => ''),
       getConversationWorkspacePayload: vi.fn(() => ({ working_dir: '/workspace/project' })),
+      setAuth: vi.fn(),
       allowPath: vi.fn(),
       isPathAllowed: vi.fn(() => true),
       resolvePath: vi.fn((targetPath: string) => targetPath),
@@ -1210,6 +1252,7 @@ describe('RemoteConversation', () => {
       getAuthHeaders: vi.fn(() => ({ 'Content-Type': 'application/json' })),
       getRuntimeSessionApiKey: vi.fn(() => ''),
       getConversationWorkspacePayload: vi.fn(() => ({ working_dir: '/workspace/project' as const })),
+      setAuth: vi.fn(),
       allowPath: vi.fn(),
       isPathAllowed: vi.fn(() => true),
       resolvePath: vi.fn((targetPath: string) => targetPath),

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -10,6 +10,7 @@ import type { ConfirmationPolicy } from '../security/confirmationPolicy';
 import type { SecurityAnalyzer } from '../security/analyzer';
 import { RemoteState } from './RemoteState';
 import { RemoteWorkspace } from '../../workspace/RemoteWorkspace';
+import { DEFAULT_REMOTE_WORKING_DIR } from '../../workspace/RemoteWorkspace';
 import {
   isAgentServerWorkspace,
   type AgentServerWorkspace,
@@ -258,7 +259,7 @@ export class RemoteConversation extends EventEmitter {
     const payloadWorkingDir = typeof options.workspace?.working_dir === 'string' && options.workspace.working_dir.trim()
       ? options.workspace.working_dir.trim()
       : undefined;
-    const workspaceRoot = normalizedWorkspaceRoot ?? payloadWorkingDir ?? process.cwd();
+    const workspaceRoot = normalizedWorkspaceRoot ?? payloadWorkingDir ?? DEFAULT_REMOTE_WORKING_DIR;
     const serverUrl = normalizeRemoteServerUrl(options.serverUrl);
 
     return {

--- a/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
+++ b/packages/agent-sdk/src/sdk/conversation/RemoteConversation.ts
@@ -343,6 +343,11 @@ export class RemoteConversation extends EventEmitter {
     }
     if (oldApiKey !== newApiKey && this.ownsWorkspaceClient) {
       this.workspaceClient = this.createOwnedWorkspaceClient(this.serverUrl, this.workspaceRoot);
+    } else if (oldApiKey !== newApiKey) {
+      this.workspaceClient.setAuth({
+        cloudApiKey: settings.secrets?.cloudApiKey,
+        runtimeSessionApiKey: settings.secrets?.runtimeSessionApiKey,
+      });
     }
   }
 

--- a/packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts
@@ -17,16 +17,15 @@ describe('RemoteConversation workspaceRoot', () => {
     delete (globalThis as unknown as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot;
   });
 
-  it('defaults to process.cwd() and ignores globalThis.vscodeWorkspaceRoot', () => {
+  it('defaults to the Python-parity remote working dir and ignores globalThis.vscodeWorkspaceRoot', () => {
     (globalThis as unknown as { vscodeWorkspaceRoot?: string }).vscodeWorkspaceRoot = '/should-not-use';
-    vi.spyOn(process, 'cwd').mockReturnValue('/cwd');
 
     const conversation = new RemoteConversation({
       serverUrl: 'http://localhost:3000',
       settings: makeSettings(),
     });
 
-    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/cwd');
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('workspace/project');
   });
 
   it('uses an explicit workspaceRoot when provided (trimmed)', () => {
@@ -42,15 +41,13 @@ describe('RemoteConversation workspaceRoot', () => {
   });
 
   it('treats empty workspaceRoot as unset', () => {
-    vi.spyOn(process, 'cwd').mockReturnValue('/cwd');
-
     const conversation = new RemoteConversation({
       serverUrl: 'http://localhost:3000',
       settings: makeSettings(),
       workspaceRoot: '   ',
     });
 
-    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('/cwd');
+    expect((conversation as unknown as { workspaceRoot: string }).workspaceRoot).toBe('workspace/project');
   });
 
   it('uses workspace.working_dir when the legacy serverUrl path provides one', () => {

--- a/packages/agent-sdk/src/workspace/AppleWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/AppleWorkspace.ts
@@ -133,6 +133,10 @@ export class AppleWorkspace implements AgentServerWorkspace {
     return this.remote.getConversationWorkspacePayload();
   }
 
+  setAuth(params: { cloudApiKey?: string; runtimeSessionApiKey?: string }): void {
+    this.remote.setAuth(params);
+  }
+
   allowPath(targetPath: string): void {
     this.remote.allowPath(targetPath);
   }

--- a/packages/agent-sdk/src/workspace/BaseWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/BaseWorkspace.ts
@@ -38,6 +38,7 @@ export interface AgentServerWorkspace extends BaseWorkspace {
   getAuthHeaders(extra?: Record<string, string>): Record<string, string>;
   getRuntimeSessionApiKey(): string;
   getConversationWorkspacePayload(): ConversationWorkspacePayload;
+  setAuth(params: { cloudApiKey?: string; runtimeSessionApiKey?: string }): void;
 }
 
 export function isAgentServerWorkspace(
@@ -68,6 +69,7 @@ export function isAgentServerWorkspace(
     typeof candidate.getServerUrl === 'function' &&
     typeof candidate.getAuthHeaders === 'function' &&
     typeof candidate.getRuntimeSessionApiKey === 'function' &&
-    typeof candidate.getConversationWorkspacePayload === 'function'
+    typeof candidate.getConversationWorkspacePayload === 'function' &&
+    typeof candidate.setAuth === 'function'
   );
 }

--- a/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
@@ -31,6 +31,9 @@ const normalizeEncoding = (encoding: WorkspaceEncoding): NodeBufferEncoding => {
   return encoding as NodeBufferEncoding;
 };
 
+const normalizeSecret = (value: string | undefined): string | undefined =>
+  typeof value === 'string' && value.trim() ? value.trim() : undefined;
+
 export interface RemoteWorkspaceOptions {
   host: string;
   /**
@@ -102,8 +105,8 @@ export class RemoteWorkspace implements AgentServerWorkspace {
   readonly root: string;
 
   private readonly host: string;
-  private readonly cloudApiKey?: string;
-  private readonly runtimeSessionApiKey?: string;
+  private cloudApiKey?: string;
+  private runtimeSessionApiKey?: string;
   private readonly pollIntervalMs: number;
   private readonly httpTimeoutMs: number;
 
@@ -116,12 +119,8 @@ export class RemoteWorkspace implements AgentServerWorkspace {
 
   constructor(options: RemoteWorkspaceOptions) {
     this.host = normalizeRemoteHostUrl(options.host);
-    this.cloudApiKey = typeof options.cloudApiKey === 'string' && options.cloudApiKey.trim()
-      ? options.cloudApiKey.trim()
-      : undefined;
-    this.runtimeSessionApiKey = typeof options.runtimeSessionApiKey === 'string' && options.runtimeSessionApiKey.trim()
-      ? options.runtimeSessionApiKey.trim()
-      : undefined;
+    this.cloudApiKey = normalizeSecret(options.cloudApiKey);
+    this.runtimeSessionApiKey = normalizeSecret(options.runtimeSessionApiKey);
     this.root = normalizePosixRoot(options.workingDir ?? '/workspace');
     this.pollIntervalMs = typeof options.pollIntervalMs === 'number' ? Math.max(0, options.pollIntervalMs) : 100;
     this.httpTimeoutMs = typeof options.httpTimeoutMs === 'number' ? Math.max(0, options.httpTimeoutMs) : 60_000;
@@ -145,6 +144,11 @@ export class RemoteWorkspace implements AgentServerWorkspace {
     return {
       working_dir: this.root,
     };
+  }
+
+  setAuth(params: { cloudApiKey?: string; runtimeSessionApiKey?: string }): void {
+    this.cloudApiKey = normalizeSecret(params.cloudApiKey);
+    this.runtimeSessionApiKey = normalizeSecret(params.runtimeSessionApiKey);
   }
 
   allowPath(targetPath: string): void {

--- a/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
+++ b/packages/agent-sdk/src/workspace/RemoteWorkspace.ts
@@ -10,6 +10,7 @@ import { normalizeRemoteUrl } from '../shared/remoteUrl';
 import { isOpenHandsCloudServerUrl } from '../shared/cloudServers';
 
 const normalizeRemoteHostUrl = normalizeRemoteUrl;
+export const DEFAULT_REMOTE_WORKING_DIR = 'workspace/project';
 
 const normalizePosixRoot = (raw: string): string => {
   const normalized = path.posix.normalize(raw.trim() || '/');
@@ -121,7 +122,7 @@ export class RemoteWorkspace implements AgentServerWorkspace {
     this.host = normalizeRemoteHostUrl(options.host);
     this.cloudApiKey = normalizeSecret(options.cloudApiKey);
     this.runtimeSessionApiKey = normalizeSecret(options.runtimeSessionApiKey);
-    this.root = normalizePosixRoot(options.workingDir ?? '/workspace');
+    this.root = normalizePosixRoot(options.workingDir ?? DEFAULT_REMOTE_WORKING_DIR);
     this.pollIntervalMs = typeof options.pollIntervalMs === 'number' ? Math.max(0, options.pollIntervalMs) : 100;
     this.httpTimeoutMs = typeof options.httpTimeoutMs === 'number' ? Math.max(0, options.httpTimeoutMs) : 60_000;
 

--- a/packages/agent-sdk/src/workspace/__tests__/remote.workspace.test.ts
+++ b/packages/agent-sdk/src/workspace/__tests__/remote.workspace.test.ts
@@ -144,6 +144,27 @@ describe('RemoteWorkspace', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('updates auth headers after setAuth', async () => {
+    let uploadCalls = 0;
+    const fetchMock = vi.fn(async (_url: string, init?: any) => {
+      uploadCalls += 1;
+      expect(init?.headers?.['X-Session-API-Key']).toBe(uploadCalls === 1 ? 'session-key-1' : 'session-key-2');
+      return okJson({ ok: true }) as any;
+    });
+    (globalThis as any).fetch = fetchMock;
+
+    const ws = new RemoteWorkspace({
+      host: 'http://localhost:3000',
+      workingDir: '/workspace/project',
+      runtimeSessionApiKey: 'session-key-1',
+    });
+
+    await ws.writeFile('hello.txt', 'hello');
+    ws.setAuth({ runtimeSessionApiKey: 'session-key-2' });
+    expect(ws.getRuntimeSessionApiKey()).toBe('session-key-2');
+    await ws.writeFile('hello.txt', 'hello');
+  });
+
   it('reports liveness via /health', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       expect(url).toBe('http://localhost:3000/health');

--- a/packages/agent-sdk/src/workspace/__tests__/remote.workspace.test.ts
+++ b/packages/agent-sdk/src/workspace/__tests__/remote.workspace.test.ts
@@ -28,6 +28,12 @@ describe('RemoteWorkspace', () => {
     expect(() => ws.resolvePath('/etc/passwd')).toThrowError(/Path escapes workspace root/i);
   });
 
+  it('defaults to the generic server-side workspace/project root', () => {
+    const ws = new RemoteWorkspace({ host: 'http://localhost:3000' });
+    expect(ws.root).toBe('workspace/project');
+    expect(ws.getConversationWorkspacePayload()).toEqual({ working_dir: 'workspace/project' });
+  });
+
   it('executes commands via bash endpoints and returns a CommandResult', async () => {
     const commandId = '00000000-0000-0000-0000-000000000001';
     const event1Id = '00000000-0000-0000-0000-000000000002';

--- a/src/__tests__/extension.chatView.test.ts
+++ b/src/__tests__/extension.chatView.test.ts
@@ -51,7 +51,7 @@ describe('Chat view behavior', () => {
     expect(options?.settings?.secrets?.runtimeSessionApiKey).toBe('runtime-token');
     expect(options?.serverUrl).toBeUndefined();
     expect(options?.workspace?.kind).toBe('remote');
-    expect(options?.workspace?.root).toBe('/test/workspace');
+    expect(options?.workspace?.root).toBe('workspace/project');
   });
 
   it('does not inject runtimeSessionApiKey when missing', async () => {

--- a/src/__tests__/extension.chatView.test.ts
+++ b/src/__tests__/extension.chatView.test.ts
@@ -49,6 +49,9 @@ describe('Chat view behavior', () => {
     const { Conversation } = await import('@smolpaws/agent-sdk');
     const options = (Conversation as unknown as Mock).mock.calls.at(-1)?.[0] as any;
     expect(options?.settings?.secrets?.runtimeSessionApiKey).toBe('runtime-token');
+    expect(options?.serverUrl).toBeUndefined();
+    expect(options?.workspace?.kind).toBe('remote');
+    expect(options?.workspace?.root).toBe('/test/workspace');
   });
 
   it('does not inject runtimeSessionApiKey when missing', async () => {

--- a/src/__tests__/extension.test.harness.ts
+++ b/src/__tests__/extension.test.harness.ts
@@ -117,18 +117,50 @@ vi.mock('@smolpaws/agent-sdk', () => {
   }
 
   const Workspace = vi.fn((options: any = {}) => {
+    const remoteState = {
+      cloudApiKey: options.cloudApiKey,
+      runtimeSessionApiKey: options.runtimeSessionApiKey,
+    };
+    const getAuthHeaders = (extra: Record<string, string> = {}) => {
+      const headers = { ...extra };
+      if (remoteState.cloudApiKey) {
+        headers.Authorization = `Bearer ${remoteState.cloudApiKey}`;
+      } else if (remoteState.runtimeSessionApiKey) {
+        headers['X-Session-API-Key'] = remoteState.runtimeSessionApiKey;
+      }
+      return headers;
+    };
+    const setAuth = (next: { cloudApiKey?: string; runtimeSessionApiKey?: string }) => {
+      remoteState.cloudApiKey = next.cloudApiKey;
+      remoteState.runtimeSessionApiKey = next.runtimeSessionApiKey;
+    };
+
     if (options.kind === 'remote') {
+      const root = options.workingDir ?? options.workspaceRoot ?? 'workspace/project';
+      const serverUrl = options.serverUrl ?? 'http://localhost:3000';
       return {
         kind: 'remote',
-        root: options.workingDir ?? options.workspaceRoot ?? 'workspace/project',
-        serverUrl: options.serverUrl,
+        root,
+        serverUrl,
+        getServerUrl: () => serverUrl,
+        getAuthHeaders,
+        getRuntimeSessionApiKey: () => remoteState.runtimeSessionApiKey ?? '',
+        getConversationWorkspacePayload: () => ({ working_dir: root }),
+        setAuth,
       };
     }
     if (options.kind === 'apple') {
+      const root = options.root ?? '/workspace';
+      const serverUrl = options.serverUrl ?? 'http://localhost:3000';
       return {
         kind: 'apple',
-        root: options.root ?? '/workspace',
-        serverUrl: options.serverUrl ?? null,
+        root,
+        serverUrl,
+        getServerUrl: () => serverUrl,
+        getAuthHeaders,
+        getRuntimeSessionApiKey: () => remoteState.runtimeSessionApiKey ?? '',
+        getConversationWorkspacePayload: () => ({ working_dir: root }),
+        setAuth,
       };
     }
     return {

--- a/src/__tests__/extension.test.harness.ts
+++ b/src/__tests__/extension.test.harness.ts
@@ -116,9 +116,32 @@ vi.mock('@smolpaws/agent-sdk', () => {
     getRegisteredValues = vi.fn(() => registeredSecretValues);
   }
 
+  const Workspace = vi.fn((options: any = {}) => {
+    if (options.kind === 'remote') {
+      return {
+        kind: 'remote',
+        root: options.workingDir ?? options.workspaceRoot ?? '/workspace',
+        serverUrl: options.serverUrl,
+      };
+    }
+    if (options.kind === 'apple') {
+      return {
+        kind: 'apple',
+        root: options.root ?? '/workspace',
+        serverUrl: options.serverUrl ?? null,
+      };
+    }
+    return {
+      kind: 'local',
+      root: options.root ?? '/workspace',
+    };
+  });
+
   const Conversation = vi.fn((options: any) => {
     const emitter = new EventEmitter() as any;
-    emitter.mode = options?.serverUrl ? 'remote' : 'local';
+    emitter.mode = options?.workspace?.kind === 'remote' || options?.workspace?.kind === 'apple' || options?.serverUrl
+      ? 'remote'
+      : 'local';
     emitter.conversationId = options?.conversationId ?? null;
     emitter.status = 'offline';
     emitter.getConversationId = vi.fn(() => emitter.conversationId);
@@ -162,6 +185,7 @@ vi.mock('@smolpaws/agent-sdk', () => {
     AgentContext,
     Conversation,
     SecretRegistry,
+    Workspace,
     loadSkillsFromDir: vi.fn(() => ({ repoSkills: new Map(), knowledgeSkills: new Map(), agentSkills: new Map() })),
     isBashCommand: vi.fn((event: any) => event?.type === 'BashCommand'),
     isBashOutput: vi.fn((event: any) => event?.type === 'BashOutput'),

--- a/src/__tests__/extension.test.harness.ts
+++ b/src/__tests__/extension.test.harness.ts
@@ -120,7 +120,7 @@ vi.mock('@smolpaws/agent-sdk', () => {
     if (options.kind === 'remote') {
       return {
         kind: 'remote',
-        root: options.workingDir ?? options.workspaceRoot ?? '/workspace',
+        root: options.workingDir ?? options.workspaceRoot ?? 'workspace/project',
         serverUrl: options.serverUrl,
       };
     }

--- a/src/extension/conversationLifecycle.ts
+++ b/src/extension/conversationLifecycle.ts
@@ -272,7 +272,7 @@ export function createConversationLifecycleOrchestrator(deps: ConversationLifecy
         ? Workspace({
           kind: 'remote',
           serverUrl: effectiveServerUrl,
-          workingDir: workspaceRoot,
+          workingDir: isCloudRemote ? '/workspace/project' : undefined,
           cloudApiKey: settings.secrets?.cloudApiKey,
           runtimeSessionApiKey: settings.secrets?.runtimeSessionApiKey,
         })

--- a/src/extension/conversationLifecycle.ts
+++ b/src/extension/conversationLifecycle.ts
@@ -9,6 +9,7 @@ import {
   loadSkillsFromDir,
   type SecretRegistry,
   type Skill,
+  Workspace,
 } from '@smolpaws/agent-sdk';
 import { bootstrapCloudRemoteConversation, type CloudBootstrapResult } from '../cloud/cloudRemoteBootstrap';
 import { getServerCloudApiKeySecretKey } from '../auth/serverCloudApiKeys';
@@ -267,11 +268,21 @@ export function createConversationLifecycleOrchestrator(deps: ConversationLifecy
         savedId = bootstrapConversationId;
       }
 
+      const remoteWorkspace = desiredMode === 'remote' && effectiveServerUrl
+        ? Workspace({
+          kind: 'remote',
+          serverUrl: effectiveServerUrl,
+          workingDir: workspaceRoot,
+          cloudApiKey: settings.secrets?.cloudApiKey,
+          runtimeSessionApiKey: settings.secrets?.runtimeSessionApiKey,
+        })
+        : undefined;
+
       const conversationOptions = {
-        serverUrl: effectiveServerUrl,
         settings,
-        workspaceRoot,
-        tools: settings.serverUrl ? undefined : resolveLocalTools(),
+        workspace: remoteWorkspace,
+        workspaceRoot: desiredMode === 'local' ? workspaceRoot : undefined,
+        tools: desiredMode === 'local' ? resolveLocalTools() : undefined,
         secrets,
         persistenceDir,
         agentContext,

--- a/src/extension/conversationLifecycle.ts
+++ b/src/extension/conversationLifecycle.ts
@@ -272,6 +272,7 @@ export function createConversationLifecycleOrchestrator(deps: ConversationLifecy
         ? Workspace({
           kind: 'remote',
           serverUrl: effectiveServerUrl,
+          // Cloud sandboxes expect absolute /workspace/project; generic remote stays on the Python-parity relative default.
           workingDir: isCloudRemote ? '/workspace/project' : undefined,
           cloudApiKey: settings.secrets?.cloudApiKey,
           runtimeSessionApiKey: settings.secrets?.runtimeSessionApiKey,


### PR DESCRIPTION
## Summary
- make injected `AgentServerWorkspace` instances refreshable when auth secrets rotate
- switch the extension's remote-mode conversation creation to pass a real remote workspace instead of `serverUrl + workspaceRoot`
- align generic TS `RemoteWorkspace` defaults with Python parity by using the server-side `workspace/project` root, while keeping cloud sandboxes on `/workspace/project`
- cover the auth-refresh and remote workspace consumer behavior in SDK and extension tests

## Validation
- `npx vitest run packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts`
- `npx vitest run packages/agent-sdk/src/workspace/__tests__/remote.workspace.test.ts`
- `npx vitest run packages/agent-sdk/src/sdk/conversation/__tests__/RemoteConversation.workspaceRoot.test.ts`
- `npx vitest run packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts`
- `npx vitest run src/__tests__/extension.chatView.test.ts -t "injects a per-server runtimeSessionApiKey when present"`
- `npm run typecheck`
- `npm run lint`
- `AGENT_SDK_DIR=/Users/enyst/repos/agent-sdk npm run e2e:agent-server` *(suite is pending-only locally in this environment, but no failures)*
- `npm test` *(still red in pre-existing unrelated SDK suites: `TerminalTool.session`, `glob-grep`, and `llm.profile-selection` timeouts/environment issues; the targeted coverage above passes on this branch)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1005" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace authentication can now be refreshed dynamically, allowing API keys and session tokens to be updated at runtime without recreating the workspace instance.
  * Remote workspace objects are now passed into conversation configuration for remote runs.

* **Bug Fixes**
  * Default working directory for remote execution now uses a consistent, stable remote path rather than the process working directory.

* **Tests**
  * Added and updated tests to cover default remote roots and dynamic auth refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Gemini Code Assist reviewed the PR and did not raise actionable issues.
- Devin Review reported no issues.
- CodeRabbit initially raised two accurate nitpicks; both were addressed in follow-up commit `b0e02d7` by hardening the remote workspace test harness and documenting the cloud-vs-generic remote working-dir split.
- No inline review threads remained unresolved at merge time (`Review Thread Gate` green).
- Attempted the repo-required local roasted review in a clean worktree, but the `openhands` session could not fetch PR metadata because `gh` auth was unavailable in that isolated worktree (`HTTP 401: Bad credentials`). Since the local review could not execute, I relied on the completed GitHub AI reviews plus green CI for this merge.
