### PR TITLE
fix: conversation profile selector scroll + enabled input (oh-tab-dhb5)

### DIFF
--- a/packages/agent-sdk/src/tools/__tests__/TerminalTool.session.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/TerminalTool.session.test.ts
@@ -27,7 +27,7 @@ describe('TerminalTool session behavior', () => {
     secrets.register('GITHUB_TOKEN', 'ghp_example123');
 
     const result = await tool.execute(
-      tool.validate({ command: 'node -e "process.stdout.write(process.env.GITHUB_TOKEN||\'\')"', timeout: 0.2 }),
+      tool.validate({ command: 'node -e "process.stdout.write(process.env.GITHUB_TOKEN||\'\')"', timeout: 1 }),
       { workspace, secrets },
     );
 
@@ -52,7 +52,7 @@ describe('TerminalTool session behavior', () => {
       secrets.register(secretName, 'super-secret');
 
       const result = await tool.execute(
-        tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 0.2 }),
+        tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 1 }),
         { workspace, secrets },
       );
 
@@ -83,13 +83,13 @@ describe('TerminalTool session behavior', () => {
       secrets.register(secretName, 'super-secret');
 
       const trigger = await tool.execute(
-        tool.validate({ command: 'node -e "process.stdout.write(\'OH_TAB_TEST_SECRET_EXTRA\')"', timeout: 0.2 }),
+        tool.validate({ command: 'node -e "process.stdout.write(\'OH_TAB_TEST_SECRET_EXTRA\')"', timeout: 1 }),
         { workspace, secrets },
       );
       expect(trigger.exit_code).toBe(0);
 
       const check = await tool.execute(
-        tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 0.2 }),
+        tool.validate({ command: 'node -e "process.stdout.write(Object.keys(process.env).join(\',\'))"', timeout: 1 }),
         { workspace, secrets },
       );
       expect(check.exit_code).toBe(0);
@@ -130,22 +130,32 @@ describe('TerminalTool session behavior', () => {
     const start = await tool.execute(
       tool.validate({
         command: 'echo "Enter name:"; read name; echo "Hello $name"',
-        timeout: 0.1,
+        timeout: 0.3,
       }),
       { workspace },
     );
     expect(start.exit_code).toBe(-1);
-    const combinedStart = `${start.stdout ?? ''}${start.stderr ?? ''}`;
+
+    let combinedStart = `${start.stdout ?? ''}${start.stderr ?? ''}`;
+    for (let i = 0; i < 5 && !combinedStart.includes('Enter name:'); i += 1) {
+      const follow = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.2 }), { workspace });
+      combinedStart += `${follow.stdout ?? ''}${follow.stderr ?? ''}`;
+    }
     expect(combinedStart).toContain('Enter name:');
 
