### PR TITLE
fix(webview): allow service worker via CSP worker-src

### DIFF
--- a/src/webview/getWebviewHtml.ts
+++ b/src/webview/getWebviewHtml.ts
@@ -16,6 +16,8 @@ export function getWebviewHtml(context: vscode.ExtensionContext, webview: vscode
     `media-src ${webview.cspSource} blob:`,
     `style-src ${webview.cspSource} 'unsafe-inline'`,
     `font-src ${webview.cspSource}`,
+    // VS Code webviews rely on a service worker; allow it explicitly.
+    `worker-src ${webview.cspSource}`,
     `script-src ${webview.cspSource}`,
   ].join('; ');
 


### PR DESCRIPTION
### What
Add `worker-src` to the webview Content-Security-Policy so VS Code can register the webview service worker.

### Why
Without `worker-src`, the webview can fail to load with:
> Could not register service worker: InvalidStateError: The document is in an invalid state

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enabled web worker execution in webviews to support service worker functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->