### PR TITLE
release: 0.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openhands-tab",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openhands-tab",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "bundleDependencies": [
         "ws"
       ],
@@ -14142,7 +14142,7 @@
     },
     "packages/agent-sdk": {
       "name": "@smolpaws/agent-sdk",
-      "version": "0.9.2",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "OpenHands Tab",
   "publisher": "openhands",
   "icon": "media/icons/openhands-icon.png",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "A VS Code extension to interact with OpenHands agents in a dedicated sidebar chat view",
   "license": "MIT",
   "workspaces": [

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@smolpaws/agent-sdk",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "TypeScript models and guards for the OpenHands agent-sdk wire protocol",
   "license": "MIT",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## Summary
- bump the extension version to 0.9.3
- bump @smolpaws/agent-sdk to 0.9.3 in the workspace package
- refresh the lockfile for the coordinated release

## Validation
- version bump only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.9.3 across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Review
- Gemini reviewed the release bump and reported no further comments needed.
- Devin review reported no issues.
- Mandatory roasted review was recorded via Agent Mail (`PinkStone`) and approved the diff as a consistent root/package/lockfile version bump.
- CodeRabbit reported no actionable comments.
