### PR TITLE
feat: support custom agent identity prefixes

### DIFF
--- a/packages/agent-sdk/src/sdk/context/__tests__/agent-context.test.ts
+++ b/packages/agent-sdk/src/sdk/context/__tests__/agent-context.test.ts
@@ -9,6 +9,7 @@ describe('AgentContext', () => {
       const context = new AgentContext();
 
       expect(context.skills).toEqual([]);
+      expect(context.systemMessagePrefix).toBeUndefined();
       expect(context.systemMessageSuffix).toBeUndefined();
       expect(context.userMessageSuffix).toBeUndefined();
       expect(context.loadUserSkills).toBe(false);
@@ -29,10 +30,12 @@ describe('AgentContext', () => {
 
     it('creates context with custom suffixes', () => {
       const context = new AgentContext({
+        systemMessagePrefix: 'System identity',
         systemMessageSuffix: 'System info',
         userMessageSuffix: 'User info',
       });
 
+      expect(context.systemMessagePrefix).toBe('System identity');
       expect(context.systemMessageSuffix).toBe('System info');
       expect(context.userMessageSuffix).toBe('User info');
     });
@@ -311,6 +314,23 @@ describe('AgentContext', () => {
       expect(suffix).toContain('Additional custom instructions.');
       expect(suffix).toContain('<CUSTOM_SECRETS>');
       expect(suffix).toContain('**$API_KEY**');
+    });
+  });
+
+  describe('getSystemMessagePrefix', () => {
+    it('returns null when no prefix is configured', () => {
+      const context = new AgentContext();
+      expect(context.getSystemMessagePrefix()).toBeNull();
+    });
+
+    it('returns null for empty or whitespace-only prefixes', () => {
+      expect(new AgentContext({ systemMessagePrefix: '' }).getSystemMessagePrefix()).toBeNull();
+      expect(new AgentContext({ systemMessagePrefix: '   ' }).getSystemMessagePrefix()).toBeNull();
+    });
+
+    it('returns the trimmed prefix when configured', () => {
+      const context = new AgentContext({ systemMessagePrefix: '  You are smolpaws.  ' });
+      expect(context.getSystemMessagePrefix()).toBe('You are smolpaws.');
     });
   });
 

--- a/packages/agent-sdk/src/sdk/context/agent-context.ts
+++ b/packages/agent-sdk/src/sdk/context/agent-context.ts
@@ -29,6 +29,9 @@ export class AgentContext {
   /** List of available skills that can extend the user's input. */
   skills: Skill[];
 
+  /** Optional prefix to prepend to the system prompt. */
+  systemMessagePrefix?: string;
+
   /** Optional suffix to append to the system prompt. */
   systemMessageSuffix?: string;
 
@@ -40,11 +43,13 @@ export class AgentContext {
 
   constructor(params?: {
     skills?: Skill[];
+    systemMessagePrefix?: string;
     systemMessageSuffix?: string;
     userMessageSuffix?: string;
     loadUserSkills?: boolean;
   }) {
     this.skills = params?.skills ?? [];
+    this.systemMessagePrefix = params?.systemMessagePrefix;
     this.systemMessageSuffix = params?.systemMessageSuffix;
     this.userMessageSuffix = params?.userMessageSuffix;
     this.loadUserSkills = params?.loadUserSkills ?? false;
@@ -182,6 +187,11 @@ export class AgentContext {
 
     const suffix = parts.join('\n\n');
     return suffix || null;
+  }
+
+  getSystemMessagePrefix(): string | null {
+    const prefix = this.systemMessagePrefix?.trim();
+    return prefix || null;
   }
 
   /**

--- a/packages/agent-sdk/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk/src/sdk/runtime/Agent.ts
@@ -34,7 +34,7 @@ import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
-import { SYSTEM_PROMPT } from './systemPrompt';
+import { SYSTEM_PROMPT, SYSTEM_PROMPT_IDENTITY } from './systemPrompt';
 import {
   redactAndTruncateArgs,
   sanitizeChatRequestForDebug,
@@ -1019,6 +1019,13 @@ export class Agent extends EventEmitter {
 
   private buildSystemPrompt(): string {
     let systemPrompt = SYSTEM_PROMPT;
+    if (this.agentContext) {
+      const prefix = this.agentContext.getSystemMessagePrefix();
+      if (prefix) {
+        const promptBody = systemPrompt.replace(`${SYSTEM_PROMPT_IDENTITY}\n\n`, '');
+        systemPrompt = prefix + '\n\n' + promptBody;
+      }
+    }
     if (!this.shouldIncludeSecurityRiskAssessment()) {
       systemPrompt = systemPrompt.replace(SECURITY_RISK_ASSESSMENT_SECTION, '');
     }

--- a/packages/agent-sdk/src/sdk/runtime/Agent.ts
+++ b/packages/agent-sdk/src/sdk/runtime/Agent.ts
@@ -34,7 +34,7 @@ import { SecretRegistry } from './SecretRegistry';
 import type { AgentContext } from '../context';
 import { createToolCallErrorEvents } from './toolCallErrorEvents';
 import { classifyConversationErrorCode, ClassifiedToolExecutionError, classifyError } from './errorPolicy';
-import { SYSTEM_PROMPT, SYSTEM_PROMPT_IDENTITY } from './systemPrompt';
+import { SYSTEM_PROMPT_BODY, SYSTEM_PROMPT_IDENTITY } from './systemPrompt';
 import {
   redactAndTruncateArgs,
   sanitizeChatRequestForDebug,
@@ -1018,14 +1018,8 @@ export class Agent extends EventEmitter {
   }
 
   private buildSystemPrompt(): string {
-    let systemPrompt = SYSTEM_PROMPT;
-    if (this.agentContext) {
-      const prefix = this.agentContext.getSystemMessagePrefix();
-      if (prefix) {
-        const promptBody = systemPrompt.replace(`${SYSTEM_PROMPT_IDENTITY}\n\n`, '');
-        systemPrompt = prefix + '\n\n' + promptBody;
-      }
-    }
+    const promptIdentity = this.agentContext?.getSystemMessagePrefix() ?? SYSTEM_PROMPT_IDENTITY;
+    let systemPrompt = `${promptIdentity}\n\n${SYSTEM_PROMPT_BODY}`;
     if (!this.shouldIncludeSecurityRiskAssessment()) {
       systemPrompt = systemPrompt.replace(SECURITY_RISK_ASSESSMENT_SECTION, '');
     }

--- a/packages/agent-sdk/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts
+++ b/packages/agent-sdk/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts
@@ -69,6 +69,43 @@ describe('Agent system prompt', () => {
     expect(systemPromptEvent.system_prompt.text).toBe(systemPrompt);
   });
 
+  it('prepends the latest AgentContext systemMessagePrefix on each LLM request', async () => {
+    const settings: OpenHandsSettings = {
+      llm: { model: 'test-model' },
+      agent: {},
+      conversation: { maxIterations: 3 },
+      confirmation: { policy: 'never' },
+      secrets: {},
+    };
+    const log = new EventLog();
+    const llm = new RecordingLLM();
+    const agentContext = new AgentContext({
+      systemMessagePrefix: 'You are smolpaws, the tiny cat agent based on OpenHands.',
+    });
+
+    const agent = new Agent({
+      settings,
+      events: log,
+      workspaceRoot: createWorkspaceRoot(),
+      llmClient: llm,
+      agentContext,
+    });
+
+    await agent.run('hi');
+    expect(llm.requests[0]?.systemPrompt.startsWith('You are smolpaws, the tiny cat agent based on OpenHands.')).toBe(true);
+    expect(llm.requests[0]?.systemPrompt).not.toContain('You are OpenHands agent');
+
+    agentContext.systemMessagePrefix = 'You are smolpaws, alive and helpful.';
+    await agent.run('hi again');
+    expect(llm.requests[1]?.systemPrompt.startsWith('You are smolpaws, alive and helpful.')).toBe(true);
+    expect(llm.requests[1]?.systemPrompt).not.toContain('You are smolpaws, the tiny cat agent based on OpenHands.');
+    expect(llm.requests[1]?.systemPrompt).not.toContain('You are OpenHands agent');
+
+    agentContext.systemMessagePrefix = undefined;
+    await agent.run('hi again (cleared)');
+    expect(llm.requests[2]?.systemPrompt.startsWith('You are OpenHands agent')).toBe(true);
+  });
+
   it('includes the latest AgentContext systemMessageSuffix on each LLM request', async () => {
     const settings: OpenHandsSettings = {
       llm: { model: 'test-model' },

--- a/packages/agent-sdk/src/sdk/runtime/systemPrompt.ts
+++ b/packages/agent-sdk/src/sdk/runtime/systemPrompt.ts
@@ -1,8 +1,6 @@
 export const SYSTEM_PROMPT_IDENTITY = 'You are OpenHands agent, a helpful AI assistant that can interact with a computer to solve tasks.';
 
-export const SYSTEM_PROMPT = `${SYSTEM_PROMPT_IDENTITY}
-
-<ROLE>
+export const SYSTEM_PROMPT_BODY = `<ROLE>
 * Your primary role is to assist users by executing commands, modifying code, and solving technical problems effectively. You should be thorough, methodical, and prioritize quality over speed.
 * If the user asks a question, like "why is X happening", don't try to fix the problem. Just give an answer to the question.
 </ROLE>
@@ -153,3 +151,7 @@ When using tools that support the security_risk parameter, assess the safety ris
   - When possible, use more targeted approaches like finding the PID from a pidfile or using application-specific shutdown commands
 </PROCESS_MANAGEMENT>
 `;
+
+export const SYSTEM_PROMPT = `${SYSTEM_PROMPT_IDENTITY}
+
+${SYSTEM_PROMPT_BODY}`;

--- a/packages/agent-sdk/src/sdk/runtime/systemPrompt.ts
+++ b/packages/agent-sdk/src/sdk/runtime/systemPrompt.ts
@@ -1,4 +1,6 @@
-export const SYSTEM_PROMPT = `You are OpenHands agent, a helpful AI assistant that can interact with a computer to solve tasks.
+export const SYSTEM_PROMPT_IDENTITY = 'You are OpenHands agent, a helpful AI assistant that can interact with a computer to solve tasks.';
+
+export const SYSTEM_PROMPT = `${SYSTEM_PROMPT_IDENTITY}
 
 <ROLE>
 * Your primary role is to assist users by executing commands, modifying code, and solving technical problems effectively. You should be thorough, methodical, and prioritize quality over speed.
@@ -151,4 +153,3 @@ When using tools that support the security_risk parameter, assess the safety ris
   - When possible, use more targeted approaches like finding the PID from a pidfile or using application-specific shutdown commands
 </PROCESS_MANAGEMENT>
 `;
-


### PR DESCRIPTION
## Summary
- add an AgentContext system-message prefix seam in the SDK
- let Agent replace the stock identity line while keeping the upstream operational prompt body intact
- cover the new prefix behavior with focused AgentContext and Agent system-prompt tests

## Validation
- npx vitest run packages/agent-sdk/src/sdk/context/__tests__/agent-context.test.ts packages/agent-sdk/src/sdk/runtime/__tests__/Agent.system-prompt.test.ts --exclude='.git/**'
- npm pack

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1010" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional system message prefix configuration to customize how agents identify themselves in system prompts.
  * System message prefixes can be dynamically updated during agent runtime and are applied to all subsequent LLM requests.
  * Empty or unset prefixes automatically revert to default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Gemini flagged one missing edge-case test for empty/whitespace prefixes; added the coverage and resolved the inline thread.
- Mandatory roasted review was recorded via Agent Mail (`PinkStone`): initial concern was that the first implementation removed the stock identity line with brittle string replacement inside `Agent.buildSystemPrompt()`.
- Follow-up commit `0b12b0e` addressed that by composing the system prompt structurally as `identity + body` via a dedicated `SYSTEM_PROMPT_BODY` constant; reviewer result: **APPROVED after latest structural follow-up**.
- Devin review reported no issues.
- CodeRabbit never produced actionable inline feedback on this PR after the final push; proceeded once all required checks and review-thread gates were green per repo policy.