-    const reply = await tool.execute(
+    let reply = await tool.execute(
       tool.validate({
         command: 'John',
         is_input: true,
-        timeout: 0.2,
+        timeout: 1,
       }),
       { workspace },
     );
+
+    for (let i = 0; i < 5 && reply.exit_code === -1; i += 1) {
+      reply = await tool.execute(tool.validate({ command: '', is_input: true, timeout: 0.5 }), { workspace });
+    }
+
     expect(reply.exit_code).toBe(0);
     expect(`${reply.stdout ?? ''}${reply.stderr ?? ''}`).toContain('Hello John');
 
@@ -157,14 +167,17 @@ describe('TerminalTool session behavior', () => {
     created.push(dir);
     const tool = new TerminalTool();
 
-    await tool.execute(tool.validate({ command: 'export OH_TAB_TEST_VAR=bar', timeout: 0.2 }), { workspace });
-    const before = await tool.execute(tool.validate({ command: 'echo $OH_TAB_TEST_VAR', timeout: 0.2 }), { workspace });
+    const exportResult = await tool.execute(tool.validate({ command: 'export OH_TAB_TEST_VAR=bar', timeout: 1 }), { workspace });
+    expect(exportResult.exit_code).toBe(0);
+
+    const before = await tool.execute(tool.validate({ command: 'echo $OH_TAB_TEST_VAR', timeout: 1 }), { workspace });
+    expect(before.exit_code).toBe(0);
     expect((before.stdout ?? '').trim()).toBe('bar');
 
     const reset = await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
     expect(reset.exit_code).toBe(0);
 
-    const after = await tool.execute(tool.validate({ command: 'echo $OH_TAB_TEST_VAR', timeout: 0.2 }), { workspace });
+    const after = await tool.execute(tool.validate({ command: 'echo $OH_TAB_TEST_VAR', timeout: 1 }), { workspace });
     expect((after.stdout ?? '').trim()).toBe('');
 
     await tool.execute(tool.validate({ command: '', reset: true }), { workspace });
@@ -302,7 +315,7 @@ describe('TerminalTool session behavior', () => {
     expect(polled.exit_code).toBe(0);
     expect(`${polled.stdout ?? ''}${polled.stderr ?? ''}`).toContain('done');
 
-    const next = await tool.execute(tool.validate({ command: 'echo ok', timeout: 0.2 }), { workspace });
+    const next = await tool.execute(tool.validate({ command: 'echo ok', timeout: 1 }), { workspace });
     expect(next.exit_code).toBe(0);
     expect((next.stdout ?? '').trim()).toBe('ok');
 
@@ -319,7 +332,7 @@ describe('TerminalTool session behavior', () => {
 
     await new Promise<void>((resolve) => setTimeout(resolve, 400));
 
-    const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
+    const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 1 }), { workspace });
     expect(next.exit_code).toBe(0);
     expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('first');
     expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('second');
@@ -340,7 +353,7 @@ describe('TerminalTool session behavior', () => {
 
     await new Promise<void>((resolve) => setTimeout(resolve, 400));
 
-    const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 0.2 }), { workspace });
+    const next = await tool.execute(tool.validate({ command: 'echo second', timeout: 1 }), { workspace });
     expect(next.exit_code).toBe(0);
     expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('first');
     expect(`${next.stdout ?? ''}${next.stderr ?? ''}`).toContain('second');

--- a/src/extension/chatViewProvider.ts
+++ b/src/extension/chatViewProvider.ts
@@ -87,6 +87,10 @@ export function registerChatViewProvider(deps: RegisterChatViewProviderDeps): vs
         getConversationMode: deps.conversation.getConversationMode,
         getConversationStoreRoot: deps.conversation.getConversationStoreRoot,
         resolveConversationStoreRoot: deps.conversation.resolveConversationStoreRoot,
+        getLlmProfilesStoreRoot:
+          deps.context.extensionMode !== vscode.ExtensionMode.Production && typeof process.env.E2E_LLM_PROFILES_DIR === 'string'
+            ? () => process.env.E2E_LLM_PROFILES_DIR
+            : undefined,
         setWebviewReadyState: (conversationId, lastSeenSeq) => {
           deps.state.setChatWebviewReady(true);
           deps.state.setChatLastConversationId(conversationId);

--- a/src/webview-src/__tests__/App.advanced.test.tsx
+++ b/src/webview-src/__tests__/App.advanced.test.tsx
@@ -944,11 +944,10 @@ describe('App - Advanced Test Coverage', () => {
       const initial = 'Please read @rethen';
       const caret = initial.indexOf('@') + 1 + 2; // after "@re"
 
-      Object.defineProperty(textarea, 'selectionStart', { value: caret, configurable: true });
-      Object.defineProperty(textarea, 'selectionEnd', { value: caret, configurable: true });
-      fireEvent.select(textarea);
-
       fireEvent.change(textarea, { target: { value: initial } });
+      textarea.focus();
+      textarea.setSelectionRange(caret, caret);
+      fireEvent.select(textarea);
 
       await waitFor(() => {
         expect(mockApi.postMessage).toHaveBeenCalledWith({ type: 'requestWorkspaceFiles' });

--- a/src/webview-src/components/InputArea.tsx
+++ b/src/webview-src/components/InputArea.tsx
@@ -152,7 +152,7 @@ export function InputArea({
   };
 
   const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
-    if (disabled || !onPasteImageFiles) return;
+    if (!onPasteImageFiles) return;
 
     const items = e.clipboardData?.items;
     if (!items || items.length === 0) return;
@@ -186,7 +186,7 @@ export function InputArea({
             ${isFocused
               ? 'shadow-glow-outline border-white/[0.08]'
               : 'shadow-event border-white/[0.06]'}
-            ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+            ${disabled ? 'opacity-75' : ''}
           `}
           style={{
             background: isFocused
@@ -207,7 +207,6 @@ export function InputArea({
             onFocus={() => { setIsFocused(true); emitSelection(textareaRef.current); }}
             onBlur={() => setIsFocused(false)}
             onPaste={handlePaste}
-            disabled={disabled}
             placeholder={placeholder}
             rows={1}
             className={`

--- a/src/webview-src/components/inputArea/LlmProfileSelector.tsx
+++ b/src/webview-src/components/inputArea/LlmProfileSelector.tsx
@@ -79,7 +79,12 @@ export function LlmProfileSelector({
             </div>
           </div>
 
-          <div className="p-2 space-y-1" role="listbox" aria-label="LLM profiles">
+          <div
+            className="p-2 space-y-1 max-h-80 overflow-y-auto"
+            role="listbox"
+            aria-label="LLM profiles"
+            data-testid="llm-profile-selector-listbox"
+          >
             {sanitizedProfiles.length === 0 ? (
               <div className="px-3 py-2 text-sm opacity-60">No profiles found</div>
             ) : (

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -25,21 +25,45 @@ export async function run(): Promise<void> {
   const profileId = `e2e-ui-${uniqueId}`;
   const profilePath = path.join(llmProfilesDir, `${profileId}.json`);
 
+  const longListAnchorId = 'gemini-flash-summarizer';
+  const longListProfileCount = 40;
+  const longListProfilePaths: string[] = [];
+
   await fs.mkdir(skillsDir, { recursive: true });
   await fs.writeFile(skillPath, '# E2E UI Skill\n\nHello from UI E2E.\n', 'utf8');
 
   await fs.mkdir(llmProfilesDir, { recursive: true });
+
+  // Seed one baseline profile (existing test coverage).
   saveSdkProfile(profileId, { model: 'gpt-5-mini' }, { rootDir: llmProfilesDir, includeSecrets: false });
+
+  // Seed a long list of profiles to ensure the Conversation dropdown is scrollable and complete.
+  // Include an anchor ID that we want to select near the end of the list.
+  for (let i = 0; i < longListProfileCount; i += 1) {
+    const id = `e2e-ui-long-${String(i).padStart(2, '0')}`;
+    const p = path.join(llmProfilesDir, `${id}.json`);
+    longListProfilePaths.push(p);
+    saveSdkProfile(id, { model: 'gpt-5-mini' }, { rootDir: llmProfilesDir, includeSecrets: false });
+  }
+
+  // This profile name matches the reported real-world case.
+  const anchorPath = path.join(llmProfilesDir, `${longListAnchorId}.json`);
+  longListProfilePaths.push(anchorPath);
+  saveSdkProfile(longListAnchorId, { provider: 'gemini', model: 'gemini-2.0-flash' }, { rootDir: llmProfilesDir, includeSecrets: false });
 
   const cfg = vscode.workspace.getConfiguration();
   const settingsSnapshot: Record<string, unknown> = {
     'openhands.hal.enabled': cfg.inspect('openhands.hal.enabled')?.globalValue,
     'openhands.hal.mode': cfg.inspect('openhands.hal.mode')?.globalValue,
+    'openhands.llm.profileId': cfg.inspect('openhands.llm.profileId')?.globalValue,
     'openhands.confirmation.policy': cfg.inspect('openhands.confirmation.policy')?.globalValue,
     'openhands.confirmation.risky.threshold': cfg.inspect('openhands.confirmation.risky.threshold')?.globalValue,
     'openhands.serverUrl': cfg.inspect('openhands.serverUrl')?.globalValue,
     'openhands.servers': cfg.inspect('openhands.servers')?.globalValue,
   };
+
+  // Persist the reported profile selection before opening the chat view.
+  await vscode.workspace.getConfiguration('openhands').update('llm.profileId', longListAnchorId, vscode.ConfigurationTarget.Global);
   const restoreSettings = async () => {
     await Promise.all(
       Object.entries(settingsSnapshot).map(([key, value]) =>
@@ -87,9 +111,107 @@ export async function run(): Promise<void> {
       `[e2e/uiFlowsUi:suite] first selector [data-testid="header-totals-row"] visible in ${firstSelectorNow - firstSelectorStartMs}ms (suite_elapsed=${firstSelectorNow - suiteStartMs}ms)`
     );
 
+
+    // Regression coverage (oh-tab-dhb5): input should be enabled even when a persisted
+    // LLM profile is selected (eg from a prior VS Code session).
+    await webview.waitForSelector('#openhands-chat-input', { timeoutMs: 15000, visible: true });
+    await pollUntil(async () => {
+      const disabled = await webview.evaluate(() => {
+        const el = document.getElementById('openhands-chat-input') as HTMLTextAreaElement | null;
+        return el ? el.disabled : null;
+      });
+      return disabled === false;
+    }, 15000);
+
+    // Regression coverage (oh-tab-dhb5): Conversation LLM profile dropdown should be scrollable
+    // when many profiles exist.
+    await webview.click('button[aria-label="LLM profile"]');
+    await webview.waitForSelector('[data-testid="llm-profile-selector-listbox"]', { timeoutMs: 15000, visible: true });
+
+    const scrollInfo = await webview.evaluate(() => {
+      const list = document.querySelector('[data-testid="llm-profile-selector-listbox"]') as HTMLElement | null;
+      if (!list) return null;
+      const style = window.getComputedStyle(list);
+      return {
+        overflowY: style.overflowY,
+        clientHeight: list.clientHeight,
+        scrollHeight: list.scrollHeight,
+      };
+    });
+
+    if (!scrollInfo) {
+      throw new Error('Expected LLM profile listbox to exist, but it was not found');
+    }
+
+    if (scrollInfo.overflowY !== 'auto' && scrollInfo.overflowY !== 'scroll') {
+      throw new Error(`Expected LLM profile listbox overflow-y to be auto/scroll, got '${scrollInfo.overflowY}'`);
+    }
+
+    if (scrollInfo.scrollHeight <= scrollInfo.clientHeight) {
+      throw new Error(
+        `Expected LLM profile listbox to be scrollable (scrollHeight=${scrollInfo.scrollHeight}, clientHeight=${scrollInfo.clientHeight})`
+      );
+    }
+
+    const anchorResult = await webview.evaluate((anchorId) => {
+      const shadowRoot = document.body?.shadowRoot ?? null;
+      const list = (
+        document.querySelector('[data-testid="llm-profile-selector-listbox"]') ??
+        shadowRoot?.querySelector('[data-testid="llm-profile-selector-listbox"]')
+      ) as HTMLElement | null;
+      if (!list) {
+        return { ok: false, reason: 'missing_listbox' as const };
+      }
+
+      const options = list.querySelectorAll('button[aria-label^="Select profile "]').length;
+      const selector = `button[aria-label="Select profile ${anchorId}"]`;
+      const btn = list.querySelector(selector) as HTMLElement | null;
+      if (!btn) {
+        return {
+          ok: false,
+          reason: 'missing_anchor' as const,
+          options,
+          scrollTop: list.scrollTop,
+          scrollHeight: list.scrollHeight,
+          clientHeight: list.clientHeight,
+        };
+      }
+
+      return {
+        ok: true,
+        reason: 'ok' as const,
+        options,
+        scrollTop: list.scrollTop,
+        scrollHeight: list.scrollHeight,
+        clientHeight: list.clientHeight,
+      };
+    }, longListAnchorId);
+
+    if (!anchorResult.ok) {
+      throw new Error(
+        `Expected profile '${longListAnchorId}' to be reachable in the Conversation dropdown after scrolling. ` +
+        `Debug: ${JSON.stringify(anchorResult)}`
+      );
+    }
+
+    const minExpectedProfiles = longListProfileCount + 2;
+    const optionCount = typeof anchorResult.options === 'number' ? anchorResult.options : 0;
+    if (optionCount < minExpectedProfiles) {
+      throw new Error(
+        `Expected at least ${minExpectedProfiles} profiles in the Conversation dropdown (got ${optionCount}). ` +
+        `Debug: ${JSON.stringify(anchorResult)}`
+      );
+    }
+
+
+    // Close the dropdown.
+    await webview.click('button[aria-label="LLM profile"]');
+
+
     // Context picker: open, select a file, close.
     await webview.click('[data-testid="open-context-picker"]');
     await webview.waitForSelector('[data-testid="context-picker"]', { timeoutMs: 15000, visible: true });
+
 
     const optionSelector = '[data-testid="context-picker"] [role="option"]';
     const captureContextDebug = async () => {
@@ -280,5 +402,9 @@ export async function run(): Promise<void> {
     await restoreSettings();
     await fs.rm(skillPath, { force: true });
     await fs.rm(profilePath, { force: true });
+    for (const p of longListProfilePaths) {
+      await fs.rm(p, { force: true });
+    }
+
   }
 }

--- a/tests/e2e/suite/uiFlowsUi.ts
+++ b/tests/e2e/suite/uiFlowsUi.ts
@@ -19,13 +19,15 @@ export async function run(): Promise<void> {
   }
 
   const skillsDir = path.join(os.homedir(), '.openhands', 'skills');
-  const llmProfilesDir = path.join(os.homedir(), '.openhands', 'llm-profiles');
+  const llmProfilesDir = process.env.E2E_LLM_PROFILES_DIR
+    ? path.resolve(process.env.E2E_LLM_PROFILES_DIR)
+    : path.join(os.homedir(), '.openhands', 'llm-profiles');
   const uniqueId = randomUUID();
   const skillPath = path.join(skillsDir, `e2e-ui-skill-${uniqueId}.md`);
   const profileId = `e2e-ui-${uniqueId}`;
   const profilePath = path.join(llmProfilesDir, `${profileId}.json`);
 
-  const longListAnchorId = 'gemini-flash-summarizer';
+  const longListAnchorId = `e2e-ui-anchor-${uniqueId}`;
   const longListProfileCount = 40;
   const longListProfilePaths: string[] = [];
 
@@ -46,10 +48,10 @@ export async function run(): Promise<void> {
     saveSdkProfile(id, { model: 'gpt-5-mini' }, { rootDir: llmProfilesDir, includeSecrets: false });
   }
 
-  // This profile name matches the reported real-world case.
+  // Anchor profile used to validate that long lists remain fully populated.
   const anchorPath = path.join(llmProfilesDir, `${longListAnchorId}.json`);
   longListProfilePaths.push(anchorPath);
-  saveSdkProfile(longListAnchorId, { provider: 'gemini', model: 'gemini-2.0-flash' }, { rootDir: llmProfilesDir, includeSecrets: false });
+  saveSdkProfile(longListAnchorId, { model: 'gpt-5-mini' }, { rootDir: llmProfilesDir, includeSecrets: false });
 
   const cfg = vscode.workspace.getConfiguration();
   const settingsSnapshot: Record<string, unknown> = {

--- a/tests/e2e/uiFlowsUi.test.ts
+++ b/tests/e2e/uiFlowsUi.test.ts
@@ -45,6 +45,7 @@ describe('OpenHands-Tab UI Flows (Playwright) E2E', function () {
             E2E_MOCK_ATTACHMENTS: '1',
             E2E_UI: '1',
             E2E_CDP_PORT: String(port),
+            E2E_LLM_PROFILES_DIR: path.join(userDataDir, 'llm-profiles'),
           },
         });
         const now = Date.now();


### PR DESCRIPTION
Fixes oh-tab-dhb5.

### What changed
- Conversation LLM profile dropdown is now scrollable (max-height + overflow-y).
- Chat input is no longer disabled when status is offline; you can type/paste even while disconnected (send remains disabled).
- UI E2E (uiFlowsUi) seeds many profiles and asserts the conversation dropdown is scrollable and fully populated.
- UI E2E now uses an isolated profiles dir (`E2E_LLM_PROFILES_DIR`) so it does not touch `~/.openhands/llm-profiles`.

### Notes
- Includes small test robustness tweaks (TerminalTool session timeouts; context insertion selection test uses setSelectionRange).

### Bead

```

oh-tab-dhb5: LLM Profiles: conversation dropdown missing profiles; input disabled after reload
Status: in_progress
Priority: P1
Type: bug
Created: 2026-03-26 16:30
Updated: 2026-03-26 16:44

Description:
## Problem

Two possibly-related regressions around **LLM Profiles** in the Conversation UI.

### A) Conversation LLM Profiles dropdown missing some profiles
- In the **LLM Profiles** view, the profile list includes profiles like `gemini-flash-summarizer`.
- In the **Conversation** view’s LLM Profiles dropdown, that profile does **not** appear (only a subset shows).

Hypothesis: the Conversation dropdown list is either (a) not scrollable and profiles past the fold are inaccessible, or (b) is being populated from a different source than the Profiles view and is incomplete/truncated.

#### Repro
1. Ensure many profiles exist; include `gemini-flash-summarizer`.
2. Open **LLM Profiles** view → confirm `gemini-flash-summarizer` exists in its list.
3. Go back to Conversation view → open the LLM Profiles dropdown.

**Actual:** `gemini-flash-summarizer` is missing from Conversation dropdown.
**Expected:** Conversation dropdown shows the full profile list (with scrolling if needed).

#### Notes
- Consider reusing the scrolling/virtualization behavior used in the Profiles view dropdown (if any), or add `overflow-y-auto` with a max-height to the Conversation dropdown menu.

---

### B) Input box disabled after VS Code reload when a specific profile is selected
- With `gemini-flash-summarizer` selected (persisted from earlier), after reloading VS Code and starting a new conversation, the Conversation input prompt box was **disabled** (couldn’t type the initial prompt).
- Workaround: switch to another profile → input becomes enabled → then switching back to `gemini-flash-summarizer` works.

#### Repro
1. Select `gemini-flash-summarizer` in Conversation view.
2. Reload VS Code.
3. Start a new conversation / open Conversation view.

**Actual:** input disabled until switching profiles.
**Expected:** input should be enabled immediately; selected profile should not block typing.

#### Notes / suspected cause
- Input disabling in Conversation view may be tied to connection status (`offline`) or a profile-switch pending state; switching profiles may inadvertently trigger a reconnect/status update that re-enables the input.
- Check whether on reload we’re stuck in `offline` status until a profile selection event causes `ensureConversationAndConnection()` or a status update.

## Acceptance Criteria
- Conversation dropdown always contains the complete profile list (scrollable if needed).
- After reload, with any previously selected profile, the input is enabled and you can type immediately.
- Add E2E coverage for: many profiles → dropdown scroll → selecting one near end; and reload-with-profile-selected → input enabled.


```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard paste handling in input area when image-paste support is unavailable
  * Input controls now reflect disabled state without disabling the text area element

* **UI/UX Improvements**
  * LLM profile selector is scrollable and includes an anchor profile for easier navigation
  * Chat input re-enables correctly when a persisted profile is selected

* **Tests**
  * Increased test timeouts and retry logic to reduce flakiness
  * E2E tests seed and validate long profile lists and scrolling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->