### PR TITLE
refactor: require workspaces for remote conversations

### DIFF
--- a/packages/agent-sdk/AGENTS.md
+++ b/packages/agent-sdk/AGENTS.md
@@ -15,8 +15,8 @@ The SDK is organized into seven main layers:
 High-level conversation management with dual-mode support (local vs remote execution):
 
 - **`Conversation()` factory** - Auto-detects mode based on configuration
-  - Returns `LocalConversation` when no serverUrl provided
-  - Returns `RemoteConversation` when serverUrl is configured
+  - Returns `LocalConversation` when given a local workspace / `workspaceRoot`
+  - Returns `RemoteConversation` when given an `AgentServerWorkspace`
   - Event-driven API with `.on()` listeners for status, events, errors
   - Unified interface for both local and remote agent execution
 
@@ -291,11 +291,10 @@ or alternatives.
 This is the main API used by the OpenHands-Tab extension:
 
 ```typescript
-import { Conversation, type ConversationInstance } from '@smolpaws/agent-sdk';
+import { Conversation, Workspace, type ConversationInstance } from '@smolpaws/agent-sdk';
 
 // Create a conversation (auto-detects local vs remote mode)
 const conversation: ConversationInstance = Conversation({
-  serverUrl: 'http://localhost:3000', // or undefined for local mode
   settings: {
     llm: {
       model: 'claude-sonnet-4-20250514',
@@ -308,7 +307,11 @@ const conversation: ConversationInstance = Conversation({
       llmApiKey: process.env.ANTHROPIC_API_KEY,
     },
   },
-  workspaceRoot: '/path/to/workspace',
+  workspace: Workspace({
+    kind: 'remote',
+    serverUrl: 'http://localhost:3000',
+    workingDir: 'workspace/project',
+  }),
 });
 
 // Listen to events
@@ -365,9 +368,12 @@ const localConversation = Conversation({
 
 // Remote mode - connects to agent-server (RECOMMENDED)
 const remoteConversation = Conversation({
-  serverUrl: 'http://localhost:3000', // can be localhost or remote
   settings: { /* ... */ },
-  workspaceRoot: '/workspace',
+  workspace: Workspace({
+    kind: 'remote',
+    serverUrl: 'http://localhost:3000', // can be localhost or remote
+    workingDir: 'workspace/project',
+  }),
 });
 ```
 ### Creating an LLM Client (Low-Level)

--- a/packages/agent-sdk/docs/python-parity.md
+++ b/packages/agent-sdk/docs/python-parity.md
@@ -413,7 +413,7 @@ classDiagram
 
 ### TypeScript shape
 
-- `Conversation()` selects `LocalConversation` (in-process) or `RemoteConversation` (WebSocket) based on `serverUrl` presence
+- `Conversation()` selects `LocalConversation` (in-process) or `RemoteConversation` (WebSocket) based on workspace type, matching Python's factory shape
 - `LocalConversation`: Builds Agent, EventLog, ConversationState, SecretRegistry; emits status/event/error/terminal
 - `RemoteConversation`: WebSocket client with reconnect/replay, event deduplication, dynamic settings mutation
 

