### PR TITLE
fix: tighten agent-sdk package contents

### DIFF
--- a/packages/agent-sdk/eslint.config.js
+++ b/packages/agent-sdk/eslint.config.js
@@ -51,7 +51,7 @@ module.exports = [
     rules: {
       ...eslint.configs.recommended.rules,
       ...tseslint.configs.recommended.rules,
-      '@typescript-eslint/no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/no-explicit-any': 'off',
       'no-undef': 'off',
       'no-tabs': 'error',

--- a/packages/agent-sdk/eslint.config.js
+++ b/packages/agent-sdk/eslint.config.js
@@ -10,7 +10,7 @@ module.exports = [
   },
   {
     files: ['src/**/*.ts'],
-    ignores: ['src/**/__tests__/**'],
+    ignores: ['src/**/__tests__/**', 'src/**/*.test.ts', 'src/**/*.spec.ts'],
     languageOptions: {
       parser: tsparser,
       parserOptions: {
@@ -36,7 +36,7 @@ module.exports = [
     },
   },
   {
-    files: ['src/**/__tests__/**/*.ts'],
+    files: ['src/**/__tests__/**/*.ts', 'src/**/*.test.ts', 'src/**/*.spec.ts'],
     languageOptions: {
       parser: tsparser,
       parserOptions: {
@@ -51,7 +51,9 @@ module.exports = [
     rules: {
       ...eslint.configs.recommended.rules,
       ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-unused-vars': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
+      'no-undef': 'off',
       'no-tabs': 'error',
     },
   },

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -27,7 +27,7 @@
     "build:types": "tsc -p tsconfig.json",
     "lint": "eslint ./src",
     "pack:verify": "npm run build && node scripts/verify-pack.mjs",
-    "prepublishOnly": "npm run pack:verify",
+    "prepack": "node scripts/verify-pack.mjs",
     "test": "vitest run",
     "prepare": "npm run build"
   },

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -26,6 +26,8 @@
     "build:bundle": "tsup --config tsup.config.ts",
     "build:types": "tsc -p tsconfig.json",
     "lint": "eslint ./src",
+    "pack:verify": "npm run build && node scripts/verify-pack.mjs",
+    "prepublishOnly": "npm run pack:verify",
     "test": "vitest run",
     "prepare": "npm run build"
   },

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -27,7 +27,7 @@
     "build:types": "tsc -p tsconfig.json",
     "lint": "eslint ./src",
     "pack:verify": "npm run build && node scripts/verify-pack.mjs",
-    "prepack": "node scripts/verify-pack.mjs",
+    "prepack": "npm run build && node scripts/verify-pack.mjs",
     "test": "vitest run",
     "prepare": "npm run build"
   },

--- a/packages/agent-sdk/scripts/verify-pack.mjs
+++ b/packages/agent-sdk/scripts/verify-pack.mjs
@@ -1,0 +1,47 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(readFileSync(path.join(packageDir, 'package.json'), 'utf8'));
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const packed = JSON.parse(
+  execFileSync(
+    npmCommand,
+    ['pack', '--json', '--dry-run', '--ignore-scripts'],
+    {
+      cwd: packageDir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'inherit'],
+    },
+  ),
+);
+
+if (!Array.isArray(packed) || packed.length !== 1) {
+  throw new Error(`Expected a single packed artifact, received: ${JSON.stringify(packed)}`);
+}
+
+const [{ name, version, files = [] }] = packed;
+const forbiddenEntries = files
+  .map((file) => file.path)
+  .filter((filePath) => filePath.endsWith('.test.d.ts') || filePath.endsWith('.spec.d.ts'));
+
+if (name !== manifest.name) {
+  throw new Error(`Packed package name mismatch: expected ${manifest.name}, received ${name}`);
+}
+
+if (version !== manifest.version) {
+  throw new Error(`Packed package version mismatch: expected ${manifest.version}, received ${version}`);
+}
+
+if (forbiddenEntries.length > 0) {
+  throw new Error(
+    `Packed artifact unexpectedly includes test declarations:\n${forbiddenEntries
+      .map((filePath) => `- ${filePath}`)
+      .join('\n')}`,
+  );
+}
+
+console.log(`Verified ${name}@${version} pack contents (${files.length} entries).`);

--- a/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/Conversation.factory.test.ts
@@ -30,7 +30,6 @@ vi.mock('../llm', async () => {
       ];
 
       return {
-        // eslint-disable-next-line @typescript-eslint/require-await
         async *streamChat(_request: unknown) {
           void _request;
           const next = sequences[callIndex] ?? [];

--- a/packages/agent-sdk/src/sdk/conversation/LocalConversation.secretStorage.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/LocalConversation.secretStorage.test.ts
@@ -25,7 +25,6 @@ vi.mock('../llm', async () => {
       }
 
       return {
-        // eslint-disable-next-line @typescript-eslint/require-await
         async *streamChat(_request: ChatCompletionRequest) {
           void _request;
           yield { type: 'finish' };

--- a/packages/agent-sdk/src/sdk/conversation/LocalConversation.test.ts
+++ b/packages/agent-sdk/src/sdk/conversation/LocalConversation.test.ts
@@ -14,7 +14,6 @@ class FakeLLM implements LLMClient {
     this.responses = responses;
   }
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async *streamChat(_request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
     const next = this.responses.shift() ?? [];
     for (const chunk of next) {
@@ -26,7 +25,6 @@ class FakeLLM implements LLMClient {
 class RecordingLLM implements LLMClient {
   requests: ChatCompletionRequest[] = [];
 
-  // eslint-disable-next-line @typescript-eslint/require-await
   async *streamChat(request: ChatCompletionRequest): AsyncGenerator<LLMStreamChunk> {
     this.requests.push(request);
     yield { type: 'finish' };

--- a/packages/agent-sdk/src/sdk/security/__tests__/analyzer.test.ts
+++ b/packages/agent-sdk/src/sdk/security/__tests__/analyzer.test.ts
@@ -119,7 +119,6 @@ describe('LLMSecurityAnalyzer', () => {
     it('returns HIGH risk when securityRisk throws', () => {
       // Create a subclass that throws
       class ThrowingAnalyzer extends LLMSecurityAnalyzer {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         override securityRisk(action: ActionEvent): SecurityRisk {
           throw new Error('Unexpected error');
         }

--- a/packages/agent-sdk/src/sdk/security/__tests__/analyzer.test.ts
+++ b/packages/agent-sdk/src/sdk/security/__tests__/analyzer.test.ts
@@ -119,7 +119,7 @@ describe('LLMSecurityAnalyzer', () => {
     it('returns HIGH risk when securityRisk throws', () => {
       // Create a subclass that throws
       class ThrowingAnalyzer extends LLMSecurityAnalyzer {
-        override securityRisk(action: ActionEvent): SecurityRisk {
+        override securityRisk(_action: ActionEvent): SecurityRisk {
           throw new Error('Unexpected error');
         }
       }

--- a/packages/agent-sdk/src/tools/__tests__/zod-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/zod-tool.test.ts
@@ -12,7 +12,7 @@ class TestTool extends ZodTool<{ message: string; count?: number }, string> {
     count: z.number().optional(),
   });
 
-  async execute(args: { message: string; count?: number }, context: ToolContext): Promise<string> {
+  async execute(args: { message: string; count?: number }, _context: ToolContext): Promise<string> {
     const count = args.count ?? 1;
     return args.message.repeat(count);
   }
@@ -29,7 +29,10 @@ class NestedSchemaTool extends ZodTool<{ config: { enabled: boolean; options: st
     }),
   });
 
-  async execute(args: { config: { enabled: boolean; options: string[] } }, context: ToolContext): Promise<void> {
+  async execute(
+    _args: { config: { enabled: boolean; options: string[] } },
+    _context: ToolContext,
+  ): Promise<void> {
     // Do nothing
   }
 }
@@ -46,7 +49,7 @@ class CustomParametersTool extends ZodTool<{ value: string }, string> {
     },
   };
 
-  async execute(args: { value: string }, context: ToolContext): Promise<string> {
+  async execute(args: { value: string }, _context: ToolContext): Promise<string> {
     return args.value;
   }
 }

--- a/packages/agent-sdk/src/tools/__tests__/zod-tool.test.ts
+++ b/packages/agent-sdk/src/tools/__tests__/zod-tool.test.ts
@@ -12,7 +12,6 @@ class TestTool extends ZodTool<{ message: string; count?: number }, string> {
     count: z.number().optional(),
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(args: { message: string; count?: number }, context: ToolContext): Promise<string> {
     const count = args.count ?? 1;
     return args.message.repeat(count);
@@ -30,7 +29,6 @@ class NestedSchemaTool extends ZodTool<{ config: { enabled: boolean; options: st
     }),
   });
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(args: { config: { enabled: boolean; options: string[] } }, context: ToolContext): Promise<void> {
     // Do nothing
   }
@@ -48,7 +46,6 @@ class CustomParametersTool extends ZodTool<{ value: string }, string> {
     },
   };
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async execute(args: { value: string }, context: ToolContext): Promise<string> {
     return args.value;
   }

--- a/packages/agent-sdk/tsconfig.json
+++ b/packages/agent-sdk/tsconfig.json
@@ -16,5 +16,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/__tests__/**"]
+  "exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.spec.ts"]
 }


### PR DESCRIPTION
## Summary
- stop emitting `*.test.d.ts` files into the published `@smolpaws/agent-sdk` package
- add an SDK pack verification script that checks the packed version and rejects shipped test declarations
- hook that verification into `prepublishOnly` so publish-time package regressions fail early

## Verification
- `npm run pack:verify -w @smolpaws/agent-sdk`
- `npm test -w @smolpaws/agent-sdk`
- `npm test`
- `npm run typecheck`
- `npm run lint`
- `npm run build`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/enyst/openhands-tab/pull/1019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved ESLint configuration to better differentiate rules for test and source files.
  * Added package verification scripts to validate packed contents before publishing.
  * Updated TypeScript configuration to exclude test files from compilation.
  * Removed obsolete lint-disable comments and adjusted test scaffolding to satisfy lint rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enyst/OpenHands-Tab/pull/1019?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->