### PR TITLE
test: isolate E2E LLM profiles store

### DIFF
--- a/packages/agent-sdk/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk/src/sdk/llm/profiles.ts
@@ -41,7 +41,13 @@ const expandHomeDir = (value: string): string => {
 };
 
 const resolveRootDir = (options: LLMProfileStoreOptions = {}): string => {
-  const rootDir = options.rootDir ?? DEFAULT_LLM_PROFILES_DIR;
+  const rawEnvRoot =
+    typeof process !== 'undefined'
+      ? (process.env.OPENHANDS_LLM_PROFILES_DIR ?? process.env.E2E_LLM_PROFILES_DIR ?? '')
+      : '';
+  const envRoot = typeof rawEnvRoot === 'string' ? rawEnvRoot.trim() : '';
+
+  const rootDir = options.rootDir ?? (envRoot || DEFAULT_LLM_PROFILES_DIR);
   return path.resolve(expandHomeDir(rootDir));
 };
 
@@ -255,7 +261,8 @@ const stripSecrets = (config: LLMConfiguration): LLMConfiguration => {
 };
 
 const ensureDefaultProfilesForDefaultStore = (rootDir: string, options: LLMProfileStoreOptions): void => {
-  if (options.rootDir) return;
+  const defaultRootDir = resolveRootDir({});
+  if (options.rootDir && path.resolve(rootDir) !== defaultRootDir) return;
   try {
     ensureDefaultProfiles({ ...options, rootDir });
   } catch (error) {

--- a/packages/agent-sdk/src/sdk/llm/profiles.ts
+++ b/packages/agent-sdk/src/sdk/llm/profiles.ts
@@ -41,11 +41,11 @@ const expandHomeDir = (value: string): string => {
 };
 
 const resolveRootDir = (options: LLMProfileStoreOptions = {}): string => {
-  const rawEnvRoot =
+  const envRoot = (
     typeof process !== 'undefined'
       ? (process.env.OPENHANDS_LLM_PROFILES_DIR ?? process.env.E2E_LLM_PROFILES_DIR ?? '')
-      : '';
-  const envRoot = typeof rawEnvRoot === 'string' ? rawEnvRoot.trim() : '';
+      : ''
+  ).trim();
 
   const rootDir = options.rootDir ?? (envRoot || DEFAULT_LLM_PROFILES_DIR);
   return path.resolve(expandHomeDir(rootDir));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,22 +225,19 @@ function ensureE2eLlmProfilesStoreDir(context: vscode.ExtensionContext): void {
     process.env.TEST_NAME.trim().length > 0;
   if (!isE2e) return;
 
-  const existing = typeof process.env.E2E_LLM_PROFILES_DIR === 'string'
-    ? process.env.E2E_LLM_PROFILES_DIR.trim()
-    : '';
-  if (existing) return;
+  const explicitE2e = process.env.E2E_LLM_PROFILES_DIR?.trim() ?? '';
+  const explicitSdk = process.env.OPENHANDS_LLM_PROFILES_DIR?.trim() ?? '';
+  const rootDir = path.resolve(explicitE2e || explicitSdk || path.join(context.globalStorageUri.fsPath, 'llm-profiles'));
 
-  const rootDir = path.join(context.globalStorageUri.fsPath, 'llm-profiles');
   try {
     fs.mkdirSync(rootDir, { recursive: true, mode: 0o700 });
   } catch {
     // best-effort only
   }
 
+  // Keep both env vars in sync so all call sites agree.
   process.env.E2E_LLM_PROFILES_DIR = rootDir;
-  if (typeof process.env.OPENHANDS_LLM_PROFILES_DIR !== 'string' || !process.env.OPENHANDS_LLM_PROFILES_DIR.trim()) {
-    process.env.OPENHANDS_LLM_PROFILES_DIR = rootDir;
-  }
+  process.env.OPENHANDS_LLM_PROFILES_DIR = rootDir;
 }
 
 export function activate(context: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -225,9 +225,9 @@ function ensureE2eLlmProfilesStoreDir(context: vscode.ExtensionContext): void {
     process.env.TEST_NAME.trim().length > 0;
   if (!isE2e) return;
 
-  const explicitE2e = process.env.E2E_LLM_PROFILES_DIR?.trim() ?? '';
   const explicitSdk = process.env.OPENHANDS_LLM_PROFILES_DIR?.trim() ?? '';
-  const rootDir = path.resolve(explicitE2e || explicitSdk || path.join(context.globalStorageUri.fsPath, 'llm-profiles'));
+  const explicitE2e = process.env.E2E_LLM_PROFILES_DIR?.trim() ?? '';
+  const rootDir = path.resolve(explicitSdk || explicitE2e || path.join(context.globalStorageUri.fsPath, 'llm-profiles'));
 
   try {
     fs.mkdirSync(rootDir, { recursive: true, mode: 0o700 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,7 @@
 import * as vscode from 'vscode';
+import fs from 'fs';
+import path from 'path';
+
 import { type HalStateSnapshot } from './shared/halTypes';
 import { maskSecretsInText } from './shared/maskSecrets';
 import { safeStringify } from './shared/safeStringify';
@@ -212,9 +215,40 @@ function syncLocalUserMessageSuffix(): void {
   localAgentContext.userMessageSuffix = env ?? undefined;
 }
 
+function ensureE2eLlmProfilesStoreDir(context: vscode.ExtensionContext): void {
+  const extensionMode = vscode.ExtensionMode;
+  const isProduction =
+    extensionMode?.Production !== undefined ? context.extensionMode === extensionMode.Production : true;
+  const isE2e =
+    !isProduction &&
+    typeof process.env.TEST_NAME === 'string' &&
+    process.env.TEST_NAME.trim().length > 0;
+  if (!isE2e) return;
+
+  const existing = typeof process.env.E2E_LLM_PROFILES_DIR === 'string'
+    ? process.env.E2E_LLM_PROFILES_DIR.trim()
+    : '';
+  if (existing) return;
+
+  const rootDir = path.join(context.globalStorageUri.fsPath, 'llm-profiles');
+  try {
+    fs.mkdirSync(rootDir, { recursive: true, mode: 0o700 });
+  } catch {
+    // best-effort only
+  }
+
+  process.env.E2E_LLM_PROFILES_DIR = rootDir;
+  if (typeof process.env.OPENHANDS_LLM_PROFILES_DIR !== 'string' || !process.env.OPENHANDS_LLM_PROFILES_DIR.trim()) {
+    process.env.OPENHANDS_LLM_PROFILES_DIR = rootDir;
+  }
+}
+
 export function activate(context: vscode.ExtensionContext) {
   const secrets = new SecretRegistry(context.secrets);
   secretRegistry = secrets;
+
+
+  ensureE2eLlmProfilesStoreDir(context);
 
   const devBridgeLogger = createDevBridgeLogger({ secretRegistry: secrets });
   const cfg = vscode.workspace.getConfiguration();

--- a/tests/e2e/suite/defaultProfilesSeeding.ts
+++ b/tests/e2e/suite/defaultProfilesSeeding.ts
@@ -17,15 +17,15 @@ const DEFAULT_PROFILE_IDS = [
 type LlmProfilesResult = { profiles?: string[] } | undefined;
 
 const getProfilesDir = (): string => {
-  const fromEnv = typeof process.env.E2E_LLM_PROFILES_DIR === 'string'
-    ? process.env.E2E_LLM_PROFILES_DIR.trim()
-    : '';
-  if (fromEnv) return path.resolve(fromEnv);
-
   const fromSdkEnv = typeof process.env.OPENHANDS_LLM_PROFILES_DIR === 'string'
     ? process.env.OPENHANDS_LLM_PROFILES_DIR.trim()
     : '';
   if (fromSdkEnv) return path.resolve(fromSdkEnv);
+
+  const fromEnv = typeof process.env.E2E_LLM_PROFILES_DIR === 'string'
+    ? process.env.E2E_LLM_PROFILES_DIR.trim()
+    : '';
+  if (fromEnv) return path.resolve(fromEnv);
 
   return path.join(os.homedir(), '.openhands', 'llm-profiles');
 };

--- a/tests/e2e/suite/defaultProfilesSeeding.ts
+++ b/tests/e2e/suite/defaultProfilesSeeding.ts
@@ -16,7 +16,19 @@ const DEFAULT_PROFILE_IDS = [
 
 type LlmProfilesResult = { profiles?: string[] } | undefined;
 
-const getProfilesDir = (): string => path.join(os.homedir(), '.openhands', 'llm-profiles');
+const getProfilesDir = (): string => {
+  const fromEnv = typeof process.env.E2E_LLM_PROFILES_DIR === 'string'
+    ? process.env.E2E_LLM_PROFILES_DIR.trim()
+    : '';
+  if (fromEnv) return path.resolve(fromEnv);
+
+  const fromSdkEnv = typeof process.env.OPENHANDS_LLM_PROFILES_DIR === 'string'
+    ? process.env.OPENHANDS_LLM_PROFILES_DIR.trim()
+    : '';
+  if (fromSdkEnv) return path.resolve(fromSdkEnv);
+
+  return path.join(os.homedir(), '.openhands', 'llm-profiles');
+};
 
 const readJson = async (filePath: string): Promise<Record<string, unknown>> => {
   const raw = await fs.readFile(filePath, 'utf8');
@@ -37,8 +49,15 @@ export async function run(): Promise<void> {
     return Boolean(diag?.chat?.hasView && diag?.chat?.webviewReady);
   }, 15000);
 
+  // Trigger best-effort default profile seeding in the active store.
+  await vscode.commands.executeCommand('openhands._listProfiles');
+
+
   // 1) Fresh install: default profiles should be seeded on disk.
   const profilesDir = getProfilesDir();
+
+
+
 
   await pollUntil(async () => {
     try {

--- a/tests/e2e/suite/llmProfiles.ts
+++ b/tests/e2e/suite/llmProfiles.ts
@@ -10,6 +10,7 @@ type WebviewActionResult = {
 
 type ErrorInfo = { seq?: number; code?: unknown; detail?: unknown; error?: unknown } | null;
 
+
 export async function run(): Promise<void> {
   const mock = await startMockLlmServer();
 
@@ -150,6 +151,7 @@ export async function run(): Promise<void> {
       const ui = await vscode.commands.executeCommand<any>('openhands._queryUiState');
       return Array.isArray(ui?.llmProfiles) && ui.llmProfiles.includes(uiProfileId);
     }, 15000);
+
 
     // Select via UI and immediately send to verify no race.
     await vscode.commands.executeCommand('openhands._webviewAction', {


### PR DESCRIPTION
Ensure E2E runs never touch a developer's real `~/.openhands/llm-profiles`.

### What changed
- Extension: when running under E2E (non-production + `TEST_NAME`), set `E2E_LLM_PROFILES_DIR`/`OPENHANDS_LLM_PROFILES_DIR` to a per-run directory under the VS Code user-data-dir globalStorage.
- Agent SDK: LLM profile store now honors `OPENHANDS_LLM_PROFILES_DIR` (and `E2E_LLM_PROFILES_DIR`) as the default root.
- E2E suites that validate default profile seeding now resolve the store dir via env override.

### Verification
- `npm run typecheck` ✅
- `npm test` ✅
- `npm run lint` ✅
- `npm run e2e` ✅

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-variable-driven resolution for the LLM profiles directory with deterministic on-disk setup in test runs.

* **Bug Fixes**
  * Fixed conditional default-profile seeding so profiles are only skipped when genuinely using a non-default store.

* **Tests**
  * Enhanced E2E tests to honor env var overrides, trigger profile seeding during setup, and use the resolved profiles directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->