--- a/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
@@ -62,16 +62,10 @@ afterEach(async () => {
 });
 
 describe('Conversation factory', () => {
-  it('returns LocalConversation when serverUrl is omitted', () => {
+  it('returns LocalConversation when no remote workspace is provided', () => {
     const conversation = Conversation({ settings: baseSettings });
     expect(conversation.mode).toBe('local');
     expect(conversation).toBeInstanceOf(LocalConversation);
-  });
-
-  it('returns RemoteConversation when serverUrl is provided', () => {
-    const conversation = Conversation({ serverUrl: 'http://localhost:3000', settings: baseSettings });
-    expect(conversation.mode).toBe('remote');
-    expect(conversation).toBeInstanceOf(RemoteConversation);
   });
 
   it('returns RemoteConversation when given a remote workspace', () => {
@@ -98,7 +92,7 @@ describe('Conversation factory', () => {
     })).toBe(false);
   });
 
-  it('keeps auth fresh on the serverUrl factory path when settings change', async () => {
+  it('keeps auth fresh on the remote workspace factory path when settings change', async () => {
     let uploadCalls = 0;
     const fetchMock = vi.fn((url: string, init?: { headers?: Record<string, string>; method?: string }) => {
       if (url.includes('/api/file/upload')) {
@@ -113,9 +107,13 @@ describe('Conversation factory', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const conversation = Conversation({
-      serverUrl: 'http://localhost:3000',
       settings: { ...baseSettings, secrets: { runtimeSessionApiKey: 'session-key-1' } },
-      workspaceRoot: '/workspace',
+      workspace: Workspace({
+        kind: 'remote',
+        serverUrl: 'http://localhost:3000',
+        workingDir: '/workspace',
+        runtimeSessionApiKey: 'session-key-1',
+      }),
     });
 
     expect(conversation).toBeInstanceOf(RemoteConversation);
@@ -129,7 +127,7 @@ describe('Conversation factory', () => {
       secrets: { runtimeSessionApiKey: 'session-key-2' },
     });
     const workspace2 = remoteConversation.getWorkspace();
-    expect(workspace2).not.toBe(workspace1);
+    expect(workspace2).toBe(workspace1);
 
     await workspace2.writeFile('notes.txt', 'hello');
   });

--- a/packages/agent-sdk/src/sdk/conversation/index.ts
+++ b/packages/agent-sdk/src/sdk/conversation/index.ts
@@ -16,7 +16,6 @@ export type ConversationMode = 'local' | 'remote';
 export type ConversationInstance = (LocalConversation | RemoteConversation) & { mode: ConversationMode };
 
 export interface ConversationFactoryOptions {
-  serverUrl?: string | null;
   settings: OpenHandsSettings;
   workspace?: BaseWorkspace;
   workspaceRoot?: string;
@@ -40,16 +39,6 @@ export function Conversation(options: ConversationFactoryOptions): ConversationI
     return new RemoteConversation({
       settings: options.settings,
       workspace: options.workspace,
-      conversationId: options.conversationId,
-      tools: options.tools,
-      includeDefaultTools: options.includeDefaultTools,
-    }) as ConversationInstance;
-  }
-  if (options.serverUrl) {
-    return new RemoteConversation({
-      serverUrl: options.serverUrl,
-      settings: options.settings,
-      workspaceRoot: options.workspaceRoot,
       conversationId: options.conversationId,
       tools: options.tools,
       includeDefaultTools: options.includeDefaultTools,


### PR DESCRIPTION
## Summary
- remove the legacy `Conversation({ serverUrl, ... })` factory path and require a remote workspace for remote-mode conversations
- update the factory coverage to assert the workspace-first auth-refresh behavior explicitly
- align SDK usage docs and python parity notes with the workspace-first factory contract

## Validation
- `npx vitest run packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts`
- `npm run typecheck`
- `npm run lint`
- `npm test` *(still red in pre-existing unrelated SDK suites: `llm.streamer`, `TerminalTool.session`, `glob-grep`, `tools`, `Agent.profile-api-key`, and `terminal.integration`; no new failures were introduced by this slice)*

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1006" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `Workspace` configuration object for cleaner API setup.
  * Workspace object now determines local vs. remote conversation mode based on configuration type.

* **Documentation**
  * Updated documentation to reflect new workspace-based configuration pattern.

* **Breaking Changes**
  * Conversation factory options now require `workspace` object instead of direct `serverUrl` or `workspaceRoot` parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Gemini Code Assist reviewed the PR and did not raise actionable issues.
- Devin Review reported no issues.
- CodeRabbit completed with no actionable comments.
- No inline review threads remained unresolved at merge time (`Review Thread Gate` green).
- The local roasted-review path remains blocked in this environment because the isolated clean-worktree `openhands` session cannot fetch GitHub PR metadata (`gh` auth returns `HTTP 401` inside that session), so I relied on the completed GitHub AI reviews plus green CI for this merge.
