### PR TITLE
release: bump SDK to 0.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhands-tab",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhands-tab",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "bundleDependencies": [
         "ws"
       ],
@@ -14142,7 +14142,7 @@
     },
     "packages/agent-sdk": {
       "name": "@smolpaws/agent-sdk",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenHands Tab",
   "publisher": "openhands",
   "icon": "media/icons/openhands-icon.png",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A VS Code extension to interact with OpenHands agents in a dedicated sidebar chat view",
   "license": "MIT",
   "workspaces": [

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smolpaws/agent-sdk",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "TypeScript models and guards for the OpenHands agent-sdk wire protocol",
   "license": "MIT",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- bump OpenHands-Tab and @smolpaws/agent-sdk from 0.9.1 to 0.9.2
- publish the already-landed AppleWorkspace and remote workspace-first SDK surface
- unblock downstream clean-break workspace adoption in smolpaws

## Testing
- npm run build -w @smolpaws/agent-sdk
- npx vitest run packages/agent-sdk/src/workspace/__tests__/apple.workspace.test.ts packages/agent-sdk/src/workspace/__tests__/workspace.factory.test.ts packages/agent-sdk/src/sdk/__tests__/remoteConversation.test.ts

### Review
- Devin reviewed the release bump and reported no issues.
- Gemini reviewed the release bump and reported no issues.
- CodeRabbit suggested adding a package CHANGELOG; I did not take that change because this repo does not maintain per-package changelogs and the package readiness checks are already covered by CI plus the targeted SDK build/tests above.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1007" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 0.9.2 for the VS Code extension and Agent SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
